### PR TITLE
feat(web): build plans configurator, orders and download behind a flag (build plans 5/10)

### DIFF
--- a/docs/cnc-packs.md
+++ b/docs/cnc-packs.md
@@ -465,6 +465,71 @@ Emails reuse the existing SMTP config (`SMTP_USER`, `SMTP_PASSWORD`,
 `EMAIL_FROM`) and `ADMIN_EMAIL` for the pack-failed notification. Every send is
 best-effort: the order is already paid and durable by the time one runs.
 
+## The web surface
+
+Three routes, all under `/build-plans` and all server-gated by the `cnc-packs`
+flag through `requireCncPacksFlag()` in `build-plans-page.ts`. The gate is a
+`notFound()`, not a hidden button: the manufacturing licence ships marked DRAFT
+until the Australian IP review lands, so the shop must not be reachable at all —
+and every page carries `noindex, follow` on top, because noindex alone would
+still leave a publicly browsable shop.
+
+| Route | What it is |
+| --- | --- |
+| `/build-plans` | The hero and the configurator. Server-renders the catalogue, then hands it to a client component for the choosing. |
+| `/build-plans/orders` | The buyer's own orders, newest first. |
+| `/build-plans/orders/[licenceId]` | One order: status timeline, the configuration it was bought under, and the download button once it is ready. |
+
+`FEATURE_FLAG_OVERRIDES=cnc-packs` is how you reach any of them locally.
+
+### The configurator
+
+Seven steps, in the order they appear: **board**, **size**, **kicker**,
+**options**, **engrave**, **licensee**, **tier**. Each one fires a
+`CNC Configurator Changed` funnel event debounced by 900 ms, so a buyer
+dragging through the option list produces one event describing where they
+stopped rather than twenty describing where they passed through.
+
+Board is a read-only statement rather than a select, because v1 sells one board
+and a select with a single option is a choice that is not one. It becomes a
+select the day a second board goes on sale, and the `board` step is already in
+the funnel contract so that day does not also need an analytics change.
+
+State lives in a reducer in `configurator-state.ts`, and the options a wall may
+carry come from the backend catalogue rather than the client — the same registry
+checkout validates against, so the configurator cannot offer a combination the
+order would reject.
+
+### The draft
+
+Every change is written to IndexedDB under `cnc:configurator-draft`, debounced
+by 600 ms, and read back once before the first save can run.
+
+This exists for exactly one flow: an anonymous buyer configures a wall, presses
+Buy, and is sent through OAuth. That leaves the page entirely, so without the
+draft they come back to the defaults and have to configure it again — at the
+exact moment they had decided to pay. The restore is also why the sign-in
+callback URL is `/build-plans` rather than wherever the modal was opened from.
+
+The draft is cleared twice: once when checkout succeeds (the wall has been
+bought, so there is nothing left to restore) and once on sign-out, because it
+carries the licensee name and email and the next person on a shared machine has
+no business seeing them.
+
+### Polling an unfinished pack
+
+`/build-plans/orders/[licenceId]` re-queries every 5 s
+(`ORDER_POLL_INTERVAL_MS`) while the order is `queued` or `generating`, and
+stops once it reaches a terminal status. A pack takes a couple of minutes to
+cut, so five seconds is fast enough that the page never feels stuck and slow
+enough that a buyer leaving the tab open over lunch costs a few hundred
+requests rather than a few hundred thousand.
+
+Order timestamps are formatted with `createOrderDateFormatter`, which pins
+`timeZone: 'UTC'`. The page is server-rendered and then hydrated, and those are
+two runtimes in two zones; without the pin the same instant prints as two
+different clock times and React reports a hydration mismatch.
+
 ## Local end-to-end
 
 ```

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -8,7 +8,7 @@ Two kinds, and they fail in different ways.
 
 **Server flags** (`SERVER_FEATURE_FLAG_KEYS`) resolve during SSR via `getServerFeatureFlag` and decide whether a route renders at all — with one off, its route is a plain `notFound()`. A client-resolved flag could not do this: by the time the browser knows the answer the HTML has already shipped.
 
-The registry is **empty today**. `gyms-directory` was the only server flag; `/gyms` and its three facet routes now render for everyone and the flag is gone. The machinery below stays for the next route that needs it — and the diagnostics endpoint still answers any key you name.
+`cnc-packs` is the registry's only entry today, and the first one resolved with `allowAnonymous: true` — build packs are bought by people who have never signed in, so a gate that only evaluated for a session would keep `/build-plans` signed-in-only however the dashboard is configured. (`gyms-directory` was the previous occupant; `/gyms` and its three facet routes now render for everyone and that flag is gone.)
 
 ## How a server flag resolves
 

--- a/packages/shared/analytics/src/cnc-funnel.ts
+++ b/packages/shared/analytics/src/cnc-funnel.ts
@@ -1,0 +1,192 @@
+// The CNC build-pack funnel event contract (plan section B6).
+//
+// One purchase journey — land on /build-plans, configure a wall, sign in, pay,
+// download the pack — is measured across a server page, a client configurator
+// and the backend's Stripe webhook. Every one of those call sites imports this
+// module instead of typing a string literal, because a single character of
+// drift splits the funnel into two PostHog events nobody notices until someone
+// tries to read the conversion rate.
+//
+// Why here and not in `events.ts`: `SHARED_EVENTS` is scoped to events fired by
+// BOTH web and mobile, and that scoping is what makes it useful. Build plans are
+// a www surface with no mobile counterpart (the plan's B1 says so explicitly:
+// "No mobile changes"), so they live in their own module — the same reasoning,
+// and the same shape, as `gym-funnel.ts`.
+//
+// The contract in one paragraph:
+//
+//  * Names live in `CNC_FUNNEL_EVENTS`. Never inline the string.
+//  * Props come from the builders below, which return `{ name, properties }`
+//    TOGETHER, so a caller physically cannot pair one event's props with
+//    another event's name.
+//  * Property names are snake_case here, unlike `gym-funnel.ts`'s camelCase.
+//    That is deliberate and matches `board-render-events.ts`: the two properties
+//    this funnel will most often be broken down by — `board_name`, `size_id` —
+//    already exist in PostHog under those exact names from the board-render
+//    contract (docs/board-render-analytics.md), and a second spelling of
+//    `board_name` would make a cross-surface breakdown silently drop rows.
+//  * Property VALUES are identifiers, never copy: never translated, never
+//    title-cased, never derived from what the buyer typed. The licensee's name,
+//    email and customer site name are personal data and appear in NO event here.
+//  * Every value is `string | number | boolean`, because web's `track()`
+//    (packages/web/app/lib/analytics.ts) types properties that way — an array or
+//    a nested object is a compile error at the call site.
+
+import type { AnalyticsPropertyValue } from './client';
+
+/**
+ * Canonical event names. `as const` so the values are literal types and a typo
+ * at a call site is a compile error rather than a new PostHog event.
+ *
+ * `PackPurchased` and `PackDownloaded` have no builder here: both are fired by
+ * the BACKEND, from its own `BackendAnalyticsEvent` union
+ * (packages/backend/src/services/analytics/posthog.ts), where a purchase is
+ * confirmed by the Stripe webhook and a download by the authenticated stream
+ * route. Neither event can be trusted from a browser — a client-side "purchased"
+ * is a claim, not a payment. They are listed anyway because this file is where
+ * someone reading the funnel looks for the full step list, and a name that
+ * exists in two places has to be spelled identically in both.
+ */
+export const CNC_FUNNEL_EVENTS = {
+  PageViewed: 'Build Plans Page Viewed',
+  ConfiguratorChanged: 'Build Plans Configurator Changed',
+  ArtworkPlaced: 'Build Plans Artwork Placed',
+  CheckoutStarted: 'Build Plans Checkout Started',
+  /** Backend-fired, on `checkout.session.completed`. */
+  PackPurchased: 'Build Plans Pack Purchased',
+  /** Backend-fired, by the authenticated download route. */
+  PackDownloaded: 'Build Plans Pack Downloaded',
+} as const;
+
+export type CncFunnelEventKey = keyof typeof CNC_FUNNEL_EVENTS;
+export type CncFunnelEventName = (typeof CNC_FUNNEL_EVENTS)[CncFunnelEventKey];
+
+/**
+ * Which licence the buyer is looking at or buying.
+ *
+ * Restates `CncLicenceTier` from `@boardsesh/shared-schema` rather than
+ * importing it: a shared package may depend on other shared packages, and this
+ * one deliberately depends on none — `@boardsesh/analytics` is imported by
+ * mobile, and pulling the whole GraphQL type surface in behind one union would
+ * put every schema change on Metro's critical path. Two members, and adding a
+ * third to the schema without adding it here is a compile error at the call
+ * site, which is the intended nudge.
+ */
+export type CncTier = 'personal' | 'commercial_single';
+
+/**
+ * Which step of the configurator moved.
+ *
+ * The step vocabulary, not the field name: `Configurator Changed` fires on step
+ * COMPLETION, not per keystroke, so "the buyer got as far as options" is the
+ * question it answers. A per-field event would drown the funnel in noise from
+ * eleven manufacturing selects and tell nobody where people give up.
+ *
+ * `licensee` deliberately reports only that the step was completed. Nothing
+ * about who they are leaves the browser.
+ */
+export type CncConfiguratorStep = 'board' | 'size' | 'kicker' | 'options' | 'engrave' | 'licensee' | 'tier';
+
+/**
+ * A name paired with the exact properties that name expects. Builders return
+ * this so a caller cannot hand one event's props to another event's name.
+ */
+export type CncFunnelPayload<
+  TName extends CncFunnelEventName,
+  TProperties extends Record<string, AnalyticsPropertyValue>,
+> = {
+  name: TName;
+  properties: TProperties;
+};
+
+/**
+ * The board tuple every event in this funnel carries.
+ *
+ * Present on the page view too, where nothing is configured yet: the page
+ * defaults the configurator to the first catalogue entry, so "which wall did
+ * people arrive looking at" is a real question with a real answer, and a funnel
+ * whose first step lacks the breakdown property cannot be broken down at all.
+ */
+export type CncConfigProps = {
+  board_name: string;
+  layout_id: number;
+  size_id: number;
+  /** Whether the wall being configured includes the kicker panels. */
+  kicker: boolean;
+  has_artwork: boolean;
+};
+
+export type CncPageViewedInput = {
+  config: CncConfigProps;
+  /** Catalogue version the prices and option lists came from. */
+  catalog_version: string;
+};
+
+export type CncConfiguratorChangedInput = {
+  step: CncConfiguratorStep;
+  config: CncConfigProps;
+};
+
+export type CncArtworkPlacedInput = {
+  config: CncConfigProps;
+  /** How many artwork items sit on the wall AFTER this placement. */
+  artwork_count: number;
+};
+
+export type CncCheckoutStartedInput = {
+  config: CncConfigProps;
+  tier: CncTier;
+  /** Price shown at the moment Buy was pressed, in cents of `currency`. */
+  amount_cents: number;
+  currency: string;
+};
+
+export function cncBuildPlansPageViewed(
+  input: CncPageViewedInput,
+): CncFunnelPayload<typeof CNC_FUNNEL_EVENTS.PageViewed, CncConfigProps & { catalog_version: string }> {
+  return {
+    name: CNC_FUNNEL_EVENTS.PageViewed,
+    properties: { ...input.config, catalog_version: input.catalog_version },
+  };
+}
+
+export function cncConfiguratorChanged(
+  input: CncConfiguratorChangedInput,
+): CncFunnelPayload<typeof CNC_FUNNEL_EVENTS.ConfiguratorChanged, CncConfigProps & { step: CncConfiguratorStep }> {
+  return {
+    name: CNC_FUNNEL_EVENTS.ConfiguratorChanged,
+    properties: { ...input.config, step: input.step },
+  };
+}
+
+export function cncArtworkPlaced(
+  input: CncArtworkPlacedInput,
+): CncFunnelPayload<typeof CNC_FUNNEL_EVENTS.ArtworkPlaced, CncConfigProps & { artwork_count: number }> {
+  return {
+    name: CNC_FUNNEL_EVENTS.ArtworkPlaced,
+    properties: { ...input.config, artwork_count: input.artwork_count },
+  };
+}
+
+/**
+ * Fired when the buyer presses Buy and the checkout mutation is sent — not when
+ * Stripe answers. The paired confirmation is the backend's
+ * `Build Plans Pack Purchased`, so the drop between the two is exactly "opened
+ * Stripe and did not pay", which is the number worth watching.
+ */
+export function cncCheckoutStarted(
+  input: CncCheckoutStartedInput,
+): CncFunnelPayload<
+  typeof CNC_FUNNEL_EVENTS.CheckoutStarted,
+  CncConfigProps & { tier: CncTier; amount_cents: number; currency: string }
+> {
+  return {
+    name: CNC_FUNNEL_EVENTS.CheckoutStarted,
+    properties: {
+      ...input.config,
+      tier: input.tier,
+      amount_cents: input.amount_cents,
+      currency: input.currency,
+    },
+  };
+}

--- a/packages/shared/analytics/src/index.ts
+++ b/packages/shared/analytics/src/index.ts
@@ -104,3 +104,22 @@ export {
   type GymQrSearchParams,
   type GymQrLanding,
 } from './gym-funnel';
+// www-only CNC build-pack funnel (plan section B6). Out of SHARED_EVENTS for the
+// same reason as the gym funnel above: /build-plans has no mobile counterpart.
+export {
+  CNC_FUNNEL_EVENTS,
+  cncBuildPlansPageViewed,
+  cncConfiguratorChanged,
+  cncArtworkPlaced,
+  cncCheckoutStarted,
+  type CncFunnelEventKey,
+  type CncFunnelEventName,
+  type CncFunnelPayload,
+  type CncTier,
+  type CncConfiguratorStep,
+  type CncConfigProps,
+  type CncPageViewedInput,
+  type CncConfiguratorChangedInput,
+  type CncArtworkPlacedInput,
+  type CncCheckoutStartedInput,
+} from './cnc-funnel';

--- a/packages/shared/i18n/locales/de/cnc.json
+++ b/packages/shared/i18n/locales/de/cnc.json
@@ -1,0 +1,274 @@
+{
+  "metadata": {
+    "buildPlans": {
+      "title": "Baupläne für ein Board zu Hause",
+      "description": "Schnittfertige CNC-Dateien für eine Kletterwand zu Hause: jedes Panel, jede Einschlagmutter und jede LED-Bohrung gesetzt, aufgeteilt auf die Platten, die deine Werkstatt vorrätig hat."
+    },
+    "orders": {
+      "title": "Deine Baupläne",
+      "description": "Jedes Bau-Pack, das du gekauft hast, und wie weit es ist."
+    },
+    "order": {
+      "title": "Bauplan {{licenceId}}",
+      "description": "Status und Download für ein Bau-Pack von Boardsesh."
+    }
+  },
+  "hero": {
+    "title": "Baupläne für dein Board zu Hause",
+    "subtitle": "DXF-Dateien, die eine CNC-Werkstatt direkt fräst. Jedes Panel, das Einschlagmutter-Raster, die LED-Bohrungen und die Fußleiste, aufgeteilt auf die Platten, die deine Werkstatt ohnehin hat.",
+    "firstBoard": "Das Kilter Homewall ist das erste unterstützte Board. Weitere folgen.",
+    "included": {
+      "heading": "Was du bekommst",
+      "dxf": "Eine DXF-Datei pro Panel, dazu Montagezeichnungen für die ganze Wand.",
+      "pdf": "Druckbare Bögen in A3 oder Tabloid, damit du das Layout prüfen kannst, bevor jemand zuschneidet.",
+      "bom": "Eine Zuschnittliste: Plattenzahl, Panelmaße und jede Bohrung gezählt.",
+      "licence": "Eine Lizenz mit deinem Namen, gültig für eine Wand."
+    },
+    "trademarkNote": "Boardsesh ist weder mit Aurora Climbing noch mit Kilter noch mit einem anderen Board-Hersteller verbunden. Das hier sind Pläne für eine Wand, die mit Griffen und LEDs läuft, die du selbst kaufst."
+  },
+  "tiers": {
+    "heading": "Wähl eine Lizenz",
+    "intro": "Eine Lizenz, eine Wand. Für eine zweite Wand brauchst du eine zweite Lizenz.",
+    "personal": {
+      "name": "Privat",
+      "blurb": "Bau eine Wand für dich selbst. Garage, Schuppen, freies Zimmer."
+    },
+    "commercial": {
+      "name": "Gewerblich, ein Bau",
+      "blurb": "Bau eine Wand für eine*n Kund*in oder eine Halle. Die Anlage steht namentlich in der Lizenz."
+    },
+    "contact": {
+      "heading": "Baust du mehr als eine?",
+      "body": "Über Zehner-Packs und OEM-Konditionen redet man, dafür gibt es keinen Kaufen-Button. Sag uns, was du baust, und wir melden uns mit einem Preis.",
+      "cta": "Schreib uns",
+      "subject": "Baupläne: Lizenz für mehrere Bauten"
+    },
+    "licenceLink": "Lizenz lesen",
+    "ordersLink": "Deine Baupläne"
+  },
+  "configurator": {
+    "heading": "Konfiguriere deine Wand",
+    "intro": "Alles hier unten ändert, was gefräst wird. Nimm die Werte, mit denen deine Werkstatt arbeitet.",
+    "board": {
+      "label": "Board",
+      "help": "Das Kilter Homewall ist heute das einzige Board im Verkauf."
+    },
+    "size": {
+      "label": "Wandgröße",
+      "help": "Die Kilter-Größe, die du baust. Sie legt das Griffraster und die Wandmaße fest."
+    },
+    "kicker": {
+      "label": "Fußleiste",
+      "help": "Das schräge Panel ganz unten. Nur die 12-ft-Wände haben eine.",
+      "include": "Fußleiste einbauen",
+      "exclude": "Ohne Fußleiste"
+    },
+    "options": {
+      "heading": "Fertigung",
+      "help": "Die Standardwerte sind die, mit denen wir bauen. Pass sie an deine Werkstatt an.",
+      "sheetStock": {
+        "label": "Plattenformat",
+        "help": "Das Sperrholz, aus dem deine Werkstatt schneidet. Mit einer 3,6-m-Platte lässt sich eine Wandreihe ohne Stoß schneiden.",
+        "values": {
+          "2440x1220": "2440 × 1220 mm",
+          "3600x1220": "3600 × 1220 mm"
+        }
+      },
+      "panelThicknessMm": {
+        "label": "Paneldicke",
+        "help": "18 mm ist Standard. Dünner federt, dicker ist schwerer aufzuhängen.",
+        "values": {
+          "15": "15 mm",
+          "18": "18 mm",
+          "21": "21 mm"
+        }
+      },
+      "tnutHoleDiameterMm": {
+        "label": "Einschlagmutter-Bohrung",
+        "help": "Passend zum Schaft der Einschlagmuttern, die du gekauft hast. 12,5 mm passt zu den üblichen M10.",
+        "values": {
+          "11_1": "11,1 mm",
+          "12": "12 mm",
+          "12_5": "12,5 mm",
+          "13": "13 mm"
+        }
+      },
+      "ledHoleDiameterMm": {
+        "label": "LED-Bohrung",
+        "help": "Passend zum LED-Set, das du hinter der Wand verlegst.",
+        "values": {
+          "8": "8 mm",
+          "10": "10 mm",
+          "12_5": "12,5 mm",
+          "12_7": "12,7 mm"
+        }
+      },
+      "kickerMatClearanceMm": {
+        "label": "Abstand der Fußleiste über der Matte",
+        "help": "Wie viel Luft die Fußleiste über deiner Matte lässt.",
+        "values": {
+          "50": "50 mm",
+          "75": "75 mm",
+          "100": "100 mm"
+        }
+      },
+      "studClearanceOffsetMm": {
+        "label": "Abstand zu den Ständern",
+        "help": "Verschiebt das Griffraster seitlich, damit keine Bohrung auf einem Ständer landet.",
+        "values": {
+          "0": "Keiner",
+          "30": "30 mm",
+          "60": "60 mm"
+        }
+      },
+      "gridPitchMm": {
+        "label": "Griffabstand",
+        "help": "100 mm für einen metrischen Bau, 101,6 mm für genau 4 Zoll.",
+        "values": {
+          "100": "100 mm",
+          "101_6": "101,6 mm (4 Zoll)"
+        }
+      },
+      "dxfFlavour": {
+        "label": "DXF-Format",
+        "help": "R12 schreibt echte Kreise, die mehr Maschinensteuerungen als Bohrpunkte lesen.",
+        "values": {
+          "R12_circles": "R12, Kreise",
+          "R2010_polylines": "R2010, Polylinien"
+        }
+      },
+      "paper": {
+        "label": "Druckbögen",
+        "help": "Das Papierformat der Kontrollausdrucke.",
+        "values": {
+          "A3": "A3",
+          "TABLOID": "Tabloid"
+        }
+      },
+      "engraveHoldIds": {
+        "label": "Griffnummern gravieren",
+        "help": "Fräst die Kilter-Griffnummer neben jede Einschlagmutter.",
+        "values": {
+          "false": "Aus",
+          "true": "An"
+        }
+      },
+      "engraveAngleTicks": {
+        "label": "Winkel der Madenschrauben gravieren",
+        "help": "Fräst eine Markierung, die zeigt, wohin jede Madenschraube zeigt.",
+        "values": {
+          "false": "Aus",
+          "true": "An"
+        }
+      }
+    },
+    "engrave": {
+      "heading": "Gravur",
+      "help": "Beides ist standardmäßig aus. Es ergibt nur an einer Kilter-Wand Sinn, und das Pack lässt sich auch ohne sauber fräsen.",
+      "note": "Griffnummern und Madenschrauben-Winkel stammen aus Kilters eigenem Layout. Wir klären rechtlich noch, ob wir sie mitliefern dürfen. Lass sie also aus, wenn du auf diese Antwort nicht warten willst."
+    },
+    "summary": {
+      "heading": "Was gefräst wird",
+      "loading": "Panele werden berechnet…",
+      "wall": "Wand",
+      "wallValue": "{{width}} × {{height}} mm",
+      "kickerHeight": "Höhe der Fußleiste",
+      "kickerHeightValue": "{{height}} mm",
+      "panels": "Panele",
+      "panelsValue_one": "{{count}} Panel",
+      "panelsValue_other": "{{count}} Panele",
+      "sheets": "Platten",
+      "sheetsValue_one": "{{count}} Platte",
+      "sheetsValue_other": "{{count}} Platten",
+      "tnuts": "Einschlagmutter-Bohrungen",
+      "leds": "LED-Bohrungen",
+      "skippedLeds": "An einem Stoß ausgelassene LEDs",
+      "warningsHeading": "Gut zu wissen"
+    },
+    "licensee": {
+      "heading": "Auf wen die Lizenz läuft",
+      "help": "Das steht in jeder Datei im Pack, eine geleakte Kopie führt also zur Lizenz zurück.",
+      "name": "Name auf der Lizenz",
+      "email": "E-Mail",
+      "emailHelp": "Wohin das Pack geht, sobald es fertig ist.",
+      "siteName": "Name der Kundschaft oder Halle",
+      "siteHelp": "Die eine Anlage, die diese gewerbliche Lizenz abdeckt.",
+      "required": "Füll das aus, bevor du kaufst."
+    },
+    "licence": {
+      "accept": "Ich akzeptiere die Fertigungslizenz",
+      "link": "Lies sie vorher"
+    }
+  },
+  "cta": {
+    "buy": "Pläne kaufen",
+    "buySignedOut": "Anmelden und kaufen",
+    "buying": "Kasse wird geöffnet…",
+    "signInTitle": "Zum Kaufen anmelden",
+    "signInBody": "Deine Lizenz braucht ein Konto, auf dem sie liegt. Wir bringen dich direkt zurück zu deiner Konfiguration."
+  },
+  "errors": {
+    "CNC_INVALID_CONFIG": "Diese Kombination lässt sich nicht fräsen. Änder oben etwas, dann prüfen wir es neu.",
+    "CNC_WORKER_UNAVAILABLE": "Der Plangenerator antwortet gerade nicht. Es wurde nichts abgebucht. Probier es in einer Minute nochmal.",
+    "CNC_CHECKOUT_UNAVAILABLE": "Zahlungen sind gerade nicht möglich. Es wurde nichts abgebucht. Probier es gleich nochmal.",
+    "generic": "Das ist nicht durchgegangen. Es wurde nichts abgebucht."
+  },
+  "status": {
+    "pending_payment": "Warten auf Zahlung",
+    "queued": "In der Warteschlange",
+    "generating": "Dateien werden zugeschnitten",
+    "ready": "Bereit zum Download",
+    "failed": "Nicht erstellt",
+    "cancelled": "Bezahlung abgelaufen",
+    "refunded": "Erstattet"
+  },
+  "orders": {
+    "heading": "Deine Baupläne",
+    "intro": "Jedes Pack, das du gekauft hast, neuestes zuerst. Eine Lizenz bleibt deine, egal was mit dieser Seite passiert.",
+    "empty": "Hier ist noch nichts.",
+    "emptyCta": "Wand konfigurieren",
+    "board": "Wand",
+    "tier": "Lizenztyp",
+    "created": "Bestellt",
+    "view": "Öffnen",
+    "loadError": "Wir konnten deine Baupläne nicht laden. Lad die Seite neu."
+  },
+  "order": {
+    "heading": "Bauplan {{licenceId}}",
+    "back": "Alle deine Baupläne",
+    "licence": "Lizenz",
+    "board": "Wand",
+    "tier": "Lizenztyp",
+    "placed": "Bestellt",
+    "size": "Größe des Packs",
+    "sizeValue": "{{megabytes}} MB",
+    "downloads": "Downloads",
+    "timeline": {
+      "heading": "Wie weit es ist",
+      "paid": "Bezahlt",
+      "queued": "In der Warteschlange für den Generator",
+      "generating": "Dateien werden zugeschnitten",
+      "ready": "Bereit zum Download"
+    },
+    "waiting": "Ein Pack braucht ein paar Minuten. Diese Seite aktualisiert sich selbst.",
+    "download": "Pack herunterladen",
+    "downloading": "Link wird geholt…",
+    "downloadError": "Der Link ist nicht angekommen. Probier es nochmal.",
+    "checkoutSuccess": "Die Zahlung ist durch. Dein Pack wird gerade zugeschnitten.",
+    "checkoutCancelled": "Die Bezahlung wurde abgebrochen. Es wurde nichts abgebucht.",
+    "failed": {
+      "heading": "Dieser wurde nicht erstellt",
+      "contact": "Schreib uns, wir kümmern uns darum",
+      "subject": "Bauplan {{licenceId}} wurde nicht erstellt"
+    },
+    "refunded": {
+      "heading": "Erstattet",
+      "body": "Diese Bestellung wurde erstattet, deshalb ist der Download aus. Kauf ihn neu, wenn du bauen willst."
+    },
+    "notFound": {
+      "heading": "Diesen Bauplan gibt es nicht",
+      "body": "Entweder existiert die Lizenz nicht oder sie gehört zu einem anderen Konto."
+    },
+    "loadError": "Wir konnten diesen Bauplan nicht laden. Lad die Seite neu."
+  }
+}

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -797,6 +797,7 @@
       "about": "Über uns",
       "help": "Hilfe",
       "docs": "Doku",
+      "buildPlans": "Baupläne",
       "playlists": "Playlists",
       "auroraMigration": "Aurora-Migration",
       "legal": "Impressum",

--- a/packages/shared/i18n/locales/en-US/cnc.json
+++ b/packages/shared/i18n/locales/en-US/cnc.json
@@ -1,0 +1,274 @@
+{
+  "metadata": {
+    "buildPlans": {
+      "title": "Build plans for a home board",
+      "description": "Cut-ready CNC files for a home climbing wall: every panel, T-nut and LED hole placed, laid out on the sheets your shop stocks."
+    },
+    "orders": {
+      "title": "Your build plans",
+      "description": "Every build pack you have bought and where each one is up to."
+    },
+    "order": {
+      "title": "Build plan {{licenceId}}",
+      "description": "Status and download for one Boardsesh build pack."
+    }
+  },
+  "hero": {
+    "title": "Build plans for your home board",
+    "subtitle": "DXF files a CNC shop cuts straight from. Every panel, the T-nut grid, the LED holes and the kicker, laid out on the sheets your shop already stocks.",
+    "firstBoard": "Kilter Homewall is the first supported board. More boards follow.",
+    "included": {
+      "heading": "What you get",
+      "dxf": "One DXF per panel, plus assembly drawings for the whole wall.",
+      "pdf": "Printable A3 or Tabloid sheets, so you can check the layout before anyone cuts.",
+      "bom": "A cut list: sheet count, panel sizes, and every hole counted.",
+      "licence": "A licence with your name on it, good for one wall."
+    },
+    "trademarkNote": "Boardsesh is not affiliated with Aurora Climbing, Kilter or any board maker. These are plans for building a wall that works with holds and LEDs you buy yourself."
+  },
+  "tiers": {
+    "heading": "Pick a licence",
+    "intro": "One licence, one wall. A second wall needs a second licence.",
+    "personal": {
+      "name": "Personal",
+      "blurb": "Build one wall for yourself. Your garage, your shed, your spare room."
+    },
+    "commercial": {
+      "name": "Commercial, single build",
+      "blurb": "Build one wall for one customer or one gym. The installation is named on the licence."
+    },
+    "contact": {
+      "heading": "Building more than one?",
+      "body": "Ten-build packs and OEM terms are a conversation, not a checkout button. Tell us what you are building and we will come back with a price.",
+      "cta": "Email us",
+      "subject": "Build plans: multi-build licence"
+    },
+    "licenceLink": "Read the licence",
+    "ordersLink": "Your build plans"
+  },
+  "configurator": {
+    "heading": "Configure your wall",
+    "intro": "Everything below changes what gets cut. Pick the numbers your shop works to.",
+    "board": {
+      "label": "Board",
+      "help": "Kilter Homewall is the only board on sale today."
+    },
+    "size": {
+      "label": "Wall size",
+      "help": "The Kilter size you are building. It sets the hold grid and the wall dimensions."
+    },
+    "kicker": {
+      "label": "Kicker",
+      "help": "The angled panel at the bottom. Only the 12 ft walls have one.",
+      "include": "Include the kicker",
+      "exclude": "No kicker"
+    },
+    "options": {
+      "heading": "Manufacturing",
+      "help": "Defaults are what we build to. Change them to match your shop.",
+      "sheetStock": {
+        "label": "Sheet size",
+        "help": "The plywood your shop cuts from. A 3.6 m sheet lets a wall row be cut without a seam.",
+        "values": {
+          "2440x1220": "2440 × 1220 mm",
+          "3600x1220": "3600 × 1220 mm"
+        }
+      },
+      "panelThicknessMm": {
+        "label": "Panel thickness",
+        "help": "18 mm is standard. Thinner flexes, thicker is heavier to hang.",
+        "values": {
+          "15": "15 mm",
+          "18": "18 mm",
+          "21": "21 mm"
+        }
+      },
+      "tnutHoleDiameterMm": {
+        "label": "T-nut hole",
+        "help": "Match the barrel on the T-nuts you bought. 12.5 mm suits the common M10.",
+        "values": {
+          "11_1": "11.1 mm",
+          "12": "12 mm",
+          "12_5": "12.5 mm",
+          "13": "13 mm"
+        }
+      },
+      "ledHoleDiameterMm": {
+        "label": "LED hole",
+        "help": "Match the LED kit you are running behind the wall.",
+        "values": {
+          "8": "8 mm",
+          "10": "10 mm",
+          "12_5": "12.5 mm",
+          "12_7": "12.7 mm"
+        }
+      },
+      "kickerMatClearanceMm": {
+        "label": "Kicker clearance above the mat",
+        "help": "How much space the kicker leaves above your mat.",
+        "values": {
+          "50": "50 mm",
+          "75": "75 mm",
+          "100": "100 mm"
+        }
+      },
+      "studClearanceOffsetMm": {
+        "label": "Stud clearance",
+        "help": "Shifts the hold grid sideways so no hole lands on a stud.",
+        "values": {
+          "0": "None",
+          "30": "30 mm",
+          "60": "60 mm"
+        }
+      },
+      "gridPitchMm": {
+        "label": "Hold spacing",
+        "help": "100 mm for a metric build, 101.6 mm if you want exactly 4 inches.",
+        "values": {
+          "100": "100 mm",
+          "101_6": "101.6 mm (4 in)"
+        }
+      },
+      "dxfFlavour": {
+        "label": "DXF format",
+        "help": "R12 writes real circles, which more machine controllers read as drill points.",
+        "values": {
+          "R12_circles": "R12, circles",
+          "R2010_polylines": "R2010, polylines"
+        }
+      },
+      "paper": {
+        "label": "Printed sheets",
+        "help": "The paper size the check prints come on.",
+        "values": {
+          "A3": "A3",
+          "TABLOID": "Tabloid"
+        }
+      },
+      "engraveHoldIds": {
+        "label": "Engrave hold numbers",
+        "help": "Routes the Kilter hold number next to every T-nut.",
+        "values": {
+          "false": "Off",
+          "true": "On"
+        }
+      },
+      "engraveAngleTicks": {
+        "label": "Engrave set-screw angles",
+        "help": "Routes a tick showing which way each set screw points.",
+        "values": {
+          "false": "Off",
+          "true": "On"
+        }
+      }
+    },
+    "engrave": {
+      "heading": "Engraving",
+      "help": "Both are off by default. They only make sense on a Kilter wall, and the pack cuts fine without them.",
+      "note": "Hold numbers and set-screw angles come from Kilter's own layout. We are still getting legal advice on shipping them, so leave them off if you would rather not wait for that answer."
+    },
+    "summary": {
+      "heading": "What gets cut",
+      "loading": "Working out the panels…",
+      "wall": "Wall",
+      "wallValue": "{{width}} × {{height}} mm",
+      "kickerHeight": "Kicker height",
+      "kickerHeightValue": "{{height}} mm",
+      "panels": "Panels",
+      "panelsValue_one": "{{count}} panel",
+      "panelsValue_other": "{{count}} panels",
+      "sheets": "Sheets",
+      "sheetsValue_one": "{{count}} sheet",
+      "sheetsValue_other": "{{count}} sheets",
+      "tnuts": "T-nut holes",
+      "leds": "LED holes",
+      "skippedLeds": "LEDs skipped at a seam",
+      "warningsHeading": "Worth knowing"
+    },
+    "licensee": {
+      "heading": "Who the licence names",
+      "help": "This goes on every file in the pack, so a leaked copy traces back to the licence.",
+      "name": "Name on the licence",
+      "email": "Email",
+      "emailHelp": "Where the pack lands when it is ready.",
+      "siteName": "Customer or gym name",
+      "siteHelp": "The one installation this commercial licence covers.",
+      "required": "Fill this in before you buy."
+    },
+    "licence": {
+      "accept": "I accept the manufacturing licence",
+      "link": "Read it first"
+    }
+  },
+  "cta": {
+    "buy": "Buy the plans",
+    "buySignedOut": "Sign in and buy",
+    "buying": "Opening checkout…",
+    "signInTitle": "Sign in to buy",
+    "signInBody": "Your licence needs an account to live on. We will bring you straight back to your configuration."
+  },
+  "errors": {
+    "CNC_INVALID_CONFIG": "That combination will not cut. Change something above and we will re-check it.",
+    "CNC_WORKER_UNAVAILABLE": "The plan generator is not answering right now. Nothing was charged. Try again in a minute.",
+    "CNC_CHECKOUT_UNAVAILABLE": "Payments are not available right now. Nothing was charged. Try again shortly.",
+    "generic": "That did not go through. Nothing was charged."
+  },
+  "status": {
+    "pending_payment": "Waiting on payment",
+    "queued": "In the queue",
+    "generating": "Cutting the files",
+    "ready": "Ready to download",
+    "failed": "Did not build",
+    "cancelled": "Checkout expired",
+    "refunded": "Refunded"
+  },
+  "orders": {
+    "heading": "Your build plans",
+    "intro": "Every pack you have bought, newest first. A licence stays yours whatever happens to this page.",
+    "empty": "Nothing here yet.",
+    "emptyCta": "Configure a wall",
+    "board": "Wall",
+    "tier": "Licence type",
+    "created": "Ordered",
+    "view": "Open",
+    "loadError": "We could not load your build plans. Reload the page."
+  },
+  "order": {
+    "heading": "Build plan {{licenceId}}",
+    "back": "All your build plans",
+    "licence": "Licence",
+    "board": "Wall",
+    "tier": "Licence type",
+    "placed": "Ordered",
+    "size": "Pack size",
+    "sizeValue": "{{megabytes}} MB",
+    "downloads": "Downloads",
+    "timeline": {
+      "heading": "Where it is up to",
+      "paid": "Paid",
+      "queued": "Queued for the generator",
+      "generating": "Cutting the files",
+      "ready": "Ready to download"
+    },
+    "waiting": "Packs take a couple of minutes. This page updates itself.",
+    "download": "Download the pack",
+    "downloading": "Getting your link…",
+    "downloadError": "That link did not come through. Try again.",
+    "checkoutSuccess": "Payment went through. Your pack is being cut now.",
+    "checkoutCancelled": "Checkout was cancelled. Nothing was charged.",
+    "failed": {
+      "heading": "This one did not build",
+      "contact": "Email us and we will sort it out",
+      "subject": "Build plan {{licenceId}} did not build"
+    },
+    "refunded": {
+      "heading": "Refunded",
+      "body": "This order was refunded, so the download is switched off. Buy again whenever you are ready to build."
+    },
+    "notFound": {
+      "heading": "No such build plan",
+      "body": "Either that licence does not exist or it belongs to another account."
+    },
+    "loadError": "We could not load this build plan. Reload the page."
+  }
+}

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -797,6 +797,7 @@
       "about": "About",
       "help": "Help",
       "docs": "Developer docs",
+      "buildPlans": "Build plans",
       "playlists": "Playlists",
       "auroraMigration": "Aurora migration",
       "legal": "Legal",

--- a/packages/shared/i18n/locales/es/cnc.json
+++ b/packages/shared/i18n/locales/es/cnc.json
@@ -1,0 +1,274 @@
+{
+  "metadata": {
+    "buildPlans": {
+      "title": "Planos para construir un plafón en casa",
+      "description": "Archivos CNC listos para cortar de un muro de escalada en casa: cada panel, cada tuerca en T y cada agujero de LED colocados, repartidos en las planchas que tiene tu taller."
+    },
+    "orders": {
+      "title": "Tus planos de construcción",
+      "description": "Todos los packs que has comprado y en qué punto está cada uno."
+    },
+    "order": {
+      "title": "Plano de construcción {{licenceId}}",
+      "description": "Estado y descarga de un pack de construcción de Boardsesh."
+    }
+  },
+  "hero": {
+    "title": "Planos para construir tu plafón en casa",
+    "subtitle": "Archivos DXF que un taller CNC corta directamente. Cada panel, la retícula de tuercas en T, los agujeros de LED y la repisa, repartidos en las planchas que tu taller ya tiene.",
+    "firstBoard": "El Kilter Homewall es el primer plafón compatible. Vendrán más.",
+    "included": {
+      "heading": "Qué te llevas",
+      "dxf": "Un DXF por panel, más los planos de montaje del muro entero.",
+      "pdf": "Hojas imprimibles en A3 o Tabloid, para revisar la distribución antes de que nadie corte.",
+      "bom": "Una lista de corte: cuántas planchas, las medidas de los paneles y todos los agujeros contados.",
+      "licence": "Una licencia a tu nombre, válida para un muro."
+    },
+    "trademarkNote": "Boardsesh no está afiliado a Aurora Climbing, a Kilter ni a ningún fabricante de plafones. Estos son planos para construir un muro que funciona con presas y LEDs que compras por tu cuenta."
+  },
+  "tiers": {
+    "heading": "Elige una licencia",
+    "intro": "Una licencia, un muro. Un segundo muro necesita una segunda licencia.",
+    "personal": {
+      "name": "Personal",
+      "blurb": "Construye un muro para ti. Tu garaje, tu trastero, la habitación que te sobra."
+    },
+    "commercial": {
+      "name": "Comercial, una construcción",
+      "blurb": "Construye un muro para un cliente o un rocódromo. La instalación va nombrada en la licencia."
+    },
+    "contact": {
+      "heading": "¿Vas a construir más de uno?",
+      "body": "Los packs de diez construcciones y las condiciones OEM se hablan, no se pulsan en un botón de compra. Cuéntanos qué vas a construir y te damos precio.",
+      "cta": "Escríbenos",
+      "subject": "Planos de construcción: licencia para varias construcciones"
+    },
+    "licenceLink": "Lee la licencia",
+    "ordersLink": "Tus planos de construcción"
+  },
+  "configurator": {
+    "heading": "Configura tu muro",
+    "intro": "Todo lo de abajo cambia lo que se corta. Elige los números con los que trabaja tu taller.",
+    "board": {
+      "label": "Plafón",
+      "help": "El Kilter Homewall es el único plafón a la venta hoy."
+    },
+    "size": {
+      "label": "Tamaño del muro",
+      "help": "El tamaño de Kilter que vas a construir. Define la retícula de presas y las medidas del muro."
+    },
+    "kicker": {
+      "label": "Repisa",
+      "help": "El panel inclinado de abajo. Solo la tienen los muros de 12 ft.",
+      "include": "Incluir la repisa",
+      "exclude": "Sin repisa"
+    },
+    "options": {
+      "heading": "Fabricación",
+      "help": "Los valores por defecto son con los que construimos nosotros. Cámbialos para que encajen con tu taller.",
+      "sheetStock": {
+        "label": "Tamaño de plancha",
+        "help": "El contrachapado del que corta tu taller. Con una plancha de 3,6 m sale una fila entera del muro sin junta.",
+        "values": {
+          "2440x1220": "2440 × 1220 mm",
+          "3600x1220": "3600 × 1220 mm"
+        }
+      },
+      "panelThicknessMm": {
+        "label": "Grosor del panel",
+        "help": "18 mm es lo estándar. Más fino flexa, más grueso pesa más al colgarlo.",
+        "values": {
+          "15": "15 mm",
+          "18": "18 mm",
+          "21": "21 mm"
+        }
+      },
+      "tnutHoleDiameterMm": {
+        "label": "Agujero de tuerca en T",
+        "help": "Ajústalo al cuerpo de las tuercas en T que compraste. 12,5 mm va bien con las M10 habituales.",
+        "values": {
+          "11_1": "11,1 mm",
+          "12": "12 mm",
+          "12_5": "12,5 mm",
+          "13": "13 mm"
+        }
+      },
+      "ledHoleDiameterMm": {
+        "label": "Agujero de LED",
+        "help": "Ajústalo al kit de LEDs que vas a montar detrás del muro.",
+        "values": {
+          "8": "8 mm",
+          "10": "10 mm",
+          "12_5": "12,5 mm",
+          "12_7": "12,7 mm"
+        }
+      },
+      "kickerMatClearanceMm": {
+        "label": "Separación de la repisa sobre la colchoneta",
+        "help": "Cuánto espacio deja la repisa por encima de tu colchoneta.",
+        "values": {
+          "50": "50 mm",
+          "75": "75 mm",
+          "100": "100 mm"
+        }
+      },
+      "studClearanceOffsetMm": {
+        "label": "Holgura de montantes",
+        "help": "Desplaza la retícula de presas de lado para que ningún agujero caiga sobre un montante.",
+        "values": {
+          "0": "Ninguna",
+          "30": "30 mm",
+          "60": "60 mm"
+        }
+      },
+      "gridPitchMm": {
+        "label": "Separación entre presas",
+        "help": "100 mm para una construcción métrica, 101,6 mm si quieres exactamente 4 pulgadas.",
+        "values": {
+          "100": "100 mm",
+          "101_6": "101,6 mm (4 pulgadas)"
+        }
+      },
+      "dxfFlavour": {
+        "label": "Formato DXF",
+        "help": "R12 escribe círculos de verdad, que más controladores de máquina leen como puntos de taladro.",
+        "values": {
+          "R12_circles": "R12, círculos",
+          "R2010_polylines": "R2010, polilíneas"
+        }
+      },
+      "paper": {
+        "label": "Hojas impresas",
+        "help": "El tamaño de papel en el que salen las impresiones de comprobación.",
+        "values": {
+          "A3": "A3",
+          "TABLOID": "Tabloid"
+        }
+      },
+      "engraveHoldIds": {
+        "label": "Grabar los números de presa",
+        "help": "Fresa el número de presa de Kilter junto a cada tuerca en T.",
+        "values": {
+          "false": "Desactivado",
+          "true": "Activado"
+        }
+      },
+      "engraveAngleTicks": {
+        "label": "Grabar el ángulo de los tornillos prisioneros",
+        "help": "Fresa una marca que indica hacia dónde apunta cada tornillo prisionero.",
+        "values": {
+          "false": "Desactivado",
+          "true": "Activado"
+        }
+      }
+    },
+    "engrave": {
+      "heading": "Grabado",
+      "help": "Los dos vienen desactivados. Solo tienen sentido en un muro Kilter, y el pack se corta perfectamente sin ellos.",
+      "note": "Los números de presa y los ángulos de los tornillos salen de la propia distribución de Kilter. Todavía estamos consultando con abogados si podemos incluirlos, así que déjalos desactivados si prefieres no esperar a esa respuesta."
+    },
+    "summary": {
+      "heading": "Qué se corta",
+      "loading": "Calculando los paneles…",
+      "wall": "Muro",
+      "wallValue": "{{width}} × {{height}} mm",
+      "kickerHeight": "Altura de la repisa",
+      "kickerHeightValue": "{{height}} mm",
+      "panels": "Paneles",
+      "panelsValue_one": "{{count}} panel",
+      "panelsValue_other": "{{count}} paneles",
+      "sheets": "Planchas",
+      "sheetsValue_one": "{{count}} plancha",
+      "sheetsValue_other": "{{count}} planchas",
+      "tnuts": "Agujeros de tuerca en T",
+      "leds": "Agujeros de LED",
+      "skippedLeds": "LEDs omitidos en una junta",
+      "warningsHeading": "Conviene saberlo"
+    },
+    "licensee": {
+      "heading": "A nombre de quién va la licencia",
+      "help": "Esto va en todos los archivos del pack, así que una copia filtrada se rastrea hasta la licencia.",
+      "name": "Nombre en la licencia",
+      "email": "Email",
+      "emailHelp": "Adónde llega el pack cuando esté listo.",
+      "siteName": "Nombre del cliente o del rocódromo",
+      "siteHelp": "La única instalación que cubre esta licencia comercial.",
+      "required": "Rellena esto antes de comprar."
+    },
+    "licence": {
+      "accept": "Acepto la licencia de fabricación",
+      "link": "Léela antes"
+    }
+  },
+  "cta": {
+    "buy": "Compra los planos",
+    "buySignedOut": "Inicia sesión y compra",
+    "buying": "Abriendo el pago…",
+    "signInTitle": "Inicia sesión para comprar",
+    "signInBody": "Tu licencia necesita una cuenta donde vivir. Te devolvemos justo a tu configuración."
+  },
+  "errors": {
+    "CNC_INVALID_CONFIG": "Esa combinación no se puede cortar. Cambia algo de arriba y lo volvemos a comprobar.",
+    "CNC_WORKER_UNAVAILABLE": "El generador de planos no responde ahora mismo. No se ha cobrado nada. Inténtalo dentro de un minuto.",
+    "CNC_CHECKOUT_UNAVAILABLE": "Los pagos no están disponibles ahora mismo. No se ha cobrado nada. Inténtalo en un rato.",
+    "generic": "Eso no ha salido. No se ha cobrado nada."
+  },
+  "status": {
+    "pending_payment": "Esperando el pago",
+    "queued": "En la cola",
+    "generating": "Cortando los archivos",
+    "ready": "Listo para descargar",
+    "failed": "No se generó",
+    "cancelled": "El pago caducó",
+    "refunded": "Reembolsado"
+  },
+  "orders": {
+    "heading": "Tus planos de construcción",
+    "intro": "Todos los packs que has comprado, del más nuevo al más antiguo. La licencia es tuya pase lo que pase con esta página.",
+    "empty": "Aquí no hay nada todavía.",
+    "emptyCta": "Configura un muro",
+    "board": "Muro",
+    "tier": "Tipo de licencia",
+    "created": "Pedido",
+    "view": "Abrir",
+    "loadError": "No hemos podido cargar tus planos de construcción. Recarga la página."
+  },
+  "order": {
+    "heading": "Plano de construcción {{licenceId}}",
+    "back": "Todos tus planos de construcción",
+    "licence": "Licencia",
+    "board": "Muro",
+    "tier": "Tipo de licencia",
+    "placed": "Pedido",
+    "size": "Tamaño del pack",
+    "sizeValue": "{{megabytes}} MB",
+    "downloads": "Descargas",
+    "timeline": {
+      "heading": "En qué punto está",
+      "paid": "Pagado",
+      "queued": "En cola para el generador",
+      "generating": "Cortando los archivos",
+      "ready": "Listo para descargar"
+    },
+    "waiting": "Los packs tardan un par de minutos. Esta página se actualiza sola.",
+    "download": "Descargar el pack",
+    "downloading": "Preparando tu enlace…",
+    "downloadError": "Ese enlace no ha llegado. Inténtalo otra vez.",
+    "checkoutSuccess": "El pago ha entrado. Tu pack se está cortando ahora mismo.",
+    "checkoutCancelled": "Se canceló el pago. No se ha cobrado nada.",
+    "failed": {
+      "heading": "Este no se generó",
+      "contact": "Escríbenos y lo arreglamos",
+      "subject": "El plano de construcción {{licenceId}} no se generó"
+    },
+    "refunded": {
+      "heading": "Reembolsado",
+      "body": "Este pedido se reembolsó, así que la descarga está desactivada. Cómpralo otra vez cuando quieras construir."
+    },
+    "notFound": {
+      "heading": "No existe ese plano de construcción",
+      "body": "O esa licencia no existe o pertenece a otra cuenta."
+    },
+    "loadError": "No hemos podido cargar este plano de construcción. Recarga la página."
+  }
+}

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -797,6 +797,7 @@
       "about": "Sobre nosotros",
       "help": "Ayuda",
       "docs": "Documentación",
+      "buildPlans": "Planos de construcción",
       "playlists": "Listas",
       "auroraMigration": "Migración desde Aurora",
       "legal": "Aviso legal",

--- a/packages/shared/i18n/locales/fr/cnc.json
+++ b/packages/shared/i18n/locales/fr/cnc.json
@@ -1,0 +1,274 @@
+{
+  "metadata": {
+    "buildPlans": {
+      "title": "Plans de construction pour une board maison",
+      "description": "Des fichiers CNC prêts à découper pour un mur d'escalade maison : chaque panneau, chaque écrou à griffes et chaque perçage LED placé, répartis sur les plaques que ton atelier a en stock."
+    },
+    "orders": {
+      "title": "Tes plans de construction",
+      "description": "Tous les packs que tu as achetés et où chacun en est."
+    },
+    "order": {
+      "title": "Plan de construction {{licenceId}}",
+      "description": "Statut et téléchargement d'un pack de construction Boardsesh."
+    }
+  },
+  "hero": {
+    "title": "Plans de construction pour ta board maison",
+    "subtitle": "Des fichiers DXF qu'un atelier CNC découpe tels quels. Chaque panneau, la trame d'écrous à griffes, les perçages LED et le kicker, répartis sur les plaques que ton atelier a déjà en stock.",
+    "firstBoard": "Le Kilter Homewall est la première board prise en charge. D'autres suivront.",
+    "included": {
+      "heading": "Ce que tu reçois",
+      "dxf": "Un DXF par panneau, plus les plans de montage du mur complet.",
+      "pdf": "Des planches imprimables en A3 ou Tabloid, pour vérifier la disposition avant que quelqu'un découpe.",
+      "bom": "Une liste de débit : nombre de plaques, dimensions des panneaux et chaque perçage compté.",
+      "licence": "Une licence à ton nom, valable pour un mur."
+    },
+    "trademarkNote": "Boardsesh n'est affilié ni à Aurora Climbing, ni à Kilter, ni à aucun fabricant de boards. Ce sont des plans pour construire un mur qui fonctionne avec des prises et des LED que tu achètes toi-même."
+  },
+  "tiers": {
+    "heading": "Choisis une licence",
+    "intro": "Une licence, un mur. Un deuxième mur demande une deuxième licence.",
+    "personal": {
+      "name": "Personnelle",
+      "blurb": "Construis un mur pour toi. Ton garage, ton abri, la pièce en trop."
+    },
+    "commercial": {
+      "name": "Commerciale, une construction",
+      "blurb": "Construis un mur pour un client ou une salle. L'installation est nommée sur la licence."
+    },
+    "contact": {
+      "heading": "Tu en construis plusieurs ?",
+      "body": "Les packs dix constructions et les conditions OEM, ça se discute, ça ne se clique pas. Dis-nous ce que tu construis et on revient vers toi avec un prix.",
+      "cta": "Écris-nous",
+      "subject": "Plans de construction : licence multi-constructions"
+    },
+    "licenceLink": "Lis la licence",
+    "ordersLink": "Tes plans de construction"
+  },
+  "configurator": {
+    "heading": "Configure ton mur",
+    "intro": "Tout ce qui suit change ce qui sera découpé. Prends les valeurs avec lesquelles ton atelier travaille.",
+    "board": {
+      "label": "Board",
+      "help": "Le Kilter Homewall est la seule board en vente aujourd'hui."
+    },
+    "size": {
+      "label": "Taille du mur",
+      "help": "La taille Kilter que tu construis. Elle fixe la trame de prises et les dimensions du mur."
+    },
+    "kicker": {
+      "label": "Kicker",
+      "help": "Le panneau incliné du bas. Seuls les murs de 12 ft en ont un.",
+      "include": "Inclure le kicker",
+      "exclude": "Sans kicker"
+    },
+    "options": {
+      "heading": "Fabrication",
+      "help": "Les valeurs par défaut sont celles avec lesquelles on construit. Change-les pour coller à ton atelier.",
+      "sheetStock": {
+        "label": "Format de plaque",
+        "help": "Le contreplaqué dans lequel ton atelier découpe. Une plaque de 3,6 m permet de sortir une rangée du mur sans raccord.",
+        "values": {
+          "2440x1220": "2440 × 1220 mm",
+          "3600x1220": "3600 × 1220 mm"
+        }
+      },
+      "panelThicknessMm": {
+        "label": "Épaisseur des panneaux",
+        "help": "18 mm, c'est le standard. Plus fin, ça fléchit ; plus épais, c'est plus lourd à fixer.",
+        "values": {
+          "15": "15 mm",
+          "18": "18 mm",
+          "21": "21 mm"
+        }
+      },
+      "tnutHoleDiameterMm": {
+        "label": "Perçage écrou à griffes",
+        "help": "À ajuster au fût des écrous à griffes que tu as achetés. 12,5 mm convient aux M10 courants.",
+        "values": {
+          "11_1": "11,1 mm",
+          "12": "12 mm",
+          "12_5": "12,5 mm",
+          "13": "13 mm"
+        }
+      },
+      "ledHoleDiameterMm": {
+        "label": "Perçage LED",
+        "help": "À ajuster au kit LED que tu fais passer derrière le mur.",
+        "values": {
+          "8": "8 mm",
+          "10": "10 mm",
+          "12_5": "12,5 mm",
+          "12_7": "12,7 mm"
+        }
+      },
+      "kickerMatClearanceMm": {
+        "label": "Garde du kicker au-dessus du tapis",
+        "help": "L'espace que le kicker laisse au-dessus de ton tapis.",
+        "values": {
+          "50": "50 mm",
+          "75": "75 mm",
+          "100": "100 mm"
+        }
+      },
+      "studClearanceOffsetMm": {
+        "label": "Dégagement des montants",
+        "help": "Décale la trame de prises latéralement pour qu'aucun perçage ne tombe sur un montant.",
+        "values": {
+          "0": "Aucun",
+          "30": "30 mm",
+          "60": "60 mm"
+        }
+      },
+      "gridPitchMm": {
+        "label": "Entraxe des prises",
+        "help": "100 mm pour une construction métrique, 101,6 mm si tu veux exactement 4 pouces.",
+        "values": {
+          "100": "100 mm",
+          "101_6": "101,6 mm (4 pouces)"
+        }
+      },
+      "dxfFlavour": {
+        "label": "Format DXF",
+        "help": "Le R12 écrit de vrais cercles, que davantage de commandes numériques lisent comme des points de perçage.",
+        "values": {
+          "R12_circles": "R12, cercles",
+          "R2010_polylines": "R2010, polylignes"
+        }
+      },
+      "paper": {
+        "label": "Planches imprimées",
+        "help": "Le format papier des tirages de contrôle.",
+        "values": {
+          "A3": "A3",
+          "TABLOID": "Tabloid"
+        }
+      },
+      "engraveHoldIds": {
+        "label": "Graver les numéros de prise",
+        "help": "Usine le numéro de prise Kilter à côté de chaque écrou à griffes.",
+        "values": {
+          "false": "Désactivé",
+          "true": "Activé"
+        }
+      },
+      "engraveAngleTicks": {
+        "label": "Graver l'angle des vis de blocage",
+        "help": "Usine un repère qui montre dans quel sens pointe chaque vis de blocage.",
+        "values": {
+          "false": "Désactivé",
+          "true": "Activé"
+        }
+      }
+    },
+    "engrave": {
+      "heading": "Gravure",
+      "help": "Les deux sont désactivés par défaut. Ça n'a de sens que sur un mur Kilter, et le pack se découpe très bien sans.",
+      "note": "Les numéros de prise et les angles de vis viennent du plan de Kilter. On attend encore un avis juridique pour les livrer, donc laisse-les désactivés si tu préfères ne pas attendre cette réponse."
+    },
+    "summary": {
+      "heading": "Ce qui sera découpé",
+      "loading": "Calcul des panneaux…",
+      "wall": "Mur",
+      "wallValue": "{{width}} × {{height}} mm",
+      "kickerHeight": "Hauteur du kicker",
+      "kickerHeightValue": "{{height}} mm",
+      "panels": "Panneaux",
+      "panelsValue_one": "{{count}} panneau",
+      "panelsValue_other": "{{count}} panneaux",
+      "sheets": "Plaques",
+      "sheetsValue_one": "{{count}} plaque",
+      "sheetsValue_other": "{{count}} plaques",
+      "tnuts": "Perçages d'écrous à griffes",
+      "leds": "Perçages LED",
+      "skippedLeds": "LED sautées à un raccord",
+      "warningsHeading": "Bon à savoir"
+    },
+    "licensee": {
+      "heading": "Au nom de qui est la licence",
+      "help": "Ça figure sur chaque fichier du pack : une copie qui fuite remonte à la licence.",
+      "name": "Nom sur la licence",
+      "email": "E-mail",
+      "emailHelp": "Là où le pack arrive une fois prêt.",
+      "siteName": "Nom du client ou de la salle",
+      "siteHelp": "L'unique installation que couvre cette licence commerciale.",
+      "required": "À remplir avant d'acheter."
+    },
+    "licence": {
+      "accept": "J'accepte la licence de fabrication",
+      "link": "Lis-la d'abord"
+    }
+  },
+  "cta": {
+    "buy": "Acheter les plans",
+    "buySignedOut": "Se connecter et acheter",
+    "buying": "Ouverture du paiement…",
+    "signInTitle": "Connecte-toi pour acheter",
+    "signInBody": "Ta licence a besoin d'un compte où vivre. On te ramène directement à ta configuration."
+  },
+  "errors": {
+    "CNC_INVALID_CONFIG": "Cette combinaison ne se découpe pas. Change quelque chose au-dessus et on revérifie.",
+    "CNC_WORKER_UNAVAILABLE": "Le générateur de plans ne répond pas pour l'instant. Rien n'a été débité. Réessaie dans une minute.",
+    "CNC_CHECKOUT_UNAVAILABLE": "Les paiements ne sont pas disponibles pour l'instant. Rien n'a été débité. Réessaie un peu plus tard.",
+    "generic": "Ça n'est pas passé. Rien n'a été débité."
+  },
+  "status": {
+    "pending_payment": "En attente de paiement",
+    "queued": "Dans la file",
+    "generating": "Découpe des fichiers",
+    "ready": "Prêt à télécharger",
+    "failed": "Pas généré",
+    "cancelled": "Paiement expiré",
+    "refunded": "Remboursé"
+  },
+  "orders": {
+    "heading": "Tes plans de construction",
+    "intro": "Tous les packs que tu as achetés, du plus récent au plus ancien. Une licence reste la tienne quoi qu'il arrive à cette page.",
+    "empty": "Rien ici pour l'instant.",
+    "emptyCta": "Configurer un mur",
+    "board": "Mur",
+    "tier": "Type de licence",
+    "created": "Commandé",
+    "view": "Ouvrir",
+    "loadError": "On n'a pas pu charger tes plans de construction. Recharge la page."
+  },
+  "order": {
+    "heading": "Plan de construction {{licenceId}}",
+    "back": "Tous tes plans de construction",
+    "licence": "Licence",
+    "board": "Mur",
+    "tier": "Type de licence",
+    "placed": "Commandé",
+    "size": "Taille du pack",
+    "sizeValue": "{{megabytes}} Mo",
+    "downloads": "Téléchargements",
+    "timeline": {
+      "heading": "Où ça en est",
+      "paid": "Payé",
+      "queued": "En file d'attente pour le générateur",
+      "generating": "Découpe des fichiers",
+      "ready": "Prêt à télécharger"
+    },
+    "waiting": "Un pack prend deux ou trois minutes. Cette page se met à jour toute seule.",
+    "download": "Télécharger le pack",
+    "downloading": "Récupération de ton lien…",
+    "downloadError": "Ce lien n'est pas passé. Réessaie.",
+    "checkoutSuccess": "Le paiement est passé. Ton pack est en cours de découpe.",
+    "checkoutCancelled": "Le paiement a été annulé. Rien n'a été débité.",
+    "failed": {
+      "heading": "Celui-ci n'a pas été généré",
+      "contact": "Écris-nous, on règle ça",
+      "subject": "Le plan de construction {{licenceId}} n'a pas été généré"
+    },
+    "refunded": {
+      "heading": "Remboursé",
+      "body": "Cette commande a été remboursée, le téléchargement est donc coupé. Rachète-la quand tu seras prêt à construire."
+    },
+    "notFound": {
+      "heading": "Pas de plan de construction ici",
+      "body": "Soit cette licence n'existe pas, soit elle appartient à un autre compte."
+    },
+    "loadError": "On n'a pas pu charger ce plan de construction. Recharge la page."
+  }
+}

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -797,6 +797,7 @@
       "about": "À propos",
       "help": "Aide",
       "docs": "Doc développeur",
+      "buildPlans": "Plans de construction",
       "playlists": "Playlists",
       "auroraMigration": "Migration Aurora",
       "legal": "Mentions légales",

--- a/packages/shared/i18n/src/config.ts
+++ b/packages/shared/i18n/src/config.ts
@@ -46,12 +46,13 @@ export const ALL_NAMESPACES = [
   'boards',
   'kiosk',
   'gyms',
+  'cnc',
 ] as const;
 export type Namespace = (typeof ALL_NAMESPACES)[number];
 
 /**
  * Namespaces available in the mobile app. Web-only namespaces (`marketing`,
- * `admin`, `gyms`) are excluded so Metro never bundles them.
+ * `admin`, `gyms`, `cnc`) are excluded so Metro never bundles them.
  */
 export const MOBILE_NAMESPACES = [
   'common',

--- a/packages/web/app/__test-helpers__/i18n-mock.ts
+++ b/packages/web/app/__test-helpers__/i18n-mock.ts
@@ -28,6 +28,7 @@ import enAurora from '@boardsesh/i18n/locales/en-US/aurora.json';
 import enAuth from '@boardsesh/i18n/locales/en-US/auth.json';
 import enBoards from '@boardsesh/i18n/locales/en-US/boards.json';
 import enClimbs from '@boardsesh/i18n/locales/en-US/climbs.json';
+import enCnc from '@boardsesh/i18n/locales/en-US/cnc.json';
 import enCommon from '@boardsesh/i18n/locales/en-US/common.json';
 import enFeed from '@boardsesh/i18n/locales/en-US/feed.json';
 import enGyms from '@boardsesh/i18n/locales/en-US/gyms.json';
@@ -46,6 +47,7 @@ const CATALOGS: Record<string, unknown> = {
   auth: enAuth,
   boards: enBoards,
   climbs: enClimbs,
+  cnc: enCnc,
   common: enCommon,
   feed: enFeed,
   gyms: enGyms,

--- a/packages/web/app/build-plans/__tests__/build-plans-metadata.test.ts
+++ b/packages/web/app/build-plans/__tests__/build-plans-metadata.test.ts
@@ -1,4 +1,6 @@
+import type { ReactElement } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { CncOrder } from '@boardsesh/shared-schema';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 
 vi.mock('server-only', () => ({}));
@@ -43,6 +45,45 @@ const ROUTES = [
   { name: '/build-plans', generateMetadata: buildPlansRoute.generateMetadata, base: '/build-plans' },
   { name: '/build-plans/orders', generateMetadata: ordersRoute.generateMetadata, base: '/build-plans/orders' },
 ];
+
+/**
+ * The props the route hands `OrderStatus`, read off the returned element tree.
+ *
+ * The page is a server component that returns plain elements, so walking them
+ * beats mounting the whole MUI + i18n stack to learn what one prop resolved to.
+ */
+function orderStatusProps(tree: ReactElement): { checkoutOutcome: 'success' | 'cancelled' | null } {
+  const page = (tree.props as { children: ReactElement }).children;
+  const orderStatus = (page.props as { children: ReactElement }).children;
+  return orderStatus.props as { checkoutOutcome: 'success' | 'cancelled' | null };
+}
+
+function cncOrder(overrides: Partial<CncOrder> = {}): CncOrder {
+  return {
+    id: '41',
+    licenceId: 'BS-CNC-K7QM3T',
+    tier: 'personal',
+    status: 'queued',
+    boardName: 'kilter',
+    layoutId: 8,
+    sizeId: 25,
+    setIds: '26,27,28,29',
+    options: {},
+    artwork: [],
+    licenseeName: 'Sam Bouldering',
+    customerSiteName: null,
+    amountCents: 14900,
+    currency: 'AUD',
+    createdAt: '2026-09-01T02:14:11.402Z',
+    paidAt: null,
+    generatedAt: null,
+    zipSizeBytes: null,
+    downloadCount: 0,
+    lastDownloadedAt: null,
+    errorMessage: null,
+    ...overrides,
+  };
+}
 
 function mockLocale(locale: string) {
   getServerTranslation.mockResolvedValue({
@@ -188,5 +229,128 @@ describe('the orders pages need a session', () => {
       }),
     ).rejects.toThrow('NEXT_REDIRECT');
     expect(redirect).toHaveBeenCalledWith('/auth/login?callbackUrl=%2Fbuild-plans%2Forders%2FBS-CNC-K7QM3T');
+  });
+});
+
+describe('metadata while the flag is off', () => {
+  const ORDER_ROUTE_PROPS = {
+    params: Promise.resolve({ licenceId: 'BS-CNC-K7QM3T' }),
+    searchParams: Promise.resolve({}),
+  };
+
+  it('says nothing but noindex on any of the three routes', async () => {
+    getServerFeatureFlag.mockResolvedValue(false);
+
+    const all = [
+      { route: '/build-plans', metadata: await buildPlansRoute.generateMetadata() },
+      { route: '/build-plans/orders', metadata: await ordersRoute.generateMetadata() },
+      { route: '/build-plans/orders/[licenceId]', metadata: await orderRoute.generateMetadata(ORDER_ROUTE_PROPS) },
+    ];
+
+    for (const { route, metadata } of all) {
+      // Bare on purpose: `generateMetadata` runs before the page body can
+      // `notFound()`, so a title, description or canonical here would describe
+      // the shape of a surface that answers 404 to everyone.
+      expect({ route, metadata }).toEqual({ route, metadata: { robots: { index: false, follow: true } } });
+    }
+  });
+
+  it('leaks neither the licence id nor a route-shaped canonical', async () => {
+    getServerFeatureFlag.mockResolvedValue(false);
+
+    const metadata = await orderRoute.generateMetadata(ORDER_ROUTE_PROPS);
+
+    expect(metadata.title).toBeUndefined();
+    expect(metadata.description).toBeUndefined();
+    expect(metadata.alternates).toBeUndefined();
+    expect(metadata.openGraph).toBeUndefined();
+    expect(JSON.stringify(metadata)).not.toContain('BS-CNC-K7QM3T');
+  });
+
+  it('resolves the flag through the same gate the page body uses', async () => {
+    getServerFeatureFlag.mockResolvedValue(false);
+
+    await buildPlansRoute.generateMetadata();
+
+    expect(getServerFeatureFlag).toHaveBeenCalledWith('cnc-packs', {
+      distinctId: 'user-uuid-1',
+      allowAnonymous: true,
+    });
+  });
+
+  it('goes back to the full metadata the moment the flag is on', async () => {
+    const metadata = await buildPlansRoute.generateMetadata();
+
+    expect(metadata.alternates?.canonical).toBe('/build-plans');
+    expect(metadata.description).toBeTruthy();
+  });
+});
+
+describe('the licence id in the path', () => {
+  async function openOrder(licenceId: string) {
+    return orderRoute.default({
+      params: Promise.resolve({ licenceId }),
+      searchParams: Promise.resolve({}),
+    });
+  }
+
+  it('404s anything that is not a licence id, before it reaches a query', async () => {
+    for (const licenceId of [
+      '../../etc/passwd',
+      'bs-cnc-k7qm3t',
+      'BS-CNC-K7QM3',
+      'BS-CNC-K7QM3TT',
+      'BS-CNC-K7QM3T\n',
+      'BS-CNC-K7QM_T',
+      '',
+    ]) {
+      notFound.mockClear();
+      executeAuthenticatedGraphQL.mockClear();
+
+      await expect(openOrder(licenceId)).rejects.toThrow('NEXT_NOT_FOUND');
+      // The point of checking first: a junk id must never reach the login
+      // callback URL or the GraphQL variables.
+      expect({ licenceId, queried: executeAuthenticatedGraphQL.mock.calls.length }).toEqual({ licenceId, queried: 0 });
+      expect(redirect).not.toHaveBeenCalled();
+    }
+  });
+
+  it('lets a well-formed licence id through', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ cncOrder: cncOrder() });
+
+    await expect(openOrder('BS-CNC-K7QM3T')).resolves.toBeTruthy();
+    expect(notFound).not.toHaveBeenCalled();
+  });
+});
+
+describe('the ?checkout= param', () => {
+  async function openOrderWith(checkout: string | string[] | undefined) {
+    executeAuthenticatedGraphQL.mockResolvedValue({ cncOrder: cncOrder() });
+    return orderRoute.default({
+      params: Promise.resolve({ licenceId: 'BS-CNC-K7QM3T' }),
+      searchParams: Promise.resolve({ checkout }),
+    });
+  }
+
+  it('reads the outcome out of a repeated param', async () => {
+    // `?checkout=success&checkout=success` parses as an array. Comparing that
+    // to a string is always false, which silently swallows the alert Stripe
+    // sent the buyer back for.
+    for (const outcome of ['success', 'cancelled'] as const) {
+      const tree = await openOrderWith([outcome, 'cancelled']);
+      expect(orderStatusProps(tree).checkoutOutcome).toBe(outcome);
+    }
+  });
+
+  it('still reads a plain string param', async () => {
+    const tree = await openOrderWith('success');
+    expect(orderStatusProps(tree).checkoutOutcome).toBe('success');
+  });
+
+  it('ignores an unknown outcome, an empty array and a missing param', async () => {
+    for (const checkout of ['whatever', [], ['nope'], undefined] as (string | string[] | undefined)[]) {
+      const tree = await openOrderWith(checkout);
+      expect({ checkout, outcome: orderStatusProps(tree).checkoutOutcome }).toEqual({ checkout, outcome: null });
+    }
   });
 });

--- a/packages/web/app/build-plans/__tests__/build-plans-metadata.test.ts
+++ b/packages/web/app/build-plans/__tests__/build-plans-metadata.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('server-only', () => ({}));
+
+const notFound = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+);
+const redirect = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error('NEXT_REDIRECT');
+  }),
+);
+vi.mock('next/navigation', () => ({ notFound, redirect }));
+
+const getServerTranslation = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/i18n/server', () => ({ getServerTranslation, loadServerResources: vi.fn() }));
+
+const getPosthogDistinctId = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/feature-flags/server-distinct-id', () => ({ getPosthogDistinctId }));
+
+const getServerFeatureFlag = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/feature-flags/server-feature-flag', () => ({ getServerFeatureFlag }));
+
+// The catalogue fetch would otherwise open a GraphQL client against a backend
+// that is not running. Every test here is about the gate and the metadata.
+const cachedCatalogQuery = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/graphql/server-cached-client', () => ({ createCachedGraphQLQuery: () => cachedCatalogQuery }));
+
+const executeAuthenticatedGraphQL = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/graphql/server-graphql', () => ({ executeAuthenticatedGraphQL }));
+
+const getServerAuthToken = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/auth/server-auth', () => ({ getServerAuthToken }));
+
+const buildPlansRoute = await import('../page');
+const ordersRoute = await import('../orders/page');
+const orderRoute = await import('../orders/[licenceId]/page');
+
+const ROUTES = [
+  { name: '/build-plans', generateMetadata: buildPlansRoute.generateMetadata, base: '/build-plans' },
+  { name: '/build-plans/orders', generateMetadata: ordersRoute.generateMetadata, base: '/build-plans/orders' },
+];
+
+function mockLocale(locale: string) {
+  getServerTranslation.mockResolvedValue({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog('cnc', key, options),
+    i18n: {},
+    locale,
+  });
+}
+
+beforeEach(() => {
+  notFound.mockClear();
+  redirect.mockClear();
+  getServerTranslation.mockReset();
+  mockLocale('en-US');
+  getPosthogDistinctId.mockReset().mockResolvedValue('user-uuid-1');
+  getServerFeatureFlag.mockReset().mockResolvedValue(true);
+  cachedCatalogQuery.mockReset().mockResolvedValue({ cncCatalog: { version: 'test', entries: [] } });
+  executeAuthenticatedGraphQL.mockReset().mockResolvedValue({ myCncOrders: [] });
+  getServerAuthToken.mockReset().mockResolvedValue('session-cookie');
+});
+
+describe('robots', () => {
+  it('ships noindex, follow on every build-plans route while the flag is on', async () => {
+    for (const route of ROUTES) {
+      const metadata = await route.generateMetadata();
+      // Launch removes this from `/build-plans` and nothing else — the orders
+      // pages are a purchase history and stay out of the index forever. Note
+      // the gate is BOTH: the pages also 404 while the flag is off, because
+      // noindex alone would leave a publicly reachable shop.
+      expect({ route: route.name, robots: metadata.robots }).toEqual({
+        route: route.name,
+        robots: { index: false, follow: true },
+      });
+    }
+  });
+
+  it('keeps a single order page out of the index too, licence id and all', async () => {
+    const metadata = await orderRoute.generateMetadata({
+      params: Promise.resolve({ licenceId: 'BS-CNC-K7QM3T' }),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(metadata.robots).toEqual({ index: false, follow: true });
+    expect(metadata.alternates?.canonical).toBe('/build-plans/orders/BS-CNC-K7QM3T');
+  });
+});
+
+describe('canonicals and titles', () => {
+  it('self-canonicalises each route on its own clean base', async () => {
+    for (const route of ROUTES) {
+      const metadata = await route.generateMetadata();
+      expect({ route: route.name, canonical: metadata.alternates?.canonical }).toEqual({
+        route: route.name,
+        canonical: route.base,
+      });
+    }
+  });
+
+  it('carries the canonical into the locale prefix', async () => {
+    mockLocale('de');
+    const metadata = await buildPlansRoute.generateMetadata();
+    expect(metadata.alternates?.canonical).toBe('/de/build-plans');
+  });
+
+  it('gives each route a unique, brand-suffixed title', async () => {
+    const titles = await Promise.all(
+      ROUTES.map(async (route) => {
+        const { title } = await route.generateMetadata();
+        expect(title).toHaveProperty('absolute');
+        return title && typeof title === 'object' && 'absolute' in title ? title.absolute : '';
+      }),
+    );
+
+    expect(new Set(titles).size).toBe(ROUTES.length);
+    for (const title of titles) {
+      expect(title).toMatch(/ \| Boardsesh$/);
+    }
+  });
+});
+
+describe('the flag gate', () => {
+  it('404s /build-plans when the flag is off', async () => {
+    getServerFeatureFlag.mockResolvedValue(false);
+
+    await expect(buildPlansRoute.default()).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFound).toHaveBeenCalledTimes(1);
+  });
+
+  it('404s the orders pages too — the gate is not just the shop front', async () => {
+    getServerFeatureFlag.mockResolvedValue(false);
+
+    await expect(ordersRoute.default()).rejects.toThrow('NEXT_NOT_FOUND');
+    await expect(
+      orderRoute.default({
+        params: Promise.resolve({ licenceId: 'BS-CNC-K7QM3T' }),
+        searchParams: Promise.resolve({}),
+      }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+  });
+
+  it('evaluates the flag for signed-out visitors, not only for a session', async () => {
+    // Without `allowAnonymous` a null distinct id short-circuits to false and
+    // the shop would stay signed-in-only however the rollout is configured —
+    // which is fatal for a page whose whole funnel starts with a stranger.
+    getPosthogDistinctId.mockResolvedValue(null);
+
+    await buildPlansRoute.default();
+
+    expect(getServerFeatureFlag).toHaveBeenCalledWith('cnc-packs', { distinctId: null, allowAnonymous: true });
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it('resolves the flag against the signed-in person when there is one', async () => {
+    await buildPlansRoute.default();
+
+    expect(getServerFeatureFlag).toHaveBeenCalledWith('cnc-packs', {
+      distinctId: 'user-uuid-1',
+      allowAnonymous: true,
+    });
+  });
+
+  it('renders the page when the flag is on', async () => {
+    await expect(buildPlansRoute.default()).resolves.toBeTruthy();
+    expect(notFound).not.toHaveBeenCalled();
+  });
+});
+
+describe('the orders pages need a session', () => {
+  it('sends a signed-out visitor to login with a callback back to the list', async () => {
+    getServerAuthToken.mockResolvedValue(undefined);
+
+    await expect(ordersRoute.default()).rejects.toThrow('NEXT_REDIRECT');
+    expect(redirect).toHaveBeenCalledWith('/auth/login?callbackUrl=%2Fbuild-plans%2Forders');
+  });
+
+  it('sends them back to the order they were opening, not to the list', async () => {
+    getServerAuthToken.mockResolvedValue(undefined);
+
+    await expect(
+      orderRoute.default({
+        params: Promise.resolve({ licenceId: 'BS-CNC-K7QM3T' }),
+        searchParams: Promise.resolve({}),
+      }),
+    ).rejects.toThrow('NEXT_REDIRECT');
+    expect(redirect).toHaveBeenCalledWith('/auth/login?callbackUrl=%2Fbuild-plans%2Forders%2FBS-CNC-K7QM3T');
+  });
+});

--- a/packages/web/app/build-plans/__tests__/cnc-error.test.ts
+++ b/packages/web/app/build-plans/__tests__/cnc-error.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { cncErrorKey } from '../cnc-error';
+
+/**
+ * The whole point of `cncErrorKey` is that it never throws. It runs inside a
+ * catch block, so anything it does not understand has to become `generic`
+ * rather than a second error on top of the first — which is why most of these
+ * cases are shapes it was never designed for.
+ */
+describe('cncErrorKey', () => {
+  it('reads the code a resolver set on the first matching error', () => {
+    const error = { response: { errors: [{ extensions: { code: 'CNC_INVALID_CONFIG' } }] } };
+
+    expect(cncErrorKey(error)).toBe('CNC_INVALID_CONFIG');
+  });
+
+  it('keeps the three backend codes apart', () => {
+    const withCode = (code: string) => ({ response: { errors: [{ extensions: { code } }] } });
+
+    expect(cncErrorKey(withCode('CNC_WORKER_UNAVAILABLE'))).toBe('CNC_WORKER_UNAVAILABLE');
+    expect(cncErrorKey(withCode('CNC_CHECKOUT_UNAVAILABLE'))).toBe('CNC_CHECKOUT_UNAVAILABLE');
+  });
+
+  it('skips entries with no usable code and takes the one that has it', () => {
+    const error = {
+      response: {
+        errors: [
+          null,
+          'a string where an object was expected',
+          { message: 'no extensions at all' },
+          { extensions: null },
+          { extensions: { code: 'SOMETHING_ELSE' } },
+          { extensions: { code: 'CNC_CHECKOUT_UNAVAILABLE' } },
+        ],
+      },
+    };
+
+    expect(cncErrorKey(error)).toBe('CNC_CHECKOUT_UNAVAILABLE');
+  });
+
+  it('falls back to generic for a code the UI has no message for', () => {
+    expect(cncErrorKey({ response: { errors: [{ extensions: { code: 'INTERNAL_SERVER_ERROR' } }] } })).toBe('generic');
+  });
+
+  it('falls back to generic for the transport failures that carry no GraphQL body', () => {
+    // An aborted fetch, a dropped connection, a proxy's HTML error page, and a
+    // thrown string all reach the same catch block as a real GraphQL error.
+    expect(cncErrorKey(new TypeError('Failed to fetch'))).toBe('generic');
+    expect(cncErrorKey('network down')).toBe('generic');
+    expect(cncErrorKey(null)).toBe('generic');
+    expect(cncErrorKey(undefined)).toBe('generic');
+    expect(cncErrorKey({ response: '<html>502 Bad Gateway</html>' })).toBe('generic');
+    expect(cncErrorKey({ response: { errors: 'not an array' } })).toBe('generic');
+    expect(cncErrorKey({ response: { errors: [] } })).toBe('generic');
+  });
+});

--- a/packages/web/app/build-plans/__tests__/configurator-state.test.ts
+++ b/packages/web/app/build-plans/__tests__/configurator-state.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from 'vite-plus/test';
+import type { CncCatalogEntry } from '@boardsesh/shared-schema';
+import {
+  CNC_ENGRAVE_OPTION_KEYS,
+  checkoutBlockers,
+  configuratorReducer,
+  defaultOptions,
+  engraveOptions,
+  fromDraft,
+  hasKickerSets,
+  initialConfiguratorState,
+  optionValueKey,
+  setIdsFor,
+  toBoardConfigInput,
+  toDraft,
+  visibleMachiningOptions,
+  type CncConfiguratorState,
+} from '../configurator/configurator-state';
+
+/**
+ * A trimmed stand-in for the real catalogue, carrying one option of every
+ * shape the backend actually publishes: a string, a fractional number, a
+ * kicker-only number, and the two booleans that are engrave toggles.
+ */
+function tenByTwelve(): CncCatalogEntry {
+  return {
+    boardName: 'kilter',
+    layoutId: 8,
+    sizeId: 25,
+    setIds: '26,27,28,29',
+    label: '10x12',
+    kickerOptional: true,
+    manufacturingOptions: [
+      {
+        key: 'sheetStock',
+        values: ['2440x1220', '3600x1220'],
+        defaultValue: '2440x1220',
+        valueType: 'string',
+        kickerOnly: false,
+      },
+      {
+        key: 'tnutHoleDiameterMm',
+        values: ['11.1', '12.5'],
+        defaultValue: '12.5',
+        valueType: 'number',
+        kickerOnly: false,
+      },
+      {
+        key: 'kickerMatClearanceMm',
+        values: ['50', '75'],
+        defaultValue: '50',
+        valueType: 'number',
+        kickerOnly: true,
+      },
+      {
+        key: 'engraveHoldIds',
+        values: ['false', 'true'],
+        defaultValue: 'false',
+        valueType: 'boolean',
+        kickerOnly: false,
+      },
+      {
+        key: 'engraveAngleTicks',
+        values: ['false', 'true'],
+        defaultValue: 'false',
+        valueType: 'boolean',
+        kickerOnly: false,
+      },
+    ],
+    tiers: [
+      { tier: 'personal', amountCents: 14900, currency: 'AUD' },
+      { tier: 'commercial_single', amountCents: 75000, currency: 'AUD' },
+    ],
+  };
+}
+
+/** A 10 ft wall: no kicker sets at all, so nothing to opt out of. */
+function sevenByTen(): CncCatalogEntry {
+  return { ...tenByTwelve(), sizeId: 17, setIds: '26,27', label: '7x10', kickerOptional: false };
+}
+
+describe('option defaults', () => {
+  it('fills every published option from the catalogue, not from a hardcoded list', () => {
+    expect(defaultOptions(tenByTwelve())).toEqual({
+      sheetStock: '2440x1220',
+      tnutHoleDiameterMm: '12.5',
+      kickerMatClearanceMm: '50',
+      engraveHoldIds: 'false',
+      engraveAngleTicks: 'false',
+    });
+  });
+
+  it('opens with the kicker IN on a wall that has one', () => {
+    // Opt-out, not opt-in: a buyer who never noticed the toggle gets the wall
+    // they expected rather than a pack missing its bottom row.
+    expect(initialConfiguratorState(tenByTwelve()).includeKicker).toBe(true);
+    expect(initialConfiguratorState(sevenByTen()).includeKicker).toBe(false);
+  });
+
+  it('resets options to the new size’s defaults when the size changes, and keeps the buyer', () => {
+    const start: CncConfiguratorState = {
+      ...initialConfiguratorState(tenByTwelve()),
+      options: { ...defaultOptions(tenByTwelve()), sheetStock: '3600x1220' },
+      licenseeName: 'Sam',
+      licenseeEmail: 'sam@example.com',
+    };
+
+    const next = configuratorReducer(start, { type: 'selectSize', entry: sevenByTen() });
+
+    // A value carried onto a size that does not allow it is a checkout the
+    // backend rejects with an error the buyer cannot act on.
+    expect(next.options.sheetStock).toBe('2440x1220');
+    expect(next.sizeId).toBe(17);
+    expect({ name: next.licenseeName, email: next.licenseeEmail }).toEqual({
+      name: 'Sam',
+      email: 'sam@example.com',
+    });
+  });
+
+  it('clears the customer site name when the tier drops back to personal', () => {
+    const commercial: CncConfiguratorState = {
+      ...initialConfiguratorState(tenByTwelve()),
+      tier: 'commercial_single',
+      customerSiteName: 'Northside Boulder',
+    };
+
+    expect(configuratorReducer(commercial, { type: 'setTier', tier: 'personal' }).customerSiteName).toBe('');
+  });
+});
+
+describe('kicker-only and engrave options', () => {
+  it('hides a kickerOnly option once the kicker is off', () => {
+    const entry = tenByTwelve();
+    const withKicker = visibleMachiningOptions(entry, true).map((option) => option.key);
+    const withoutKicker = visibleMachiningOptions(entry, false).map((option) => option.key);
+
+    expect(withKicker).toContain('kickerMatClearanceMm');
+    expect(withoutKicker).not.toContain('kickerMatClearanceMm');
+  });
+
+  it('keeps the engrave toggles out of the machining step in both cases', () => {
+    for (const includeKicker of [true, false]) {
+      const keys = visibleMachiningOptions(tenByTwelve(), includeKicker).map((option) => option.key);
+      for (const engraveKey of CNC_ENGRAVE_OPTION_KEYS) {
+        expect(keys).not.toContain(engraveKey);
+      }
+    }
+  });
+
+  it('serves the engrave toggles their own list, in catalogue order', () => {
+    expect(engraveOptions(tenByTwelve()).map((option) => option.key)).toEqual(['engraveHoldIds', 'engraveAngleTicks']);
+  });
+});
+
+describe('set ids', () => {
+  it('drops both kicker sets together when the kicker is off', () => {
+    expect(setIdsFor(tenByTwelve(), true)).toBe('26,27,28,29');
+    // Never one of them: the backend rejects half a kicker outright.
+    expect(setIdsFor(tenByTwelve(), false)).toBe('26,27');
+  });
+
+  it('leaves a kickerless wall alone', () => {
+    expect(hasKickerSets(sevenByTen())).toBe(false);
+    expect(setIdsFor(sevenByTen(), false)).toBe('26,27');
+  });
+});
+
+describe('config to mutation input', () => {
+  it('coerces every option back to the type the catalogue holds it as', () => {
+    const state = initialConfiguratorState(tenByTwelve());
+    const input = toBoardConfigInput(state, tenByTwelve());
+
+    expect(input.options).toEqual({
+      sheetStock: '2440x1220',
+      tnutHoleDiameterMm: 12.5,
+      kickerMatClearanceMm: 50,
+      engraveHoldIds: false,
+      engraveAngleTicks: false,
+    });
+  });
+
+  it('sends only keys the entry still publishes, never a leftover from another size', () => {
+    const state: CncConfiguratorState = {
+      ...initialConfiguratorState(tenByTwelve()),
+      options: { ...defaultOptions(tenByTwelve()), retiredOption: 'whatever' },
+    };
+
+    // The backend rejects unknown option keys rather than dropping them, so a
+    // stale key that reached the wire would fail the whole checkout.
+    expect(Object.keys(toBoardConfigInput(state, tenByTwelve()).options)).not.toContain('retiredOption');
+  });
+
+  it('carries the board tuple and the kicker decision through as one unit', () => {
+    const state = { ...initialConfiguratorState(tenByTwelve()), includeKicker: false };
+    expect(toBoardConfigInput(state, tenByTwelve())).toMatchObject({
+      boardName: 'kilter',
+      layoutId: 8,
+      sizeId: 25,
+      setIds: '26,27',
+    });
+  });
+});
+
+describe('buy gate', () => {
+  const ready: CncConfiguratorState = {
+    ...initialConfiguratorState(tenByTwelve()),
+    licenseeName: 'Sam Bouldering',
+    licenseeEmail: 'sam@example.com',
+    licenceAccepted: true,
+  };
+
+  it('lets a complete personal order through', () => {
+    expect(checkoutBlockers(ready)).toEqual([]);
+  });
+
+  it('blocks on a missing name, a broken email, and an unaccepted licence', () => {
+    expect(checkoutBlockers({ ...ready, licenseeName: '   ' })).toContain('licenseeName');
+    expect(checkoutBlockers({ ...ready, licenseeEmail: 'sam@example' })).toContain('licenseeEmail');
+    expect(checkoutBlockers({ ...ready, licenceAccepted: false })).toContain('licenceAccepted');
+  });
+
+  it('requires a customer site name only for a commercial licence', () => {
+    const commercial = { ...ready, tier: 'commercial_single' as const, customerSiteName: '' };
+    expect(checkoutBlockers(commercial)).toContain('customerSiteName');
+    expect(checkoutBlockers({ ...commercial, customerSiteName: 'Northside Boulder' })).toEqual([]);
+  });
+});
+
+describe('draft persistence', () => {
+  it('never stores licence acceptance', () => {
+    const draft = toDraft({ ...initialConfiguratorState(tenByTwelve()), licenceAccepted: true });
+    // Acceptance is an act. Restoring it would let a browser that ticked the box
+    // once arrive at checkout pre-accepted without anyone reading anything.
+    expect(Object.keys(draft)).not.toContain('licenceAccepted');
+  });
+
+  it('round-trips a configuration and comes back un-accepted', () => {
+    const state: CncConfiguratorState = {
+      ...initialConfiguratorState(tenByTwelve()),
+      options: { ...defaultOptions(tenByTwelve()), sheetStock: '3600x1220' },
+      tier: 'commercial_single',
+      licenseeName: 'Sam',
+      licenseeEmail: 'sam@example.com',
+      customerSiteName: 'Northside Boulder',
+      licenceAccepted: true,
+    };
+
+    const restored = fromDraft(JSON.parse(JSON.stringify(toDraft(state))), [tenByTwelve(), sevenByTen()]);
+
+    expect(restored).toMatchObject({
+      sizeId: 25,
+      tier: 'commercial_single',
+      customerSiteName: 'Northside Boulder',
+      licenceAccepted: false,
+    });
+    expect(restored?.options.sheetStock).toBe('3600x1220');
+  });
+
+  it('falls back to today’s default for an option value the catalogue has dropped', () => {
+    const draft = { ...toDraft(initialConfiguratorState(tenByTwelve())), options: { sheetStock: '1200x600' } };
+
+    expect(fromDraft(draft, [tenByTwelve()])?.options.sheetStock).toBe('2440x1220');
+  });
+
+  it('discards a draft whose board tuple is no longer on sale', () => {
+    const draft = { ...toDraft(initialConfiguratorState(tenByTwelve())), sizeId: 999 };
+
+    expect(fromDraft(draft, [tenByTwelve(), sevenByTen()])).toBeNull();
+  });
+
+  it('discards anything that is not a draft at all', () => {
+    for (const value of [null, undefined, 'draft', 42, [], { sizeId: '25' }]) {
+      expect(fromDraft(value, [tenByTwelve()])).toBeNull();
+    }
+  });
+});
+
+describe('option value keys', () => {
+  it('maps every character i18next would read structurally', () => {
+    // The catalogs are written against this function: `12.5` must not nest a
+    // `12` object with a `5` inside it.
+    expect(optionValueKey('12.5')).toBe('12_5');
+    expect(optionValueKey('101.6')).toBe('101_6');
+    expect(optionValueKey('2440x1220')).toBe('2440x1220');
+    expect(optionValueKey('R12_circles')).toBe('R12_circles');
+    expect(optionValueKey('true')).toBe('true');
+  });
+});

--- a/packages/web/app/build-plans/__tests__/configurator-tier-picker.test.tsx
+++ b/packages/web/app/build-plans/__tests__/configurator-tier-picker.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { CncCatalog } from '@boardsesh/shared-schema';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+/**
+ * Covers the tier picker only: fix for a checkbox row that let a screen
+ * reader believe both licence tiers could be on at once. Everything else the
+ * full configurator does (draft restore, analytics, layout preview, checkout)
+ * is exercised by `configurator-state.test.ts` and `use-cnc-checkout.ts`'s own
+ * unit tests, so the mocks below stub those paths to their simplest values.
+ */
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+vi.mock('@/app/components/i18n/locale-link', () => ({
+  default: ({ href, children }: { href: string; children?: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null }),
+}));
+
+vi.mock('@/app/components/providers/auth-modal-provider', () => ({
+  useAuthModal: () => ({ openAuthModal: vi.fn() }),
+}));
+
+const useWsAuthToken = vi.hoisted(() => vi.fn());
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({ useWsAuthToken }));
+
+vi.mock('@/app/lib/user-preferences-db', () => ({
+  getPreference: vi.fn().mockResolvedValue(null),
+  setPreference: vi.fn().mockResolvedValue(undefined),
+  removePreference: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/app/lib/cnc-funnel-analytics', () => ({
+  trackCncFunnelEvent: vi.fn(),
+}));
+
+vi.mock('../configurator/use-cnc-layout', () => ({
+  useCncLayout: () => ({ summary: null, isLoading: false, errorKey: null }),
+}));
+
+vi.mock('../configurator/use-cnc-checkout', () => ({
+  useCncCheckout: () => ({ startCheckout: vi.fn(), isStarting: false, errorKey: null }),
+}));
+
+const ConfiguratorModule = await import('../configurator/configurator');
+const Configurator = ConfiguratorModule.default;
+
+function catalog(): CncCatalog {
+  return {
+    version: '1',
+    entries: [
+      {
+        boardName: 'kilter',
+        layoutId: 8,
+        sizeId: 25,
+        setIds: '26,27,28,29',
+        label: '10x12',
+        kickerOptional: false,
+        manufacturingOptions: [],
+        tiers: [
+          { tier: 'personal', amountCents: 14900, currency: 'AUD' },
+          { tier: 'commercial_single', amountCents: 75000, currency: 'AUD' },
+        ],
+      },
+    ],
+  };
+}
+
+function renderConfigurator() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Configurator catalog={catalog()} locale="en-US" />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  useWsAuthToken.mockReset().mockReturnValue({ token: null, isAuthenticated: false });
+});
+
+describe('tier picker', () => {
+  it('renders the two licence tiers as one mutually exclusive radio group', () => {
+    renderConfigurator();
+
+    const group = screen.getByRole('radiogroup');
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(2);
+    // The subtitle above the tiers becomes the group's accessible name, so a
+    // screen reader announces what the choice is for, not just "radio group".
+    expect(group.parentElement?.textContent).toContain('Pick a licence');
+
+    // Personal is the default, opening state.
+    expect((radios[0] as HTMLInputElement).checked).toBe(true);
+    expect((radios[1] as HTMLInputElement).checked).toBe(false);
+  });
+
+  it('selecting the commercial tier deselects personal', () => {
+    renderConfigurator();
+
+    const [personalRadio, commercialRadio] = screen.getAllByRole('radio') as HTMLInputElement[];
+    fireEvent.click(commercialRadio);
+
+    expect(commercialRadio.checked).toBe(true);
+    expect(personalRadio.checked).toBe(false);
+  });
+});

--- a/packages/web/app/build-plans/__tests__/format-date.test.ts
+++ b/packages/web/app/build-plans/__tests__/format-date.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { createOrderDateFormatter } from '../format-date';
+
+describe('createOrderDateFormatter', () => {
+  it('formats in UTC regardless of the environment time zone', () => {
+    // 2026-09-01T23:30:00Z is 2026-09-02 in any zone ahead of UTC and
+    // 2026-09-01 behind it. Pinning the zone means the server render (any
+    // machine) and the client render (any browser) always agree.
+    const formatter = createOrderDateFormatter('en-US', { dateStyle: 'medium' });
+    expect(formatter.format(new Date('2026-09-01T23:30:00.000Z'))).toBe('Sep 1, 2026');
+  });
+
+  it('keeps every option it is given, adding only the time zone', () => {
+    const formatter = createOrderDateFormatter('en-US', { dateStyle: 'medium', timeStyle: 'short' });
+    expect(formatter.format(new Date('2026-09-01T02:14:11.402Z'))).toBe('Sep 1, 2026, 2:14 AM');
+  });
+});

--- a/packages/web/app/build-plans/__tests__/layout-summary.test.ts
+++ b/packages/web/app/build-plans/__tests__/layout-summary.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readLayoutSummary } from '../configurator/layout-summary';
+
+/**
+ * A trimmed but otherwise faithful `LayoutResponse` from the pack generator:
+ * snake_case Python, a `wall` block, a `bom_preview` block, a panel array and
+ * a warnings array. Kept as a fixture rather than built field by field in each
+ * test so the shape this module actually reads is written down once.
+ */
+const GENERATOR_LAYOUT = {
+  wall: { width_mm: 3048, height_mm: 3658, kicker_height_mm: 305 },
+  bom_preview: { sheets: 6, tnut_count: 812, led_count: 411, skipped_seam_leds: 7 },
+  panels: [{ index: 0 }, { index: 1 }, { index: 2 }, { index: 3 }],
+  warnings: ['Kicker clearance is below the recommended 60 mm'],
+  // A field this module has never heard of. The generator adds these as it
+  // learns to build more walls, and none of them may break the summary.
+  toolpath_hints: { plunge_rate_mm_s: 4 },
+};
+
+describe('readLayoutSummary', () => {
+  it('pulls every summary number out of a generator response', () => {
+    expect(readLayoutSummary(GENERATOR_LAYOUT)).toEqual({
+      wallWidthMm: 3048,
+      wallHeightMm: 3658,
+      kickerHeightMm: 305,
+      panelCount: 4,
+      sheets: 6,
+      tnutCount: 812,
+      ledCount: 411,
+      skippedSeamLeds: 7,
+      warnings: ['Kicker clearance is below the recommended 60 mm'],
+    });
+  });
+
+  it('is unaffected by a field the generator added', () => {
+    const withNewField = { ...GENERATOR_LAYOUT, bom_preview: { ...GENERATOR_LAYOUT.bom_preview, glue_litres: 2.5 } };
+
+    expect(readLayoutSummary(withNewField).sheets).toBe(6);
+  });
+
+  it('nulls a renamed field instead of crashing the configurator', () => {
+    // The cost of a generator rename is one missing row in a preview card, not
+    // a page that fails to render before anyone can buy anything.
+    const renamed = { ...GENERATOR_LAYOUT, wall: { width_millimetres: 3048, height_mm: 3658 } };
+
+    const summary = readLayoutSummary(renamed);
+    expect(summary.wallWidthMm).toBeNull();
+    expect(summary.wallHeightMm).toBe(3658);
+  });
+
+  it('rejects numbers that are not finite', () => {
+    const broken = { wall: { width_mm: Number.NaN, height_mm: Number.POSITIVE_INFINITY } };
+
+    expect(readLayoutSummary(broken).wallWidthMm).toBeNull();
+    expect(readLayoutSummary(broken).wallHeightMm).toBeNull();
+  });
+
+  it('drops non-string warnings rather than rendering them', () => {
+    const noisy = { ...GENERATOR_LAYOUT, warnings: ['a real warning', 42, null, { message: 'an object' }] };
+
+    expect(readLayoutSummary(noisy).warnings).toEqual(['a real warning']);
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'not a layout'],
+    ['an array', []],
+    ['an empty object', {}],
+  ])('returns an all-null summary for %s', (_label, layout) => {
+    expect(readLayoutSummary(layout)).toEqual({
+      wallWidthMm: null,
+      wallHeightMm: null,
+      kickerHeightMm: null,
+      panelCount: null,
+      sheets: null,
+      tnutCount: null,
+      ledCount: null,
+      skippedSeamLeds: null,
+      warnings: [],
+    });
+  });
+});

--- a/packages/web/app/build-plans/__tests__/order-display.test.ts
+++ b/packages/web/app/build-plans/__tests__/order-display.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vite-plus/test';
+import type { CncCatalog } from '@boardsesh/shared-schema';
+import { orderStatusChipColor, wallLabel } from '../order-display';
+
+function catalogEntry(sizeId: number, label: string) {
+  return {
+    boardName: 'kilter',
+    layoutId: 8,
+    sizeId,
+    setIds: '26,27,28,29',
+    label,
+    kickerOptional: true,
+    manufacturingOptions: [],
+    tiers: [],
+  };
+}
+
+const CATALOG: CncCatalog = {
+  version: '2026-09-06.1',
+  entries: [catalogEntry(25, '10x12'), catalogEntry(23, '8x12')],
+};
+
+const ORDER_10X12 = { boardName: 'kilter', layoutId: 8, sizeId: 25 };
+
+describe('wallLabel', () => {
+  it('uses the catalogue label when the entry is still on sale', () => {
+    expect(wallLabel(CATALOG, ORDER_10X12)).toBe('10x12');
+  });
+
+  it('falls back to the size id when the entry has been retired', () => {
+    // A licence outlives the catalogue. Blanking the wall on an order somebody
+    // paid for would be the worst possible answer to a retired entry, and "25"
+    // is still enough for a buyer to recognise their own.
+    expect(wallLabel(CATALOG, { ...ORDER_10X12, sizeId: 17 })).toBe('17');
+  });
+
+  it('falls back when the catalogue could not be fetched at all', () => {
+    expect(wallLabel(null, ORDER_10X12)).toBe('25');
+  });
+
+  it('matches on the whole tuple, not the size id alone', () => {
+    // Size ids are per-board, so a Tension 25 is not a Kilter 25 and must not
+    // borrow its label.
+    expect(wallLabel(CATALOG, { ...ORDER_10X12, boardName: 'tension' })).toBe('25');
+    expect(wallLabel(CATALOG, { ...ORDER_10X12, layoutId: 1 })).toBe('25');
+  });
+});
+
+describe('orderStatusChipColor', () => {
+  it('reads each status as a verdict rather than a stage', () => {
+    expect(orderStatusChipColor('ready')).toBe('success');
+    expect(orderStatusChipColor('queued')).toBe('info');
+    expect(orderStatusChipColor('generating')).toBe('info');
+    expect(orderStatusChipColor('failed')).toBe('error');
+    // Nothing broke — the download is simply switched off.
+    expect(orderStatusChipColor('refunded')).toBe('warning');
+    // Nobody was charged, so a lapsed checkout is not a problem at all.
+    expect(orderStatusChipColor('cancelled')).toBe('default');
+    expect(orderStatusChipColor('pending_payment')).toBe('default');
+  });
+});

--- a/packages/web/app/build-plans/__tests__/order-status.test.tsx
+++ b/packages/web/app/build-plans/__tests__/order-status.test.tsx
@@ -27,13 +27,23 @@ vi.mock('@/app/lib/i18n/use-locale-router', () => ({
 }));
 
 const graphqlRequest = vi.hoisted(() => vi.fn());
+// The same helper the component derives the download origin from, so the two
+// agree in the test exactly as they do at runtime.
+const BACKEND_GRAPHQL_URL = 'https://backend.example/graphql';
 vi.mock('@/app/lib/graphql/client', () => ({
   createGraphQLHttpClient: () => ({ request: graphqlRequest }),
+  getGraphQLHttpUrl: () => BACKEND_GRAPHQL_URL,
 }));
 
 const OrderStatusModule = await import('../orders/[licenceId]/order-status');
 const OrderStatus = OrderStatusModule.default;
-const { orderRefetchInterval, ORDER_POLL_INTERVAL_MS } = OrderStatusModule;
+const {
+  orderRefetchInterval,
+  nextOrderPollInterval,
+  isBackendDownloadUrl,
+  ORDER_POLL_INTERVAL_MS,
+  MAX_CONSECUTIVE_NULL_POLLS,
+} = OrderStatusModule;
 
 function order(overrides: Partial<CncOrder> = {}): CncOrder {
   return {
@@ -107,6 +117,49 @@ describe('polling', () => {
     }
   });
 
+  it('does not stop on a transient null — it polls the last known status', () => {
+    // `cncOrder` answers null for a blip as well as for a revoked licence.
+    // Reading `false` out of that would settle the page forever on a pack that
+    // is still being cut.
+    for (let nullPolls = 0; nullPolls < MAX_CONSECUTIVE_NULL_POLLS; nullPolls += 1) {
+      expect({ nullPolls, interval: nextOrderPollInterval('generating', nullPolls) }).toEqual({
+        nullPolls,
+        interval: ORDER_POLL_INTERVAL_MS,
+      });
+    }
+  });
+
+  it('gives up after enough nulls in a row', () => {
+    expect(nextOrderPollInterval('generating', MAX_CONSECUTIVE_NULL_POLLS)).toBe(false);
+    expect(nextOrderPollInterval('generating', MAX_CONSECUTIVE_NULL_POLLS + 3)).toBe(false);
+  });
+
+  it('still stops on a terminal status however many nulls came before it', () => {
+    for (const status of ['ready', 'failed', 'cancelled', 'refunded'] satisfies CncOrderStatus[]) {
+      expect({ status, interval: nextOrderPollInterval(status, 0) }).toEqual({ status, interval: false });
+    }
+  });
+
+  it('keeps asking after a null answer, then stops at the cap', async () => {
+    vi.useFakeTimers();
+    try {
+      graphqlRequest.mockResolvedValue({ cncOrder: null });
+      renderStatus(order({ status: 'queued' }));
+
+      // One tick per interval while the nulls keep coming.
+      for (let poll = 1; poll <= MAX_CONSECUTIVE_NULL_POLLS; poll += 1) {
+        await vi.advanceTimersByTimeAsync(ORDER_POLL_INTERVAL_MS + 50);
+        expect({ poll, calls: graphqlRequest.mock.calls.length }).toEqual({ poll, calls: poll });
+      }
+
+      // And nothing after the cap, however long the tab stays open.
+      await vi.advanceTimersByTimeAsync(ORDER_POLL_INTERVAL_MS * 4);
+      expect(graphqlRequest).toHaveBeenCalledTimes(MAX_CONSECUTIVE_NULL_POLLS);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not re-fetch a ready order after the first render', async () => {
     renderStatus(order({ status: 'ready' }));
 
@@ -142,6 +195,53 @@ describe('download', () => {
     const [document, variables] = graphqlRequest.mock.calls[0] as [string, Record<string, unknown>];
     expect(document).toContain('CreateCncDownloadGrant');
     expect(variables).toEqual({ licenceId: 'BS-CNC-K7QM3T' });
+  });
+
+  it('refuses a grant URL on any other origin', async () => {
+    graphqlRequest.mockResolvedValue({
+      createCncDownloadGrant: {
+        url: 'https://evil.example/api/cnc/packs/BS-CNC-K7QM3T/download?token=abc',
+        expiresAt: '2026-09-01T02:22:00.000Z',
+      },
+    });
+
+    renderStatus(order({ status: 'ready' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Download the pack' }));
+
+    await waitFor(() => expect(screen.getByText('That link did not come through. Try again.')).toBeTruthy());
+    expect(locationAssign).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Download the pack' }).hasAttribute('disabled')).toBe(false);
+  });
+
+  it('shows the same error for a malformed grant URL instead of throwing', async () => {
+    graphqlRequest.mockResolvedValue({
+      createCncDownloadGrant: { url: 'not a url', expiresAt: '2026-09-01T02:22:00.000Z' },
+    });
+
+    renderStatus(order({ status: 'ready' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Download the pack' }));
+
+    await waitFor(() => expect(screen.getByText('That link did not come through. Try again.')).toBeTruthy());
+    expect(locationAssign).not.toHaveBeenCalled();
+  });
+
+  it('accepts only the backend origin the GraphQL client already talks to', () => {
+    for (const url of [
+      'https://backend.example/api/cnc/packs/BS-CNC-K7QM3T/download?token=abc',
+      'https://backend.example/anything',
+    ]) {
+      expect({ url, allowed: isBackendDownloadUrl(url) }).toEqual({ url, allowed: true });
+    }
+
+    for (const url of [
+      'https://backend.example.evil.test/api/cnc/packs/BS-CNC-K7QM3T/download',
+      'http://backend.example/api/cnc/packs/BS-CNC-K7QM3T/download',
+      'https://evil.test/api/cnc/packs/BS-CNC-K7QM3T/download',
+      '/api/cnc/packs/BS-CNC-K7QM3T/download',
+      '',
+    ]) {
+      expect({ url, allowed: isBackendDownloadUrl(url) }).toEqual({ url, allowed: false });
+    }
   });
 
   it('shows an error and re-enables the button when the grant fails', async () => {

--- a/packages/web/app/build-plans/__tests__/order-status.test.tsx
+++ b/packages/web/app/build-plans/__tests__/order-status.test.tsx
@@ -20,6 +20,12 @@ vi.mock('@/app/components/i18n/locale-link', () => ({
 const useWsAuthToken = vi.hoisted(() => vi.fn());
 vi.mock('@/app/hooks/use-ws-auth-token', () => ({ useWsAuthToken }));
 
+const routerReplace = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/i18n/use-locale-router', () => ({
+  useLocaleRouter: () => ({ replace: routerReplace }),
+  usePathnameWithoutLocale: () => '/build-plans/orders/BS-CNC-K7QM3T',
+}));
+
 const graphqlRequest = vi.hoisted(() => vi.fn());
 vi.mock('@/app/lib/graphql/client', () => ({
   createGraphQLHttpClient: () => ({ request: graphqlRequest }),
@@ -69,6 +75,7 @@ const locationAssign = vi.fn();
 
 beforeEach(() => {
   useWsAuthToken.mockReset().mockReturnValue({ token: 'ws-token', isAuthenticated: true });
+  routerReplace.mockReset();
   // Default to "the order has not changed" so a component that DOES poll (a
   // queued order) does not blow up on an undefined response mid-test.
   graphqlRequest.mockReset().mockResolvedValue({ cncOrder: null });
@@ -152,6 +159,32 @@ describe('download', () => {
     renderStatus(order({ status: 'generating' }));
 
     expect(screen.queryByRole('button', { name: 'Download the pack' })).toBeNull();
+  });
+
+  it('disables the download button while there is no auth token yet', () => {
+    useWsAuthToken.mockReturnValue({ token: null, isAuthenticated: true });
+    renderStatus(order({ status: 'ready' }));
+
+    // A click with no token would only fail inside handleDownload; disabling
+    // up front means there is nothing to click before the token arrives.
+    expect(screen.getByRole('button', { name: 'Download the pack' }).hasAttribute('disabled')).toBe(true);
+  });
+});
+
+describe('checkout param cleanup', () => {
+  it('strips ?checkout= from the URL once the outcome has been shown', () => {
+    renderStatus(order({ status: 'queued' }), 'success');
+
+    // The alert already said what happened; a refresh of this URL must not
+    // repeat it, so the query param is replaced away rather than left in place.
+    expect(routerReplace).toHaveBeenCalledTimes(1);
+    expect(routerReplace).toHaveBeenCalledWith('/build-plans/orders/BS-CNC-K7QM3T');
+  });
+
+  it('leaves the URL alone when there is no checkout outcome to clean up', () => {
+    renderStatus(order({ status: 'ready' }), null);
+
+    expect(routerReplace).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/web/app/build-plans/__tests__/order-status.test.tsx
+++ b/packages/web/app/build-plans/__tests__/order-status.test.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { CncOrder, CncOrderStatus } from '@boardsesh/shared-schema';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+vi.mock('@/app/components/i18n/locale-link', () => ({
+  default: ({ href, children }: { href: string; children?: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+const useWsAuthToken = vi.hoisted(() => vi.fn());
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({ useWsAuthToken }));
+
+const graphqlRequest = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: graphqlRequest }),
+}));
+
+const OrderStatusModule = await import('../orders/[licenceId]/order-status');
+const OrderStatus = OrderStatusModule.default;
+const { orderRefetchInterval, ORDER_POLL_INTERVAL_MS } = OrderStatusModule;
+
+function order(overrides: Partial<CncOrder> = {}): CncOrder {
+  return {
+    id: '41',
+    licenceId: 'BS-CNC-K7QM3T',
+    tier: 'personal',
+    status: 'ready',
+    boardName: 'kilter',
+    layoutId: 8,
+    sizeId: 25,
+    setIds: '26,27,28,29',
+    options: {},
+    artwork: [],
+    licenseeName: 'Sam Bouldering',
+    customerSiteName: null,
+    amountCents: 14900,
+    currency: 'AUD',
+    createdAt: '2026-09-01T02:14:11.402Z',
+    paidAt: '2026-09-01T02:15:00.000Z',
+    generatedAt: '2026-09-01T02:17:00.000Z',
+    zipSizeBytes: 4_200_000,
+    downloadCount: 0,
+    lastDownloadedAt: null,
+    errorMessage: null,
+    ...overrides,
+  };
+}
+
+function renderStatus(initialOrder: CncOrder, checkoutOutcome: 'success' | 'cancelled' | null = null) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <OrderStatus initialOrder={initialOrder} wallLabel="10x12" checkoutOutcome={checkoutOutcome} locale="en-US" />
+    </QueryClientProvider>,
+  );
+}
+
+const locationAssign = vi.fn();
+
+beforeEach(() => {
+  useWsAuthToken.mockReset().mockReturnValue({ token: 'ws-token', isAuthenticated: true });
+  // Default to "the order has not changed" so a component that DOES poll (a
+  // queued order) does not blow up on an undefined response mid-test.
+  graphqlRequest.mockReset().mockResolvedValue({ cncOrder: null });
+  locationAssign.mockReset();
+  // jsdom's own `location` is not assignable; replace the whole object so the
+  // component's `window.location.assign(url)` is observable.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: { assign: locationAssign, href: 'http://localhost/build-plans/orders/BS-CNC-K7QM3T' },
+  });
+});
+
+describe('polling', () => {
+  it('keeps polling while an order is still moving', () => {
+    for (const status of ['pending_payment', 'queued', 'generating'] satisfies CncOrderStatus[]) {
+      expect({ status, interval: orderRefetchInterval(status) }).toEqual({
+        status,
+        interval: ORDER_POLL_INTERVAL_MS,
+      });
+    }
+  });
+
+  it('stops the moment the pack is ready, and for every other terminal status', () => {
+    // The whole point: a buyer who leaves the tab open on a finished pack must
+    // not sit there asking the backend the same settled question forever.
+    for (const status of ['ready', 'failed', 'cancelled', 'refunded'] satisfies CncOrderStatus[]) {
+      expect({ status, interval: orderRefetchInterval(status) }).toEqual({ status, interval: false });
+    }
+  });
+
+  it('does not re-fetch a ready order after the first render', async () => {
+    renderStatus(order({ status: 'ready' }));
+
+    // The button, not the status text: "Ready to download" is deliberately
+    // both the chip label and the last timeline step, so a text query matches
+    // twice and tells you nothing.
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Download the pack' })).toBeTruthy());
+    // `initialData` seeds the cache from the server render, and a settled
+    // status turns the interval off, so nothing should have gone out.
+    expect(graphqlRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe('download', () => {
+  it('asks for a fresh grant and sends the browser to it', async () => {
+    graphqlRequest.mockResolvedValue({
+      createCncDownloadGrant: {
+        url: 'https://backend.example/api/cnc/packs/BS-CNC-K7QM3T/download?token=abc',
+        expiresAt: '2026-09-01T02:22:00.000Z',
+      },
+    });
+
+    renderStatus(order({ status: 'ready' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Download the pack' }));
+
+    await waitFor(() => expect(locationAssign).toHaveBeenCalledTimes(1));
+    expect(locationAssign).toHaveBeenCalledWith(
+      'https://backend.example/api/cnc/packs/BS-CNC-K7QM3T/download?token=abc',
+    );
+
+    // The grant mutation, with the licence id — not a cached URL, because a
+    // grant lasts five minutes and a cached one is a dead link most of the time.
+    const [document, variables] = graphqlRequest.mock.calls[0] as [string, Record<string, unknown>];
+    expect(document).toContain('CreateCncDownloadGrant');
+    expect(variables).toEqual({ licenceId: 'BS-CNC-K7QM3T' });
+  });
+
+  it('shows an error and re-enables the button when the grant fails', async () => {
+    graphqlRequest.mockRejectedValue(new Error('nope'));
+
+    renderStatus(order({ status: 'ready' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Download the pack' }));
+
+    await waitFor(() => expect(screen.getByText('That link did not come through. Try again.')).toBeTruthy());
+    expect(locationAssign).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Download the pack' }).hasAttribute('disabled')).toBe(false);
+  });
+
+  it('offers no download at all before the pack is ready', () => {
+    renderStatus(order({ status: 'generating' }));
+
+    expect(screen.queryByRole('button', { name: 'Download the pack' })).toBeNull();
+  });
+});
+
+describe('terminal states', () => {
+  it('explains a refund instead of offering a download', () => {
+    renderStatus(order({ status: 'refunded' }));
+
+    expect(screen.queryByRole('button', { name: 'Download the pack' })).toBeNull();
+    expect(screen.getByText(/refunded, so the download is switched off/)).toBeTruthy();
+  });
+
+  it('shows the fixed public failure message and a way to reach a human', () => {
+    const publicMessage =
+      'This pack could not be generated. Boardsesh has been notified and will be in touch by email.';
+    renderStatus(order({ status: 'failed', errorMessage: publicMessage }));
+
+    expect(screen.getByText(publicMessage)).toBeTruthy();
+    const contact = screen.getByText('Email us and we will sort it out');
+    expect(contact.closest('a')?.getAttribute('href')).toContain('mailto:support@boardsesh.com');
+  });
+
+  it('reports the checkout outcome the buyer came back with', () => {
+    renderStatus(order({ status: 'queued' }), 'success');
+    expect(screen.getByText('Payment went through. Your pack is being cut now.')).toBeTruthy();
+  });
+});

--- a/packages/web/app/build-plans/__tests__/use-cnc-checkout.test.ts
+++ b/packages/web/app/build-plans/__tests__/use-cnc-checkout.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { CreateCncCheckoutSessionInput } from '@boardsesh/shared-schema';
+
+const graphqlRequest = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: graphqlRequest }),
+}));
+
+const removePreference = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/user-preferences-db', () => ({ removePreference }));
+
+const { useCncCheckout, isStripeCheckoutUrl, STRIPE_CHECKOUT_ORIGIN } =
+  await import('../configurator/use-cnc-checkout');
+const { CNC_CONFIGURATOR_DRAFT_KEY } = await import('../configurator/configurator-state');
+
+const locationAssign = vi.fn();
+
+const CHECKOUT_INPUT: CreateCncCheckoutSessionInput = {
+  config: { boardName: 'kilter', layoutId: 8, sizeId: 25, setIds: '26,27,28,29', options: {} },
+  tier: 'personal',
+  licenseeName: 'Sam Bouldering',
+  licenseeEmail: 'sam@example.com',
+  acceptLicence: true,
+};
+
+function checkoutUrlResponse(checkoutUrl: string) {
+  return { createCncCheckoutSession: { orderId: '41', licenceId: 'BS-CNC-K7QM3T', checkoutUrl } };
+}
+
+/** A `graphql-request` ClientError, walked by shape rather than by `instanceof`. */
+function graphqlError(code: string) {
+  return { response: { errors: [{ message: 'nope', extensions: { code } }] } };
+}
+
+beforeEach(() => {
+  graphqlRequest.mockReset();
+  removePreference.mockReset().mockResolvedValue(undefined);
+  locationAssign.mockReset();
+  // jsdom's own `location` is not assignable; replace the whole object so the
+  // hook's `window.location.assign(url)` is observable.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: { assign: locationAssign, href: 'http://localhost/build-plans' },
+  });
+});
+
+describe('isStripeCheckoutUrl', () => {
+  it('accepts Stripe-hosted checkout, whatever the path and query carry', () => {
+    expect(isStripeCheckoutUrl(`${STRIPE_CHECKOUT_ORIGIN}/c/pay/cs_test_a1b2c3#fidkd`)).toBe(true);
+  });
+
+  it('rejects every near-miss origin', () => {
+    // The look-alikes that matter: a suffixed hostname, a subdomain of an
+    // attacker's zone, plain http, and an entirely different site.
+    for (const url of [
+      'https://checkout.stripe.com.evil.example/c/pay/cs_test',
+      'https://checkout.stripe.com.evil.example',
+      'https://evil.example/checkout.stripe.com',
+      'http://checkout.stripe.com/c/pay/cs_test',
+      'https://dashboard.stripe.com/c/pay/cs_test',
+    ]) {
+      expect({ url, allowed: isStripeCheckoutUrl(url) }).toEqual({ url, allowed: false });
+    }
+  });
+
+  it('returns false rather than throwing on a URL that does not parse', () => {
+    for (const url of ['', 'not a url', '/c/pay/cs_test', 'javascript:alert(1)']) {
+      expect({ url, allowed: isStripeCheckoutUrl(url) }).toEqual({ url, allowed: false });
+    }
+  });
+});
+
+describe('useCncCheckout', () => {
+  it('sends the browser to a Stripe checkout URL and wipes the saved draft', async () => {
+    graphqlRequest.mockResolvedValue(checkoutUrlResponse(`${STRIPE_CHECKOUT_ORIGIN}/c/pay/cs_test_a1b2c3`));
+
+    const { result } = renderHook(() => useCncCheckout('ws-token'));
+    await act(async () => {
+      await result.current.startCheckout(CHECKOUT_INPUT);
+    });
+
+    expect(locationAssign).toHaveBeenCalledWith(`${STRIPE_CHECKOUT_ORIGIN}/c/pay/cs_test_a1b2c3`);
+    expect(removePreference).toHaveBeenCalledWith(CNC_CONFIGURATOR_DRAFT_KEY);
+    expect(result.current.errorKey).toBeNull();
+    // Never cleared on the success path: the navigation is already in flight,
+    // and a re-enabled button is a second Stripe session for one wall.
+    expect(result.current.isStarting).toBe(true);
+  });
+
+  it('refuses to navigate to a URL on any other origin', async () => {
+    graphqlRequest.mockResolvedValue(checkoutUrlResponse('https://evil.example/c/pay/cs_test_a1b2c3'));
+
+    const { result } = renderHook(() => useCncCheckout('ws-token'));
+    await act(async () => {
+      await result.current.startCheckout(CHECKOUT_INPUT);
+    });
+
+    expect(locationAssign).not.toHaveBeenCalled();
+    await waitFor(() => expect(result.current.errorKey).toBe('generic'));
+    expect(result.current.isStarting).toBe(false);
+    // Nothing was charged, so the configuration the buyer typed must survive
+    // for the retry.
+    expect(removePreference).not.toHaveBeenCalled();
+  });
+
+  it('shows the same error for a malformed URL instead of throwing', async () => {
+    graphqlRequest.mockResolvedValue(checkoutUrlResponse('https://'));
+
+    const { result } = renderHook(() => useCncCheckout('ws-token'));
+    // No rejection escapes: `startCheckout` resolves, which is what keeps this
+    // off the unhandled-rejection path.
+    await act(async () => {
+      await expect(result.current.startCheckout(CHECKOUT_INPUT)).resolves.toBeUndefined();
+    });
+
+    expect(locationAssign).not.toHaveBeenCalled();
+    await waitFor(() => expect(result.current.errorKey).toBe('generic'));
+    expect(result.current.isStarting).toBe(false);
+  });
+
+  it('maps each backend error code to its own message key', async () => {
+    for (const code of ['CNC_INVALID_CONFIG', 'CNC_WORKER_UNAVAILABLE', 'CNC_CHECKOUT_UNAVAILABLE']) {
+      graphqlRequest.mockRejectedValueOnce(graphqlError(code));
+
+      const { result } = renderHook(() => useCncCheckout('ws-token'));
+      await act(async () => {
+        await result.current.startCheckout(CHECKOUT_INPUT);
+      });
+
+      await waitFor(() => expect({ code, errorKey: result.current.errorKey }).toEqual({ code, errorKey: code }));
+      expect(result.current.isStarting).toBe(false);
+    }
+  });
+
+  it('falls back to the generic key for a transport failure', async () => {
+    graphqlRequest.mockRejectedValue(new Error('fetch failed'));
+
+    const { result } = renderHook(() => useCncCheckout('ws-token'));
+    await act(async () => {
+      await result.current.startCheckout(CHECKOUT_INPUT);
+    });
+
+    await waitFor(() => expect(result.current.errorKey).toBe('generic'));
+    expect(locationAssign).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/build-plans/build-plans-content.tsx
+++ b/packages/web/app/build-plans/build-plans-content.tsx
@@ -1,0 +1,173 @@
+import 'server-only';
+import React from 'react';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import MuiLink from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import type { CncCatalog, CncLicenceTier } from '@boardsesh/shared-schema';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { themeTokens } from '@/app/theme/theme-config';
+import { formatPrice } from './configurator/configurator-state';
+import styles from './build-plans.module.css';
+
+/**
+ * Where a ten-build or OEM enquiry goes. A mailto rather than a form on
+ * purpose: those deals are a conversation about what someone is building, and a
+ * contact form would collect three fields and then need a human anyway.
+ */
+const MULTI_BUILD_CONTACT_EMAIL = 'support@boardsesh.com';
+
+/**
+ * The server-rendered half of `/build-plans`: heading, what you get, and what
+ * the two licences cost.
+ *
+ * Server, not client, and that is the point of splitting it from the
+ * configurator. This is the copy a search engine and a first paint see — an h1,
+ * real paragraphs, real prices, and crawlable links to the licence and to the
+ * buyer's own orders — none of which should wait on hydration or on a flag the
+ * browser has to resolve for itself.
+ *
+ * Prices are formatted from the catalogue's `amountCents` with the request's
+ * own locale, so the number on the page is the number Stripe will charge, in
+ * the currency the catalogue set it in.
+ */
+export default async function BuildPlansContent({ catalog, locale }: { catalog: CncCatalog | null; locale: string }) {
+  const { t } = await getServerTranslation('cnc');
+
+  // Every entry carries the same two tier prices today. Taking them from the
+  // first entry rather than the tier list of whichever wall is selected keeps
+  // this component free of configurator state; the configurator shows the price
+  // for the wall actually chosen.
+  const tiers = catalog?.entries[0]?.tiers ?? [];
+  const priceFor = (tier: CncLicenceTier): string | null => {
+    const price = tiers.find((candidate) => candidate.tier === tier);
+    return price ? formatPrice(price.amountCents, price.currency, locale) : null;
+  };
+
+  const contactHref = `mailto:${MULTI_BUILD_CONTACT_EMAIL}?subject=${encodeURIComponent(t('tiers.contact.subject'))}`;
+
+  return (
+    <>
+      <Box component="section" className={styles.hero}>
+        <Typography variant="h1" className={styles.heroTitle}>
+          {t('hero.title')}
+        </Typography>
+        <Typography variant="body1" className={styles.heroSubtitle}>
+          {t('hero.subtitle')}
+        </Typography>
+        <Typography variant="body2" component="p" className={styles.firstBoard}>
+          {t('hero.firstBoard')}
+        </Typography>
+
+        <Box sx={{ mt: 3 }}>
+          <Typography variant="h2" className={styles.sectionHeading}>
+            {t('hero.included.heading')}
+          </Typography>
+          <ul className={styles.includedList}>
+            <li>
+              <Typography variant="body1" component="span">
+                {t('hero.included.dxf')}
+              </Typography>
+            </li>
+            <li>
+              <Typography variant="body1" component="span">
+                {t('hero.included.pdf')}
+              </Typography>
+            </li>
+            <li>
+              <Typography variant="body1" component="span">
+                {t('hero.included.bom')}
+              </Typography>
+            </li>
+            <li>
+              <Typography variant="body1" component="span">
+                {t('hero.included.licence')}
+              </Typography>
+            </li>
+          </ul>
+        </Box>
+      </Box>
+
+      <Box component="section">
+        <Typography variant="h2" className={styles.sectionHeading}>
+          {t('tiers.heading')}
+        </Typography>
+        <Typography variant="body1" sx={{ mb: 2 }}>
+          {t('tiers.intro')}
+        </Typography>
+
+        <Box className={styles.tierGrid}>
+          <Card className={styles.tierCard} variant="outlined">
+            <CardContent>
+              <Typography variant="h3" className={styles.sectionHeading}>
+                {t('tiers.personal.name')}
+              </Typography>
+              {priceFor('personal') && (
+                <Typography
+                  variant="h4"
+                  className={styles.tierPrice}
+                  sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}
+                >
+                  {priceFor('personal')}
+                </Typography>
+              )}
+              <Typography variant="body2" color="text.secondary">
+                {t('tiers.personal.blurb')}
+              </Typography>
+            </CardContent>
+          </Card>
+
+          <Card className={styles.tierCard} variant="outlined">
+            <CardContent>
+              <Typography variant="h3" className={styles.sectionHeading}>
+                {t('tiers.commercial.name')}
+              </Typography>
+              {priceFor('commercial_single') && (
+                <Typography
+                  variant="h4"
+                  className={styles.tierPrice}
+                  sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}
+                >
+                  {priceFor('commercial_single')}
+                </Typography>
+              )}
+              <Typography variant="body2" color="text.secondary">
+                {t('tiers.commercial.blurb')}
+              </Typography>
+            </CardContent>
+          </Card>
+        </Box>
+
+        <Card className={styles.contactCard} variant="outlined" sx={{ mt: 2 }}>
+          <CardContent>
+            <Typography variant="h3" className={styles.sectionHeading}>
+              {t('tiers.contact.heading')}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              {t('tiers.contact.body')}
+            </Typography>
+            <MuiLink href={contactHref} variant="body2">
+              {t('tiers.contact.cta')}
+            </MuiLink>
+          </CardContent>
+        </Card>
+
+        <Stack direction="row" spacing={3} sx={{ mt: 2 }} flexWrap="wrap">
+          <MuiLink component={LocaleLink} href="/build-plans/licence" variant="body2">
+            {t('tiers.licenceLink')}
+          </MuiLink>
+          <MuiLink component={LocaleLink} href="/build-plans/orders" variant="body2">
+            {t('tiers.ordersLink')}
+          </MuiLink>
+        </Stack>
+      </Box>
+
+      <Typography variant="body2" color="text.secondary" className={styles.trademarkNote}>
+        {t('hero.trademarkNote')}
+      </Typography>
+    </>
+  );
+}

--- a/packages/web/app/build-plans/build-plans-page.ts
+++ b/packages/web/app/build-plans/build-plans-page.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { GET_CNC_CATALOG, type GetCncCatalogQueryResponse } from '@boardsesh/graphql/operations/cnc-packs';
 import type { CncCatalog } from '@boardsesh/shared-schema';
@@ -32,13 +33,27 @@ import { createCachedGraphQLQuery } from '@/app/lib/graphql/server-cached-client
  * surface does not exist, and a 403 would confirm to anyone poking at the URL
  * that it is about to.
  */
-export async function requireCncPacksFlag(): Promise<void> {
+export async function isCncPacksEnabled(): Promise<boolean> {
   const distinctId = await getPosthogDistinctId();
-  const enabled = await getServerFeatureFlag(CNC_PACKS_FLAG, { distinctId, allowAnonymous: true });
-  if (!enabled) {
+  return getServerFeatureFlag(CNC_PACKS_FLAG, { distinctId, allowAnonymous: true });
+}
+
+export async function requireCncPacksFlag(): Promise<void> {
+  if (!(await isCncPacksEnabled())) {
     notFound();
   }
 }
+
+/**
+ * What `generateMetadata` returns while the flag is off.
+ *
+ * Deliberately bare. `generateMetadata` runs before the page body, so it
+ * cannot `notFound()` its way out — and a real title, description and
+ * canonical would describe a shop that answers 404, handing a crawler (or
+ * anyone reading the response) the shape of an unreleased surface. Robots is
+ * the whole payload: nothing to index, nothing to leak.
+ */
+export const CNC_FLAG_OFF_METADATA: Metadata = { robots: { index: false, follow: true } };
 
 /**
  * Sixty seconds.

--- a/packages/web/app/build-plans/build-plans-page.ts
+++ b/packages/web/app/build-plans/build-plans-page.ts
@@ -1,0 +1,85 @@
+import 'server-only';
+import { notFound } from 'next/navigation';
+import { GET_CNC_CATALOG, type GetCncCatalogQueryResponse } from '@boardsesh/graphql/operations/cnc-packs';
+import type { CncCatalog } from '@boardsesh/shared-schema';
+import { CNC_PACKS_FLAG } from '@/app/flags';
+import { getPosthogDistinctId } from '@/app/lib/feature-flags/server-distinct-id';
+import { getServerFeatureFlag } from '@/app/lib/feature-flags/server-feature-flag';
+import { createCachedGraphQLQuery } from '@/app/lib/graphql/server-cached-client';
+
+/**
+ * The one gate every `/build-plans*` route calls, and the one catalogue fetch
+ * the public pages share.
+ *
+ * Both live here rather than being copy-pasted into four route files because
+ * getting either wrong is silent: a page that forgets the flag is a publicly
+ * reachable shop for a product whose licence is still marked DRAFT, and a page
+ * that fetches the catalogue its own way is a second cache key for four rows of
+ * static registry data.
+ */
+
+/**
+ * 404 unless the `cnc-packs` flag is on for this visitor.
+ *
+ * `allowAnonymous: true` is load-bearing, not boilerplate. Build plans are
+ * bought by people who have never signed in — the whole funnel starts with a
+ * stranger reading the page — so without the opt-in the gate would resolve
+ * `no-distinct-id` for every anonymous visitor and the surface would stay
+ * signed-in-only however the PostHog rollout is configured (see the note on
+ * `ServerFeatureFlagOptions.allowAnonymous`).
+ *
+ * `notFound()` rather than a redirect or a 403: while the flag is off this
+ * surface does not exist, and a 403 would confirm to anyone poking at the URL
+ * that it is about to.
+ */
+export async function requireCncPacksFlag(): Promise<void> {
+  const distinctId = await getPosthogDistinctId();
+  const enabled = await getServerFeatureFlag(CNC_PACKS_FLAG, { distinctId, allowAnonymous: true });
+  if (!enabled) {
+    notFound();
+  }
+}
+
+/**
+ * Sixty seconds.
+ *
+ * The catalogue is a hardcoded registry in the backend, so it only changes on a
+ * deploy — but the prices on this page are the prices Stripe will charge, and a
+ * long TTL means a price correction is visible to some visitors and not others
+ * for as long as the TTL runs. A minute keeps that window shorter than the time
+ * it takes to notice.
+ */
+const CATALOG_REVALIDATE_SECONDS = 60;
+
+/**
+ * Wall clock ceiling on the catalogue fetch. Without one a wedged backend hangs
+ * the render instead of degrading it; the caller turns a rejection into the
+ * outage state.
+ */
+const CATALOG_TIMEOUT_MS = 4_000;
+
+const cachedCncCatalog = createCachedGraphQLQuery<GetCncCatalogQueryResponse>(
+  GET_CNC_CATALOG,
+  'cnc-catalog',
+  CATALOG_REVALIDATE_SECONDS,
+  CATALOG_TIMEOUT_MS,
+);
+
+/**
+ * The catalogue, cached and unauthenticated.
+ *
+ * Cached rather than per-request (`executeGraphQL`) because `cncCatalog` is
+ * public, identical for everyone, and the same four entries on every render —
+ * exactly what the shared data cache is for. Returns null on failure so the
+ * page can say the shop is having a moment instead of throwing a 500 at
+ * somebody who came to spend money.
+ */
+export async function fetchCncCatalog(): Promise<CncCatalog | null> {
+  try {
+    const response = await cachedCncCatalog();
+    return response.cncCatalog;
+  } catch (error) {
+    console.error('fetchCncCatalog failed:', error);
+    return null;
+  }
+}

--- a/packages/web/app/build-plans/build-plans.module.css
+++ b/packages/web/app/build-plans/build-plans.module.css
@@ -1,0 +1,124 @@
+/* Colour values are the CSS custom properties defined in index.css, which are
+   generated from theme-config.ts. No hex ever lands in this file. */
+
+.page {
+  max-width: 900px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 24px 24px 64px;
+  padding-top: calc(var(--global-header-height) + 32px);
+}
+
+@media (max-width: 576px) {
+  .page {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+}
+
+.hero {
+  margin-bottom: 32px;
+}
+
+.heroTitle {
+  margin: 0 0 12px;
+}
+
+.heroSubtitle {
+  max-width: 62ch;
+}
+
+.firstBoard {
+  display: inline-block;
+  margin-top: 12px;
+  padding: 4px 10px;
+  border-radius: var(--border-radius-full);
+  background: var(--neutral-100);
+  color: var(--bs-text-brand-muted);
+}
+
+.sectionHeading {
+  font-size: var(--font-size-xl);
+  margin: 0 0 4px;
+}
+
+.stepHeading {
+  margin: 0 0 4px;
+}
+
+.includedList {
+  margin: 8px 0 0;
+  padding-left: 20px;
+}
+
+.includedList li {
+  margin-bottom: 4px;
+}
+
+.tierGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.tierCard {
+  height: 100%;
+}
+
+.tierPrice {
+  margin: 4px 0 8px;
+}
+
+.contactCard {
+  background: var(--neutral-50);
+}
+
+.configurator {
+  margin-top: 32px;
+}
+
+/* One column on a phone, two once there is room: eleven selects in a single
+   column is a very long scroll on a laptop. */
+.optionGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.summary {
+  border: 1px solid var(--neutral-200);
+  border-radius: var(--border-radius-lg);
+  padding: 16px;
+}
+
+.summaryRow {
+  gap: 16px;
+}
+
+.trademarkNote {
+  margin-top: 32px;
+}
+
+.orderList {
+  margin-top: 24px;
+}
+
+.orderCard {
+  margin-bottom: 12px;
+}
+
+.orderMeta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px 24px;
+  margin-top: 8px;
+}
+
+.timeline {
+  margin: 16px 0 0;
+  padding-left: 20px;
+}
+
+.timeline li {
+  margin-bottom: 4px;
+}

--- a/packages/web/app/build-plans/cnc-error.ts
+++ b/packages/web/app/build-plans/cnc-error.ts
@@ -1,0 +1,47 @@
+/**
+ * Turn a GraphQL failure into the one thing the buyer needs: which of these
+ * four things went wrong.
+ *
+ * The backend keeps the cases apart on purpose (see `toGraphQLWorkerError` in
+ * packages/backend/src/graphql/resolvers/cnc-packs/queries.ts):
+ * `CNC_INVALID_CONFIG` means change something, `CNC_WORKER_UNAVAILABLE` means
+ * try again shortly, `CNC_CHECKOUT_UNAVAILABLE` means payments are down. A UI
+ * that collapses them into "something went wrong" leaves the buyer with a
+ * genuinely bad configuration retrying it forever, which is exactly the
+ * confusion the codes exist to prevent.
+ *
+ * The returned value is an i18n key suffix under `errors.` in the `cnc`
+ * namespace, so a new code is a catalog entry plus one line here.
+ */
+
+const KNOWN_ERROR_CODES = ['CNC_INVALID_CONFIG', 'CNC_WORKER_UNAVAILABLE', 'CNC_CHECKOUT_UNAVAILABLE'] as const;
+
+export type CncErrorKey = (typeof KNOWN_ERROR_CODES)[number] | 'generic';
+
+/**
+ * `graphql-request` throws a `ClientError` whose `response.errors[]` carries
+ * the `extensions.code` the resolver set. Nothing here uses `instanceof`: the
+ * shape is walked defensively so a transport error, an aborted fetch or a
+ * proxy's HTML error page all land on `generic` instead of throwing inside the
+ * error handler.
+ */
+export function cncErrorKey(error: unknown): CncErrorKey {
+  if (typeof error !== 'object' || error === null) return 'generic';
+
+  const response = (error as { response?: unknown }).response;
+  if (typeof response !== 'object' || response === null) return 'generic';
+
+  const errors = (response as { errors?: unknown }).errors;
+  if (!Array.isArray(errors)) return 'generic';
+
+  for (const entry of errors) {
+    if (typeof entry !== 'object' || entry === null) continue;
+    const extensions = (entry as { extensions?: unknown }).extensions;
+    if (typeof extensions !== 'object' || extensions === null) continue;
+    const code = (extensions as { code?: unknown }).code;
+    const match = KNOWN_ERROR_CODES.find((known) => known === code);
+    if (match) return match;
+  }
+
+  return 'generic';
+}

--- a/packages/web/app/build-plans/configurator/configurator-state.ts
+++ b/packages/web/app/build-plans/configurator/configurator-state.ts
@@ -1,0 +1,359 @@
+import type {
+  CncBoardConfigInput,
+  CncCatalogEntry,
+  CncLicenceTier,
+  CncManufacturingOption,
+} from '@boardsesh/shared-schema';
+
+/**
+ * Everything the configurator knows, and every pure function that reads it.
+ *
+ * Deliberately free of React, MUI, GraphQL and the browser: the reducer and the
+ * mapping to a checkout input are where a mistake costs someone money, so they
+ * are unit-testable without mounting anything. `configurator.tsx` holds the
+ * hooks and the markup and nothing else.
+ */
+
+/**
+ * Set ids for the Kilter Homewall's removable kicker panels.
+ *
+ * RESTATED from `CNC_KICKER_SET_IDS` in
+ * packages/backend/src/services/cnc/catalog.ts, not imported: a web module must
+ * not reach into the backend package. The backend stays the authority — it
+ * re-validates the submitted set ids on every checkout and rejects a half
+ * kicker — so the worst a drift here can do is offer a toggle the server then
+ * refuses, never sell a wall that is not what was configured.
+ */
+export const CNC_KICKER_SET_IDS: readonly number[] = [28, 29];
+
+/**
+ * The two manufacturing options that are engraving decisions rather than
+ * machining ones.
+ *
+ * They live in the catalogue's `manufacturingOptions` like everything else, but
+ * they get their own step in the UI: both are Kilter-specific, both are off
+ * pending the IP review, and burying them among sheet sizes and hole diameters
+ * would have people flipping them without reading why they are off.
+ */
+export const CNC_ENGRAVE_OPTION_KEYS: readonly string[] = ['engraveHoldIds', 'engraveAngleTicks'];
+
+/** IndexedDB key the in-progress configuration is parked under across a sign-in round trip. */
+export const CNC_CONFIGURATOR_DRAFT_KEY = 'cnc:configurator-draft';
+
+export type CncConfiguratorState = {
+  boardName: string;
+  layoutId: number;
+  sizeId: number;
+  /** Only ever true for a size whose catalogue entry says `kickerOptional`. */
+  includeKicker: boolean;
+  /**
+   * Chosen manufacturing values, in the STRING form the catalogue publishes
+   * them in. Coerced back to their real type by `valueType` on the way out —
+   * see `toBoardConfigInput`. Keeping one representation in state means a
+   * `<select>` value, a draft on disk and a comparison against `values[]` are
+   * all the same string, with no place for `18` and `'18'` to disagree.
+   */
+  options: Record<string, string>;
+  tier: CncLicenceTier;
+  licenseeName: string;
+  licenseeEmail: string;
+  customerSiteName: string;
+  licenceAccepted: boolean;
+};
+
+export type CncConfiguratorAction =
+  | { type: 'selectSize'; entry: CncCatalogEntry }
+  | { type: 'setKicker'; includeKicker: boolean }
+  | { type: 'setOption'; key: string; value: string }
+  | { type: 'setTier'; tier: CncLicenceTier }
+  | { type: 'setLicenseeName'; value: string }
+  | { type: 'setLicenseeEmail'; value: string }
+  | { type: 'setCustomerSiteName'; value: string }
+  | { type: 'setLicenceAccepted'; accepted: boolean }
+  | { type: 'restoreDraft'; state: CncConfiguratorState };
+
+/** Default values for every option a catalogue entry publishes, as strings. */
+export function defaultOptions(entry: CncCatalogEntry): Record<string, string> {
+  const options: Record<string, string> = {};
+  for (const option of entry.manufacturingOptions) {
+    options[option.key] = option.defaultValue;
+  }
+  return options;
+}
+
+/** The configurator's opening position: the first entry on sale, at its defaults. */
+export function initialConfiguratorState(entry: CncCatalogEntry): CncConfiguratorState {
+  return {
+    boardName: entry.boardName,
+    layoutId: entry.layoutId,
+    sizeId: entry.sizeId,
+    // A kicker is opt-OUT, not opt-in: the walls that have one are almost
+    // always built with it, and a buyer who did not notice the toggle gets the
+    // wall they expected rather than a pack missing its bottom row.
+    includeKicker: entry.kickerOptional,
+    options: defaultOptions(entry),
+    tier: 'personal',
+    licenseeName: '',
+    licenseeEmail: '',
+    customerSiteName: '',
+    licenceAccepted: false,
+  };
+}
+
+export function findEntry(entries: readonly CncCatalogEntry[], state: CncConfiguratorState): CncCatalogEntry | null {
+  return (
+    entries.find(
+      (entry) =>
+        entry.boardName === state.boardName && entry.layoutId === state.layoutId && entry.sizeId === state.sizeId,
+    ) ?? null
+  );
+}
+
+export function configuratorReducer(state: CncConfiguratorState, action: CncConfiguratorAction): CncConfiguratorState {
+  switch (action.type) {
+    case 'selectSize': {
+      // Options are reset to the new entry's defaults rather than carried over.
+      // Two entries can publish different option sets, and a value carried onto
+      // a size that does not allow it is a checkout the backend rejects with an
+      // error the buyer cannot act on. Who they are and which licence they
+      // picked survive — those are about the buyer, not the wall.
+      return {
+        ...state,
+        boardName: action.entry.boardName,
+        layoutId: action.entry.layoutId,
+        sizeId: action.entry.sizeId,
+        includeKicker: action.entry.kickerOptional,
+        options: defaultOptions(action.entry),
+      };
+    }
+    case 'setKicker':
+      return { ...state, includeKicker: action.includeKicker };
+    case 'setOption':
+      return { ...state, options: { ...state.options, [action.key]: action.value } };
+    case 'setTier':
+      // Dropping back to personal clears the site name: it is meaningless on a
+      // personal licence, and the backend rejects a personal order that carries
+      // one rather than ignoring it.
+      return {
+        ...state,
+        tier: action.tier,
+        customerSiteName: action.tier === 'commercial_single' ? state.customerSiteName : '',
+      };
+    case 'setLicenseeName':
+      return { ...state, licenseeName: action.value };
+    case 'setLicenseeEmail':
+      return { ...state, licenseeEmail: action.value };
+    case 'setCustomerSiteName':
+      return { ...state, customerSiteName: action.value };
+    case 'setLicenceAccepted':
+      // Acceptance is never restored, only given: see `fromDraft`.
+      return { ...state, licenceAccepted: action.accepted };
+    case 'restoreDraft':
+      return action.state;
+  }
+}
+
+/**
+ * The machining options to show, in catalogue order.
+ *
+ * Two exclusions. `kickerOnly` options disappear when no kicker is being built,
+ * because a mat clearance on a wall with nothing to clear is a control that
+ * changes nothing in the pack. The engrave options are pulled out into their
+ * own step (see `CNC_ENGRAVE_OPTION_KEYS`).
+ */
+export function visibleMachiningOptions(
+  entry: CncCatalogEntry,
+  includeKicker: boolean,
+): readonly CncManufacturingOption[] {
+  return entry.manufacturingOptions.filter(
+    (option) => !CNC_ENGRAVE_OPTION_KEYS.includes(option.key) && (includeKicker || !option.kickerOnly),
+  );
+}
+
+/** The engrave toggles, in catalogue order. Empty when the entry publishes none. */
+export function engraveOptions(entry: CncCatalogEntry): readonly CncManufacturingOption[] {
+  return entry.manufacturingOptions.filter((option) => CNC_ENGRAVE_OPTION_KEYS.includes(option.key));
+}
+
+/**
+ * An option value as an i18n key segment.
+ *
+ * Catalogue values carry characters i18next reads structurally: `12.5` would
+ * nest a `12` object with a `5` inside it. Dots become underscores, and
+ * anything else outside `[A-Za-z0-9_-]` goes the same way, so `12.5` is
+ * `12_5` and `101.6` is `101_6`. The catalogs are written against this
+ * function; changing it renames every value key.
+ */
+export function optionValueKey(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/g, '_');
+}
+
+/** Comma-joined set ids for the wall as configured, kicker in or out. */
+export function setIdsFor(entry: CncCatalogEntry, includeKicker: boolean): string {
+  const setIds = entry.setIds
+    .split(',')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+  if (includeKicker) {
+    return setIds.join(',');
+  }
+  return setIds.filter((setId) => !CNC_KICKER_SET_IDS.includes(Number(setId))).join(',');
+}
+
+/** Whether this entry's set list actually contains kicker sets to drop. */
+export function hasKickerSets(entry: CncCatalogEntry): boolean {
+  return entry.setIds.split(',').some((segment) => CNC_KICKER_SET_IDS.includes(Number(segment.trim())));
+}
+
+/**
+ * Read a stored string back as the type the catalogue holds it as.
+ *
+ * `valueType` is `typeof` the catalogue's own default, so it is exactly one of
+ * `'boolean'`, `'number'` or `'string'`. Anything unparseable falls through as
+ * the string, which the backend's own matcher then rejects by value — better a
+ * named validation error than a silent `NaN` in a machining dimension.
+ */
+export function coerceOptionValue(raw: string, valueType: string): string | number | boolean {
+  if (valueType === 'boolean') return raw === 'true';
+  if (valueType === 'number') {
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : raw;
+  }
+  return raw;
+}
+
+/**
+ * The configuration as the GraphQL input the layout preview, artwork validation
+ * and checkout all take. One mapping, so a preview can never disagree with what
+ * is bought.
+ *
+ * Only options the entry still publishes are sent, and each is coerced by its
+ * own `valueType`. A key left over in state from a previous size is dropped
+ * rather than forwarded — the backend rejects unknown option keys outright.
+ */
+export function toBoardConfigInput(state: CncConfiguratorState, entry: CncCatalogEntry): CncBoardConfigInput {
+  const options: Record<string, string | number | boolean> = {};
+  for (const option of entry.manufacturingOptions) {
+    const raw = state.options[option.key] ?? option.defaultValue;
+    options[option.key] = coerceOptionValue(raw, option.valueType);
+  }
+
+  return {
+    boardName: entry.boardName,
+    layoutId: entry.layoutId,
+    sizeId: entry.sizeId,
+    setIds: setIdsFor(entry, state.includeKicker),
+    options,
+  };
+}
+
+/** Why Buy is disabled, in the order the fields appear. Empty means buyable. */
+export type CncCheckoutBlocker = 'licenseeName' | 'licenseeEmail' | 'customerSiteName' | 'licenceAccepted';
+
+export function checkoutBlockers(state: CncConfiguratorState): CncCheckoutBlocker[] {
+  const blockers: CncCheckoutBlocker[] = [];
+  if (state.licenseeName.trim().length === 0) blockers.push('licenseeName');
+  // Deliberately the loosest possible check — a local part, an @, a dot in the
+  // domain. The address is confirmed by the pack landing in it, and a stricter
+  // regex here only ever rejects somebody's real address.
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(state.licenseeEmail.trim())) blockers.push('licenseeEmail');
+  if (state.tier === 'commercial_single' && state.customerSiteName.trim().length === 0) {
+    blockers.push('customerSiteName');
+  }
+  if (!state.licenceAccepted) blockers.push('licenceAccepted');
+  return blockers;
+}
+
+/**
+ * What gets written to IndexedDB so a sign-in round trip does not throw the
+ * configuration away.
+ *
+ * `licenceAccepted` is NOT in the draft, on purpose. Acceptance is an act, and
+ * restoring it would let a browser that once ticked the box arrive at checkout
+ * pre-accepted without anyone having read anything. The email is kept: it is
+ * the buyer's own, typed by them, in their own browser.
+ */
+export type CncConfiguratorDraft = Omit<CncConfiguratorState, 'licenceAccepted'>;
+
+export function toDraft(state: CncConfiguratorState): CncConfiguratorDraft {
+  const { licenceAccepted: _accepted, ...draft } = state;
+  return draft;
+}
+
+function isRecordOfStrings(value: unknown): value is Record<string, string> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.values(value).every((entry) => typeof entry === 'string')
+  );
+}
+
+/**
+ * Rebuild state from a stored draft, or return null.
+ *
+ * Everything is re-checked against the CURRENT catalogue rather than trusted:
+ * a draft can be weeks old, and a size that has been retired or an option value
+ * that has been dropped would otherwise come back as a configuration the buyer
+ * can see but not buy. A stale option value falls back to today's default; a
+ * stale board tuple discards the draft entirely.
+ */
+export function fromDraft(raw: unknown, entries: readonly CncCatalogEntry[]): CncConfiguratorState | null {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return null;
+  const draft = raw as Record<string, unknown>;
+
+  if (
+    typeof draft.boardName !== 'string' ||
+    typeof draft.layoutId !== 'number' ||
+    typeof draft.sizeId !== 'number' ||
+    typeof draft.includeKicker !== 'boolean' ||
+    typeof draft.licenseeName !== 'string' ||
+    typeof draft.licenseeEmail !== 'string' ||
+    typeof draft.customerSiteName !== 'string' ||
+    (draft.tier !== 'personal' && draft.tier !== 'commercial_single') ||
+    !isRecordOfStrings(draft.options)
+  ) {
+    return null;
+  }
+
+  const entry = entries.find(
+    (candidate) =>
+      candidate.boardName === draft.boardName &&
+      candidate.layoutId === draft.layoutId &&
+      candidate.sizeId === draft.sizeId,
+  );
+  if (!entry) return null;
+
+  const options: Record<string, string> = {};
+  for (const option of entry.manufacturingOptions) {
+    const stored = draft.options[option.key];
+    options[option.key] = stored !== undefined && option.values.includes(stored) ? stored : option.defaultValue;
+  }
+
+  return {
+    boardName: entry.boardName,
+    layoutId: entry.layoutId,
+    sizeId: entry.sizeId,
+    includeKicker: entry.kickerOptional && draft.includeKicker,
+    options,
+    tier: draft.tier,
+    licenseeName: draft.licenseeName,
+    licenseeEmail: draft.licenseeEmail,
+    customerSiteName: draft.tier === 'commercial_single' ? draft.customerSiteName : '',
+    licenceAccepted: false,
+  };
+}
+
+/** The price the chosen tier is on sale for, or null when the entry has no such tier. */
+export function tierPrice(
+  entry: CncCatalogEntry,
+  tier: CncLicenceTier,
+): { amountCents: number; currency: string } | null {
+  const price = entry.tiers.find((candidate) => candidate.tier === tier);
+  return price ? { amountCents: price.amountCents, currency: price.currency } : null;
+}
+
+/** Money as the locale writes it. Cents in, "A$149.00" out. */
+export function formatPrice(amountCents: number, currency: string, locale: string): string {
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(amountCents / 100);
+}

