### PR TITLE
fix(backend): keep a GitHub outage from swallowing a QA verdict

### DIFF
--- a/docs/crowdsourced-qa.md
+++ b/docs/crowdsourced-qa.md
@@ -281,17 +281,22 @@ Every backend log line for this feature is tagged `[qa]`.
 
 - **Every GitHub write stopped at once.** Almost always the App key: expired, revoked, or the App
   uninstalled from the repo. `[github-app] could not mint an installation token` names the cause —
-  a 401 means the key is wrong, and a 404 on `/repos/.../installation` is reported as its own
-  sentence, because it is never a missing repo: the JWT was accepted, so the App simply has no
-  installation that can see the repo. Fix it under the App's **Install App** page, or add the repo
-  to the installation's **Repository access** when it is set to "Only select repositories".
+  a 401 means the key is wrong, and a 404 on `/repos/.../installation` gets its own sentence naming
+  the two things it can be, because GitHub answers the same 404 for each. Either the App cannot see
+  the repo (fix under the App's **Install App** page, or add the repo to the installation's
+  **Repository access** when it is set to "Only select repositories"), or the repo path itself is
+  wrong — renamed, deleted, or a typo in `QA_GITHUB_REPO` / `FEEDBACK_GITHUB_REPO`. The message
+  prints the slug it asked for, so check that against the repo before touching App settings.
   The installation id is re-looked-up after any failure, so a reinstall recovers without a restart,
   and a failed mint is negative-cached for 30s so a broken key backs off rather than spending a
   round trip per write. Expect recovery within a minute of fixing the config, not instantly.
 - **A verdict has no head SHA.** `SELECT * FROM qa_verdicts WHERE head_sha IS NULL` — GitHub could
-  not be read at all when it was filed, so nothing verified which revision the tester ran. The
-  verdict still counts: refusing it would strand the tester on the preview, since the sheet they
-  file from is also the one that surfs them back to production. Read those rows against
+  not be read at all when it was filed, so nothing verified which revision the tester ran, or that
+  `pr_number` names an open pull request at all. The verdict still counts: refusing it would strand
+  the tester on the preview, since the sheet they file from is also the one that surfs them back to
+  production. These rows are **never mirrored** — `pr_number` came from the client and unverified,
+  and the comment API answers for any number while `qa-approved` gates a merge, so the mirror would
+  be writing blind. Confirm the PR by hand before replaying one, and read it against
   `bundle_created_at` rather than against the PR head.
 - **Testers see an empty list.** `[qa] open pull request lookup failed` means GitHub said no —
   usually the anonymous 60/hr ceiling on a deploy with no token. It self-heals in 30 seconds once

--- a/docs/crowdsourced-qa.md
+++ b/docs/crowdsourced-qa.md
@@ -280,11 +280,19 @@ Every backend log line for this feature is tagged `[qa]`.
   replayed by hand from the table.
 
 - **Every GitHub write stopped at once.** Almost always the App key: expired, revoked, or the App
-  uninstalled from the repo. `[github-app] could not mint an installation token` names the status —
-  a 404 on `/repos/.../installation` means the App is not installed, a 401 means the key is wrong.
+  uninstalled from the repo. `[github-app] could not mint an installation token` names the cause —
+  a 401 means the key is wrong, and a 404 on `/repos/.../installation` is reported as its own
+  sentence, because it is never a missing repo: the JWT was accepted, so the App simply has no
+  installation that can see the repo. Fix it under the App's **Install App** page, or add the repo
+  to the installation's **Repository access** when it is set to "Only select repositories".
   The installation id is re-looked-up after any failure, so a reinstall recovers without a restart,
   and a failed mint is negative-cached for 30s so a broken key backs off rather than spending a
   round trip per write. Expect recovery within a minute of fixing the config, not instantly.
+- **A verdict has no head SHA.** `SELECT * FROM qa_verdicts WHERE head_sha IS NULL` — GitHub could
+  not be read at all when it was filed, so nothing verified which revision the tester ran. The
+  verdict still counts: refusing it would strand the tester on the preview, since the sheet they
+  file from is also the one that surfs them back to production. Read those rows against
+  `bundle_created_at` rather than against the PR head.
 - **Testers see an empty list.** `[qa] open pull request lookup failed` means GitHub said no —
   usually the anonymous 60/hr ceiling on a deploy with no token. It self-heals in 30 seconds once
   GitHub answers.

