### PR TITLE
feat(backend): group ticks into inferred sessions on write

### DIFF
--- a/docs/inferred-sessions.md
+++ b/docs/inferred-sessions.md
@@ -108,6 +108,30 @@ anchor, so the outcome never depends on row order.
 old implementation deleted emptied sessions outright, orphaning their social rows and
 leaving migration `0120` to sweep up the debris.
 
+## Rollout
+
+Reconciliation is gated on **`INFERRED_SESSIONS_ENABLED=true`** in the backend
+environment. The backend has no feature-flag framework — the registry in
+`docs/feature-flags.md` is a web concern — so this is a deploy-time toggle, and
+unsetting it is the rollback.
+
+With it off, `reconcileInferredSessions` returns immediately: no rows are written and
+no query is issued. Nothing reads inferred sessions yet either, so the two halves can
+be enabled independently.
+
+The tick writers call it inside their own transaction, so a climb and its session
+assignment commit or roll back together:
+
+| writer | when |
+| --- | --- |
+| `saveTick` | on the new tick's `climbed_at` |
+| `updateTick` | on the old and the new `climbed_at` — an edit can move a tick between runs |
+| `deleteTick` | on each removed tick's `climbed_at` — a deletion can split a run |
+
+Still to wire: the Aurora / Kilter / MoonBoard / JSON importers (batched — one call per
+climber per contiguous window, never per tick, since a single import can carry 300k
+rows) and the offline outbox drain.
+
 ## What went wrong the first time
 
 The original feature kept a parallel **`inferred_sessions`** table with

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -42,6 +42,7 @@
     "@boardsesh/offline-sync": "workspace:*",
     "@boardsesh/pr-body": "workspace:*",
     "@boardsesh/queue": "workspace:*",
+    "@boardsesh/session-inference": "workspace:*",
     "@boardsesh/shared-schema": "workspace:*",
     "@boardsesh/text-redaction": "workspace:*",
     "@escape.tech/graphql-armor-cost-limit": "^2.4.3",