--- a/packages/web/app/build-plans/configurator/configurator.tsx
+++ b/packages/web/app/build-plans/configurator/configurator.tsx
@@ -1,0 +1,611 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { useTranslation } from 'react-i18next';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Checkbox from '@mui/material/Checkbox';
+import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormHelperText from '@mui/material/FormHelperText';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import MuiLink from '@mui/material/Link';
+import Select from '@mui/material/Select';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import type { CncCatalog, CncCatalogEntry, CncLicenceTier } from '@boardsesh/shared-schema';
+import {
+  cncBuildPlansPageViewed,
+  cncConfiguratorChanged,
+  cncCheckoutStarted,
+  type CncConfigProps,
+  type CncConfiguratorStep,
+} from '@boardsesh/analytics';
+import { getBoardDisplayName } from '@boardsesh/climb-actions';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { trackCncFunnelEvent } from '@/app/lib/cnc-funnel-analytics';
+import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
+import { themeTokens } from '@/app/theme/theme-config';
+import styles from '../build-plans.module.css';
+import {
+  CNC_CONFIGURATOR_DRAFT_KEY,
+  checkoutBlockers,
+  configuratorReducer,
+  engraveOptions,
+  findEntry,
+  formatPrice,
+  fromDraft,
+  hasKickerSets,
+  initialConfiguratorState,
+  optionValueKey,
+  tierPrice,
+  toBoardConfigInput,
+  toDraft,
+  visibleMachiningOptions,
+  type CncConfiguratorState,
+} from './configurator-state';
+import { useCncCheckout } from './use-cnc-checkout';
+import { useCncLayout } from './use-cnc-layout';
+
+const TIERS: readonly CncLicenceTier[] = ['personal', 'commercial_single'];
+
+/** Where the buyer lands after signing in, so the draft below is restored onto the right page. */
+const BUILD_PLANS_PATH = '/build-plans';
+
+/**
+ * Quiet period before a step's change is reported.
+ *
+ * `Build Plans Configurator Changed` measures step COMPLETION, not keystrokes:
+ * the licensee fields alone would otherwise fire an event per character and
+ * bury the one signal the funnel wants — how far down the form people get.
+ */
+const STEP_EVENT_DEBOUNCE_MS = 900;
+
+/** Same idea for the draft write: one IndexedDB round trip per pause, not per keystroke. */
+const DRAFT_SAVE_DEBOUNCE_MS = 600;
+
+type ConfiguratorProps = {
+  catalog: CncCatalog;
+  /** Resolved on the server, so prices format the same before and after hydration. */
+  locale: string;
+};
+
+export default function Configurator({ catalog, locale }: ConfiguratorProps) {
+  const { t } = useTranslation('cnc');
+  const { openAuthModal } = useAuthModal();
+  const { token, isAuthenticated } = useWsAuthToken();
+  const { data: session } = useSession();
+
+  const entries = catalog.entries;
+  const [state, dispatch] = useReducer(configuratorReducer, entries[0], initialConfiguratorState);
+  const entry = findEntry(entries, state) ?? entries[0];
+
+  const configInput = useMemo(() => toBoardConfigInput(state, entry), [state, entry]);
+  const { summary, isLoading: isLayoutLoading, errorKey: layoutErrorKey } = useCncLayout(configInput);
+  const { startCheckout, isStarting, errorKey: checkoutErrorKey } = useCncCheckout(token);
+
+  const price = tierPrice(entry, state.tier);
+  const blockers = checkoutBlockers(state);
+  const machiningOptions = visibleMachiningOptions(entry, state.includeKicker);
+  const engraveToggles = engraveOptions(entry);
+
+  // ---------------------------------------------------------------- analytics
+  const analyticsConfig: CncConfigProps = useMemo(
+    () => ({
+      board_name: entry.boardName,
+      layout_id: entry.layoutId,
+      size_id: entry.sizeId,
+      kicker: state.includeKicker,
+      // Artwork arrives with the placement editor; the property is in the
+      // contract from the first event so the funnel does not gain a column
+      // halfway through its own history.
+      has_artwork: false,
+    }),
+    [entry.boardName, entry.layoutId, entry.sizeId, state.includeKicker],
+  );
+
+  // Read through a ref inside the debounced reporter so a config change does
+  // not restart the timer — the event should describe the wall as it stands
+  // when the buyer stops fiddling, not cancel itself every time they fiddle.
+  const analyticsConfigRef = useRef(analyticsConfig);
+  analyticsConfigRef.current = analyticsConfig;
+
+  const stepTimersRef = useRef(new Map<CncConfiguratorStep, ReturnType<typeof setTimeout>>());
+  const reportStep = useCallback((step: CncConfiguratorStep) => {
+    const timers = stepTimersRef.current;
+    const existing = timers.get(step);
+    if (existing) clearTimeout(existing);
+    timers.set(
+      step,
+      setTimeout(() => {
+        timers.delete(step);
+        trackCncFunnelEvent(cncConfiguratorChanged({ step, config: analyticsConfigRef.current }));
+      }, STEP_EVENT_DEBOUNCE_MS),
+    );
+  }, []);
+
+  useEffect(() => {
+    const timers = stepTimersRef.current;
+    return () => {
+      for (const timer of timers.values()) clearTimeout(timer);
+      timers.clear();
+    };
+  }, []);
+
+  const hasReportedViewRef = useRef(false);
+  useEffect(() => {
+    if (hasReportedViewRef.current) return;
+    hasReportedViewRef.current = true;
+    trackCncFunnelEvent(
+      cncBuildPlansPageViewed({ config: analyticsConfigRef.current, catalog_version: catalog.version }),
+    );
+  }, [catalog.version]);
+
+  // -------------------------------------------------------------------- draft
+  // Restored once, before the first save can run, so a sign-in round trip comes
+  // back to the wall the buyer configured rather than to the defaults.
+  const [isDraftRestored, setIsDraftRestored] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const stored = await getPreference<unknown>(CNC_CONFIGURATOR_DRAFT_KEY);
+      if (cancelled) return;
+      const restored = fromDraft(stored, entries);
+      if (restored) dispatch({ type: 'restoreDraft', state: restored });
+      setIsDraftRestored(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [entries]);
+
+  useEffect(() => {
+    if (!isDraftRestored) return;
+    const timer = setTimeout(() => {
+      void setPreference(CNC_CONFIGURATOR_DRAFT_KEY, toDraft(state));
+    }, DRAFT_SAVE_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [state, isDraftRestored]);
+
+  // Prefill the licensee from the session, but never overwrite typing: the
+  // account's email is a good guess, not an answer, and someone buying a
+  // commercial licence for a client may well want a different address on it.
+  const hasPrefilledRef = useRef(false);
+  useEffect(() => {
+    if (hasPrefilledRef.current || !isDraftRestored) return;
+    const email = session?.user?.email;
+    const name = session?.user?.name;
+    if (!email && !name) return;
+    hasPrefilledRef.current = true;
+    if (email && state.licenseeEmail.length === 0) dispatch({ type: 'setLicenseeEmail', value: email });
+    if (name && state.licenseeName.length === 0) dispatch({ type: 'setLicenseeName', value: name });
+  }, [session, isDraftRestored, state.licenseeEmail.length, state.licenseeName.length]);
+
+  // ------------------------------------------------------------------- actions
+  const handleSizeChange = (sizeId: number) => {
+    const next = entries.find((candidate) => candidate.sizeId === sizeId);
+    if (!next) return;
+    dispatch({ type: 'selectSize', entry: next });
+    reportStep('size');
+  };
+
+  const handleBuy = () => {
+    if (!isAuthenticated) {
+      // The draft is already on disk, and OAuth leaves the page entirely, so the
+      // callback has to carry the buyer back here for the restore to happen.
+      openAuthModal({
+        title: t('cta.signInTitle'),
+        description: t('cta.signInBody'),
+        callbackUrl: BUILD_PLANS_PATH,
+      });
+      return;
+    }
+    if (blockers.length > 0 || !price) return;
+
+    trackCncFunnelEvent(
+      cncCheckoutStarted({
+        config: analyticsConfig,
+        tier: state.tier,
+        amount_cents: price.amountCents,
+        currency: price.currency,
+      }),
+    );
+    void startCheckout({
+      config: configInput,
+      tier: state.tier,
+      licenseeName: state.licenseeName.trim(),
+      licenseeEmail: state.licenseeEmail.trim(),
+      customerSiteName: state.tier === 'commercial_single' ? state.customerSiteName.trim() : null,
+      acceptLicence: true,
+    });
+  };
+
+  const errorKey = checkoutErrorKey ?? layoutErrorKey;
+
+  return (
+    <Card component="section" className={styles.configurator} id="configure">
+      <CardContent>
+        <Stack spacing={3}>
+          <Box>
+            <Typography variant="h2" className={styles.sectionHeading}>
+              {t('configurator.heading')}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {t('configurator.intro')}
+            </Typography>
+          </Box>
+
+          <BoardAndSizeStep entries={entries} state={state} onSizeChange={handleSizeChange} />
+
+          {hasKickerSets(entry) && entry.kickerOptional && (
+            <Box>
+              <Typography variant="subtitle1" className={styles.stepHeading}>
+                {t('configurator.kicker.label')}
+              </Typography>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={state.includeKicker}
+                    onChange={(event) => {
+                      dispatch({ type: 'setKicker', includeKicker: event.target.checked });
+                      reportStep('kicker');
+                    }}
+                  />
+                }
+                label={state.includeKicker ? t('configurator.kicker.include') : t('configurator.kicker.exclude')}
+              />
+              <Typography variant="body2" color="text.secondary">
+                {t('configurator.kicker.help')}
+              </Typography>
+            </Box>
+          )}
+
+          <Divider />
+
+          <Box>
+            <Typography variant="subtitle1" className={styles.stepHeading}>
+              {t('configurator.options.heading')}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              {t('configurator.options.help')}
+            </Typography>
+            <Box className={styles.optionGrid}>
+              {machiningOptions.map((option) => (
+                <FormControl key={option.key} fullWidth size="small">
+                  <InputLabel id={`cnc-option-${option.key}`}>
+                    {t(`configurator.options.${option.key}.label`)}
+                  </InputLabel>
+                  <Select
+                    labelId={`cnc-option-${option.key}`}
+                    label={t(`configurator.options.${option.key}.label`)}
+                    value={state.options[option.key] ?? option.defaultValue}
+                    onChange={(event) => {
+                      dispatch({ type: 'setOption', key: option.key, value: event.target.value });
+                      reportStep('options');
+                    }}
+                  >
+                    {option.values.map((value) => (
+                      <MenuItem key={value} value={value}>
+                        {t(`configurator.options.${option.key}.values.${optionValueKey(value)}`)}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                  <FormHelperText>{t(`configurator.options.${option.key}.help`)}</FormHelperText>
+                </FormControl>
+              ))}
+            </Box>
+          </Box>
+
+          {engraveToggles.length > 0 && (
+            <Box>
+              <Typography variant="subtitle1" className={styles.stepHeading}>
+                {t('configurator.engrave.heading')}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {t('configurator.engrave.help')}
+              </Typography>
+              <Stack sx={{ mt: 1 }}>
+                {engraveToggles.map((option) => (
+                  <FormControlLabel
+                    key={option.key}
+                    control={
+                      <Switch
+                        checked={(state.options[option.key] ?? option.defaultValue) === 'true'}
+                        onChange={(event) => {
+                          dispatch({
+                            type: 'setOption',
+                            key: option.key,
+                            value: event.target.checked ? 'true' : 'false',
+                          });
+                          reportStep('engrave');
+                        }}
+                      />
+                    }
+                    label={t(`configurator.options.${option.key}.label`)}
+                  />
+                ))}
+              </Stack>
+              <Typography variant="caption" color="text.secondary" component="p">
+                {t('configurator.engrave.note')}
+              </Typography>
+            </Box>
+          )}
+
+          <LayoutSummaryCard summary={summary} isLoading={isLayoutLoading} hasError={layoutErrorKey !== null} />
+
+          <Divider />
+
+          <Box>
+            <Typography variant="subtitle1" className={styles.stepHeading}>
+              {t('configurator.licensee.heading')}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              {t('configurator.licensee.help')}
+            </Typography>
+            <Stack spacing={2}>
+              <TextField
+                label={t('configurator.licensee.name')}
+                value={state.licenseeName}
+                onChange={(event) => dispatch({ type: 'setLicenseeName', value: event.target.value })}
+                onBlur={() => reportStep('licensee')}
+                size="small"
+                fullWidth
+                required
+              />
+              <TextField
+                label={t('configurator.licensee.email')}
+                helperText={t('configurator.licensee.emailHelp')}
+                type="email"
+                value={state.licenseeEmail}
+                onChange={(event) => dispatch({ type: 'setLicenseeEmail', value: event.target.value })}
+                onBlur={() => reportStep('licensee')}
+                size="small"
+                fullWidth
+                required
+              />
+              {state.tier === 'commercial_single' && (
+                <TextField
+                  label={t('configurator.licensee.siteName')}
+                  helperText={t('configurator.licensee.siteHelp')}
+                  value={state.customerSiteName}
+                  onChange={(event) => dispatch({ type: 'setCustomerSiteName', value: event.target.value })}
+                  onBlur={() => reportStep('licensee')}
+                  size="small"
+                  fullWidth
+                  required
+                />
+              )}
+            </Stack>
+          </Box>
+
+          <Box>
+            <Typography variant="subtitle1" className={styles.stepHeading}>
+              {t('tiers.heading')}
+            </Typography>
+            <Stack spacing={1} sx={{ mt: 1 }}>
+              {TIERS.map((tier) => {
+                const tierAmount = tierPrice(entry, tier);
+                return (
+                  <FormControlLabel
+                    key={tier}
+                    control={
+                      <Checkbox
+                        checked={state.tier === tier}
+                        onChange={() => {
+                          dispatch({ type: 'setTier', tier });
+                          reportStep('tier');
+                        }}
+                      />
+                    }
+                    label={
+                      <span>
+                        <Typography component="span" fontWeight={themeTokens.typography.fontWeight.semibold}>
+                          {tier === 'personal' ? t('tiers.personal.name') : t('tiers.commercial.name')}
+                        </Typography>
+                        {tierAmount ? (
+                          <Typography component="span" color="text.secondary">
+                            {` · ${formatPrice(tierAmount.amountCents, tierAmount.currency, locale)}`}
+                          </Typography>
+                        ) : null}
+                      </span>
+                    }
+                  />
+                );
+              })}
+            </Stack>
+          </Box>
+
+          <Box>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={state.licenceAccepted}
+                  onChange={(event) => dispatch({ type: 'setLicenceAccepted', accepted: event.target.checked })}
+                />
+              }
+              label={t('configurator.licence.accept')}
+            />
+            <MuiLink component={LocaleLink} href="/build-plans/licence" variant="body2" sx={{ ml: 1 }}>
+              {t('configurator.licence.link')}
+            </MuiLink>
+          </Box>
+
+          {errorKey && <Alert severity="error">{t(`errors.${errorKey}`)}</Alert>}
+
+          <Box>
+            <Button
+              variant="contained"
+              size="large"
+              onClick={handleBuy}
+              disabled={isStarting || (isAuthenticated && (blockers.length > 0 || !price))}
+              sx={{ textTransform: 'none' }}
+            >
+              {isStarting ? t('cta.buying') : isAuthenticated ? t('cta.buy') : t('cta.buySignedOut')}
+            </Button>
+            {isAuthenticated && blockers.length > 0 && (
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                {t('configurator.licensee.required')}
+              </Typography>
+            )}
+          </Box>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
+
+function BoardAndSizeStep({
+  entries,
+  state,
+  onSizeChange,
+}: {
+  entries: readonly CncCatalogEntry[];
+  state: CncConfiguratorState;
+  onSizeChange: (sizeId: number) => void;
+}) {
+  const { t } = useTranslation('cnc');
+  // Boards, not sizes: v1 sells one board, so the board control is a read-only
+  // statement of that rather than a select with a single option pretending to
+  // be a choice. It becomes a select the day a second board is on sale.
+  const boardNames = [...new Set(entries.map((entry) => getBoardDisplayName(entry.boardName)))];
+
+  return (
+    <Stack spacing={2}>
+      <Box>
+        <Typography variant="subtitle1" className={styles.stepHeading}>
+          {t('configurator.board.label')}
+        </Typography>
+        <Typography variant="body1">{boardNames.join(', ')}</Typography>
+        <Typography variant="body2" color="text.secondary">
+          {t('configurator.board.help')}
+        </Typography>
+      </Box>
+
+      <FormControl fullWidth size="small">
+        <InputLabel id="cnc-size">{t('configurator.size.label')}</InputLabel>
+        <Select
+          labelId="cnc-size"
+          label={t('configurator.size.label')}
+          value={String(state.sizeId)}
+          onChange={(event) => onSizeChange(Number(event.target.value))}
+        >
+          {entries.map((entry) => (
+            <MenuItem key={entry.sizeId} value={String(entry.sizeId)}>
+              {entry.label}
+            </MenuItem>
+          ))}
+        </Select>
+        <FormHelperText>{t('configurator.size.help')}</FormHelperText>
+      </FormControl>
+    </Stack>
+  );
+}
+
+function LayoutSummaryCard({
+  summary,
+  isLoading,
+  hasError,
+}: {
+  summary: ReturnType<typeof useCncLayout>['summary'];
+  isLoading: boolean;
+  hasError: boolean;
+}) {
+  const { t } = useTranslation('cnc');
+
+  // An outage does not blank the configurator: the summary is a confidence
+  // builder, and the error banner above already says what happened. Rendering
+  // nothing here beats rendering a card full of dashes.
+  if (hasError) return null;
+
+  return (
+    <Box className={styles.summary}>
+      <Typography variant="subtitle1" className={styles.stepHeading}>
+        {t('configurator.summary.heading')}
+      </Typography>
+      {!summary && isLoading && (
+        <Stack direction="row" spacing={1} alignItems="center">
+          <CircularProgress size={16} />
+          <Typography variant="body2" color="text.secondary">
+            {t('configurator.summary.loading')}
+          </Typography>
+        </Stack>
+      )}
+      {summary && (
+        <Stack spacing={0.5} sx={{ mt: 1 }}>
+          {summary.wallWidthMm !== null && summary.wallHeightMm !== null && (
+            <SummaryRow
+              label={t('configurator.summary.wall')}
+              value={t('configurator.summary.wallValue', {
+                width: summary.wallWidthMm,
+                height: summary.wallHeightMm,
+              })}
+            />
+          )}
+          {summary.kickerHeightMm !== null && (
+            <SummaryRow
+              label={t('configurator.summary.kickerHeight')}
+              value={t('configurator.summary.kickerHeightValue', { height: summary.kickerHeightMm })}
+            />
+          )}
+          {summary.panelCount !== null && (
+            <SummaryRow
+              label={t('configurator.summary.panels')}
+              value={t('configurator.summary.panelsValue', { count: summary.panelCount })}
+            />
+          )}
+          {summary.sheets !== null && (
+            <SummaryRow
+              label={t('configurator.summary.sheets')}
+              value={t('configurator.summary.sheetsValue', { count: summary.sheets })}
+            />
+          )}
+          {summary.tnutCount !== null && (
+            <SummaryRow label={t('configurator.summary.tnuts')} value={String(summary.tnutCount)} />
+          )}
+          {summary.ledCount !== null && (
+            <SummaryRow label={t('configurator.summary.leds')} value={String(summary.ledCount)} />
+          )}
+          {summary.skippedSeamLeds !== null && summary.skippedSeamLeds > 0 && (
+            <SummaryRow label={t('configurator.summary.skippedLeds')} value={String(summary.skippedSeamLeds)} />
+          )}
+          {summary.warnings.length > 0 && (
+            <Box sx={{ mt: 1 }}>
+              <Typography variant="body2" fontWeight={themeTokens.typography.fontWeight.semibold}>
+                {t('configurator.summary.warningsHeading')}
+              </Typography>
+              {summary.warnings.map((warning) => (
+                <Typography key={warning} variant="body2" color="text.secondary">
+                  {warning}
+                </Typography>
+              ))}
+            </Box>
+          )}
+        </Stack>
+      )}
+    </Box>
+  );
+}
+
+function SummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <Stack direction="row" justifyContent="space-between" className={styles.summaryRow}>
+      <Typography variant="body2" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="body2" fontWeight={themeTokens.typography.fontWeight.semibold}>
+        {value}
+      </Typography>
+    </Stack>
+  );
+}

--- a/packages/web/app/build-plans/configurator/configurator.tsx
+++ b/packages/web/app/build-plans/configurator/configurator.tsx
@@ -185,21 +185,33 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
   // account's email is a good guess, not an answer, and someone buying a
   // commercial licence for a client may well want a different address on it.
   const hasPrefilledRef = useRef(false);
+  // The dependency is "are these fields still empty", not how long they are.
+  // Depending on `.length` re-runs this effect on every keystroke to reach a
+  // guard that already returned on the first one, and it reads as though the
+  // prefill cares about the value when all it cares about is emptiness.
+  const isLicenseeEmailEmpty = state.licenseeEmail.length === 0;
+  const isLicenseeNameEmpty = state.licenseeName.length === 0;
   useEffect(() => {
     if (hasPrefilledRef.current || !isDraftRestored) return;
     const email = session?.user?.email;
     const name = session?.user?.name;
     if (!email && !name) return;
     hasPrefilledRef.current = true;
-    if (email && state.licenseeEmail.length === 0) dispatch({ type: 'setLicenseeEmail', value: email });
-    if (name && state.licenseeName.length === 0) dispatch({ type: 'setLicenseeName', value: name });
-  }, [session, isDraftRestored, state.licenseeEmail.length, state.licenseeName.length]);
+    if (email && isLicenseeEmailEmpty) dispatch({ type: 'setLicenseeEmail', value: email });
+    if (name && isLicenseeNameEmpty) dispatch({ type: 'setLicenseeName', value: name });
+  }, [session, isDraftRestored, isLicenseeEmailEmpty, isLicenseeNameEmpty]);
 
   // ------------------------------------------------------------------- actions
   const handleSizeChange = (sizeId: number) => {
     const next = entries.find((candidate) => candidate.sizeId === sizeId);
     if (!next) return;
     dispatch({ type: 'selectSize', entry: next });
+    // Picking a size is also picking a board, because a catalogue entry names
+    // both. Today every entry is a Kilter Homewall so this branch never fires,
+    // and `board` would be the one step in the funnel contract that never
+    // appears — leaving a gap in the funnel the day a second board goes on
+    // sale and the size select starts spanning two of them.
+    if (next.boardName !== entry.boardName) reportStep('board');
     reportStep('size');
   };
 

--- a/packages/web/app/build-plans/configurator/configurator.tsx
+++ b/packages/web/app/build-plans/configurator/configurator.tsx
@@ -14,9 +14,12 @@ import Divider from '@mui/material/Divider';
 import FormControl from '@mui/material/FormControl';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormHelperText from '@mui/material/FormHelperText';
+import FormLabel from '@mui/material/FormLabel';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import MuiLink from '@mui/material/Link';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
 import Select from '@mui/material/Select';
 import Stack from '@mui/material/Stack';
 import Switch from '@mui/material/Switch';
@@ -390,40 +393,45 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
           </Box>
 
           <Box>
-            <Typography variant="subtitle1" className={styles.stepHeading}>
-              {t('tiers.heading')}
-            </Typography>
-            <Stack spacing={1} sx={{ mt: 1 }}>
-              {TIERS.map((tier) => {
-                const tierAmount = tierPrice(entry, tier);
-                return (
-                  <FormControlLabel
-                    key={tier}
-                    control={
-                      <Checkbox
-                        checked={state.tier === tier}
-                        onChange={() => {
-                          dispatch({ type: 'setTier', tier });
-                          reportStep('tier');
-                        }}
-                      />
-                    }
-                    label={
-                      <span>
-                        <Typography component="span" fontWeight={themeTokens.typography.fontWeight.semibold}>
-                          {tier === 'personal' ? t('tiers.personal.name') : t('tiers.commercial.name')}
-                        </Typography>
-                        {tierAmount ? (
-                          <Typography component="span" color="text.secondary">
-                            {` · ${formatPrice(tierAmount.amountCents, tierAmount.currency, locale)}`}
+            {/* A licence tier is a mutually exclusive choice, not a set of
+                independent switches — a `RadioGroup` says that in the
+                accessibility tree, where the old checkbox row let a screen
+                reader user believe both tiers could be on at once. */}
+            <FormControl component="fieldset">
+              <FormLabel component="legend" className={styles.stepHeading}>
+                {t('tiers.heading')}
+              </FormLabel>
+              <RadioGroup
+                value={state.tier}
+                onChange={(event) => {
+                  dispatch({ type: 'setTier', tier: event.target.value as CncLicenceTier });
+                  reportStep('tier');
+                }}
+              >
+                {TIERS.map((tier) => {
+                  const tierAmount = tierPrice(entry, tier);
+                  return (
+                    <FormControlLabel
+                      key={tier}
+                      value={tier}
+                      control={<Radio />}
+                      label={
+                        <span>
+                          <Typography component="span" fontWeight={themeTokens.typography.fontWeight.semibold}>
+                            {tier === 'personal' ? t('tiers.personal.name') : t('tiers.commercial.name')}
                           </Typography>
-                        ) : null}
-                      </span>
-                    }
-                  />
-                );
-              })}
-            </Stack>
+                          {tierAmount ? (
+                            <Typography component="span" color="text.secondary">
+                              {` · ${formatPrice(tierAmount.amountCents, tierAmount.currency, locale)}`}
+                            </Typography>
+                          ) : null}
+                        </span>
+                      }
+                    />
+                  );
+                })}
+              </RadioGroup>
+            </FormControl>
           </Box>
 
           <Box>

--- a/packages/web/app/build-plans/configurator/layout-summary.ts
+++ b/packages/web/app/build-plans/configurator/layout-summary.ts
@@ -1,0 +1,65 @@
+/**
+ * Reading the generator's layout response without pretending to model it.
+ *
+ * `cncLayout` returns opaque JSON on purpose (see the note on `GET_CNC_LAYOUT`
+ * in `@boardsesh/graphql`): the shape is the pack generator's own
+ * `LayoutResponse`, it is snake_case Python, and it grows as the generator
+ * learns to build more walls. Mirroring it field by field would make every
+ * generator change a coordinated four-package deploy.
+ *
+ * So this module narrows only the handful of numbers the summary card shows,
+ * and treats every one of them as optional. A generator that adds a field is
+ * invisible here; a generator that renames one costs a missing row in a
+ * summary, not a crashed configurator.
+ */
+
+export type CncLayoutSummary = {
+  wallWidthMm: number | null;
+  wallHeightMm: number | null;
+  kickerHeightMm: number | null;
+  panelCount: number | null;
+  sheets: number | null;
+  tnutCount: number | null;
+  ledCount: number | null;
+  skippedSeamLeds: number | null;
+  warnings: string[];
+};
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function readNumber(source: Record<string, unknown> | null, key: string): number | null {
+  if (!source) return null;
+  const value = source[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Pull the summary numbers out of a layout response.
+ *
+ * Returns a summary with every field null rather than throwing on a payload it
+ * does not recognise: the card renders the rows it has and stays quiet about
+ * the rest, which is the right behaviour for a preview that exists to build
+ * confidence before a purchase.
+ */
+export function readLayoutSummary(layout: unknown): CncLayoutSummary {
+  const root = readRecord(layout);
+  const wall = readRecord(root?.wall);
+  const bom = readRecord(root?.bom_preview);
+  const panels = root?.panels;
+  const warnings = root?.warnings;
+
+  return {
+    wallWidthMm: readNumber(wall, 'width_mm'),
+    wallHeightMm: readNumber(wall, 'height_mm'),
+    kickerHeightMm: readNumber(wall, 'kicker_height_mm'),
+    panelCount: Array.isArray(panels) ? panels.length : null,
+    sheets: readNumber(bom, 'sheets'),
+    tnutCount: readNumber(bom, 'tnut_count'),
+    ledCount: readNumber(bom, 'led_count'),
+    skippedSeamLeds: readNumber(bom, 'skipped_seam_leds'),
+    warnings: Array.isArray(warnings) ? warnings.filter((entry): entry is string => typeof entry === 'string') : [],
+  };
+}

--- a/packages/web/app/build-plans/configurator/use-cnc-checkout.ts
+++ b/packages/web/app/build-plans/configurator/use-cnc-checkout.ts
@@ -8,7 +8,9 @@ import {
   type CreateCncCheckoutSessionMutationVariables,
 } from '@boardsesh/graphql/operations/cnc-packs';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { removePreference } from '@/app/lib/user-preferences-db';
 import { cncErrorKey, type CncErrorKey } from '../cnc-error';
+import { CNC_CONFIGURATOR_DRAFT_KEY } from './configurator-state';
 
 export type CncCheckoutResult = {
   startCheckout: (input: CreateCncCheckoutSessionInput) => Promise<void>;
@@ -44,6 +46,11 @@ export function useCncCheckout(authToken: string | null): CncCheckoutResult {
           CreateCncCheckoutSessionMutationResponse,
           CreateCncCheckoutSessionMutationVariables
         >(CREATE_CNC_CHECKOUT_SESSION, { input });
+        // The sale is confirmed: the draft has done its job, and a buyer's name
+        // and email have no reason to sit in this browser's IndexedDB once
+        // Stripe has the order. `removePreference` swallows its own errors, so
+        // a failed wipe never blocks the redirect that follows it.
+        await removePreference(CNC_CONFIGURATOR_DRAFT_KEY);
         window.location.assign(response.createCncCheckoutSession.checkoutUrl);
       } catch (error) {
         setErrorKey(cncErrorKey(error));

--- a/packages/web/app/build-plans/configurator/use-cnc-checkout.ts
+++ b/packages/web/app/build-plans/configurator/use-cnc-checkout.ts
@@ -19,6 +19,32 @@ export type CncCheckoutResult = {
 };
 
 /**
+ * The only origin this hook will hand the browser to.
+ *
+ * `checkoutUrl` arrives from the backend, which builds it from Stripe's own
+ * session response — but it is still a server-supplied string that goes
+ * straight into `window.location`. Pinning the origin means a compromised or
+ * misconfigured backend cannot turn the Buy button into an open redirect onto
+ * a phishing page that looks like a payment form.
+ */
+export const STRIPE_CHECKOUT_ORIGIN = 'https://checkout.stripe.com';
+
+/**
+ * `true` only for a well-formed URL on Stripe's hosted checkout origin.
+ *
+ * The `new URL()` parse is guarded because a malformed string throws, and a
+ * throw here would escape as an unhandled rejection rather than showing the
+ * buyer an error.
+ */
+export function isStripeCheckoutUrl(url: string): boolean {
+  try {
+    return new URL(url).origin === STRIPE_CHECKOUT_ORIGIN;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Open Stripe Checkout for a configured pack.
  *
  * Not a React Query mutation, deliberately: the success path leaves the app
@@ -46,12 +72,21 @@ export function useCncCheckout(authToken: string | null): CncCheckoutResult {
           CreateCncCheckoutSessionMutationResponse,
           CreateCncCheckoutSessionMutationVariables
         >(CREATE_CNC_CHECKOUT_SESSION, { input });
+        const { checkoutUrl } = response.createCncCheckoutSession;
+        if (!isStripeCheckoutUrl(checkoutUrl)) {
+          // Same generic error as any other failed start, and the draft is
+          // deliberately left alone: nothing was charged, so the buyer should
+          // find their configuration still there when they retry.
+          setErrorKey('generic');
+          setIsStarting(false);
+          return;
+        }
         // The sale is confirmed: the draft has done its job, and a buyer's name
         // and email have no reason to sit in this browser's IndexedDB once
         // Stripe has the order. `removePreference` swallows its own errors, so
         // a failed wipe never blocks the redirect that follows it.
         await removePreference(CNC_CONFIGURATOR_DRAFT_KEY);
-        window.location.assign(response.createCncCheckoutSession.checkoutUrl);
+        window.location.assign(checkoutUrl);
       } catch (error) {
         setErrorKey(cncErrorKey(error));
         setIsStarting(false);

--- a/packages/web/app/build-plans/configurator/use-cnc-checkout.ts
+++ b/packages/web/app/build-plans/configurator/use-cnc-checkout.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { CreateCncCheckoutSessionInput } from '@boardsesh/shared-schema';
+import {
+  CREATE_CNC_CHECKOUT_SESSION,
+  type CreateCncCheckoutSessionMutationResponse,
+  type CreateCncCheckoutSessionMutationVariables,
+} from '@boardsesh/graphql/operations/cnc-packs';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { cncErrorKey, type CncErrorKey } from '../cnc-error';
+
+export type CncCheckoutResult = {
+  startCheckout: (input: CreateCncCheckoutSessionInput) => Promise<void>;
+  isStarting: boolean;
+  errorKey: CncErrorKey | null;
+};
+
+/**
+ * Open Stripe Checkout for a configured pack.
+ *
+ * Not a React Query mutation, deliberately: the success path leaves the app
+ * entirely, so there is no cache to invalidate and no result to render. What is
+ * left is a request, a pending flag and an error — which is this hook.
+ *
+ * `window.location.assign`, not `router.push`: `checkoutUrl` is a Stripe-hosted
+ * page on another origin, and Next's router only knows about this one.
+ *
+ * `isStarting` is never cleared on success. The navigation is already in
+ * flight, and flipping the button back to "Buy" while the browser is leaving
+ * invites a second click and a second Stripe session for one wall.
+ */
+export function useCncCheckout(authToken: string | null): CncCheckoutResult {
+  const [isStarting, setIsStarting] = useState(false);
+  const [errorKey, setErrorKey] = useState<CncErrorKey | null>(null);
+
+  const startCheckout = useCallback(
+    async (input: CreateCncCheckoutSessionInput) => {
+      setErrorKey(null);
+      setIsStarting(true);
+      try {
+        const client = createGraphQLHttpClient(authToken);
+        const response = await client.request<
+          CreateCncCheckoutSessionMutationResponse,
+          CreateCncCheckoutSessionMutationVariables
+        >(CREATE_CNC_CHECKOUT_SESSION, { input });
+        window.location.assign(response.createCncCheckoutSession.checkoutUrl);
+      } catch (error) {
+        setErrorKey(cncErrorKey(error));
+        setIsStarting(false);
+      }
+    },
+    [authToken],
+  );
+
+  return { startCheckout, isStarting, errorKey };
+}

--- a/packages/web/app/build-plans/configurator/use-cnc-layout.ts
+++ b/packages/web/app/build-plans/configurator/use-cnc-layout.ts
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { CncBoardConfigInput } from '@boardsesh/shared-schema';
+import {
+  GET_CNC_LAYOUT,
+  type GetCncLayoutQueryResponse,
+  type GetCncLayoutQueryVariables,
+} from '@boardsesh/graphql/operations/cnc-packs';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { cncErrorKey, type CncErrorKey } from '../cnc-error';
+import { readLayoutSummary, type CncLayoutSummary } from './layout-summary';
+
+/**
+ * How long the configuration has to sit still before we ask the generator.
+ *
+ * Every select in the configurator changes the layout, and the resolver is
+ * rate-limited per caller, so a buyer flipping through five options must not
+ * spend five of their allowance. 400 ms is below the point where the summary
+ * feels detached from the control that changed it and well above the interval
+ * between two clicks on the same select.
+ */
+const LAYOUT_DEBOUNCE_MS = 400;
+
+/**
+ * Debounce a value by identity of its JSON form.
+ *
+ * Keyed on the serialised config rather than the object, because the
+ * configurator rebuilds the input object on every render — an identity-based
+ * debounce would restart its timer forever and never settle.
+ */
+function useDebouncedConfig(config: CncBoardConfigInput | null): CncBoardConfigInput | null {
+  const configKey = config ? JSON.stringify(config) : '';
+  const [settled, setSettled] = useState(configKey);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setSettled(configKey), LAYOUT_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [configKey]);
+
+  if (!settled) return null;
+  // Reparse rather than keep a second copy in a ref: the settled key IS the
+  // value, and handing back the live object would return the un-debounced
+  // config whenever a change landed between the timer firing and this render.
+  return JSON.parse(settled) as CncBoardConfigInput;
+}
+
+export type CncLayoutResult = {
+  summary: CncLayoutSummary | null;
+  isLoading: boolean;
+  errorKey: CncErrorKey | null;
+};
+
+/**
+ * The panel layout for a configuration, debounced.
+ *
+ * Asks for the hole-free variant: it is the one the anonymous preview is
+ * allowed to fetch (the hole list is authenticated and ~40 KB bigger, and only
+ * the placement editor needs it), and every number the summary card shows comes
+ * from `bom_preview` rather than from the holes themselves.
+ *
+ * No auth token is passed. The layout resolver is public for exactly this
+ * reason — the preview is what makes someone want to buy, so it must render
+ * before anyone is asked to sign in.
+ */
+export function useCncLayout(config: CncBoardConfigInput | null): CncLayoutResult {
+  const debouncedConfig = useDebouncedConfig(config);
+  const configKey = debouncedConfig ? JSON.stringify(debouncedConfig) : '';
+
+  const query = useQuery({
+    queryKey: ['cncLayout', configKey] as const,
+    queryFn: async () => {
+      if (!debouncedConfig) throw new Error('useCncLayout: queryFn ran without a config');
+      const client = createGraphQLHttpClient();
+      const response = await client.request<GetCncLayoutQueryResponse, GetCncLayoutQueryVariables>(GET_CNC_LAYOUT, {
+        config: debouncedConfig,
+        includeHoles: false,
+      });
+      return readLayoutSummary(response.cncLayout);
+    },
+    enabled: debouncedConfig !== null,
+    // The generator caches layouts for a minute of its own; match it here so
+    // stepping back to a configuration already seen costs nothing at all.
+    staleTime: 60_000,
+    // A rejected layout is a verdict, not a hiccup: retrying an invalid config
+    // gives the same answer three times and delays the message that tells the
+    // buyer what to change.
+    retry: false,
+  });
+
+  return {
+    summary: query.data ?? null,
+    isLoading: query.isFetching,
+    errorKey: query.error ? cncErrorKey(query.error) : null,
+  };
+}

--- a/packages/web/app/build-plans/format-date.ts
+++ b/packages/web/app/build-plans/format-date.ts
@@ -1,0 +1,14 @@
+/**
+ * Build one `Intl.DateTimeFormat` for order timestamps, pinned to UTC.
+ *
+ * An order date is server-rendered first and then re-rendered on the client
+ * once React hydrates. Those are two different runtimes — a US server, a
+ * browser in any time zone — and `Intl.DateTimeFormat` defaults to the
+ * runtime's local zone, so the same instant would print as two different
+ * clock times and React would flag a hydration mismatch. Pinning
+ * `timeZone: 'UTC'` makes both renders agree, following the same fix already
+ * used for weekday labels in `insights-tab.tsx`.
+ */
+export function createOrderDateFormatter(locale: string, options: Intl.DateTimeFormatOptions): Intl.DateTimeFormat {
+  return new Intl.DateTimeFormat(locale, { ...options, timeZone: 'UTC' });
+}

--- a/packages/web/app/build-plans/order-display.ts
+++ b/packages/web/app/build-plans/order-display.ts
@@ -1,0 +1,49 @@
+import type { CncCatalog, CncOrderStatus } from '@boardsesh/shared-schema';
+
+/**
+ * The two presentation decisions the orders list and the order page both make,
+ * kept in one place so a status can never be green on one screen and grey on
+ * the other.
+ */
+
+/** How each status reads at a glance. Not a colour, a verdict. */
+export function orderStatusChipColor(status: CncOrderStatus): 'default' | 'info' | 'success' | 'error' | 'warning' {
+  switch (status) {
+    case 'ready':
+      return 'success';
+    case 'queued':
+    case 'generating':
+      return 'info';
+    case 'failed':
+      return 'error';
+    // Refunded is a warning rather than an error: nothing broke, the download
+    // is simply switched off. `cancelled` is a lapsed checkout, which is not a
+    // problem at all — nobody was charged.
+    case 'refunded':
+      return 'warning';
+    case 'pending_payment':
+    case 'cancelled':
+      return 'default';
+  }
+}
+
+/**
+ * The wall's catalogue label ("10x12"), or the raw size id when the catalogue
+ * no longer carries that entry.
+ *
+ * A retired entry must not blank out an order somebody paid for — the licence
+ * outlives the catalogue, and "25" is still enough for a buyer to recognise
+ * their own wall.
+ */
+export function wallLabel(
+  catalog: CncCatalog | null,
+  order: { boardName: string; layoutId: number; sizeId: number },
+): string {
+  const entry = catalog?.entries.find(
+    (candidate) =>
+      candidate.boardName === order.boardName &&
+      candidate.layoutId === order.layoutId &&
+      candidate.sizeId === order.sizeId,
+  );
+  return entry?.label ?? String(order.sizeId);
+}

--- a/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
+++ b/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import MuiLink from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { getBoardDisplayName } from '@boardsesh/climb-actions';
+import type { CncOrder, CncOrderStatus } from '@boardsesh/shared-schema';
+import {
+  CREATE_CNC_DOWNLOAD_GRANT,
+  GET_CNC_ORDER,
+  type CreateCncDownloadGrantMutationResponse,
+  type CreateCncDownloadGrantMutationVariables,
+  type GetCncOrderQueryResponse,
+  type GetCncOrderQueryVariables,
+} from '@boardsesh/graphql/operations/cnc-packs';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { themeTokens } from '@/app/theme/theme-config';
+import { cncErrorKey, type CncErrorKey } from '../../cnc-error';
+import { orderStatusChipColor } from '../../order-display';
+import styles from '../../build-plans.module.css';
+
+/**
+ * How often an unfinished pack is re-checked.
+ *
+ * A pack takes a couple of minutes to cut, so five seconds is fast enough that
+ * the page never feels stuck and slow enough that a buyer leaving the tab open
+ * over lunch costs a few hundred requests, not a few hundred thousand.
+ */
+export const ORDER_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * Statuses that are still moving on their own.
+ *
+ * `pending_payment` is NOT one of them, and that is the subtle case: it moves
+ * only when Stripe's webhook lands, which happens within seconds of a
+ * successful checkout — so it is polled too. What is deliberately excluded is
+ * every TERMINAL status: `ready`, `failed`, `cancelled` and `refunded` never
+ * change again without a human, so polling them is pure waste.
+ */
+const LIVE_STATUSES: readonly CncOrderStatus[] = ['pending_payment', 'queued', 'generating'];
+
+/**
+ * The React Query `refetchInterval` for one status: a number while the order is
+ * still moving, `false` once it has settled.
+ *
+ * Exported because "does polling actually stop at `ready`" is the question
+ * worth a test, and asserting it against a pure function beats waiting on
+ * timers around a mounted component.
+ */
+export function orderRefetchInterval(status: CncOrderStatus): number | false {
+  return LIVE_STATUSES.includes(status) ? ORDER_POLL_INTERVAL_MS : false;
+}
+
+/** The four steps a paid order walks, in order. */
+const TIMELINE_STEPS = ['paid', 'queued', 'generating', 'ready'] as const;
+type TimelineStep = (typeof TIMELINE_STEPS)[number];
+
+/** How far along a status is. -1 means nothing has happened yet (unpaid). */
+function timelineProgress(status: CncOrderStatus): number {
+  switch (status) {
+    case 'pending_payment':
+    case 'cancelled':
+      return -1;
+    case 'queued':
+      return 1;
+    case 'generating':
+      return 2;
+    case 'ready':
+    case 'refunded':
+      return 3;
+    // A failed order was paid, queued and picked up — it just never finished.
+    // Showing it stalled at "cutting the files" is more honest than resetting
+    // the timeline to nothing.
+    case 'failed':
+      return 2;
+  }
+}
+
+const SUPPORT_EMAIL = 'support@boardsesh.com';
+
+type OrderStatusProps = {
+  /** Server-fetched, so the first paint already shows the real status. */
+  initialOrder: CncOrder;
+  wallLabel: string;
+  checkoutOutcome: 'success' | 'cancelled' | null;
+  locale: string;
+};
+
+export default function OrderStatus({ initialOrder, wallLabel, checkoutOutcome, locale }: OrderStatusProps) {
+  const { t } = useTranslation('cnc');
+  const { token } = useWsAuthToken();
+  const [downloadErrorKey, setDownloadErrorKey] = useState<CncErrorKey | null>(null);
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const licenceId = initialOrder.licenceId;
+
+  const query = useQuery({
+    queryKey: ['cncOrder', licenceId] as const,
+    queryFn: async () => {
+      if (!token) throw new Error('OrderStatus: queryFn ran without a token');
+      const client = createGraphQLHttpClient(token);
+      const response = await client.request<GetCncOrderQueryResponse, GetCncOrderQueryVariables>(GET_CNC_ORDER, {
+        licenceId,
+      });
+      return response.cncOrder;
+    },
+    initialData: initialOrder,
+    // Without these two the server-rendered order is treated as infinitely old,
+    // so React Query refetches it the instant the component mounts — one wasted
+    // round trip per page load, on data that was fetched microseconds earlier
+    // in the very same request. `staleTime` matches the poll interval because
+    // that IS the freshness contract here; `refetchInterval` fires regardless
+    // of staleness, so a live order still polls on time.
+    initialDataUpdatedAt: () => Date.now(),
+    staleTime: ORDER_POLL_INTERVAL_MS,
+    enabled: !!token,
+    // Re-read from the latest data on every tick, so the moment the pack turns
+    // `ready` the next interval is `false` and the polling stops by itself.
+    refetchInterval: (result) => (result.state.data ? orderRefetchInterval(result.state.data.status) : false),
+  });
+
+  const order = query.data ?? initialOrder;
+
+  const handleDownload = useCallback(async () => {
+    setDownloadErrorKey(null);
+    setIsDownloading(true);
+    try {
+      const client = createGraphQLHttpClient(token);
+      const response = await client.request<
+        CreateCncDownloadGrantMutationResponse,
+        CreateCncDownloadGrantMutationVariables
+      >(CREATE_CNC_DOWNLOAD_GRANT, { licenceId });
+      // A fresh grant on every click: it lasts five minutes, so a cached one is
+      // a dead link most of the time. The navigation leaves the app, so the
+      // pending flag is deliberately not cleared on the success path.
+      window.location.assign(response.createCncDownloadGrant.url);
+    } catch (error) {
+      setDownloadErrorKey(cncErrorKey(error));
+      setIsDownloading(false);
+    }
+  }, [token, licenceId]);
+
+  const dateFormat = new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'short' });
+  const progress = timelineProgress(order.status);
+  const failedSubject = encodeURIComponent(t('order.failed.subject', { licenceId }));
+
+  return (
+    <>
+      <MuiLink component={LocaleLink} href="/build-plans/orders" variant="body2">
+        {t('order.back')}
+      </MuiLink>
+
+      <Typography variant="h1" className={styles.heroTitle} sx={{ mt: 1 }}>
+        {t('order.heading', { licenceId })}
+      </Typography>
+
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
+        <Chip size="small" color={orderStatusChipColor(order.status)} label={t(`status.${order.status}`)} />
+      </Stack>
+
+      {checkoutOutcome === 'success' && (
+        <Alert severity="success" sx={{ mb: 2 }}>
+          {t('order.checkoutSuccess')}
+        </Alert>
+      )}
+      {checkoutOutcome === 'cancelled' && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          {t('order.checkoutCancelled')}
+        </Alert>
+      )}
+      {query.isError && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {t('order.loadError')}
+        </Alert>
+      )}
+
+      <Box className={styles.orderMeta}>
+        <OrderField label={t('order.licence')} value={order.licenceId} />
+        <OrderField label={t('order.board')} value={`${getBoardDisplayName(order.boardName)} ${wallLabel}`} />
+        <OrderField
+          label={t('order.tier')}
+          value={order.tier === 'personal' ? t('tiers.personal.name') : t('tiers.commercial.name')}
+        />
+        <OrderField label={t('order.placed')} value={dateFormat.format(new Date(order.createdAt))} />
+        {order.zipSizeBytes !== null && (
+          <OrderField
+            label={t('order.size')}
+            value={t('order.sizeValue', { megabytes: Math.max(1, Math.round(order.zipSizeBytes / 1_000_000)) })}
+          />
+        )}
+        <OrderField label={t('order.downloads')} value={String(order.downloadCount)} />
+      </Box>
+
+      <Box sx={{ mt: 3 }}>
+        <Typography variant="subtitle1" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+          {t('order.timeline.heading')}
+        </Typography>
+        <ol className={styles.timeline}>
+          {TIMELINE_STEPS.map((step, index) => (
+            <li key={step}>
+              <Typography variant="body2" color={index <= progress ? 'text.primary' : 'text.secondary'}>
+                {t(`order.timeline.${step satisfies TimelineStep}`)}
+              </Typography>
+            </li>
+          ))}
+        </ol>
+        {orderRefetchInterval(order.status) !== false && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            {t('order.waiting')}
+          </Typography>
+        )}
+      </Box>
+
+      {order.status === 'ready' && (
+        <Box sx={{ mt: 3 }}>
+          <Button
+            variant="contained"
+            size="large"
+            onClick={() => void handleDownload()}
+            disabled={isDownloading}
+            sx={{ textTransform: 'none' }}
+          >
+            {isDownloading ? t('order.downloading') : t('order.download')}
+          </Button>
+          {downloadErrorKey && (
+            <Alert severity="error" sx={{ mt: 2 }}>
+              {t('order.downloadError')}
+            </Alert>
+          )}
+        </Box>
+      )}
+
+      {order.status === 'failed' && (
+        <Alert severity="error" sx={{ mt: 3 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+            {t('order.failed.heading')}
+          </Typography>
+          {/* The backend replaces the generator's real error with one fixed
+              public sentence — internal paths and module names never reach a
+              buyer — so this renders `errorMessage` verbatim rather than
+              mapping it. */}
+          {order.errorMessage && <Typography variant="body2">{order.errorMessage}</Typography>}
+          <MuiLink href={`mailto:${SUPPORT_EMAIL}?subject=${failedSubject}`} variant="body2">
+            {t('order.failed.contact')}
+          </MuiLink>
+        </Alert>
+      )}
+
+      {order.status === 'refunded' && (
+        <Alert severity="warning" sx={{ mt: 3 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+            {t('order.refunded.heading')}
+          </Typography>
+          <Typography variant="body2">{t('order.refunded.body')}</Typography>
+        </Alert>
+      )}
+    </>
+  );
+}
+
+function OrderField({ label, value }: { label: string; value: string }) {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" component="p">
+        {label}
+      </Typography>
+      <Typography variant="body2">{value}</Typography>
+    </Box>
+  );
+}

--- a/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
+++ b/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import Alert from '@mui/material/Alert';
@@ -22,7 +22,7 @@ import {
 } from '@boardsesh/graphql/operations/cnc-packs';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
-import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { createGraphQLHttpClient, getGraphQLHttpUrl } from '@/app/lib/graphql/client';
 import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
 import { themeTokens } from '@/app/theme/theme-config';
 import { cncErrorKey, type CncErrorKey } from '../../cnc-error';
@@ -60,6 +60,47 @@ const LIVE_STATUSES: readonly CncOrderStatus[] = ['pending_payment', 'queued', '
  */
 export function orderRefetchInterval(status: CncOrderStatus): number | false {
   return LIVE_STATUSES.includes(status) ? ORDER_POLL_INTERVAL_MS : false;
+}
+
+/**
+ * How many polls in a row may answer `null` before the page gives up.
+ *
+ * `cncOrder` answers null for a licence that has been revoked or handed to
+ * somebody else, but also for a blip — a token that is mid-refresh, a backend
+ * that dropped one request. One null must not settle the page forever on an
+ * order that is still generating, and an endless retry on a genuinely gone
+ * order is just as wrong, so a handful of consecutive misses ends it.
+ */
+export const MAX_CONSECUTIVE_NULL_POLLS = 5;
+
+/**
+ * The React Query `refetchInterval` for the next tick.
+ *
+ * Deliberately driven by the LAST KNOWN status rather than the current
+ * response: a transient `null` carries no status at all, and reading `false`
+ * out of it would stop polling permanently on an order that is still moving.
+ */
+export function nextOrderPollInterval(lastKnownStatus: CncOrderStatus, consecutiveNullPolls: number): number | false {
+  if (consecutiveNullPolls >= MAX_CONSECUTIVE_NULL_POLLS) return false;
+  return orderRefetchInterval(lastKnownStatus);
+}
+
+/**
+ * `true` only for a well-formed URL on the backend this client already talks
+ * to, derived from the same helper that builds the GraphQL endpoint so the two
+ * can never drift apart.
+ *
+ * The grant URL is a server-supplied string that goes straight into
+ * `window.location`, so it gets the same origin pin as the Stripe redirect.
+ * The parse is guarded: a malformed URL must show the buyer an error, not
+ * throw inside the click handler.
+ */
+export function isBackendDownloadUrl(url: string): boolean {
+  try {
+    return new URL(url).origin === new URL(getGraphQLHttpUrl()).origin;
+  } catch {
+    return false;
+  }
 }
 
 /** The four steps a paid order walks, in order. */
@@ -107,6 +148,12 @@ export default function OrderStatus({ initialOrder, wallLabel, checkoutOutcome, 
 
   const licenceId = initialOrder.licenceId;
 
+  // Refs, not state: both only ever feed the next poll decision and the
+  // fallback render, and bumping React state from inside `queryFn` would
+  // re-render the component a second time for every tick.
+  const lastKnownOrderRef = useRef<CncOrder>(initialOrder);
+  const consecutiveNullPollsRef = useRef(0);
+
   // The alert above already told the buyer what happened; a refresh or a
   // bookmark of this URL must not say it again. Strip `?checkout=` once the
   // outcome has been shown, the same "clean the param after rendering it"
@@ -128,7 +175,14 @@ export default function OrderStatus({ initialOrder, wallLabel, checkoutOutcome, 
       const response = await client.request<GetCncOrderQueryResponse, GetCncOrderQueryVariables>(GET_CNC_ORDER, {
         licenceId,
       });
-      return response.cncOrder;
+      const polledOrder = response.cncOrder;
+      if (polledOrder) {
+        lastKnownOrderRef.current = polledOrder;
+        consecutiveNullPollsRef.current = 0;
+      } else {
+        consecutiveNullPollsRef.current += 1;
+      }
+      return polledOrder;
     },
     initialData: initialOrder,
     // Without these two the server-rendered order is treated as infinitely old,
@@ -140,12 +194,13 @@ export default function OrderStatus({ initialOrder, wallLabel, checkoutOutcome, 
     initialDataUpdatedAt: () => Date.now(),
     staleTime: ORDER_POLL_INTERVAL_MS,
     enabled: !!token,
-    // Re-read from the latest data on every tick, so the moment the pack turns
-    // `ready` the next interval is `false` and the polling stops by itself.
-    refetchInterval: (result) => (result.state.data ? orderRefetchInterval(result.state.data.status) : false),
+    // Re-read from the last known order on every tick, so the moment the pack
+    // turns `ready` the next interval is `false` and the polling stops by
+    // itself — while a transient `null` leaves the interval alone.
+    refetchInterval: () => nextOrderPollInterval(lastKnownOrderRef.current.status, consecutiveNullPollsRef.current),
   });
 
-  const order = query.data ?? initialOrder;
+  const order = query.data ?? lastKnownOrderRef.current;
 
   const handleDownload = useCallback(async () => {
     setDownloadErrorKey(null);
@@ -156,10 +211,16 @@ export default function OrderStatus({ initialOrder, wallLabel, checkoutOutcome, 
         CreateCncDownloadGrantMutationResponse,
         CreateCncDownloadGrantMutationVariables
       >(CREATE_CNC_DOWNLOAD_GRANT, { licenceId });
+      const grantUrl = response.createCncDownloadGrant.url;
+      if (!isBackendDownloadUrl(grantUrl)) {
+        setDownloadErrorKey('generic');
+        setIsDownloading(false);
+        return;
+      }
       // A fresh grant on every click: it lasts five minutes, so a cached one is
       // a dead link most of the time. The navigation leaves the app, so the
       // pending flag is deliberately not cleared on the success path.
-      window.location.assign(response.createCncDownloadGrant.url);
+      window.location.assign(grantUrl);
     } catch (error) {
       setDownloadErrorKey(cncErrorKey(error));
       setIsDownloading(false);

--- a/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
+++ b/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import Alert from '@mui/material/Alert';
@@ -23,8 +23,10 @@ import {
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
 import { themeTokens } from '@/app/theme/theme-config';
 import { cncErrorKey, type CncErrorKey } from '../../cnc-error';
+import { createOrderDateFormatter } from '../../format-date';
 import { orderStatusChipColor } from '../../order-display';
 import styles from '../../build-plans.module.css';
 
@@ -98,10 +100,25 @@ type OrderStatusProps = {
 export default function OrderStatus({ initialOrder, wallLabel, checkoutOutcome, locale }: OrderStatusProps) {
   const { t } = useTranslation('cnc');
   const { token } = useWsAuthToken();
+  const router = useLocaleRouter();
+  const pathnameWithoutLocale = usePathnameWithoutLocale();
   const [downloadErrorKey, setDownloadErrorKey] = useState<CncErrorKey | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
 
   const licenceId = initialOrder.licenceId;
+
+  // The alert above already told the buyer what happened; a refresh or a
+  // bookmark of this URL must not say it again. Strip `?checkout=` once the
+  // outcome has been shown, the same "clean the param after rendering it"
+  // pattern used for `?error=` on the login page.
+  useEffect(() => {
+    if (!checkoutOutcome) return;
+    router.replace(pathnameWithoutLocale);
+    // Runs once per mount with an outcome: `router` and `pathnameWithoutLocale`
+    // are omitted on purpose, since re-running this on their identity would
+    // fight the very replace it just performed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const query = useQuery({
     queryKey: ['cncOrder', licenceId] as const,
@@ -149,7 +166,7 @@ export default function OrderStatus({ initialOrder, wallLabel, checkoutOutcome, 
     }
   }, [token, licenceId]);
 
-  const dateFormat = new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'short' });
+  const dateFormat = createOrderDateFormatter(locale, { dateStyle: 'medium', timeStyle: 'short' });
   const progress = timelineProgress(order.status);
   const failedSubject = encodeURIComponent(t('order.failed.subject', { licenceId }));
 
@@ -226,7 +243,7 @@ export default function OrderStatus({ initialOrder, wallLabel, checkoutOutcome, 
             variant="contained"
             size="large"
             onClick={() => void handleDownload()}
-            disabled={isDownloading}
+            disabled={isDownloading || !token}
             sx={{ textTransform: 'none' }}
           >
             {isDownloading ? t('order.downloading') : t('order.download')}

--- a/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
+++ b/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import Alert from '@mui/material/Alert';
@@ -166,7 +166,15 @@ export default function OrderStatus({ initialOrder, wallLabel, checkoutOutcome, 
     }
   }, [token, licenceId]);
 
-  const dateFormat = createOrderDateFormatter(locale, { dateStyle: 'medium', timeStyle: 'short' });
+  // Memoised on the locale alone: constructing an `Intl.DateTimeFormat` walks
+  // the ICU locale data, and this component re-renders on every poll tick
+  // while a pack is generating. The options are a literal, so the formatter
+  // only ever needs rebuilding when the locale changes — which is to say
+  // never, within one page.
+  const dateFormat = useMemo(
+    () => createOrderDateFormatter(locale, { dateStyle: 'medium', timeStyle: 'short' }),
+    [locale],
+  );
   const progress = timelineProgress(order.status);
   const failedSubject = encodeURIComponent(t('order.failed.subject', { licenceId }));
 

--- a/packages/web/app/build-plans/orders/[licenceId]/page.tsx
+++ b/packages/web/app/build-plans/orders/[licenceId]/page.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import MuiLink from '@mui/material/Link';
+import { GET_CNC_ORDER, type GetCncOrderQueryResponse } from '@boardsesh/graphql/operations/cnc-packs';
+import type { CncOrder } from '@boardsesh/shared-schema';
+import I18nProvider from '@/app/components/providers/i18n-provider';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { getServerAuthToken } from '@/app/lib/auth/server-auth';
+import { executeAuthenticatedGraphQL } from '@/app/lib/graphql/server-graphql';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import { fetchCncCatalog, requireCncPacksFlag } from '../../build-plans-page';
+import { wallLabel } from '../../order-display';
+import styles from '../../build-plans.module.css';
+import OrderStatus from './order-status';
+
+/** One person's order, with a live status. Never cached, never static. */
+export const dynamic = 'force-dynamic';
+
+type OrderRouteProps = {
+  params: Promise<{ licenceId: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+/**
+ * `noindex, follow`. Stays that way after launch — a purchase receipt is a
+ * utility surface. The licence id is in the title because that is how a buyer
+ * picks this tab out of five open ones.
+ */
+export async function generateMetadata(props: OrderRouteProps): Promise<Metadata> {
+  const { licenceId } = await props.params;
+  const { t, locale } = await getServerTranslation('cnc');
+  return createNoIndexMetadata({
+    title: t('metadata.order.title', { licenceId }),
+    description: t('metadata.order.description'),
+    path: `/build-plans/orders/${licenceId}`,
+    locale,
+  });
+}
+
+export default async function BuildPlanOrderPage(props: OrderRouteProps) {
+  await requireCncPacksFlag();
+
+  const { licenceId } = await props.params;
+  const searchParams = await props.searchParams;
+
+  const authToken = await getServerAuthToken();
+  if (!authToken) {
+    redirect(`/auth/login?callbackUrl=${encodeURIComponent(`/build-plans/orders/${licenceId}`)}`);
+  }
+
+  const { t, locale } = await getServerTranslation('cnc');
+
+  // `cncOrder` answers null for a licence that does not exist AND for one that
+  // belongs to somebody else — deliberately indistinguishable, so this page
+  // must not treat them differently either.
+  const [order, catalog] = await Promise.all([
+    executeAuthenticatedGraphQL<GetCncOrderQueryResponse>(GET_CNC_ORDER, { licenceId }, authToken)
+      .then((response) => response.cncOrder)
+      .catch((error: unknown) => {
+        console.error('cncOrder failed:', error);
+        return null satisfies CncOrder | null;
+      }),
+    fetchCncCatalog(),
+  ]);
+
+  if (!order) {
+    return (
+      <I18nProvider locale={locale} namespaces={['common', 'cnc']}>
+        <Box component="main" className={styles.page}>
+          <Typography variant="h1" className={styles.heroTitle}>
+            {t('order.notFound.heading')}
+          </Typography>
+          <Typography variant="body1" className={styles.heroSubtitle}>
+            {t('order.notFound.body')}
+          </Typography>
+          <MuiLink component={LocaleLink} href="/build-plans/orders" variant="body2" sx={{ mt: 2, display: 'block' }}>
+            {t('order.back')}
+          </MuiLink>
+        </Box>
+      </I18nProvider>
+    );
+  }
+
+  const checkoutParam = searchParams.checkout;
+  const checkoutOutcome = checkoutParam === 'success' || checkoutParam === 'cancelled' ? checkoutParam : null;
+
+  return (
+    <I18nProvider locale={locale} namespaces={['common', 'cnc']}>
+      <Box component="main" className={styles.page}>
+        <OrderStatus
+          initialOrder={order}
+          wallLabel={wallLabel(catalog, order)}
+          checkoutOutcome={checkoutOutcome}
+          locale={locale}
+        />
+      </Box>
+    </I18nProvider>
+  );
+}

--- a/packages/web/app/build-plans/orders/[licenceId]/page.tsx
+++ b/packages/web/app/build-plans/orders/[licenceId]/page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Metadata } from 'next';
-import { redirect } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import MuiLink from '@mui/material/Link';
@@ -12,7 +12,7 @@ import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { executeAuthenticatedGraphQL } from '@/app/lib/graphql/server-graphql';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
-import { fetchCncCatalog, requireCncPacksFlag } from '../../build-plans-page';
+import { CNC_FLAG_OFF_METADATA, fetchCncCatalog, isCncPacksEnabled, requireCncPacksFlag } from '../../build-plans-page';
 import { wallLabel } from '../../order-display';
 import styles from '../../build-plans.module.css';
 import OrderStatus from './order-status';
@@ -25,12 +25,38 @@ type OrderRouteProps = {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
+const LICENCE_ID_LENGTH = 'BS-CNC-'.length + 6;
+
+/**
+ * The shape the backend mints: `BS-CNC-` plus six characters (see
+ * `generateLicenceId` in `packages/backend/src/services/cnc/licence-id.ts`,
+ * whose alphabet is a subset of this one — the route only needs to reject
+ * junk, and the backend still answers null for anything it did not issue).
+ *
+ * Checked before the id reaches the login callback URL or the GraphQL
+ * variables, so a crafted path cannot smuggle an arbitrary string through this
+ * route. The explicit length check is not redundant with the anchored pattern:
+ * `$` also matches before a trailing newline.
+ */
+const LICENCE_ID_PATTERN = /^BS-CNC-[A-Z0-9]{6}$/;
+
+/**
+ * `notFound()` rather than a 400: it matches what an unknown-but-well-formed
+ * licence already gets, which keeps "no such order", "not your order" and "not
+ * a licence id at all" indistinguishable from outside.
+ */
+function isLicenceIdShape(licenceId: string): boolean {
+  return licenceId.length === LICENCE_ID_LENGTH && LICENCE_ID_PATTERN.test(licenceId);
+}
+
 /**
  * `noindex, follow`. Stays that way after launch — a purchase receipt is a
  * utility surface. The licence id is in the title because that is how a buyer
  * picks this tab out of five open ones.
  */
 export async function generateMetadata(props: OrderRouteProps): Promise<Metadata> {
+  if (!(await isCncPacksEnabled())) return CNC_FLAG_OFF_METADATA;
+
   const { licenceId } = await props.params;
   const { t, locale } = await getServerTranslation('cnc');
   return createNoIndexMetadata({
@@ -45,6 +71,9 @@ export default async function BuildPlanOrderPage(props: OrderRouteProps) {
   await requireCncPacksFlag();
 
   const { licenceId } = await props.params;
+  if (!isLicenceIdShape(licenceId)) {
+    notFound();
+  }
   const searchParams = await props.searchParams;
 
   const authToken = await getServerAuthToken();
@@ -85,7 +114,11 @@ export default async function BuildPlanOrderPage(props: OrderRouteProps) {
     );
   }
 
-  const checkoutParam = searchParams.checkout;
+  // `?checkout=success&checkout=cancelled` parses as an array, so take the
+  // first entry rather than comparing an array to a string and silently
+  // dropping the alert Stripe sent the buyer back for.
+  const rawCheckoutParam = searchParams.checkout;
+  const checkoutParam = Array.isArray(rawCheckoutParam) ? rawCheckoutParam[0] : rawCheckoutParam;
   const checkoutOutcome = checkoutParam === 'success' || checkoutParam === 'cancelled' ? checkoutParam : null;
 
   return (

--- a/packages/web/app/build-plans/orders/orders-list.tsx
+++ b/packages/web/app/build-plans/orders/orders-list.tsx
@@ -1,0 +1,99 @@
+import 'server-only';
+import React from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { getBoardDisplayName } from '@boardsesh/climb-actions';
+import type { CncCatalog, CncOrder } from '@boardsesh/shared-schema';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { themeTokens } from '@/app/theme/theme-config';
+import { orderStatusChipColor, wallLabel } from '../order-display';
+import styles from '../build-plans.module.css';
+
+/**
+ * The buyer's purchased packs, newest first.
+ *
+ * Server-rendered: this list never changes while it is on screen (a status
+ * moves on the DETAIL page, which polls), so it needs no client bundle at all.
+ * The link into each order is a real anchor via `LocaleLink`, not a click
+ * handler, so it opens in a new tab and survives a keyboard.
+ */
+export default async function OrdersList({
+  orders,
+  catalog,
+  locale,
+}: {
+  orders: readonly CncOrder[];
+  catalog: CncCatalog | null;
+  locale: string;
+}) {
+  const { t } = await getServerTranslation('cnc');
+  const dateFormat = new Intl.DateTimeFormat(locale, { dateStyle: 'medium' });
+
+  if (orders.length === 0) {
+    return (
+      <Box sx={{ mt: 3 }}>
+        <Typography variant="body1" sx={{ mb: 1.5 }}>
+          {t('orders.empty')}
+        </Typography>
+        <Button component={LocaleLink} href="/build-plans" variant="contained" sx={{ textTransform: 'none' }}>
+          {t('orders.emptyCta')}
+        </Button>
+      </Box>
+    );
+  }
+
+  return (
+    <Box className={styles.orderList}>
+      {orders.map((order) => (
+        <Card key={order.licenceId} className={styles.orderCard} variant="outlined">
+          <CardContent>
+            <Stack direction="row" justifyContent="space-between" alignItems="center" flexWrap="wrap" gap={1}>
+              <Typography variant="subtitle1" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
+                {order.licenceId}
+              </Typography>
+              <Chip size="small" color={orderStatusChipColor(order.status)} label={t(`status.${order.status}`)} />
+            </Stack>
+
+            <Box className={styles.orderMeta}>
+              <OrderField
+                label={t('orders.board')}
+                value={`${getBoardDisplayName(order.boardName)} ${wallLabel(catalog, order)}`}
+              />
+              <OrderField
+                label={t('orders.tier')}
+                value={order.tier === 'personal' ? t('tiers.personal.name') : t('tiers.commercial.name')}
+              />
+              <OrderField label={t('orders.created')} value={dateFormat.format(new Date(order.createdAt))} />
+            </Box>
+
+            <Button
+              component={LocaleLink}
+              href={`/build-plans/orders/${order.licenceId}`}
+              size="small"
+              sx={{ mt: 1.5, textTransform: 'none' }}
+            >
+              {t('orders.view')}
+            </Button>
+          </CardContent>
+        </Card>
+      ))}
+    </Box>
+  );
+}
+
+function OrderField({ label, value }: { label: string; value: string }) {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" component="p">
+        {label}
+      </Typography>
+      <Typography variant="body2">{value}</Typography>
+    </Box>
+  );
+}

--- a/packages/web/app/build-plans/orders/orders-list.tsx
+++ b/packages/web/app/build-plans/orders/orders-list.tsx
@@ -12,6 +12,7 @@ import type { CncCatalog, CncOrder } from '@boardsesh/shared-schema';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { themeTokens } from '@/app/theme/theme-config';
+import { createOrderDateFormatter } from '../format-date';
 import { orderStatusChipColor, wallLabel } from '../order-display';
 import styles from '../build-plans.module.css';
 
@@ -33,7 +34,7 @@ export default async function OrdersList({
   locale: string;
 }) {
   const { t } = await getServerTranslation('cnc');
-  const dateFormat = new Intl.DateTimeFormat(locale, { dateStyle: 'medium' });
+  const dateFormat = createOrderDateFormatter(locale, { dateStyle: 'medium' });
 
   if (orders.length === 0) {
     return (

--- a/packages/web/app/build-plans/orders/page.tsx
+++ b/packages/web/app/build-plans/orders/page.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { GET_MY_CNC_ORDERS, type GetMyCncOrdersQueryResponse } from '@boardsesh/graphql/operations/cnc-packs';
+import type { CncOrder } from '@boardsesh/shared-schema';
+import I18nProvider from '@/app/components/providers/i18n-provider';
+import { getServerAuthToken } from '@/app/lib/auth/server-auth';
+import { executeAuthenticatedGraphQL } from '@/app/lib/graphql/server-graphql';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import { fetchCncCatalog, requireCncPacksFlag } from '../build-plans-page';
+import styles from '../build-plans.module.css';
+import OrdersList from './orders-list';
+
+/** Somebody's purchase history. Never cached, never shared, never static. */
+export const dynamic = 'force-dynamic';
+
+const ORDERS_PATH = '/build-plans/orders';
+
+/**
+ * `noindex, follow`, and this one stays that way after launch: a page that
+ * lists what one person bought is a utility surface, not a search surface. The
+ * TODO on `/build-plans` does not apply here.
+ */
+export async function generateMetadata(): Promise<Metadata> {
+  const { t, locale } = await getServerTranslation('cnc');
+  return createNoIndexMetadata({
+    title: t('metadata.orders.title'),
+    description: t('metadata.orders.description'),
+    path: ORDERS_PATH,
+    locale,
+  });
+}
+
+export default async function BuildPlansOrdersPage() {
+  await requireCncPacksFlag();
+
+  // `getServerAuthToken` is BOTH the session read and the credential: it
+  // returns the next-auth session cookie, which is what the backend accepts as
+  // a Bearer token. `getServerSession(authOptions)` would decode the same
+  // cookie a second time and still leave this page needing the raw value for
+  // the GraphQL call, so it is deliberately not used here.
+  const authToken = await getServerAuthToken();
+  if (!authToken) {
+    redirect(`/auth/login?callbackUrl=${encodeURIComponent(ORDERS_PATH)}`);
+  }
+
+  const { t, locale } = await getServerTranslation('cnc');
+
+  // The catalogue is only here to turn a size id into a wall label. A failed
+  // fetch costs the label, not the list — an order still shows its licence id,
+  // status and date, which is what someone came to check.
+  const [ordersResult, catalog] = await Promise.all([
+    executeAuthenticatedGraphQL<GetMyCncOrdersQueryResponse>(GET_MY_CNC_ORDERS, undefined, authToken)
+      .then((response) => ({ ok: true as const, orders: response.myCncOrders }))
+      .catch((error: unknown) => {
+        console.error('myCncOrders failed:', error);
+        return { ok: false as const, orders: [] as CncOrder[] };
+      }),
+    fetchCncCatalog(),
+  ]);
+
+  return (
+    <I18nProvider locale={locale} namespaces={['common', 'cnc']}>
+      <Box component="main" className={styles.page}>
+        <Typography variant="h1" className={styles.heroTitle}>
+          {t('orders.heading')}
+        </Typography>
+        <Typography variant="body1" className={styles.heroSubtitle}>
+          {t('orders.intro')}
+        </Typography>
+
+        {ordersResult.ok ? (
+          <OrdersList orders={ordersResult.orders} catalog={catalog} locale={locale} />
+        ) : (
+          <Alert severity="error" sx={{ mt: 3 }}>
+            {t('orders.loadError')}
+          </Alert>
+        )}
+      </Box>
+    </I18nProvider>
+  );
+}

--- a/packages/web/app/build-plans/orders/page.tsx
+++ b/packages/web/app/build-plans/orders/page.tsx
@@ -11,7 +11,7 @@ import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { executeAuthenticatedGraphQL } from '@/app/lib/graphql/server-graphql';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
-import { fetchCncCatalog, requireCncPacksFlag } from '../build-plans-page';
+import { CNC_FLAG_OFF_METADATA, fetchCncCatalog, isCncPacksEnabled, requireCncPacksFlag } from '../build-plans-page';
 import styles from '../build-plans.module.css';
 import OrdersList from './orders-list';
 
@@ -26,6 +26,8 @@ const ORDERS_PATH = '/build-plans/orders';
  * TODO on `/build-plans` does not apply here.
  */
 export async function generateMetadata(): Promise<Metadata> {
+  if (!(await isCncPacksEnabled())) return CNC_FLAG_OFF_METADATA;
+
   const { t, locale } = await getServerTranslation('cnc');
   return createNoIndexMetadata({
     title: t('metadata.orders.title'),

--- a/packages/web/app/build-plans/page.tsx
+++ b/packages/web/app/build-plans/page.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import type { Metadata } from 'next';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import I18nProvider from '@/app/components/providers/i18n-provider';
+import BuildPlansContent from './build-plans-content';
+import Configurator from './configurator/configurator';
+import { fetchCncCatalog, requireCncPacksFlag } from './build-plans-page';
+import styles from './build-plans.module.css';
+
+/**
+ * `noindex, follow` while `cnc-packs` is flagged off.
+ *
+ * TODO(launch): swap `createNoIndexMetadata` for `createPageMetadata` and add
+ * `/build-plans` to a sitemap shard when the flag reaches 100% — this is a
+ * search surface (people look for "kilter homewall plans"), and it is only
+ * kept out of the index because the manufacturing licence still ships marked
+ * DRAFT pending the Australian IP review. Note the gate is BOTH: the page also
+ * 404s while the flag is off, because noindex alone would leave a publicly
+ * reachable shop.
+ */
+export async function generateMetadata(): Promise<Metadata> {
+  const { t, locale } = await getServerTranslation('cnc');
+  return createNoIndexMetadata({
+    title: t('metadata.buildPlans.title'),
+    description: t('metadata.buildPlans.description'),
+    path: '/build-plans',
+    locale,
+  });
+}
+
+export default async function BuildPlansPage() {
+  await requireCncPacksFlag();
+
+  const { t, locale } = await getServerTranslation('cnc');
+  const catalog = await fetchCncCatalog();
+
+  return (
+    <I18nProvider locale={locale} namespaces={['common', 'cnc']}>
+      <Box component="main" className={styles.page}>
+        <BuildPlansContent catalog={catalog} locale={locale} />
+        {catalog && catalog.entries.length > 0 ? (
+          <Configurator catalog={catalog} locale={locale} />
+        ) : (
+          // The hero above is fully server-rendered and still tells the story;
+          // only the part that needs live prices is missing, so say that rather
+          // than replacing the whole page with an error.
+          <Alert severity="warning" sx={{ mt: 4 }}>
+            {t('errors.CNC_WORKER_UNAVAILABLE')}
+          </Alert>
+        )}
+      </Box>
+    </I18nProvider>
+  );
+}

--- a/packages/web/app/build-plans/page.tsx
+++ b/packages/web/app/build-plans/page.tsx
@@ -7,7 +7,7 @@ import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
 import I18nProvider from '@/app/components/providers/i18n-provider';
 import BuildPlansContent from './build-plans-content';
 import Configurator from './configurator/configurator';
-import { fetchCncCatalog, requireCncPacksFlag } from './build-plans-page';
+import { CNC_FLAG_OFF_METADATA, fetchCncCatalog, isCncPacksEnabled, requireCncPacksFlag } from './build-plans-page';
 import styles from './build-plans.module.css';
 
 /**
@@ -22,6 +22,10 @@ import styles from './build-plans.module.css';
  * reachable shop.
  */
 export async function generateMetadata(): Promise<Metadata> {
+  // Same gate as the page body, via the same helper. While the flag is off the
+  // route 404s, so its metadata says nothing about what lives here.
+  if (!(await isCncPacksEnabled())) return CNC_FLAG_OFF_METADATA;
+
   const { t, locale } = await getServerTranslation('cnc');
   return createNoIndexMetadata({
     title: t('metadata.buildPlans.title'),

--- a/packages/web/app/components/providers/__tests__/session-cache-buster.test.tsx
+++ b/packages/web/app/components/providers/__tests__/session-cache-buster.test.tsx
@@ -5,7 +5,11 @@ import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
 import { render } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { Persister } from '@tanstack/react-query-persist-client';
+import { CNC_CONFIGURATOR_DRAFT_KEY } from '@/app/build-plans/configurator/configurator-state';
 import { SessionCacheBuster } from '../query-client-provider';
+
+const removePreference = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/user-preferences-db', () => ({ removePreference }));
 
 function makeFakePersister(): Persister & { removeClient: ReturnType<typeof vi.fn> } {
   return {
@@ -35,6 +39,7 @@ function setup() {
 describe('SessionCacheBuster', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    removePreference.mockReset();
   });
 
   it('does not wipe on the first effect (initial mount, authenticated)', () => {
@@ -105,6 +110,45 @@ describe('SessionCacheBuster', () => {
 
     expect(persister.removeClient).toHaveBeenCalledTimes(1);
     expect(removeQueriesSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the build-plans draft on sign-out (user → null)', () => {
+    const { persister, queryClient, renderWith } = setup();
+    const view = renderWith('user-1');
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <SessionCacheBuster persister={persister} sessionUserId={null} />
+      </QueryClientProvider>,
+    );
+
+    // A build-plans draft (a buyer's name and email) sits outside the React
+    // Query cache, but it is still per-user state that must not survive into
+    // the next signed-out visitor sharing this browser.
+    expect(removePreference).toHaveBeenCalledWith(CNC_CONFIGURATOR_DRAFT_KEY);
+  });
+
+  it('clears the build-plans draft on account switch (user A → user B)', () => {
+    const { persister, queryClient, renderWith } = setup();
+    const view = renderWith('user-1');
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <SessionCacheBuster persister={persister} sessionUserId="user-2" />
+      </QueryClientProvider>,
+    );
+
+    expect(removePreference).toHaveBeenCalledWith(CNC_CONFIGURATOR_DRAFT_KEY);
+  });
+
+  it('does not touch the draft on a non-transition (first mount, same user)', () => {
+    const { persister, queryClient, renderWith } = setup();
+    const view = renderWith('user-1');
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <SessionCacheBuster persister={persister} sessionUserId="user-1" />
+      </QueryClientProvider>,
+    );
+
+    expect(removePreference).not.toHaveBeenCalled();
   });
 
   it('removeQueries predicate only matches queries flagged with meta.persist', () => {

--- a/packages/web/app/components/providers/query-client-provider.tsx
+++ b/packages/web/app/components/providers/query-client-provider.tsx
@@ -4,7 +4,9 @@ import React, { type ReactNode, useEffect, useMemo, useRef, useState } from 'rea
 import { QueryClient, type Query, useQueryClient } from '@tanstack/react-query';
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
 import { useSession } from 'next-auth/react';
+import { CNC_CONFIGURATOR_DRAFT_KEY } from '@/app/build-plans/configurator/configurator-state';
 import { createIdbPersister, PERSIST_MAX_AGE_MS } from '@/app/lib/react-query-idb-persister';
+import { removePreference } from '@/app/lib/user-preferences-db';
 
 type QueryClientProviderProps = {
   children: ReactNode;
@@ -87,6 +89,12 @@ export function SessionCacheBuster({ persister, sessionUserId }: SessionCacheBus
     Promise.resolve(persister.removeClient()).catch((error: unknown) => {
       console.error('Failed to clear persisted react-query cache on session change:', error);
     });
+    // The in-progress build-plans draft (a buyer's name and email) lives in
+    // IndexedDB outside the React Query cache, but it is exactly the same kind
+    // of per-user state: it must not survive into the next signed-out visitor
+    // or the next account on this browser. `removePreference` swallows its own
+    // errors, so this is fire-and-forget like the persister wipe above.
+    void removePreference(CNC_CONFIGURATOR_DRAFT_KEY);
   }, [queryClient, persister, sessionUserId]);
 
   return null;

--- a/packages/web/app/components/providers/site-chrome.tsx
+++ b/packages/web/app/components/providers/site-chrome.tsx
@@ -27,14 +27,25 @@ import SiteFooter from '../site-chrome/site-footer';
  * `app/layout.tsx` — it was never inside the old wrapper, and moving it under
  * `FeatureFlagsProvider` would reorder providers for no gain.
  */
-export default function SiteChrome({ children }: { children: React.ReactNode }) {
+export default function SiteChrome({
+  children,
+  showBuildPlans = false,
+}: {
+  children: React.ReactNode;
+  /**
+   * Server-resolved `cnc-packs` gate, passed straight through to SiteFooter.
+   * SiteChrome itself is a client component and must not resolve it — see the
+   * note at the call site in app/layout.tsx.
+   */
+  showBuildPlans?: boolean;
+}) {
   return (
     <StatsFilterBridgeProvider>
       <ProfileHeaderShareProvider>
         <PlaylistsAdapterProvider>
           <MarketingHeader />
           {children}
-          <SiteFooter />
+          <SiteFooter showBuildPlans={showBuildPlans} />
         </PlaylistsAdapterProvider>
       </ProfileHeaderShareProvider>
     </StatsFilterBridgeProvider>

--- a/packages/web/app/components/site-chrome/site-footer.tsx
+++ b/packages/web/app/components/site-chrome/site-footer.tsx
@@ -49,7 +49,7 @@ const GROUP_HEADING_SX = {
  * and it re-hosts the locale switcher that used to live in the user drawer —
  * without it a four-locale site would have no way to change language.
  */
-export default function SiteFooter() {
+export default function SiteFooter({ showBuildPlans = false }: { showBuildPlans?: boolean }) {
   const { t } = useTranslation('common');
   const pathname = usePathnameWithoutLocale();
 
@@ -86,6 +86,10 @@ export default function SiteFooter() {
         { href: '/playlists', label: t('footer.links.playlists') },
         { href: '/aurora-migration', label: t('footer.links.auroraMigration') },
         { href: '/docs', label: t('footer.links.docs') },
+        // The only crawl path into /build-plans, and it appears only when the
+        // `cnc-packs` flag is on — while it is off the route 404s, and a footer
+        // link to a 404 on every page of the site is a real SEO liability.
+        ...(showBuildPlans ? [{ href: '/build-plans', label: t('footer.links.buildPlans') }] : []),
       ],
     },
     {

--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -32,9 +32,23 @@ export const MOONBOARD_WIDE_ANGLES_FLAG = 'moonboard-wide-angles';
 // PostHog feature flag; values stay `undefined` (OFF) until that flag resolves.
 export const FEATURE_FLAG_KEYS = [BOARDSESH_GRADE_FLAG, GYM_KIOSK_FLAG, MOONBOARD_WIDE_ANGLES_FLAG] as const;
 
+// Gates `/build-plans` — the paid CNC build-pack configurator, the orders
+// pages, and the footer link into them. Server-resolved rather than client,
+// because this gate has to make an unreachable surface 404 rather than hide a
+// button: the manufacturing licence ships marked DRAFT until an Australian IP
+// lawyer has reviewed it and the Kilter-derived engrave layer, so the pages
+// must not be reachable — or indexable — before then.
+//
+// Resolved with `allowAnonymous: true`. Build plans are bought by people who
+// have never signed in, so a gate that only evaluates for a session would keep
+// the page signed-in-only however the dashboard is configured.
+// `FEATURE_FLAG_OVERRIDES=cnc-packs` is how you reach it locally.
+export const CNC_PACKS_FLAG = 'cnc-packs';
+
 // Keys resolved server-side by `getServerFeatureFlag`, which gate whether a
-// route renders at all. Empty since `/gyms` launched unconditionally; the
-// machinery stays because that is a different gate from the client keys above
-// (see docs/feature-flags.md). Deliberately kept out of FEATURE_FLAG_KEYS: the
-// browser provider would fetch a flag no client component reads.
-export const SERVER_FEATURE_FLAG_KEYS = [] as const;
+// route renders at all. `/gyms` launched unconditionally and emptied this list;
+// `/build-plans` is its current occupant. That is a different gate from the
+// client keys above (see docs/feature-flags.md), and these keys are
+// deliberately kept out of FEATURE_FLAG_KEYS: the browser provider would fetch
+// a flag no client component reads.
+export const SERVER_FEATURE_FLAG_KEYS = [CNC_PACKS_FLAG] as const;

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -10,9 +10,10 @@ import SiteChrome from './components/providers/site-chrome';
 import { SnackbarProvider } from './components/providers/snackbar-provider';
 import { AuthModalProvider } from './components/providers/auth-modal-provider';
 import I18nProvider from './components/providers/i18n-provider';
-import { EMPTY_FEATURE_FLAGS } from './flags';
+import { CNC_PACKS_FLAG, EMPTY_FEATURE_FLAGS } from './flags';
 import { FeatureFlagsProvider } from './components/providers/feature-flags-provider';
 import CapacitorRetirementGate from './components/capacitor-retirement/capacitor-retirement-gate';
+import { getServerFeatureFlag } from './lib/feature-flags/server-feature-flag';
 import { getLocale } from './lib/i18n/get-locale';
 import { getServerTranslation } from './lib/i18n/server';
 import { LOCALE_HTML_LANG, LOCALE_OG } from './lib/i18n/config';
@@ -63,6 +64,21 @@ export const viewport: Viewport = {
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const locale = await getLocale();
+  // Whether the footer offers a way into /build-plans. Resolved on the server
+  // because SiteFooter renders in the first paint of every page and a link that
+  // pops in after the browser resolves a flag is worse than no link.
+  //
+  // `distinctId: null` with `allowAnonymous: true`, NOT the signed-in person's
+  // id, and that is a deliberate trade: `getPosthogDistinctId` reads the
+  // next-auth session, and doing that in the ROOT layout would put a session
+  // decode in front of every render of every page on the site for one footer
+  // link. The anonymous bucket is a single shared distinct id, so this is one
+  // cached answer for everyone — right for a percentage rollout, and it means a
+  // rollout targeted at one PERSON hides the footer link from them while
+  // /build-plans itself still opens. The page's own gate resolves the real
+  // distinct id (see build-plans-page.ts) and is what actually decides
+  // reachability.
+  const showBuildPlans = await getServerFeatureFlag(CNC_PACKS_FLAG, { distinctId: null, allowAnonymous: true });
 
   return (
     <html lang={LOCALE_HTML_LANG[locale]} data-theme="dark" suppressHydrationWarning>
@@ -110,7 +126,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                     <CapacitorRetirementGate>
                       <AuthModalProvider>
                         <FeatureFlagsProvider flags={EMPTY_FEATURE_FLAGS}>
-                          <SiteChrome>{children}</SiteChrome>
+                          <SiteChrome showBuildPlans={showBuildPlans}>{children}</SiteChrome>
                         </FeatureFlagsProvider>
                       </AuthModalProvider>
                     </CapacitorRetirementGate>

--- a/packages/web/app/lib/cnc-funnel-analytics.ts
+++ b/packages/web/app/lib/cnc-funnel-analytics.ts
@@ -1,0 +1,23 @@
+import type { AnalyticsPropertyValue, CncFunnelEventName } from '@boardsesh/analytics';
+import { track } from './analytics';
+
+/**
+ * The one bridge between the CNC build-pack funnel contract
+ * (`@boardsesh/analytics`'s `cnc-funnel` module) and web's `track()`.
+ *
+ * Mirrors `trackGymFunnelEvent` exactly, and for the same reason: the contract's
+ * builders return the name and its properties TOGETHER, and this signature is
+ * what keeps them together all the way to the wire. A call site physically
+ * cannot pair one event's props with another event's name.
+ *
+ * Flat file, not `app/lib/analytics/cnc-funnel.ts`: `app/lib/analytics.ts`
+ * already exists, and a sibling `app/lib/analytics/` directory would make the
+ * `@/app/lib/analytics` specifier resolve to whichever of the two the bundler
+ * picked first.
+ */
+export function trackCncFunnelEvent(event: {
+  name: CncFunnelEventName;
+  properties: Record<string, AnalyticsPropertyValue>;
+}): void {
+  track(event.name, event.properties);
+}


### PR DESCRIPTION
## Summary

Build plans (CNC packs) slice 5 of 10: the web surface. Stacked on #5168. Everything is behind the `cnc-packs` server flag (fail-closed, `noindex` while flagged), so nothing is reachable in prod until the flag is turned on.

- `/build-plans`: server-rendered hero and tiers (AUD prices from the catalog) plus the client configurator: board, size, kicker, manufacturing options (rendered from the catalog, `kickerOnly` options hidden on kickerless walls), engrave toggles, a live summary from `cncLayout` (wall dims, panels, sheets, T-nut and LED counts), licensee form, tier, licence acceptance, Buy. Signed-out buyers go through the existing sign-in flow and come back to a draft kept in IndexedDB.
- `/build-plans/orders` and `/build-plans/orders/[licenceId]`: the buyer's packs, a status timeline that polls every 5 s while queued or generating, download via a short-lived grant, and the checkout success/cancel states.
- New `cnc` i18n namespace in all four locales; footer link behind the flag; `cnc-funnel` analytics contract (page viewed, configurator changed, checkout started) mirroring the gym funnel module.

Artwork step and the placement editor are slices 7-9; the licence page is slice 6.

Translation calls worth a native read: kicker as es `repisa`, de `Fußleiste`, fr `kicker`; set screw as fr `vis de blocage`.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 3/5 — new screens behind a server flag; no existing page changes except a flag-gated footer link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBHWJfrtZ29m47uCvX5yQC