--- a/packages/backend/src/graphql/resolvers/qa/__tests__/qa-verdicts.test.ts
+++ b/packages/backend/src/graphql/resolvers/qa/__tests__/qa-verdicts.test.ts
@@ -427,22 +427,22 @@ describe('submitQaVerdict', () => {
     expect(getHeadCommitDateMock).not.toHaveBeenCalled();
   });
 
-  it('still mirrors a verdict filed while GitHub was unreachable', async () => {
-    // The mirror runs after the row lands and may find GitHub healthy again;
-    // with no head SHA there is no revision to tally, so it reports nobody
-    // else rather than pooling verdicts from commits that may differ.
+  it('never mirrors a verdict GitHub never confirmed a PR for', async () => {
+    // `prNumber` is client-supplied and both reads failed, so it need not be an
+    // open PR — or a PR at all. The comment goes through the issues API, which
+    // answers for any number, and `qa-approved` gates a merge on a public repo,
+    // so the mirror must not fire on GitHub recovering between read and write.
     getPullRequestMock.mockResolvedValue({ status: 'unavailable' });
     readOpenPullRequestsMock.mockResolvedValue({ pullRequests: [], failed: true });
-    postVerdictCommentMock.mockResolvedValue({ id: 771, htmlUrl: 'https://github.com/c/771' });
 
     const verdict = await qaMutations.submitQaVerdict(null, { input: validInput() }, authCtx(TESTER));
-    await vi.waitFor(async () => {
-      expect(Number((await readVerdictRow(verdict.id)).github_comment_id)).toBe(771);
-    });
-    // The comment says the revision is unknown rather than quietly omitting the
-    // row: a reader comparing this verdict against the PR head has to see that
-    // nothing tied it to one.
-    expect(postVerdictCommentMock.mock.calls[0]?.[1]).toContain('| Head SHA at verdict | unknown |');
+
+    // Nothing to wait on, so give the fire-and-forget block a turn to prove it
+    // stays quiet rather than asserting before it could have run.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(postVerdictCommentMock).not.toHaveBeenCalled();
+    expect(applyQaLabelMock).not.toHaveBeenCalled();
+    expect((await readVerdictRow(verdict.id)).github_comment_id).toBeNull();
   });
 
   it('still says "not open" when the repo really has no open pull requests', async () => {

--- a/packages/backend/src/graphql/resolvers/qa/__tests__/qa-verdicts.test.ts
+++ b/packages/backend/src/graphql/resolvers/qa/__tests__/qa-verdicts.test.ts
@@ -412,11 +412,8 @@ describe('submitQaVerdict', () => {
   });
 
   it('records the verdict without a head SHA when GitHub cannot be reached at all', async () => {
-    // The row is the record and GitHub is the mirror, so an uninstalled App or
-    // a spent anonymous rate limit must not be able to refuse a verdict: the
-    // sheet a tester files it from is the one that takes them back off the
-    // preview, and rejecting the write left them stuck on the PR they were
-    // testing. A null head SHA is the runbook's "revision never verified".
+    // The row is the record and GitHub only the mirror, so an unreachable
+    // GitHub cannot refuse a verdict. Null head SHA = "revision never verified".
     getPullRequestMock.mockResolvedValue({ status: 'unavailable' });
     readOpenPullRequestsMock.mockResolvedValue({ pullRequests: [], failed: true });
 
@@ -429,17 +426,14 @@ describe('submitQaVerdict', () => {
   });
 
   it('never mirrors a verdict GitHub never confirmed a PR for', async () => {
-    // `prNumber` is client-supplied and both reads failed, so it need not be an
-    // open PR — or a PR at all. The comment goes through the issues API, which
-    // answers for any number, and `qa-approved` gates a merge on a public repo,
-    // so the mirror must not fire on GitHub recovering between read and write.
+    // With both reads failed, `prNumber` is unverified client input. The comment
+    // API answers for any number and `qa-approved` gates a merge on a public
+    // repo, so GitHub recovering mid-request must not let the mirror fire.
     getPullRequestMock.mockResolvedValue({ status: 'unavailable' });
     readOpenPullRequestsMock.mockResolvedValue({ pullRequests: [], failed: true });
 
-    // Anchored on the skip being logged, not on a timer. A bare sleep would not
-    // flake here — the mocks are never called either way — it would pass
-    // VACUOUSLY whenever the fire-and-forget block had not run yet, which is
-    // the one failure a negative assertion has to rule out.
+    // Anchored on the skip log, not a timer: a sleep here never flakes, it
+    // passes vacuously whenever the fire-and-forget block has not run yet.
     const warn = vi.spyOn(logger, 'warn');
     try {
       const verdict = await qaMutations.submitQaVerdict(null, { input: validInput() }, authCtx(TESTER));

--- a/packages/backend/src/graphql/resolvers/qa/__tests__/qa-verdicts.test.ts
+++ b/packages/backend/src/graphql/resolvers/qa/__tests__/qa-verdicts.test.ts
@@ -410,13 +410,39 @@ describe('submitQaVerdict', () => {
     expect(verdict.headSha).toBe('cachedsha000000');
   });
 
-  it('says GitHub is unreachable instead of claiming the PR is closed', async () => {
+  it('records the verdict without a head SHA when GitHub cannot be reached at all', async () => {
+    // The row is the record and GitHub is the mirror, so an uninstalled App or
+    // a spent anonymous rate limit must not be able to refuse a verdict: the
+    // sheet a tester files it from is the one that takes them back off the
+    // preview, and rejecting the write left them stuck on the PR they were
+    // testing. A null head SHA is the runbook's "revision never verified".
     getPullRequestMock.mockResolvedValue({ status: 'unavailable' });
     readOpenPullRequestsMock.mockResolvedValue({ pullRequests: [], failed: true });
 
-    await expect(qaMutations.submitQaVerdict(null, { input: validInput() }, authCtx(TESTER))).rejects.toThrow(
-      'Could not reach GitHub to verify the pull request',
-    );
+    const verdict = await qaMutations.submitQaVerdict(null, { input: validInput() }, authCtx(TESTER));
+
+    expect(verdict.headSha).toBeNull();
+    expect((await readVerdictRow(verdict.id)).head_sha).toBeNull();
+    // Nothing to look up, so no GitHub call is spent asking.
+    expect(getHeadCommitDateMock).not.toHaveBeenCalled();
+  });
+
+  it('still mirrors a verdict filed while GitHub was unreachable', async () => {
+    // The mirror runs after the row lands and may find GitHub healthy again;
+    // with no head SHA there is no revision to tally, so it reports nobody
+    // else rather than pooling verdicts from commits that may differ.
+    getPullRequestMock.mockResolvedValue({ status: 'unavailable' });
+    readOpenPullRequestsMock.mockResolvedValue({ pullRequests: [], failed: true });
+    postVerdictCommentMock.mockResolvedValue({ id: 771, htmlUrl: 'https://github.com/c/771' });
+
+    const verdict = await qaMutations.submitQaVerdict(null, { input: validInput() }, authCtx(TESTER));
+    await vi.waitFor(async () => {
+      expect(Number((await readVerdictRow(verdict.id)).github_comment_id)).toBe(771);
+    });
+    // The comment says the revision is unknown rather than quietly omitting the
+    // row: a reader comparing this verdict against the PR head has to see that
+    // nothing tied it to one.
+    expect(postVerdictCommentMock.mock.calls[0]?.[1]).toContain('| Head SHA at verdict | unknown |');
   });
 
   it('still says "not open" when the repo really has no open pull requests', async () => {

--- a/packages/backend/src/graphql/resolvers/qa/__tests__/qa-verdicts.test.ts
+++ b/packages/backend/src/graphql/resolvers/qa/__tests__/qa-verdicts.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, beforeEach, vi } from 'vite-plus/test';
 import { sql } from 'drizzle-orm';
 import { QA_PREVIEWS_MAX_PR_NUMBERS, type ConnectionContext } from '@boardsesh/shared-schema';
 import type { QaPullRequest } from '../../../../services/github-qa';
+import { logger } from '../../../../utils/logger';
 
 const {
   readOpenPullRequestsMock,
@@ -435,14 +436,23 @@ describe('submitQaVerdict', () => {
     getPullRequestMock.mockResolvedValue({ status: 'unavailable' });
     readOpenPullRequestsMock.mockResolvedValue({ pullRequests: [], failed: true });
 
-    const verdict = await qaMutations.submitQaVerdict(null, { input: validInput() }, authCtx(TESTER));
+    // Anchored on the skip being logged, not on a timer. A bare sleep would not
+    // flake here — the mocks are never called either way — it would pass
+    // VACUOUSLY whenever the fire-and-forget block had not run yet, which is
+    // the one failure a negative assertion has to rule out.
+    const warn = vi.spyOn(logger, 'warn');
+    try {
+      const verdict = await qaMutations.submitQaVerdict(null, { input: validInput() }, authCtx(TESTER));
 
-    // Nothing to wait on, so give the fire-and-forget block a turn to prove it
-    // stays quiet rather than asserting before it could have run.
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(postVerdictCommentMock).not.toHaveBeenCalled();
-    expect(applyQaLabelMock).not.toHaveBeenCalled();
-    expect((await readVerdictRow(verdict.id)).github_comment_id).toBeNull();
+      await vi.waitFor(() => {
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('recorded but not mirrored'));
+      });
+      expect(postVerdictCommentMock).not.toHaveBeenCalled();
+      expect(applyQaLabelMock).not.toHaveBeenCalled();
+      expect((await readVerdictRow(verdict.id)).github_comment_id).toBeNull();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('still says "not open" when the repo really has no open pull requests', async () => {

--- a/packages/backend/src/graphql/resolvers/qa/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/qa/mutations.ts
@@ -145,28 +145,41 @@ export const qaMutations = {
 
     if (!row) throw new Error('Could not record the verdict');
 
+    // Captured as a const so the null check below narrows inside the closure,
+    // which a reassignable `let` would not.
+    const verifiedPullRequest = pullRequest;
+
     // Fire-and-forget mirror to GitHub. Failures are logged under `[qa]` and
     // never surface to the caller; the row stands either way, and a row with
     // github_comment_id IS NULL is the "not mirrored" signal for the runbook.
     void (async () => {
+      // Nothing GitHub told us backs this row: `prNumber` came from the client
+      // and both reads failed, so it need not be an open pull request, or a
+      // pull request at all. The row is harmless — it is ours, and `head_sha
+      // IS NULL` marks it unverified — but the mirror is not: the comment goes
+      // through the issues API, which answers for any number, and `qa-approved`
+      // gates a merge on a public repo. Recover it by hand from the runbook
+      // rather than write it blind if GitHub happens to be back by now.
+      if (verifiedPullRequest === null) {
+        logger.warn(
+          `[qa] verdict ${row.id} on #${row.prNumber} is recorded but not mirrored: ` +
+            'GitHub never confirmed the pull request is open',
+        );
+        return;
+      }
       try {
-        // What everyone else found on THIS revision. A row with no head SHA has
-        // no revision to compare against, so it reports nobody rather than
-        // pooling verdicts filed against commits that may not be the same one.
-        const tally =
-          row.headSha === null
-            ? []
-            : await db
-                .select({ verdict: dbSchema.qaVerdicts.verdict, total: count() })
-                .from(dbSchema.qaVerdicts)
-                .where(
-                  and(
-                    eq(dbSchema.qaVerdicts.prNumber, row.prNumber),
-                    eq(dbSchema.qaVerdicts.headSha, row.headSha),
-                    ne(dbSchema.qaVerdicts.id, row.id),
-                  ),
-                )
-                .groupBy(dbSchema.qaVerdicts.verdict);
+        // What everyone else found on THIS revision.
+        const tally = await db
+          .select({ verdict: dbSchema.qaVerdicts.verdict, total: count() })
+          .from(dbSchema.qaVerdicts)
+          .where(
+            and(
+              eq(dbSchema.qaVerdicts.prNumber, row.prNumber),
+              eq(dbSchema.qaVerdicts.headSha, verifiedPullRequest.headSha),
+              ne(dbSchema.qaVerdicts.id, row.id),
+            ),
+          )
+          .groupBy(dbSchema.qaVerdicts.verdict);
         const totalFor = (kind: 'approved' | 'declined'): number =>
           tally.find((entry) => entry.verdict === kind)?.total ?? 0;
 

--- a/packages/backend/src/graphql/resolvers/qa/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/qa/mutations.ts
@@ -109,10 +109,11 @@ export const qaMutations = {
       if (!cached && !failed) {
         throw new Error('Pull request is not open');
       }
+      // Not logged here. This is the same event the mirror reports below, and
+      // that line carries the row id an operator needs to find it — two entries
+      // per verdict would only double the volume during the outage that
+      // produced them.
       pullRequest = cached ?? null;
-      if (!pullRequest) {
-        logger.warn(`[qa] recording the verdict on #${validated.prNumber} without a head SHA; GitHub is unreachable`);
-      }
     }
 
     const headCommittedAt = pullRequest === null ? null : toUtcTimestamp(await getHeadCommitDate(pullRequest.headSha));

--- a/packages/backend/src/graphql/resolvers/qa/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/qa/mutations.ts
@@ -83,28 +83,39 @@ export const qaMutations = {
       throw new Error('Pull request is not open');
     }
 
-    let pullRequest: QaPullRequest;
+    // Null when GitHub could not be read at all, which is a state to record a
+    // verdict in rather than one to refuse it in: the row is the record and
+    // GitHub is the mirror, so an uninstalled App or an exhausted anonymous
+    // rate limit must never leave a tester holding a finding they cannot file
+    // — the sheet they file it from is the one that surfs them back off the
+    // preview. `head_sha IS NULL` is what tells the runbook the revision behind
+    // such a verdict was never verified.
+    let pullRequest: QaPullRequest | null = null;
     if (fresh.status === 'open') {
       pullRequest = fresh.pullRequest;
     } else {
       // GitHub didn't answer the single-PR read. The cached list is a worse
       // answer than a fresh one but a much better one than losing the verdict,
-      // so fall back to it — and only give up when it has nothing either.
-      // `failed` is the reader's own flag, not a guess from an empty list: the
-      // first failure throws and the next 30 seconds are negative-cached as
-      // `[]`, and both must read the same way here.
+      // so fall back to it. `failed` is the reader's own flag, not a guess from
+      // an empty list: the first failure throws and the next 30 seconds are
+      // negative-cached as `[]`, and both must read the same way here.
       const { pullRequests: openPullRequests, failed } = await readOpenPullRequests();
-      if (failed) {
-        throw new Error('Could not reach GitHub to verify the pull request');
-      }
       const cached = openPullRequests.find((candidate) => candidate.number === validated.prNumber);
-      if (!cached) {
+      // Only a list GitHub actually answered is evidence about this PR. A
+      // healthy list without it means closed or gone, and a verdict there is
+      // one nobody can act on; a failed list means nothing at all, and reading
+      // it as a refusal is what turned a broken App installation into "you
+      // cannot leave the preview you are testing".
+      if (!cached && !failed) {
         throw new Error('Pull request is not open');
       }
-      pullRequest = cached;
+      pullRequest = cached ?? null;
+      if (!pullRequest) {
+        logger.warn(`[qa] recording the verdict on #${validated.prNumber} without a head SHA; GitHub is unreachable`);
+      }
     }
 
-    const headCommittedAt = toUtcTimestamp(await getHeadCommitDate(pullRequest.headSha));
+    const headCommittedAt = pullRequest === null ? null : toUtcTimestamp(await getHeadCommitDate(pullRequest.headSha));
     const bundleCreatedAt = toUtcTimestamp(validated.bundleCreatedAt);
 
     const [row] = await db
@@ -113,7 +124,7 @@ export const qaMutations = {
         userId: ctx.userId!,
         prNumber: validated.prNumber,
         branch: validated.branch,
-        headSha: pullRequest.headSha,
+        headSha: pullRequest?.headSha ?? null,
         headCommittedAt,
         verdict: validated.verdict,
         byTester,
@@ -139,17 +150,23 @@ export const qaMutations = {
     // github_comment_id IS NULL is the "not mirrored" signal for the runbook.
     void (async () => {
       try {
-        const tally = await db
-          .select({ verdict: dbSchema.qaVerdicts.verdict, total: count() })
-          .from(dbSchema.qaVerdicts)
-          .where(
-            and(
-              eq(dbSchema.qaVerdicts.prNumber, row.prNumber),
-              eq(dbSchema.qaVerdicts.headSha, pullRequest.headSha),
-              ne(dbSchema.qaVerdicts.id, row.id),
-            ),
-          )
-          .groupBy(dbSchema.qaVerdicts.verdict);
+        // What everyone else found on THIS revision. A row with no head SHA has
+        // no revision to compare against, so it reports nobody rather than
+        // pooling verdicts filed against commits that may not be the same one.
+        const tally =
+          row.headSha === null
+            ? []
+            : await db
+                .select({ verdict: dbSchema.qaVerdicts.verdict, total: count() })
+                .from(dbSchema.qaVerdicts)
+                .where(
+                  and(
+                    eq(dbSchema.qaVerdicts.prNumber, row.prNumber),
+                    eq(dbSchema.qaVerdicts.headSha, row.headSha),
+                    ne(dbSchema.qaVerdicts.id, row.id),
+                  ),
+                )
+                .groupBy(dbSchema.qaVerdicts.verdict);
         const totalFor = (kind: 'approved' | 'declined'): number =>
           tally.find((entry) => entry.verdict === kind)?.total ?? 0;
 

--- a/packages/backend/src/lib/__tests__/github-app-auth.test.ts
+++ b/packages/backend/src/lib/__tests__/github-app-auth.test.ts
@@ -17,6 +17,8 @@ vi.mock('../../utils/logger', () => ({
 }));
 
 const REPO = 'boardsesh/boardsesh';
+/** The App id every assertion here reads back out of the signed JWT or a log line. */
+const APP_ID = '4098323';
 const NOW = Date.parse('2026-09-05T12:00:00.000Z');
 
 const pkcs8 = generateKeyPairSync('rsa', {
@@ -61,7 +63,7 @@ function stubGitHub(options: { token?: string; expiresAt?: string; failOn?: 'ins
 
 beforeEach(() => {
   resetGithubAppAuthCache();
-  vi.stubEnv('FEEDBACK_GITHUB_APP_ID', '4098323');
+  vi.stubEnv('FEEDBACK_GITHUB_APP_ID', APP_ID);
   vi.stubEnv('FEEDBACK_GITHUB_APP_PRIVATE_KEY', pkcs8);
 });
 
@@ -150,7 +152,7 @@ describe('getInstallationAccessToken', () => {
 
     const claims = decodeJwt(jwt);
     const nowSeconds = Math.floor(NOW / 1000);
-    expect(claims.iss).toBe('4098323');
+    expect(claims.iss).toBe(APP_ID);
     // Back-dated, so GitHub's clock being slightly behind ours cannot reject it.
     expect(claims.iat).toBeLessThan(nowSeconds);
     // GitHub refuses anything claiming more than 10 minutes.
@@ -181,7 +183,7 @@ describe('getInstallationAccessToken', () => {
     // `currentDate`, because the JWT is stamped from the frozen NOW and the
     // claim check would otherwise fail against the wall clock.
     const { payload } = await jwtVerify(jwt, publicKey, { currentDate: new Date(NOW) });
-    expect(payload.iss).toBe('4098323');
+    expect(payload.iss).toBe(APP_ID);
   });
 
   it('converts a 4096-bit PKCS#1 key too', async () => {
@@ -283,7 +285,7 @@ describe('getInstallationAccessToken', () => {
     const thrown = (call as unknown[])[1];
     const message = thrown instanceof Error ? thrown.message : String(thrown);
     expect(message).toContain('boardsesh/boardsesh');
-    expect(message).toContain('4098323');
+    expect(message).toContain(APP_ID);
     // Both causes, because GitHub answers the same 404 for each: naming only
     // the installation would send an operator with a typo'd repo path to the
     // wrong settings page.

--- a/packages/backend/src/lib/__tests__/github-app-auth.test.ts
+++ b/packages/backend/src/lib/__tests__/github-app-auth.test.ts
@@ -282,8 +282,13 @@ describe('getInstallationAccessToken', () => {
     const [call] = vi.mocked(logger.error).mock.calls;
     const thrown = (call as unknown[])[1];
     const message = thrown instanceof Error ? thrown.message : String(thrown);
-    expect(message).toContain('is not installed on boardsesh/boardsesh');
+    expect(message).toContain('boardsesh/boardsesh');
     expect(message).toContain('4098323');
+    // Both causes, because GitHub answers the same 404 for each: naming only
+    // the installation would send an operator with a typo'd repo path to the
+    // wrong settings page.
+    expect(message).toContain('not installed');
+    expect(message).toContain('typo');
   });
 
   it('returns undefined when GitHub refuses the token mint', async () => {

--- a/packages/backend/src/lib/__tests__/github-app-auth.test.ts
+++ b/packages/backend/src/lib/__tests__/github-app-auth.test.ts
@@ -269,6 +269,23 @@ describe('getInstallationAccessToken', () => {
     await expect(getInstallationAccessToken(REPO, NOW)).resolves.toBeUndefined();
   });
 
+  it('logs what to actually do about a 404 on the installation lookup', async () => {
+    // `GitHub GET /repos/boardsesh/boardsesh/installation responded 404` reads
+    // as a missing repo, which is the one thing it cannot be — the JWT was
+    // accepted or GitHub would have said 401. Nobody can fix this from the
+    // deploy, so the line has to point at the App's installation settings.
+    stubGitHub({ failOn: 'installation' });
+    await getInstallationAccessToken(REPO, NOW);
+
+    // The message, not JSON.stringify over the call: an Error serialises to
+    // `{}` and the assertion would pass on any wording at all.
+    const [call] = vi.mocked(logger.error).mock.calls;
+    const thrown = (call as unknown[])[1];
+    const message = thrown instanceof Error ? thrown.message : String(thrown);
+    expect(message).toContain('is not installed on boardsesh/boardsesh');
+    expect(message).toContain('4098323');
+  });
+
   it('returns undefined when GitHub refuses the token mint', async () => {
     stubGitHub({ failOn: 'token' });
     await expect(getInstallationAccessToken(REPO, NOW)).resolves.toBeUndefined();

--- a/packages/backend/src/lib/github-app-auth.ts
+++ b/packages/backend/src/lib/github-app-auth.ts
@@ -197,6 +197,17 @@ async function signAppJwt(appId: string, privateKey: string, nowMs: number): Pro
     .sign(key);
 }
 
+/** A non-2xx from GitHub, carrying the status so a caller can read it back. */
+class GithubAppRequestError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'GithubAppRequestError';
+  }
+}
+
 async function githubAppRequest<T>(path: string, jwt: string, method: 'GET' | 'POST'): Promise<T> {
   const response = await fetch(`${GITHUB_API}${path}`, {
     method,
@@ -210,7 +221,7 @@ async function githubAppRequest<T>(path: string, jwt: string, method: 'GET' | 'P
   });
   if (!response.ok) {
     // The body is not logged: GitHub echoes the request in some error shapes.
-    throw new Error(`GitHub ${method} ${path} responded ${response.status}`);
+    throw new GithubAppRequestError(response.status, `GitHub ${method} ${path} responded ${response.status}`);
   }
   return (await response.json()) as T;
 }
@@ -219,12 +230,28 @@ async function githubAppRequest<T>(path: string, jwt: string, method: 'GET' | 'P
  * The App's installation on `owner/repo`. An App is installed once and the id
  * never changes, so this is looked up once per process.
  */
-async function getInstallationId(owner: string, name: string, jwt: string): Promise<number> {
+async function getInstallationId(owner: string, name: string, appId: string, jwt: string): Promise<number> {
   const slug = `${owner}/${name}`;
   const cached = installationIdsByRepo.get(slug);
   if (cached !== undefined) return cached;
 
-  const installation = await githubAppRequest<{ id?: number }>(`/repos/${slug}/installation`, jwt, 'GET');
+  const installation = await githubAppRequest<{ id?: number }>(`/repos/${slug}/installation`, jwt, 'GET').catch(
+    (error: unknown) => {
+      // A 404 here does not mean the repo is missing, and it is not a blip
+      // worth retrying: the JWT authenticated, or GitHub would have answered
+      // 401. It means this App has no installation that can see `slug` —
+      // never installed, since uninstalled, or installed with "Only select
+      // repositories" and this one not among them. No redeploy fixes any of
+      // those, so the log line has to name the thing that does.
+      if (error instanceof GithubAppRequestError && error.status === 404) {
+        throw new Error(
+          `the GitHub App (id ${appId}) is not installed on ${slug}, or its repository access excludes it — ` +
+            'install it on the repo, or add the repo under the installation\'s "Repository access"',
+        );
+      }
+      throw error;
+    },
+  );
   if (typeof installation.id !== 'number') {
     throw new Error(`GitHub returned no installation id for ${slug}`);
   }
@@ -252,7 +279,7 @@ async function mintInstallationToken(repo: string, nowMs: number): Promise<strin
 
   try {
     const jwt = await signAppJwt(credentials.appId, credentials.privateKey, nowMs);
-    const installationId = await getInstallationId(owner, name, jwt);
+    const installationId = await getInstallationId(owner, name, credentials.appId, jwt);
     const minted = await githubAppRequest<{ token?: string; expires_at?: string }>(
       `/app/installations/${installationId}/access_tokens`,
       jwt,
@@ -273,8 +300,9 @@ async function mintInstallationToken(repo: string, nowMs: number): Promise<strin
     });
     return minted.token;
   } catch (error) {
-    // A 404 here usually means the App is not installed on this repo rather
-    // than that the repo is missing — both look the same to us.
+    // The installation lookup turns its own 404 into a sentence naming the fix
+    // — nothing else here can tell "the App is not installed" from "the repo is
+    // gone", and the two need very different people to act.
     logger.error('[github-app] could not mint an installation token:', error);
     // Drop a stale installation id so a reinstall recovers without a restart.
     installationIdsByRepo.delete(repo);

--- a/packages/backend/src/lib/github-app-auth.ts
+++ b/packages/backend/src/lib/github-app-auth.ts
@@ -237,16 +237,20 @@ async function getInstallationId(owner: string, name: string, appId: string, jwt
 
   const installation = await githubAppRequest<{ id?: number }>(`/repos/${slug}/installation`, jwt, 'GET').catch(
     (error: unknown) => {
-      // A 404 here does not mean the repo is missing, and it is not a blip
-      // worth retrying: the JWT authenticated, or GitHub would have answered
-      // 401. It means this App has no installation that can see `slug` —
-      // never installed, since uninstalled, or installed with "Only select
-      // repositories" and this one not among them. No redeploy fixes any of
-      // those, so the log line has to name the thing that does.
+      // A 404 here is not a blip worth retrying — the JWT authenticated, or
+      // GitHub would have answered 401 — but it does not narrow to one cause.
+      // GitHub answers the same 404 whether the App cannot see `slug` (never
+      // installed, since uninstalled, or installed with "Only select
+      // repositories" and this one left out) or `slug` is not a repo at all,
+      // which a renamed or deleted repo and a typo in the configured path all
+      // produce. Both need an operator rather than a redeploy, and naming only
+      // the first sends them to the wrong page, so say both and print the slug
+      // that was asked for.
       if (error instanceof GithubAppRequestError && error.status === 404) {
         throw new Error(
-          `the GitHub App (id ${appId}) is not installed on ${slug}, or its repository access excludes it — ` +
-            'install it on the repo, or add the repo under the installation\'s "Repository access"',
+          `no installation of GitHub App ${appId} can see ${slug}: either the App is not installed there ` +
+            '(install it, or add the repo under the installation\'s "Repository access"), or that repo path ' +
+            'is wrong — renamed, deleted, or a typo in the configured repo. GitHub answers 404 for both.',
         );
       }
       throw error;


### PR DESCRIPTION
## Summary

Production is throwing `GitHub GET /repos/boardsesh/boardsesh/installation responded 404` on every mint of the Feedback Bot's installation token, which knocks every GitHub read in the backend down to the anonymous 60/hr-per-IP ceiling. That ceiling is shared by the whole Railway replica and `qaPreviews` spends it fast (one commit lookup per open PR on a cold cache), so `readOpenPullRequests` starts failing — and `submitQaVerdict` threw `Could not reach GitHub to verify the pull request` rather than recording anything.

The verdict sheet is also the screen that surfs a tester back to production, so a rejected verdict left them sitting on the preview they were testing with the toast telling them to try again.

That refusal is backwards against how the rest of the feature is written: the `qa_verdicts` row is the record, the PR comment and label are a best-effort mirror. So:

- A list GitHub actually answered stays evidence — a PR missing from a healthy list is closed or gone, and still gets refused.
- A *failed* read says nothing about the PR, so the verdict lands with `head_sha` NULL, which is already the runbook's "revision never verified" signal.
- **The mirror does not run for those rows.** `prNumber` came from the client and nothing confirmed it, so the fire-and-forget block returns early and logs the row id. The row is harmless — it is ours — but the writes are not: the comment goes through the issues API, which answers for any number, and `qa-approved` gates a merge on a public repo. Replay one by hand from the runbook after confirming the PR.

Second half is diagnosis. `GitHub GET /repos/.../installation responded 404` is not narrowed to one cause: GitHub answers the same 404 whether the App cannot see the repo or the repo path is not a repo at all — renamed, deleted, or a typo in the configured value, which comes from the environment. The log line now names both remediations and prints the slug it asked for.

**This PR does not fix the 404 itself** — that is a GitHub-side action: install the App on `boardsesh/boardsesh` (or add the repo under the installation's **Repository access**), or correct `QA_GITHUB_REPO` / `FEEDBACK_GITHUB_REPO` if the slug in the log is wrong. Until then, verdicts are recorded but not mirrored (`SELECT * FROM qa_verdicts WHERE github_comment_id IS NULL`).

Rebased onto `main` at `fa61e13`. It briefly carried two fixes for `main`-breaking oversights in #5173 ([detail here](https://github.com/boardsesh/boardsesh/pull/5174#issuecomment-5557576834)); #5196 and #5197 have since fixed both upstream, so the rebase dropped them and this is back to its own scope.

Verified on the rebased branch: `vp run typecheck:backend`, `vp check` (clean apart from two pre-existing `bottom-sheet.tsx` errors), and the full backend project — **307 files, 4369 tests, all passing**. #5197 rewrote the `qa_verdicts` insert this change restructures; the merge of the two is what that run covers.

Both Codex P2 findings are addressed; the second was a regression this PR introduced, and is the "mirror does not run" bullet above.

## Release Notes

- Filing a QA verdict works again when GitHub is unreachable, so you're never stuck on the preview you were testing

## Test plan

1. Open a PR preview, tap Finish testing.
2. Pick Approve, tap Send → "Verdict sent".
3. The sheet closes and you land back on production.
4. Reopen the sheet → your verdict shows as filed.

## Risk

Risk: 3/5 — backend resolver, changes when a verdict is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHRRj2VdfVSrEEn4rwqf9z