--- a/packages/backend/src/__tests__/inferred-session-reconcile-integration.test.ts
+++ b/packages/backend/src/__tests__/inferred-session-reconcile-integration.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vite-plus/test';
+import { sql, eq, and, asc } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import { db } from '../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import { reconcileInferredSessions } from '../services/inferred-sessions/reconcile';
+
+/**
+ * Real-DB coverage for turning a reconciliation decision into rows.
+ *
+ * The algorithm itself is unit-tested in `@boardsesh/session-inference` without a
+ * database. What is exercised here is everything that pure function cannot see: the
+ * window query, inheriting a session through its anchor, moving votes and comments off
+ * a session that loses a merge, and the unique-anchor constraint that settles
+ * concurrent reconciliation.
+ */
+
+const USER_ID = 'inf-recon-user';
+const CLIMB_UUID = 'inf-recon-climb';
+const BOARD_UUID = 'inf-recon-board';
+const HOUR = 60 * 60 * 1000;
+const MINUTE = 60 * 1000;
+const BASE = Date.UTC(2026, 4, 10, 9, 0, 0);
+
+let boardId: number;
+
+const iso = (epochMs: number) => new Date(epochMs).toISOString().replace('T', ' ').replace('Z', '');
+
+async function seedFixtures() {
+  await db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${USER_ID}, ${USER_ID + '@test.com'}, 'Reconcile User', now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+  const boardResult = await db.execute(sql`
+    INSERT INTO user_boards (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name)
+    VALUES (${BOARD_UUID}, ${BOARD_UUID}, ${USER_ID}, 'kilter', 1, 10, '1,20', 'Reconcile Board')
+    ON CONFLICT (uuid) DO UPDATE SET slug = excluded.slug
+    RETURNING id
+  `);
+  boardId = Number(Array.from(boardResult as Iterable<{ id: number }>)[0].id);
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, frames, frames_count, is_draft, is_listed, edge_left, edge_right, edge_bottom, edge_top, created_at)
+    VALUES (${CLIMB_UUID}, 'kilter', 1, 'test-setter', 'Reconcile Climb', 'p1r1', 1, false, true, 0, 100, 0, 150, '2024-01-01')
+    ON CONFLICT (uuid) DO NOTHING
+  `);
+}
+
+/** Insert a tick and return the bigserial id reconciliation anchors on. */
+async function insertTick(climbedAtMs: number, sessionId: string | null = null): Promise<number> {
+  const [row] = await db
+    .insert(dbSchema.boardseshTicks)
+    .values({
+      uuid: uuidv4(),
+      userId: USER_ID,
+      boardType: 'kilter',
+      boardId,
+      climbUuid: CLIMB_UUID,
+      angle: 40,
+      status: 'send',
+      attemptCount: 1,
+      climbedAt: iso(climbedAtMs),
+      sessionId,
+    })
+    .returning({ id: dbSchema.boardseshTicks.id });
+  return Number(row.id);
+}
+
+async function sessionsForUser() {
+  return db
+    .select({
+      id: dbSchema.boardSessions.id,
+      origin: dbSchema.boardSessions.origin,
+      anchorTickId: dbSchema.boardSessions.anchorTickId,
+      name: dbSchema.boardSessions.name,
+      startedAt: dbSchema.boardSessions.startedAt,
+      endedAt: dbSchema.boardSessions.endedAt,
+    })
+    .from(dbSchema.boardSessions)
+    .where(eq(dbSchema.boardSessions.createdByUserId, USER_ID))
+    .orderBy(asc(dbSchema.boardSessions.startedAt));
+}
+
+async function ticksForUser() {
+  return db
+    .select({ id: dbSchema.boardseshTicks.id, sessionId: dbSchema.boardseshTicks.sessionId })
+    .from(dbSchema.boardseshTicks)
+    .where(eq(dbSchema.boardseshTicks.userId, USER_ID))
+    .orderBy(asc(dbSchema.boardseshTicks.climbedAt));
+}
+
+const reconcileAt = (epochMs: number) =>
+  db.transaction((tx) => reconcileInferredSessions(tx, USER_ID, new Date(epochMs)));
+
+async function cleanup() {
+  await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id = ${USER_ID}`);
+  await db.execute(sql`DELETE FROM votes WHERE entity_type = 'session'`);
+  await db.execute(sql`DELETE FROM comments WHERE entity_type = 'session' AND user_id = ${USER_ID}`);
+  await db.execute(sql`DELETE FROM board_sessions WHERE created_by_user_id = ${USER_ID}`);
+}
+
+describe('reconcileInferredSessions (real DB)', () => {
+  beforeEach(async () => {
+    process.env.INFERRED_SESSIONS_ENABLED = 'true';
+    await cleanup();
+    await seedFixtures();
+  });
+
+  // Cleared per test, not per file: vitest reuses a worker process across files, so a
+  // failure that skipped an afterAll would leave reconciliation switched on for
+  // whatever ran next — and the tick-mutation suites would start writing sessions.
+  afterEach(() => {
+    delete process.env.INFERRED_SESSIONS_ENABLED;
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await db.execute(sql`DELETE FROM board_climbs WHERE uuid = ${CLIMB_UUID}`);
+    await db.execute(sql`DELETE FROM user_boards WHERE uuid = ${BOARD_UUID}`);
+    await db.execute(sql`DELETE FROM "users" WHERE id = ${USER_ID}`);
+  });
+
+  it('does nothing while the flag is off', async () => {
+    delete process.env.INFERRED_SESSIONS_ENABLED;
+    await insertTick(BASE);
+
+    await reconcileAt(BASE);
+
+    expect(await sessionsForUser()).toHaveLength(0);
+    expect((await ticksForUser())[0].sessionId).toBeNull();
+  });
+
+  it('creates one session per run and assigns every tick', async () => {
+    await insertTick(BASE);
+    await insertTick(BASE + 20 * MINUTE);
+    await insertTick(BASE + 10 * HOUR);
+
+    await reconcileAt(BASE);
+    await reconcileAt(BASE + 10 * HOUR);
+
+    const sessions = await sessionsForUser();
+    expect(sessions).toHaveLength(2);
+    expect(sessions.every((session) => session.origin === 'inferred')).toBe(true);
+
+    const ticks = await ticksForUser();
+    expect(ticks.every((tick) => tick.sessionId !== null)).toBe(true);
+    // The two morning climbs share a session; the evening one does not.
+    expect(ticks[0].sessionId).toBe(ticks[1].sessionId);
+    expect(ticks[2].sessionId).not.toBe(ticks[0].sessionId);
+  });
+
+  it("anchors the session on the run's lowest tick id and spans its climbs", async () => {
+    const first = await insertTick(BASE);
+    await insertTick(BASE + 30 * MINUTE);
+
+    await reconcileAt(BASE);
+
+    const [session] = await sessionsForUser();
+    expect(session.anchorTickId).toBe(first);
+    expect(session.startedAt?.getTime()).toBe(BASE);
+    expect(session.endedAt?.getTime()).toBe(BASE + 30 * MINUTE);
+  });
+
+  it('is a no-op when run again over the same window', async () => {
+    await insertTick(BASE);
+    await insertTick(BASE + 30 * MINUTE);
+
+    await reconcileAt(BASE);
+    const first = await sessionsForUser();
+    await reconcileAt(BASE);
+    const second = await sessionsForUser();
+
+    expect(second).toEqual(first);
+  });
+
+  // The case that broke v1: a back-dated import landing inside an existing run.
+  it('keeps the session id when a back-dated tick joins the run', async () => {
+    await insertTick(BASE);
+    await insertTick(BASE + 30 * MINUTE);
+    await reconcileAt(BASE);
+    const [before] = await sessionsForUser();
+
+    await insertTick(BASE - 20 * MINUTE);
+    await reconcileAt(BASE - 20 * MINUTE);
+
+    const sessions = await sessionsForUser();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe(before.id);
+    // The span grows backwards even though the identity does not move.
+    expect(sessions[0].startedAt?.getTime()).toBe(BASE - 20 * MINUTE);
+  });
+
+  it('merges two sessions a back-dated tick bridges, keeping the named one', async () => {
+    await insertTick(BASE);
+    await insertTick(BASE + 10 * HOUR);
+    await reconcileAt(BASE);
+    await reconcileAt(BASE + 10 * HOUR);
+
+    const [morning, evening] = await sessionsForUser();
+    await db
+      .update(dbSchema.boardSessions)
+      .set({ name: 'Evening burn', userEdited: true })
+      .where(eq(dbSchema.boardSessions.id, evening.id));
+
+    // Lands within 4h of both, welding the two runs together.
+    await insertTick(BASE + 4 * HOUR);
+    await insertTick(BASE + 7 * HOUR);
+    await reconcileAt(BASE + 4 * HOUR);
+
+    const sessions = await sessionsForUser();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe(evening.id);
+    expect(sessions[0].name).toBe('Evening burn');
+    expect(morning.id).not.toBe(sessions[0].id);
+  });
+
+  it('moves votes and comments off the session that loses a merge', async () => {
+    await insertTick(BASE);
+    await insertTick(BASE + 10 * HOUR);
+    await reconcileAt(BASE);
+    await reconcileAt(BASE + 10 * HOUR);
+    const [morning, evening] = await sessionsForUser();
+
+    await db.insert(dbSchema.votes).values({
+      userId: USER_ID,
+      entityType: 'session',
+      entityId: morning.id,
+      value: 1,
+    });
+
+    await insertTick(BASE + 4 * HOUR);
+    await insertTick(BASE + 7 * HOUR);
+    await reconcileAt(BASE + 4 * HOUR);
+
+    const [survivor] = await sessionsForUser();
+    const votes = await db
+      .select({ entityId: dbSchema.votes.entityId })
+      .from(dbSchema.votes)
+      .where(and(eq(dbSchema.votes.entityType, 'session'), eq(dbSchema.votes.userId, USER_ID)));
+
+    // Re-pointed onto whichever session survived, never left on the deleted row.
+    expect(votes).toHaveLength(1);
+    expect(votes[0].entityId).toBe(survivor.id);
+    expect([morning.id, evening.id]).toContain(survivor.id);
+  });
+
+  it("gives the day's loose ticks to an explicit session", async () => {
+    const explicitId = uuidv4();
+    await db.insert(dbSchema.boardSessions).values({
+      id: explicitId,
+      boardPath: '/kilter/1/10/1,20/40',
+      createdByUserId: USER_ID,
+      status: 'ended',
+    });
+    // Two climbs before Start, four inside the session.
+    await insertTick(BASE);
+    await insertTick(BASE + 15 * MINUTE);
+    await insertTick(BASE + 90 * MINUTE, explicitId);
+    await insertTick(BASE + 100 * MINUTE, explicitId);
+
+    await reconcileAt(BASE);
+
+    const ticks = await ticksForUser();
+    expect(ticks.every((tick) => tick.sessionId === explicitId)).toBe(true);
+    // No inferred session is left standing beside it.
+    const inferred = (await sessionsForUser()).filter((session) => session.origin === 'inferred');
+    expect(inferred).toHaveLength(0);
+  });
+
+  it('refuses a duplicate session for the same anchor', async () => {
+    const anchor = await insertTick(BASE);
+    await reconcileAt(BASE);
+
+    // What a second writer racing the first would attempt.
+    await expect(
+      db.insert(dbSchema.boardSessions).values({
+        id: uuidv4(),
+        boardPath: null,
+        origin: 'inferred',
+        createdByUserId: USER_ID,
+        status: 'ended',
+        anchorTickId: anchor,
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -35,6 +35,7 @@ import { resolveClimbCatalogPresence } from '../../../db/queries/climbs';
 import { resolveMoonBoardTickAngle } from '@boardsesh/db/queries';
 import { captureBackendEvent } from '../../../services/analytics/posthog';
 import { logger } from '../../../utils/logger';
+import { reconcileInferredSessions } from '../../../services/inferred-sessions/reconcile';
 import {
   acquireUserTickMutationLock,
   isDirectAuroraTwin,
@@ -714,6 +715,14 @@ export const tickMutations = {
         await tx.update(sessions).set({ lastActivity: new Date() }).where(inArray(sessions.id, sessionIds));
       }
 
+      // Removing a climb can split a run in two or empty a session outright, so the
+      // window around each deleted tick is redrawn. Deduped by timestamp because a
+      // logical ascent's rows share one climbed_at and would otherwise reconcile the
+      // same window repeatedly.
+      for (const climbedAt of new Set(affectedTicks.map((tick) => tick.climbedAt))) {
+        await reconcileInferredSessions(tx, userId, new Date(climbedAt));
+      }
+
       return { affectedTicks, detachedBetaLinks: detachedBetaLinks.length > 0 };
     });
 
@@ -1136,6 +1145,12 @@ export const tickMutations = {
             .onConflictDoNothing();
         }
 
+        // Group this climb into the session it belongs to, inside the same
+        // transaction so the tick and its assignment commit together. Inert unless
+        // INFERRED_SESSIONS_ENABLED is set. A tick that already carries an explicit
+        // session still goes through, because the run around it may need redrawing.
+        await reconcileInferredSessions(tx, userId, new Date(createdTick.climbedAt));
+
         return [createdTick];
       },
       { isolationLevel: 'read committed' },
@@ -1433,6 +1448,16 @@ export const tickMutations = {
       const sessionIds = distinctTickSessions(existingTicks);
       if (sessionIds.length > 0) {
         await tx.update(sessions).set({ lastActivity: new Date() }).where(inArray(sessions.id, sessionIds));
+      }
+
+      // An edit can move climbed_at, which moves the tick between runs — so both the
+      // window it left and the one it joined need redrawing. Reconciling the old
+      // timestamp first leaves the tick's new home authoritative.
+      for (const climbedAt of new Set([
+        ...existingTicks.map((tick) => tick.climbedAt),
+        ...updatedTicks.map((tick) => tick.climbedAt),
+      ])) {
+        await reconcileInferredSessions(tx, userId, new Date(climbedAt));
       }
 
       return { existingTicks, updatedTicks, updatedTarget, movedBetaLinks };

--- a/packages/backend/src/services/inferred-sessions/reconcile.ts
+++ b/packages/backend/src/services/inferred-sessions/reconcile.ts
@@ -1,0 +1,208 @@
+import { and, eq, inArray, or, sql } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import * as dbSchema from '@boardsesh/db/schema';
+import {
+  reconcileWindow,
+  type ExistingExplicitSession,
+  type ExistingInferredSession,
+  type SessionMerge,
+} from '@boardsesh/session-inference';
+import { logger } from '../../utils/logger';
+import { loadReconciliationWindow, type ReconciliationTransaction } from './window-loader';
+
+/**
+ * Inferred sessions are off unless the deploy says otherwise.
+ *
+ * The backend has no feature-flag framework — the registry in `docs/feature-flags.md`
+ * is a web concern — so this is an env gate, flipped per environment and rolled back by
+ * unsetting it. Nothing reads inferred rows yet either, so with it off the reconciler
+ * is inert.
+ */
+export function inferredSessionsEnabled(): boolean {
+  return process.env.INFERRED_SESSIONS_ENABLED === 'true';
+}
+
+/** Move a merged-away session's social rows onto the survivor, then drop the session. */
+async function applyMerge(tx: ReconciliationTransaction, merge: SessionMerge): Promise<void> {
+  // Re-point BEFORE deleting. v1 deleted emptied sessions outright, orphaning their
+  // votes and comments — `entity_id` is untyped text with no foreign key, so nothing
+  // caught it and migration 0120 had to sweep the debris up afterwards.
+  for (const table of [dbSchema.votes, dbSchema.comments] as const) {
+    await tx
+      .update(table)
+      .set({ entityId: merge.survivorId })
+      .where(and(eq(table.entityType, 'session'), eq(table.entityId, merge.loserId)));
+  }
+  await tx
+    .delete(dbSchema.voteCounts)
+    .where(and(eq(dbSchema.voteCounts.entityType, 'session'), eq(dbSchema.voteCounts.entityId, merge.loserId)));
+
+  await tx.delete(dbSchema.boardSessions).where(eq(dbSchema.boardSessions.id, merge.loserId));
+}
+
+/**
+ * Reassign the ticks around `touchedAt` to the sessions they belong to.
+ *
+ * Runs inside the caller's transaction so a tick and its session assignment commit or
+ * roll back together. Safe to call from every writer — save, edit, delete, importer,
+ * offline drain — because {@link reconcileWindow} returns the same answer for a window
+ * however many times it is applied.
+ *
+ * Concurrency is settled by the unique partial index on `board_sessions.anchor_tick_id`:
+ * two writers reconciling the same unassigned run both decide to create a session, and
+ * the loser's insert raises a unique violation that rolls its transaction back. The
+ * caller retries the tick write, and the second pass finds the anchor and inherits it.
+ */
+export async function reconcileInferredSessions(
+  tx: ReconciliationTransaction,
+  userId: string,
+  touchedAt: Date,
+): Promise<void> {
+  if (!inferredSessionsEnabled()) return;
+
+  const { ticks, truncated } = await loadReconciliationWindow(tx, userId, touchedAt);
+  if (truncated) {
+    logger.warn(
+      `[inferredSessions] window for ${userId} around ${touchedAt.toISOString()} hit the widening ceiling; reconciling the clipped range`,
+    );
+  }
+  if (ticks.length === 0) return;
+
+  const tickIds = ticks.map((tick) => tick.id);
+  const assignedIds = [...new Set(ticks.map((tick) => tick.sessionId).filter((id): id is string => id !== null))];
+
+  // Sessions in play: those the window's ticks already point at, plus any anchored on a
+  // tick inside it (an inferred session whose ticks all moved away still owns its
+  // anchor, and must be recognised rather than duplicated).
+  const sessionRows =
+    assignedIds.length > 0 || tickIds.length > 0
+      ? await tx
+          .select({
+            id: dbSchema.boardSessions.id,
+            origin: dbSchema.boardSessions.origin,
+            anchorTickId: dbSchema.boardSessions.anchorTickId,
+            userEdited: dbSchema.boardSessions.userEdited,
+          })
+          .from(dbSchema.boardSessions)
+          .where(
+            or(
+              assignedIds.length > 0 ? inArray(dbSchema.boardSessions.id, assignedIds) : sql`false`,
+              and(eq(dbSchema.boardSessions.origin, 'inferred'), inArray(dbSchema.boardSessions.anchorTickId, tickIds)),
+            ),
+          )
+      : [];
+
+  const existingInferred: ExistingInferredSession[] = sessionRows
+    .filter((row) => row.origin === 'inferred')
+    .map((row) => ({ id: row.id, anchorTickId: row.anchorTickId, userEdited: row.userEdited }));
+
+  // Explicit sessions are matched by day, so their own tick spans are what matter —
+  // not the window's bounds, which is why this reads the ticks rather than the session
+  // rows' started_at/ended_at (those are wall-clock, and an inferred day is derived
+  // from climbed_at).
+  const explicitIds = sessionRows.filter((row) => row.origin === 'explicit').map((row) => row.id);
+  const explicitSpans = explicitIds.length
+    ? await tx
+        .select({
+          sessionId: dbSchema.boardseshTicks.sessionId,
+          firstTickAt: sql<string>`MIN(${dbSchema.boardseshTicks.climbedAt})`,
+          lastTickAt: sql<string>`MAX(${dbSchema.boardseshTicks.climbedAt})`,
+        })
+        .from(dbSchema.boardseshTicks)
+        .where(inArray(dbSchema.boardseshTicks.sessionId, explicitIds))
+        .groupBy(dbSchema.boardseshTicks.sessionId)
+    : [];
+
+  const existingExplicit: ExistingExplicitSession[] = explicitSpans
+    .filter((row): row is typeof row & { sessionId: string } => row.sessionId !== null)
+    .map((row) => ({
+      id: row.sessionId,
+      firstTickAt: new Date(row.firstTickAt).getTime(),
+      lastTickAt: new Date(row.lastTickAt).getTime(),
+    }));
+
+  const result = reconcileWindow({ ticks, existingInferred, existingExplicit });
+
+  for (const merge of result.merges) {
+    await applyMerge(tx, merge);
+  }
+
+  for (const runResult of result.runs) {
+    let sessionId = runResult.sessionId;
+
+    if (sessionId === null) {
+      sessionId = uuidv4();
+      await tx.insert(dbSchema.boardSessions).values({
+        id: sessionId,
+        // No board path: the run's ticks may span several boards, and nothing about an
+        // inferred session is joinable anyway.
+        boardPath: null,
+        origin: 'inferred',
+        createdByUserId: userId,
+        // Already over by construction, with its bounds taken from the climbing rather
+        // than from a clock. The auto-end sweep skips origin='inferred' regardless.
+        status: 'ended',
+        startedAt: new Date(runResult.firstTickAt),
+        endedAt: new Date(runResult.lastTickAt),
+        lastActivity: new Date(runResult.lastTickAt),
+        isPermanent: false,
+        isPublic: true,
+        anchorTickId: runResult.anchorTickId,
+      });
+    } else {
+      // An inherited session's span moves as ticks join and leave it.
+      await tx
+        .update(dbSchema.boardSessions)
+        .set({
+          startedAt: new Date(runResult.firstTickAt),
+          endedAt: new Date(runResult.lastTickAt),
+          lastActivity: new Date(runResult.lastTickAt),
+        })
+        .where(and(eq(dbSchema.boardSessions.id, sessionId), eq(dbSchema.boardSessions.origin, 'inferred')));
+    }
+
+    await tx
+      .update(dbSchema.boardseshTicks)
+      .set({ sessionId })
+      // `boardsesh_ticks.id` is a bigserial read as bigint, while the algorithm works
+      // in numbers. The table is ~500k rows, so the round trip is nowhere near the
+      // safe-integer ceiling.
+      .where(inArray(dbSchema.boardseshTicks.id, runResult.tickIds.map(BigInt)));
+  }
+
+  // Sessions an explicit session took every tick from. Their social rows have nowhere
+  // sensible to go — the ticks are spread across a session that already has its own —
+  // so they are dropped with the row rather than left dangling.
+  if (result.emptiedSessionIds.length > 0) {
+    for (const table of [dbSchema.votes, dbSchema.comments] as const) {
+      await tx
+        .delete(table)
+        .where(and(eq(table.entityType, 'session'), inArray(table.entityId, result.emptiedSessionIds)));
+    }
+    await tx
+      .delete(dbSchema.voteCounts)
+      .where(
+        and(
+          eq(dbSchema.voteCounts.entityType, 'session'),
+          inArray(dbSchema.voteCounts.entityId, result.emptiedSessionIds),
+        ),
+      );
+    await tx
+      .delete(dbSchema.boardSessions)
+      .where(
+        and(
+          inArray(dbSchema.boardSessions.id, result.emptiedSessionIds),
+          eq(dbSchema.boardSessions.origin, 'inferred'),
+        ),
+      );
+  }
+}
+
+/** Convenience for callers holding a `climbed_at` string rather than a Date. */
+export async function reconcileInferredSessionsAt(
+  tx: ReconciliationTransaction,
+  userId: string,
+  climbedAt: string | Date,
+): Promise<void> {
+  await reconcileInferredSessions(tx, userId, climbedAt instanceof Date ? climbedAt : new Date(climbedAt));
+}

--- a/packages/backend/src/services/inferred-sessions/window-loader.ts
+++ b/packages/backend/src/services/inferred-sessions/window-loader.ts
@@ -1,0 +1,107 @@
+import { and, asc, eq, gte, lte } from 'drizzle-orm';
+import * as dbSchema from '@boardsesh/db/schema';
+import { SESSION_GAP_MS, expandWindow, type InferenceTick } from '@boardsesh/session-inference';
+import { db } from '../../db/client';
+
+/**
+ * The transaction handle the tick mutations already open. Reconciliation runs inside
+ * that same transaction so a tick and its session assignment commit together — v1 fired
+ * assignment after the insert and outside the transaction, with the failure swallowed,
+ * so a hiccup left ticks unassigned until the nightly cron caught them.
+ */
+export type ReconciliationTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * How wide a slice of the climber's ticks to pull on the first attempt.
+ *
+ * Runs are short — median 5 ticks, p90 15, and only 1.2% span midnight — so half a day
+ * either side covers essentially every one in a single query.
+ */
+const INITIAL_RADIUS_MS = 12 * 60 * 60 * 1000;
+
+/**
+ * Give up widening after this many doublings (12h → 192h).
+ *
+ * Reaching it would mean an unbroken chain of ticks less than 4h apart stretching over
+ * a week, which is not climbing. Bailing out keeps a pathological row from turning one
+ * tick write into an unbounded scan.
+ */
+const MAX_WIDENINGS = 4;
+
+type LoadedWindow = {
+  /** Ticks in the gap-bounded window, ascending by climbedAt. */
+  ticks: InferenceTick[];
+  /** True when widening hit its ceiling and the window may still be clipped. */
+  truncated: boolean;
+};
+
+function toInferenceTick(row: { id: bigint | number; climbedAt: string; sessionId: string | null }): InferenceTick {
+  return {
+    id: Number(row.id),
+    climbedAt: new Date(row.climbedAt).getTime(),
+    sessionId: row.sessionId,
+  };
+}
+
+/**
+ * Load every tick belonging to the run(s) around `touchedAt`, bounded on both sides by
+ * a real gap.
+ *
+ * Reconciliation is only correct over complete runs: a window that stops mid-run would
+ * let it split that run in half. The obvious query — "everything within 12h" — cannot
+ * promise that, because a long session can run past the edge. So this loads a block,
+ * expands within it, and reloads wider if the expansion reached the block's boundary
+ * with no gap to stop at.
+ *
+ * In practice the first query is enough; the loop exists so that the guarantee holds
+ * rather than usually holding.
+ */
+export async function loadReconciliationWindow(
+  tx: ReconciliationTransaction,
+  userId: string,
+  touchedAt: Date,
+): Promise<LoadedWindow> {
+  const centre = touchedAt.getTime();
+  let radius = INITIAL_RADIUS_MS;
+
+  for (let attempt = 0; attempt <= MAX_WIDENINGS; attempt++) {
+    const from = new Date(centre - radius);
+    const to = new Date(centre + radius);
+
+    const rows = await tx
+      .select({
+        id: dbSchema.boardseshTicks.id,
+        climbedAt: dbSchema.boardseshTicks.climbedAt,
+        sessionId: dbSchema.boardseshTicks.sessionId,
+      })
+      .from(dbSchema.boardseshTicks)
+      .where(
+        and(
+          eq(dbSchema.boardseshTicks.userId, userId),
+          gte(dbSchema.boardseshTicks.climbedAt, from.toISOString()),
+          lte(dbSchema.boardseshTicks.climbedAt, to.toISOString()),
+        ),
+      )
+      .orderBy(asc(dbSchema.boardseshTicks.climbedAt), asc(dbSchema.boardseshTicks.id));
+
+    const loaded = rows.map(toInferenceTick);
+    if (loaded.length === 0) return { ticks: [], truncated: false };
+
+    const windowTicks = expandWindow(loaded, centre, centre);
+    if (windowTicks.length === 0) return { ticks: [], truncated: false };
+
+    // Expansion stops at a >4h gap. If it instead stopped because it ran out of loaded
+    // rows, there may be more of this run just outside the block — widen and retry.
+    const clippedStart = windowTicks[0].id === loaded[0].id && loaded[0].climbedAt - from.getTime() <= SESSION_GAP_MS;
+    const lastLoaded = loaded[loaded.length - 1];
+    const clippedEnd =
+      windowTicks[windowTicks.length - 1].id === lastLoaded.id && to.getTime() - lastLoaded.climbedAt <= SESSION_GAP_MS;
+
+    if (!clippedStart && !clippedEnd) return { ticks: windowTicks, truncated: false };
+
+    if (attempt === MAX_WIDENINGS) return { ticks: windowTicks, truncated: true };
+    radius *= 2;
+  }
+
+  return { ticks: [], truncated: false };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       '@boardsesh/queue':
         specifier: workspace:*
         version: link:../shared/queue
+      '@boardsesh/session-inference':
+        specifier: workspace:*
+        version: link:../shared/session-inference
       '@boardsesh/shared-schema':
         specifier: workspace:*
         version: link:../shared-schema


### PR DESCRIPTION
## Summary

Step 2 of bringing back inferred sessions: the tick writers now group climbs into
sessions. **Gated on `INFERRED_SESSIONS_ENABLED=true`** — with the flag unset,
`reconcileInferredSessions` returns before issuing a single query, so this is inert
until someone turns it on.

Follows #5161, which landed the schema and the algorithm.

### What's wired

| writer | reconciles on |
| --- | --- |
| `saveTick` | the new tick's `climbed_at` |
| `updateTick` | the old **and** new `climbed_at` — an edit can move a tick between runs |
| `deleteTick` | each removed tick's `climbed_at` — a deletion can split a run |

Each call runs **inside the mutation's existing transaction**, so a climb and its
session assignment commit or roll back together. The previous implementation fired
assignment after the insert, outside the transaction, with the error swallowed by a
`.catch()` — so any hiccup left ticks unassigned until a nightly cron noticed.

### The window loader is the part worth reviewing

Reconciliation is only correct over *complete* runs: a window that stops mid-run lets
it split that run in half. "Load everything within 12h" cannot promise that, because a
long session can cross the boundary. So `loadReconciliationWindow` loads a block,
expands within it, and re-queries wider if the expansion reached the block's edge with
no gap to stop at — capped at four doublings (12h → 192h), which would require an
unbroken chain of climbs less than 4h apart for over a week.

In practice the first query always suffices: runs are median 5 ticks and only 1.2%
cross midnight. The loop exists so the guarantee holds rather than usually holds.

### Applying the result

- **Merges** re-point votes and comments onto the survivor **before** deleting the
  loser. v1 deleted emptied sessions outright; `entity_id` is untyped text with no
  foreign key, so nothing caught the orphans and migration `0120` had to sweep them up.
- **New sessions** are written already-ended, with `started_at`/`ended_at` from the
  run's own climbs rather than a clock, `board_path` null, and `anchor_tick_id` set.
- **Concurrency** is settled by the unique partial index from #5161: two writers
  reconciling the same unassigned run both try to create a session, the loser gets a
  unique violation, and its transaction rolls back for the caller to retry.

## Testing

9 real-DB integration tests in `inferred-session-reconcile-integration.test.ts`,
covering what the pure unit tests cannot see — the window query, inheriting a session
through its anchor, and the social re-pointing. The two that matter most:

- a back-dated tick joining an existing run **keeps the session id** (the v1 bug: ids
  were derived from the first tick's timestamp, so a back-dated climb re-keyed the
  session and orphaned its votes)
- a bridged merge keeps the **named** session and moves the votes onto it

Also: the flag-off case asserts no rows are written at all.

### Author-side validation

`vp run typecheck:backend` clean; the 9 integration tests pass; `@boardsesh/session-inference`
29/29 and the #5161 backend guards 9/9 still pass.

Two things the compiler and a re-read caught: `boardsesh_ticks.id` is a bigserial read
as `bigint`, so `inArray` against it needs `.map(BigInt)` while the algorithm works in
numbers; and the test's env flag is now cleared per test rather than per file, since
vitest reuses a worker across files and a thrown test would otherwise leave
reconciliation switched on for whatever ran next.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 3/5 — writes inside the tick mutation transactions, but every path is behind an env flag that is unset everywhere.

## Not in this PR

The Aurora / Kilter / MoonBoard / JSON importers and the offline outbox drain still need
wiring. Those must batch — one call per climber per contiguous window, never per tick,
since a single JSON import carries 300k rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7tYUk29Bbyrsp8wRQ58d2
