### PR TITLE
fix(shared): recover Android colors and touching MoonBoard holds

### DIFF
--- a/packages/moonboard-ocr/README.md
+++ b/packages/moonboard-ocr/README.md
@@ -1,0 +1,73 @@
+# MoonBoard screenshot parser
+
+The shared parser runs locally with Sharp/Tesseract in Node or Canvas/Tesseract in
+the browser. Accessibility metadata is a separate input to the Android collector;
+it is not substituted into this library's OCR results.
+
+## Board-aware parsing
+
+Pass the upstream `holdsetup` ID, **not** a Boardsesh layout ID:
+
+| holdsetup | Board | Grid |
+| --- | --- | --- |
+| 23 | MoonBoard 2010 | 11 × 18 |
+| 1 | MoonBoard 2016 | 11 × 18 |
+| 15 | MoonBoard Masters 2017 | 11 × 18 |
+| 17 | MoonBoard Masters 2019 | 11 × 18 |
+| 21 | MoonBoard 2024 | 11 × 18 |
+| 19 | Mini MoonBoard 2020 | 11 × 12 |
+| 22 | Mini MoonBoard 2025 | 11 × 12 |
+
+```ts
+import { parseScreenshot } from '@boardsesh/moonboard-ocr';
+
+const result = await parseScreenshot('/private/climb.png', {
+  holdsetup: 22,
+  screenshotProfile: 'android-pixel8pro-1.3.68',
+});
+```
+
+The Android profile is calibrated for Moon Climbing **1.3.68**, stock Pixel 8 Pro,
+**1008 × 2244** screenshots. Other dimensions fail closed. Mini boards have a
+shorter, vertically centered grid; selecting 12 rows without changing the crop is
+incorrect. Do not infer the setup from the detected holds: the caller must verify
+the board in the app's information panel.
+
+The original full-size/iOS behavior remains the default (`holdsetup: 21`,
+`screenshotProfile: 'legacy-ios'`). Mini iOS screenshots are **not calibrated** and
+are rejected. A declared profile is not automatic board recognition or evidence
+that an arbitrary screenshot is from that board.
+
+The browser `parseScreenshot` accepts the same options as its second argument.
+Both Node and browser `parseMultipleScreenshots` accept options as their third
+argument, after the progress callback. A shared `scheduler` can be supplied to
+reuse a Tesseract worker across a batch.
+
+```sh
+vp exec tsx packages/moonboard-ocr/src/cli.ts parse /private/screenshots \
+  --holdsetup 22 --screenshot-profile android-pixel8pro-1.3.68 \
+  --no-dedupe --output /private/parsed-climbs.json
+```
+
+For accuracy evaluation, retain every input, parse error and warning. Do not use
+hold-based deduplication to reduce the denominator. `success: true` means a parse
+was produced, not that its holds/metadata are complete or safe to import. The
+parser defaults an unreadable angle to 40 degrees; matching that value alone is
+not an angle-recognition accuracy test. English OCR cannot reliably preserve every
+Unicode name; the Android collector uses public accessibility labels separately.
+
+The companion `moonboard-scraper` repository's `android_ocr_validate.py` collects
+read-only screenshots, matches old references by board/name/setter independently
+of holds, and compares against this parser using the existing catalog importer's
+mapping. It emits private review reports only and cannot write a database. See
+that repository's `OCR_VALIDATION.md` for measured device coverage and results.
+
+## Regression tests
+
+```sh
+vp test run --project moonboard-ocr --reporter=agent
+vp exec tsc --noEmit -p packages/moonboard-ocr/tsconfig.json
+```
+
+Synthetic geometry tests verify every cell and Mini row limits; they do not count
+as real-app accuracy evidence. Existing iOS fixture tests remain unchanged.

--- a/packages/moonboard-ocr/README.md
+++ b/packages/moonboard-ocr/README.md
@@ -77,4 +77,5 @@ vp exec tsc --noEmit -p packages/moonboard-ocr/tsconfig.json
 ```
 
 Synthetic geometry tests verify every cell and Mini row limits; they do not count
-as real-app accuracy evidence. Existing iOS fixture tests remain unchanged.
+as real-app accuracy evidence. The iOS fixture suite remains a regression gate;
+earlier touching-ring fixes restored 24 visually verified rings in 21 fixtures.

--- a/packages/moonboard-ocr/README.md
+++ b/packages/moonboard-ocr/README.md
@@ -34,8 +34,8 @@ incorrect. Do not infer the setup from the detected holds: the caller must verif
 the board in the app's information panel.
 
 The original full-size/iOS behavior remains the default (`holdsetup: 21`,
-`screenshotProfile: 'legacy-ios'`). Mini iOS screenshots are **not calibrated** and
-are rejected. A declared profile is not automatic board recognition or evidence
+`screenshotProfile: 'legacy-ios'`). Other setups' iOS screenshots are **not calibrated**
+and are rejected when explicitly selected. A declared profile is not automatic board recognition or evidence
 that an arbitrary screenshot is from that board.
 
 The browser `parseScreenshot` accepts the same options as its second argument.
@@ -55,6 +55,9 @@ was produced, not that its holds/metadata are complete or safe to import. The
 parser defaults an unreadable angle to 40 degrees; matching that value alone is
 not an angle-recognition accuracy test. English OCR cannot reliably preserve every
 Unicode name; the Android collector uses public accessibility labels separately.
+Missing labelled grades stay `Unknown` with a warning; a setter-only grade is not
+copied into the community grade. Title extraction excludes rating text below a
+recognized setter line.
 
 The companion `moonboard-scraper` repository's `android_ocr_validate.py` collects
 read-only screenshots, matches old references by board/name/setter independently

--- a/packages/moonboard-ocr/README.md
+++ b/packages/moonboard-ocr/README.md
@@ -8,6 +8,10 @@ it is not substituted into this library's OCR results.
 
 Pass the upstream `holdsetup` ID, **not** a Boardsesh layout ID:
 
+Use `GRID_POSITIONS_BY_ROWS[boardRows(holdsetup)]` for normalized cell centers.
+The exported `GRID_POSITIONS` remains the legacy 18-row map for compatibility;
+it must not be used for Mini boards.
+
 | holdsetup | Board | Grid |
 | --- | --- | --- |
 | 23 | MoonBoard 2010 | 11 × 18 |

--- a/packages/moonboard-ocr/README.md
+++ b/packages/moonboard-ocr/README.md
@@ -36,6 +36,8 @@ The Android profile is calibrated for Moon Climbing **1.3.68**, stock Pixel 8 Pr
 shorter, vertically centered grid; selecting 12 rows without changing the crop is
 incorrect. Do not infer the setup from the detected holds: the caller must verify
 the board in the app's information panel.
+Other Android devices require a separately calibrated profile. Do not bypass the
+dimension check by selecting the legacy iOS profile for an Android screenshot.
 
 The original full-size/iOS behavior remains the default (`holdsetup: 21`,
 `screenshotProfile: 'legacy-ios'`). Other setups' iOS screenshots are **not calibrated**
@@ -62,6 +64,19 @@ Unicode name; the Android collector uses public accessibility labels separately.
 Missing labelled grades stay `Unknown` with a warning; a setter-only grade is not
 copied into the community grade. Title extraction excludes rating text below a
 recognized setter line.
+
+The grade parser explicitly supports the legacy iOS slash separator before the
+Setter field. Unrecognized grade suffixes remain `Unknown` with a warning rather
+than silently accepting a partial prefix; spacing/format changes need fixtures.
+
+Touching-ring recovery requires at least two plausible enclosed interiors. With
+only one (for example, a second ring damaged by a wide open gap), detection keeps
+the existing component-centroid fallback and can undercount or misplace a hold.
+A dedicated synthetic regression documents this limitation; the barely-touching
+**closed** pair is a separate passing test. A successful parse is not a guarantee
+of complete holds. The reference validator rejects the incomplete set and never
+imports it. Arbitrarily damaged screenshots need further algorithm work before
+they can be accepted without a reference or human review.
 
 The companion `moonboard-scraper` repository's `android_ocr_validate.py` collects
 read-only screenshots, matches old references by board/name/setter independently

--- a/packages/moonboard-ocr/src/__tests__/benchmark-colors.test.ts
+++ b/packages/moonboard-ocr/src/__tests__/benchmark-colors.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { detectBenchmarkCircle } from '../core/holds';
+import type { RawPixelData } from '../image-processor/types';
+
+function circles(centers: number[], radius: number, color: number[]): RawPixelData {
+  const width = 300;
+  const height = 80;
+  const pixels = new Uint8Array(width * height * 4);
+  for (const centerX of centers) {
+    for (let y = 40 - radius; y <= 40 + radius; y++) {
+      for (let x = centerX - radius; x <= centerX + radius; x++) {
+        if (Math.hypot(x - centerX, y - 40) <= radius) pixels.set(color, (y * width + x) * 4);
+      }
+    }
+    // A dark glyph reduces the colored badge area, as the real B does.
+    for (let y = 32; y < 48; y++) {
+      for (let x = centerX - 2; x < centerX + 2; x++) pixels.set([0, 0, 0], (y * width + x) * 4);
+    }
+  }
+  return { width, height, channels: 4, data: pixels };
+}
+
+describe('profile-specific benchmark badge colors', () => {
+  it('recognizes the smaller bright-gold Android badge', () => {
+    const pixels = circles([100], 19, [255, 193, 7]);
+    expect(detectBenchmarkCircle(pixels, 'android')).toBe(true);
+    expect(detectBenchmarkCircle(pixels)).toBe(false);
+  });
+
+  it('preserves muted-gold iOS badge detection', () => {
+    expect(detectBenchmarkCircle(circles([100], 24, [211, 175, 88]))).toBe(true);
+  });
+
+  it('keeps compressed bright and muted badge pixels in one component', () => {
+    const pixels = circles([100], 18, [255, 193, 7]);
+    const colors = [
+      [255, 183, 32],
+      [232, 177, 70],
+      [209, 153, 58],
+      [255, 193, 7],
+    ];
+    for (let y = 0; y < pixels.height; y++) {
+      for (let x = 0; x < pixels.width; x++) {
+        const index = (y * pixels.width + x) * 4;
+        if (pixels.data[index]) pixels.data.set(colors[x % colors.length], index);
+      }
+    }
+    expect(detectBenchmarkCircle(pixels, 'android')).toBe(true);
+    expect(detectBenchmarkCircle(pixels)).toBe(false);
+  });
+
+  it('does not combine separate small gold rating glyphs into a badge', () => {
+    expect(detectBenchmarkCircle(circles([50, 85, 120, 155, 190], 12, [255, 193, 7]), 'android')).toBe(false);
+  });
+
+  it('does not classify a red beta counter as a benchmark', () => {
+    expect(detectBenchmarkCircle(circles([100], 24, [244, 67, 54]), 'android')).toBe(false);
+  });
+});

--- a/packages/moonboard-ocr/src/__tests__/board-profiles.test.ts
+++ b/packages/moonboard-ocr/src/__tests__/board-profiles.test.ts
@@ -37,13 +37,13 @@ describe('explicit MoonBoard setup geometry', () => {
             const radius = Math.hypot(x - ring.x, y - ring.y);
             if (radius >= 21 && radius <= 27) data.set(ring.color, (y * width + x) * 4);
           }
-          // Red plastic on Masters 2017 falls inside the legacy iOS marker palette.
-          // It must not manufacture a finish hold in the explicit Android profile.
-          for (let y = 185; y <= 235; y++) {
-            for (let x = 185; x <= 235; x++) {
-              if (Math.hypot(x - 210, y - 210) <= 25) data.set([225, 82, 64], (y * width + x) * 4);
-            }
-          }
+        }
+      }
+      // Red plastic on Masters 2017 falls inside the legacy iOS marker palette.
+      // It must not manufacture a finish hold in the explicit Android profile.
+      for (let y = 185; y <= 235; y++) {
+        for (let x = 185; x <= 235; x++) {
+          if (Math.hypot(x - 210, y - 210) <= 25) data.set([225, 82, 64], (y * width + x) * 4);
         }
       }
       const holds = detectHoldsFromPixelData(

--- a/packages/moonboard-ocr/src/__tests__/board-profiles.test.ts
+++ b/packages/moonboard-ocr/src/__tests__/board-profiles.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { BOARD_PROFILES, boardRows, GRID_POSITIONS_BY_ROWS, type HoldSetup } from '../board-profiles';
+import { GRID_POSITIONS } from '../types';
+import { calculateAndroidRegions } from '../core/regions';
+import { classifyPixelColor, detectHoldsFromPixelData, findNearestGridPosition } from '../core/holds';
+import { parseWithProcessor } from '../parser-core';
+import type { ImageProcessor } from '../image-processor/types';
+
+describe('explicit MoonBoard setup geometry', () => {
+  it('preserves every legacy full-size coordinate center', () => {
+    expect(GRID_POSITIONS_BY_ROWS[18]).toEqual(GRID_POSITIONS);
+  });
+
+  it.each(Object.entries(BOARD_PROFILES))('maps every coordinate of setup %s', (id, profile) => {
+    const rows = boardRows(Number(id) as HoldSetup);
+    expect(rows).toBe(profile.rows);
+    expect(Object.keys(GRID_POSITIONS_BY_ROWS[rows])).toHaveLength(11 * rows);
+    for (const [coordinate, position] of Object.entries(GRID_POSITIONS_BY_ROWS[rows])) {
+      expect(findNearestGridPosition(position.x, position.y, rows)).toEqual({ coordinate, distance: 0 });
+    }
+  });
+
+  it.each([19, 22] as const)(
+    'detects Mini setup %s bottom, middle and top roles without inventing rows 13–18',
+    (id) => {
+      const width = 660;
+      const height = 720;
+      const data = new Uint8Array(width * height * 4).fill(255);
+      const rings = [
+        { x: 90, y: 90, color: [255, 0, 0], coordinate: 'B11', role: 'finish' },
+        { x: 330, y: 390, color: [0, 102, 255], coordinate: 'F6', role: 'hand' },
+        { x: 510, y: 630, color: [0, 255, 0], coordinate: 'I2', role: 'start' },
+      ];
+      for (const ring of rings) {
+        for (let y = ring.y - 27; y <= ring.y + 27; y++) {
+          for (let x = ring.x - 27; x <= ring.x + 27; x++) {
+            const radius = Math.hypot(x - ring.x, y - ring.y);
+            if (radius >= 21 && radius <= 27) data.set(ring.color, (y * width + x) * 4);
+          }
+          // Red plastic on Masters 2017 falls inside the legacy iOS marker palette.
+          // It must not manufacture a finish hold in the explicit Android profile.
+          for (let y = 185; y <= 235; y++) {
+            for (let x = 185; x <= 235; x++) {
+              if (Math.hypot(x - 210, y - 210) <= 25) data.set([225, 82, 64], (y * width + x) * 4);
+            }
+          }
+        }
+      }
+      const holds = detectHoldsFromPixelData(
+        { data, width, height, channels: 4 },
+        { x: 0, y: 0, width, height },
+        boardRows(id),
+        'android',
+      );
+      expect(holds.map((h) => [h.coordinate, h.type])).toEqual(rings.map((r) => [r.coordinate, r.role]));
+    },
+  );
+
+  it('rejects unknown upstream IDs and unvalidated Android dimensions', () => {
+    expect(() => boardRows(7 as HoldSetup)).toThrow('Unsupported');
+    expect(() => calculateAndroidRegions(1008, 2240, 12)).toThrow('Unvalidated');
+    expect(() => calculateAndroidRegions(2244, 1008, 18)).toThrow('Unvalidated');
+  });
+
+  it('keeps compressed Android ring reds while rejecting the legacy plastic-red range', () => {
+    expect(classifyPixelColor(230, 0, 0, 'android')).toBe('finish');
+    expect(classifyPixelColor(243, 1, 5, 'android')).toBe('finish');
+    expect(classifyPixelColor(225, 82, 64, 'android')).toBeNull();
+    expect(classifyPixelColor(244, 67, 54, 'android')).toBeNull();
+    expect(classifyPixelColor(244, 67, 54)).toBe('finish');
+    expect(classifyPixelColor(0, 240, 5, 'android')).toBe('start');
+    expect(classifyPixelColor(0, 102, 255, 'android')).toBe('hand');
+  });
+
+  it('does not silently apply the legacy 18-row crop to a Mini screenshot', async () => {
+    const processor = { getMetadata: () => ({ width: 1008, height: 2244 }) } as ImageProcessor;
+    const result = await parseWithProcessor(processor, { holdsetup: 19 });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Mini screenshots require');
+  });
+
+  it('uses a shorter, vertically centered Mini grid with the same cell spacing', () => {
+    const full = calculateAndroidRegions(1008, 2244, 18).board;
+    const mini = calculateAndroidRegions(1008, 2244, 12).board;
+    expect(mini.x).toBe(full.x);
+    expect(mini.width).toBe(full.width);
+    expect(Math.abs(mini.height / 12 - full.height / 18)).toBeLessThan(0.1);
+    expect(mini.y).toBeGreaterThan(full.y);
+    expect(mini.y + mini.height).toBeLessThan(full.y + full.height);
+  });
+});

--- a/packages/moonboard-ocr/src/__tests__/board-profiles.test.ts
+++ b/packages/moonboard-ocr/src/__tests__/board-profiles.test.ts
@@ -79,6 +79,13 @@ describe('explicit MoonBoard setup geometry', () => {
     expect(result.error).toContain('Mini screenshots require');
   });
 
+  it.each([23, 1, 15, 17] as const)('rejects unvalidated legacy iOS colors for setup %s', async (holdsetup) => {
+    const processor = { getMetadata: () => ({ width: 1008, height: 2244 }) } as ImageProcessor;
+    const result = await parseWithProcessor(processor, { holdsetup, screenshotProfile: 'legacy-ios' });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('requires a validated Android screenshot profile');
+  });
+
   it('uses a shorter, vertically centered Mini grid with the same cell spacing', () => {
     const full = calculateAndroidRegions(1008, 2244, 18).board;
     const mini = calculateAndroidRegions(1008, 2244, 12).board;

--- a/packages/moonboard-ocr/src/__tests__/cli-options.test.ts
+++ b/packages/moonboard-ocr/src/__tests__/cli-options.test.ts
@@ -1,0 +1,44 @@
+/// <reference types="node" />
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vite-plus/test';
+
+const cli = fileURLToPath(new URL('../cli.ts', import.meta.url));
+const fixture = fileURLToPath(new URL('./fixtures/ENCHANTED.PNG', import.meta.url));
+
+function invoke(command: string, ...options: string[]) {
+  return spawnSync(process.execPath, ['--import', 'tsx', cli, command, fixture, ...options], {
+    encoding: 'utf8',
+    timeout: 10_000,
+  });
+}
+
+describe('real CLI board/profile option wiring', () => {
+  it.each(['parse', 'test'])('%s rejects an unknown setup before accessing an image', (command) => {
+    const result = invoke(command, '--holdsetup', '7');
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Unsupported MoonBoard holdsetup');
+    expect(result.stdout).not.toContain('Output written');
+  });
+
+  it.each(['parse', 'test'])('%s rejects an unknown screenshot profile', (command) => {
+    const result = invoke(command, '--screenshot-profile', 'unvalidated');
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Allowed choices are legacy-ios, android-pixel8pro-1.3.68');
+    expect(result.stdout).not.toContain('Output written');
+  });
+
+  it('passes the Mini setup to the parser instead of defaulting to 2024', () => {
+    const result = invoke('test', '--holdsetup', '19');
+    expect(result.error).toBeUndefined();
+    expect(result.stdout).toContain('Mini screenshots require a validated Android profile');
+  });
+
+  it('passes the Android profile too, enforcing its real screenshot dimensions', () => {
+    // The existing iOS fixture must fail before starting Tesseract or networking.
+    const result = invoke('test', '--holdsetup', '19', '--screenshot-profile', 'android-pixel8pro-1.3.68');
+    expect(result.error).toBeUndefined();
+    expect(result.stdout).toContain('expected 1008x2244');
+    expect(result.stdout).not.toContain('Mini screenshots require');
+  });
+});

--- a/packages/moonboard-ocr/src/__tests__/fixtures/expected-results.ts
+++ b/packages/moonboard-ocr/src/__tests__/fixtures/expected-results.ts
@@ -1,6 +1,9 @@
 /**
  * Expected parsing results for all test fixtures.
  * Used by both Sharp and Canvas test suites.
+ * Touching-ring expectations were visually rechecked against the existing
+ * images in September 2026: 24 omitted rings across 21 fixtures were restored.
+ * Do not regenerate these expectations from parser output alone.
  */
 
 import type { GridCoordinate } from '../../types';
@@ -98,7 +101,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['B4', 'B6'],
-    handHolds: ['E9', 'F6', 'G12', 'G15', 'I14', 'K11'],
+    handHolds: ['E9', 'F6', 'F13', 'G12', 'G15', 'I14', 'K11'],
     finishHolds: ['I18'],
   },
   {
@@ -181,7 +184,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     userGrade: '6C/V5',
     setterGrade: null,
     isBenchmark: true,
-    startHolds: ['G5'],
+    startHolds: ['G5', 'H5'],
     handHolds: ['I16', 'I9', 'K11', 'K13', 'K15', 'K3'],
     finishHolds: ['F18', 'I18'],
   },
@@ -194,7 +197,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['E6', 'F5'],
-    handHolds: ['E9', 'H16', 'I10', 'J15', 'K5'],
+    handHolds: ['E9', 'H16', 'I10', 'J11', 'J15', 'K5', 'K6'],
     finishHolds: ['F18'],
   },
   {
@@ -241,7 +244,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     userGrade: '6B+/V4',
     setterGrade: '6B+/V4',
     isBenchmark: true,
-    startHolds: ['K5'],
+    startHolds: ['K5', 'K6'],
     handHolds: ['E16', 'G12', 'H15', 'I9', 'J11', 'K3'],
     finishHolds: ['I18'],
   },
@@ -279,8 +282,8 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['D4', 'H3'],
-    // Note: D18 blue merges with adjacent D17 in flood-fill; merged center maps to D17
-    handHolds: ['D17', 'D2', 'E15', 'G10', 'G2', 'I16', 'J4'],
+    // Both touching rings are visible; do not encode the old merged-centroid bug.
+    handHolds: ['D17', 'D18', 'D2', 'E15', 'G10', 'G2', 'I16', 'J4'],
     finishHolds: ['A18'],
   },
   {
@@ -292,7 +295,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['F6', 'H5'],
-    handHolds: ['E15', 'G17', 'H13', 'I9', 'K11', 'K2'],
+    handHolds: ['E15', 'G17', 'H13', 'H14', 'I9', 'K11', 'K2'],
     finishHolds: ['C18'],
   },
   {
@@ -304,7 +307,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['C6'],
-    handHolds: ['D10', 'G14', 'G4'],
+    handHolds: ['D10', 'D11', 'G14', 'G15', 'G4'],
     finishHolds: ['I18'],
   },
   {
@@ -328,7 +331,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['B6', 'G4'],
-    handHolds: ['B11', 'D9', 'F12', 'I15'],
+    handHolds: ['B11', 'D9', 'F12', 'F13', 'I15'],
     finishHolds: ['G18'],
   },
   {
@@ -340,7 +343,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['A4', 'C4'],
-    handHolds: ['B7', 'G10', 'G16', 'H6', 'J14'],
+    handHolds: ['B7', 'G10', 'G11', 'G16', 'H6', 'J14'],
     finishHolds: ['J18'],
   },
   {
@@ -364,7 +367,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['D7', 'H6'],
-    handHolds: ['E2', 'G10', 'G15', 'K13', 'K8'],
+    handHolds: ['E2', 'G10', 'G11', 'G15', 'K13', 'K8'],
     finishHolds: ['G18'],
   },
   {
@@ -388,7 +391,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['D7', 'K7'],
-    handHolds: ['D6', 'F15', 'I14', 'J11'],
+    handHolds: ['D6', 'F15', 'I14', 'J11', 'K11'],
     finishHolds: ['B18'],
   },
   {
@@ -424,7 +427,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['G4', 'I4'],
-    handHolds: ['A12', 'B4', 'D15', 'E10', 'G8', 'I9'],
+    handHolds: ['A12', 'B4', 'C15', 'D10', 'D15', 'E10', 'G8', 'I9'],
     finishHolds: ['F18'],
   },
   {
@@ -448,7 +451,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['B8', 'E8'],
-    handHolds: ['A8', 'F11', 'F17', 'J13', 'K9'],
+    handHolds: ['A8', 'F11', 'F12', 'F17', 'J13', 'K9'],
     finishHolds: ['B18'],
   },
   {
@@ -508,7 +511,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['C6'],
-    handHolds: ['A8', 'B12', 'D15', 'J15'],
+    handHolds: ['A8', 'B12', 'B13', 'D15', 'J15'],
     finishHolds: ['K18'],
   },
   {
@@ -544,7 +547,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['H5'],
-    handHolds: ['B14', 'C8', 'D12', 'D2', 'G16', 'H9'],
+    handHolds: ['B14', 'C8', 'D12', 'D2', 'G16', 'G17', 'H9'],
     finishHolds: ['J18'],
   },
   {
@@ -592,7 +595,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['I7', 'K6'],
-    handHolds: ['A16', 'G15', 'J10', 'K13'],
+    handHolds: ['A16', 'F15', 'G15', 'J10', 'K13'],
     finishHolds: ['B18'],
   },
   {
@@ -628,7 +631,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['I4'],
-    handHolds: ['A11', 'A14', 'C16', 'F10', 'J1', 'K10'],
+    handHolds: ['A11', 'A14', 'C16', 'E10', 'F10', 'J1', 'K10'],
     finishHolds: ['H18'],
   },
   {
@@ -652,7 +655,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['H4', 'K4'],
-    handHolds: ['A11', 'A15', 'C2', 'C7', 'D10', 'E13', 'F16', 'F6', 'G7'],
+    handHolds: ['A11', 'A15', 'C2', 'C7', 'D10', 'E13', 'E16', 'F16', 'F6', 'G7'],
     finishHolds: ['I18'],
   },
   {
@@ -664,7 +667,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     setterGrade: null,
     isBenchmark: true,
     startHolds: ['A12'],
-    handHolds: ['E9', 'F7', 'H15', 'J9', 'K5'],
+    handHolds: ['D9', 'E9', 'F7', 'H15', 'J9', 'K5'],
     finishHolds: ['I18'],
   },
   {
@@ -675,7 +678,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     userGrade: null,
     setterGrade: null,
     isBenchmark: true,
-    startHolds: ['F4'],
+    startHolds: ['E4', 'F4'],
     handHolds: ['G14', 'H15', 'J11', 'J7', 'K9'],
     finishHolds: ['C18'],
   },
@@ -723,7 +726,7 @@ export const EXPECTED_RESULTS: ExpectedClimbResult[] = [
     userGrade: null,
     setterGrade: null,
     isBenchmark: true,
-    startHolds: ['G5'],
+    startHolds: ['F5', 'G5'],
     handHolds: ['E9', 'F13', 'F16', 'I14', 'I8', 'K5'],
     finishHolds: ['C18'],
   },

--- a/packages/moonboard-ocr/src/__tests__/header-metadata.test.ts
+++ b/packages/moonboard-ocr/src/__tests__/header-metadata.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { parseHeaderText } from '../core/ocr';
+
+describe('metadata distinctions exposed by the old-catalog comparison', () => {
+  it('does not invent a community grade from the only setter grade', () => {
+    const result = parseHeaderText(['SYNTHETIC', 'Set by Setter @ 40°', 'Setter 6C+/V5']);
+    expect(result.userGrade).toBe('Unknown');
+    expect(result.setterGrade).toBe('6C+/V5');
+    expect(result.warnings).toContain('Could not extract user grade');
+    expect(result.warnings).not.toContain('Could not extract setter grade');
+  });
+
+  it('does not invent a setter grade from the only community grade', () => {
+    const result = parseHeaderText(['SYNTHETIC', 'Set by Setter @ 40°', 'User 6B/V4']);
+    expect(result.userGrade).toBe('6B/V4');
+    expect(result.setterGrade).toBe('Unknown');
+  });
+
+  it.each(['FRODO', 'FRODO Q'])('preserves a legitimate trailing letter in %s', (title) => {
+    const result = parseHeaderText([title, 'Set by Setter @ 40°', 'User 6B/V4 - Setter 6B/V4']);
+    expect(result.name).toBe('FRODO');
+  });
+
+  it('does not pick a longer star-rating artifact below the setter as the name', () => {
+    const result = parseHeaderText(['13.63', 'Set by Setter @ 40°', 'User 6B/V4 - Setter 6B/V4', '8.6.6 $4']);
+    expect(result.name).toBe('13.63');
+  });
+
+  it('preserves different explicitly labelled Android grades', () => {
+    const result = parseHeaderText(['SYNTHETIC', 'Set by Setter @ 40°', 'User 7A/V6 - Setter 6C+/V5']);
+    expect(result.userGrade).toBe('7A/V6');
+    expect(result.setterGrade).toBe('6C+/V5');
+  });
+
+  it('preserves the legacy iOS grade line', () => {
+    const result = parseHeaderText(['SYNTHETIC', 'Set by Setter @ 40°', 'Grade: User 8A/V11/ Setter 8A/V11']);
+    expect(result.userGrade).toBe('8A/V11');
+    expect(result.setterGrade).toBe('8A/V11');
+  });
+});

--- a/packages/moonboard-ocr/src/__tests__/header-metadata.test.ts
+++ b/packages/moonboard-ocr/src/__tests__/header-metadata.test.ts
@@ -37,4 +37,18 @@ describe('metadata distinctions exposed by the old-catalog comparison', () => {
     expect(result.userGrade).toBe('8A/V11');
     expect(result.setterGrade).toBe('8A/V11');
   });
+
+  it('repairs a compressed grade plus without copying the community grade', () => {
+    const result = parseHeaderText(['SYNTHETIC', 'Set by Setter @ 40°', 'User 7A/V6 - Setter 6B-+/V4']);
+    expect(result.userGrade).toBe('7A/V6');
+    expect(result.setterGrade).toBe('6B+/V4');
+    expect(result.warnings).toContain('Normalized OCR dash before grade plus');
+  });
+
+  it.each(['6B-/V4', '6BC/V4'])('does not silently accept the prefix of malformed grade %s', (grade) => {
+    const result = parseHeaderText(['SYNTHETIC', 'Set by Setter @ 40°', `User 7A/V6 - Setter ${grade}`]);
+    expect(result.userGrade).toBe('7A/V6');
+    expect(result.setterGrade).toBe('Unknown');
+    expect(result.warnings).toContain('Could not extract setter grade');
+  });
 });

--- a/packages/moonboard-ocr/src/__tests__/hold-colors.test.ts
+++ b/packages/moonboard-ocr/src/__tests__/hold-colors.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyPixelColor } from '../core/holds';
+
+describe('MoonBoard hold colors across app platforms', () => {
+  it.each([
+    [255, 0, 0, 'finish'],
+    [244, 15, 9, 'finish'],
+    [0, 255, 0, 'start'],
+    [13, 243, 10, 'start'],
+    [0, 102, 255, 'hand'],
+    [244, 67, 54, 'finish'],
+    [225, 82, 64, 'finish'],
+    [76, 175, 80, 'start'],
+    [100, 160, 80, 'start'],
+    [41, 97, 255, 'hand'],
+  ] as const)('classifies RGB(%i, %i, %i) as %s', (red, green, blue, expected) => {
+    expect(classifyPixelColor(red, green, blue)).toBe(expected);
+  });
+
+  it.each([
+    [238, 223, 80], // Yellow board background
+    [255, 255, 0],
+    [255, 255, 255], // Logo
+    [32, 32, 32], // Dark app UI
+    [0, 0, 0],
+    [0, 255, 255],
+    [255, 0, 255],
+    [255, 128, 0], // Orange benchmark marker
+  ] as const)('ignores non-hold RGB(%i, %i, %i)', (red, green, blue) => {
+    expect(classifyPixelColor(red, green, blue)).toBeNull();
+  });
+});

--- a/packages/moonboard-ocr/src/__tests__/occluded-holds.test.ts
+++ b/packages/moonboard-ocr/src/__tests__/occluded-holds.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { detectHoldsFromPixelData } from '../core/holds';
+import type { RawPixelData } from '../image-processor/types';
+
+function orderedRings(rings: { x: number; y: number; color: number[] }[]): RawPixelData {
+  const width = 660;
+  const height = 1080;
+  const pixels = new Uint8Array(width * height * 4).fill(255);
+  for (const ring of rings) {
+    for (let y = ring.y - 34; y <= ring.y + 34; y++) {
+      for (let x = ring.x - 34; x <= ring.x + 34; x++) {
+        const radius = Math.hypot(x - ring.x, y - ring.y);
+        if (radius >= 28 && radius <= 34) pixels.set(ring.color, (y * width + x) * 4);
+      }
+    }
+  }
+  return { width, height, channels: 4, data: pixels };
+}
+
+describe('overlapping rings with different roles', () => {
+  it('closes a narrow unclassified seam at a blended red/blue overlap', () => {
+    const pixels = orderedRings([
+      { x: 330, y: 510, color: [0, 102, 255] },
+      { x: 330, y: 450, color: [0, 102, 255] },
+      { x: 330, y: 390, color: [255, 0, 0] },
+    ]);
+    const seam: number[] = [];
+    for (let y = 350; y < 550; y++) {
+      for (let x = 290; x < 370; x++) {
+        const index = y * pixels.width + x;
+        if (pixels.data[index * 4] !== 0 || pixels.data[index * 4 + 2] !== 255) continue;
+        const neighbors = [index - 1, index + 1, index - pixels.width, index + pixels.width];
+        if (neighbors.some((neighbor) => pixels.data[neighbor * 4] === 255 && pixels.data[neighbor * 4 + 2] === 0)) {
+          seam.push(index);
+        }
+      }
+    }
+    expect(seam.length).toBeGreaterThan(0);
+    for (const index of seam) pixels.data.set([127, 51, 127], index * 4);
+    const holds = detectHoldsFromPixelData(
+      pixels,
+      { x: 0, y: 0, width: pixels.width, height: pixels.height },
+      18,
+      'android',
+    );
+    expect(holds.map(({ coordinate, type }) => `${coordinate}:${type}`).sort()).toEqual([
+      'F10:hand',
+      'F11:hand',
+      'F12:finish',
+    ]);
+  });
+
+  it('retains a blue hold whose top is covered by a red finish ring', () => {
+    // Reproduces the independently selected Mini 2025 failure, using synthetic
+    // geometry only: two connected blue rings, then a red ring painted above.
+    const pixels = orderedRings([
+      { x: 330, y: 510, color: [0, 102, 255] },
+      { x: 330, y: 450, color: [0, 102, 255] },
+      { x: 330, y: 390, color: [255, 0, 0] },
+    ]);
+    const holds = detectHoldsFromPixelData(
+      pixels,
+      { x: 0, y: 0, width: pixels.width, height: pixels.height },
+      18,
+      'android',
+    );
+    expect(holds.map(({ coordinate, type }) => `${coordinate}:${type}`).sort()).toEqual([
+      'F10:hand',
+      'F11:hand',
+      'F12:finish',
+    ]);
+  });
+
+  it('retains the original roles for a horizontal overlap too', () => {
+    const pixels = orderedRings([
+      { x: 390, y: 450, color: [0, 102, 255] },
+      { x: 330, y: 450, color: [0, 102, 255] },
+      { x: 270, y: 450, color: [0, 255, 0] },
+    ]);
+    const holds = detectHoldsFromPixelData(
+      pixels,
+      { x: 0, y: 0, width: pixels.width, height: pixels.height },
+      18,
+      'android',
+    );
+    expect(holds.map(({ coordinate, type }) => `${coordinate}:${type}`).sort()).toEqual([
+      'E11:start',
+      'F11:hand',
+      'G11:hand',
+    ]);
+  });
+
+  it('does not assign an unrelated enclosed red ring or a large empty gap to blue', () => {
+    const centers = [
+      [270, 390],
+      [330, 390],
+      [390, 390],
+      [450, 390],
+      [450, 450],
+      [450, 510],
+      [450, 570],
+      [390, 570],
+      [330, 570],
+      [270, 570],
+      [270, 510],
+      [270, 450],
+    ];
+    const pixels = orderedRings([
+      ...centers.map(([x, y]) => ({ x, y, color: [0, 102, 255] })),
+      { x: 330, y: 450, color: [255, 0, 0] },
+    ]);
+    const holds = detectHoldsFromPixelData(
+      pixels,
+      { x: 0, y: 0, width: pixels.width, height: pixels.height },
+      18,
+      'android',
+    );
+    const expected = centers.map(
+      ([x, y]) => `${String.fromCharCode(65 + Math.floor(x / 60))}${18 - Math.floor(y / 60)}:hand`,
+    );
+    expected.push('F11:finish');
+    expect(holds.map(({ coordinate, type }) => `${coordinate}:${type}`).sort()).toEqual(expected.sort());
+  });
+});

--- a/packages/moonboard-ocr/src/__tests__/touching-holds.test.ts
+++ b/packages/moonboard-ocr/src/__tests__/touching-holds.test.ts
@@ -112,4 +112,36 @@ describe('touching MoonBoard hold outlines', () => {
     expect(centers).toHaveLength(2);
     expect(centers.every((center) => center.type === 'start')).toBe(true);
   });
+
+  it('documents the single-centroid fallback when a damaged pair has only one closed interior', () => {
+    const pixels = outlinedCircles(
+      [
+        [330, 870],
+        [398, 870],
+      ],
+      [0, 255, 0],
+    );
+    // Open the second ring with a gap wider than the one-pixel seam repair.
+    // The outlines still touch, but only the first interior is enclosed.
+    for (let y = 833; y <= 846; y++) {
+      for (let x = 392; x <= 404; x++) pixels.data.set([255, 255, 255], (y * pixels.width + x) * 4);
+    }
+    let count = 0,
+      sumX = 0,
+      sumY = 0;
+    for (let y = 0; y < pixels.height; y++) {
+      for (let x = 0; x < pixels.width; x++) {
+        if (pixels.data[(y * pixels.width + x) * 4] !== 0) continue;
+        count++;
+        sumX += x;
+        sumY += y;
+      }
+    }
+    expect(count).toBeGreaterThan(0);
+    const centers = findCircleCenters(pixels);
+    expect(centers).toHaveLength(1);
+    expect(centers[0]).toMatchObject({ x: Math.round(sumX / count), y: Math.round(sumY / count), type: 'start' });
+    // This documents the limitation, not a claim of two-hold recovery.
+    // The reference validator must reject its incomplete coordinate/role set.
+  });
 });

--- a/packages/moonboard-ocr/src/__tests__/touching-holds.test.ts
+++ b/packages/moonboard-ocr/src/__tests__/touching-holds.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { detectHoldsFromPixelData } from '../core/holds';
+import type { RawPixelData } from '../image-processor/types';
+
+function outlinedCircles(centers: [number, number][], color: [number, number, number]): RawPixelData {
+  const width = 660;
+  const height = 1080;
+  const data = new Uint8Array(width * height * 4).fill(255);
+  for (const [centerX, centerY] of centers) {
+    for (let y = centerY - 34; y <= centerY + 34; y++) {
+      for (let x = centerX - 34; x <= centerX + 34; x++) {
+        const radius = Math.hypot(x - centerX, y - centerY);
+        if (radius < 28 || radius > 34) continue;
+        data.set(color, (y * width + x) * 4);
+      }
+    }
+  }
+  return { data, width, height, channels: 4 };
+}
+
+describe('touching MoonBoard hold outlines', () => {
+  it.each([
+    {
+      centers: [
+        [330, 870],
+        [390, 870],
+      ],
+      expected: ['F4', 'G4'],
+      color: [0, 255, 0],
+      role: 'start',
+    },
+    {
+      centers: [
+        [330, 870],
+        [390, 870],
+      ],
+      expected: ['F4', 'G4'],
+      color: [0, 102, 255],
+      role: 'hand',
+    },
+    {
+      centers: [
+        [330, 870],
+        [330, 810],
+      ],
+      expected: ['F4', 'F5'],
+      color: [255, 0, 0],
+      role: 'finish',
+    },
+    {
+      centers: [
+        [270, 870],
+        [330, 870],
+        [390, 870],
+      ],
+      expected: ['E4', 'F4', 'G4'],
+      color: [0, 255, 0],
+      role: 'start',
+    },
+    { centers: [[330, 870]], expected: ['F4'], color: [76, 175, 80], role: 'start' },
+    {
+      centers: [
+        [330, 870],
+        [390, 870],
+        [330, 810],
+        [390, 810],
+      ],
+      expected: ['F4', 'F5', 'G4', 'G5'],
+      color: [0, 102, 255],
+      role: 'hand',
+    },
+  ])('keeps each $role hold at $expected', ({ centers, expected, color, role }) => {
+    const pixels = outlinedCircles(centers as [number, number][], color as [number, number, number]);
+    const holds = detectHoldsFromPixelData(pixels, { x: 0, y: 0, width: pixels.width, height: pixels.height });
+    expect(holds.map((hold) => hold.coordinate).sort()).toEqual(expected);
+    expect(holds.every((hold) => hold.type === role)).toBe(true);
+  });
+});

--- a/packages/moonboard-ocr/src/__tests__/touching-holds.test.ts
+++ b/packages/moonboard-ocr/src/__tests__/touching-holds.test.ts
@@ -77,7 +77,7 @@ describe('touching MoonBoard hold outlines', () => {
     expect(holds.every((hold) => hold.type === role)).toBe(true);
   });
 
-  it('keeps near-miss outlines separate at 1.4 cells of center spacing', () => {
+  it('keeps independent components separate when rings do not touch', () => {
     const pixels = outlinedCircles(
       [
         [330, 870],
@@ -89,6 +89,25 @@ describe('touching MoonBoard hold outlines', () => {
     expect(centers.map(({ x, y }) => [x, y])).toEqual([
       [330, 870],
       [414, 870],
+    ]);
+    expect(centers).toHaveLength(2);
+    expect(centers.every((center) => center.type === 'start')).toBe(true);
+  });
+
+  it('separates one connected component when the two ring outlines barely touch', () => {
+    // Radius 34, centers 68 pixels apart: the outlines share one pixel.
+    // A merged centroid would be x=364; the interior scan must recover both.
+    const pixels = outlinedCircles(
+      [
+        [330, 870],
+        [398, 870],
+      ],
+      [0, 255, 0],
+    );
+    const centers = findCircleCenters(pixels);
+    expect(centers.map(({ x, y }) => [x, y])).toEqual([
+      [330, 870],
+      [398, 870],
     ]);
     expect(centers).toHaveLength(2);
     expect(centers.every((center) => center.type === 'start')).toBe(true);

--- a/packages/moonboard-ocr/src/__tests__/touching-holds.test.ts
+++ b/packages/moonboard-ocr/src/__tests__/touching-holds.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { detectHoldsFromPixelData } from '../core/holds';
+import { detectHoldsFromPixelData, findCircleCenters } from '../core/holds';
 import type { RawPixelData } from '../image-processor/types';
 
 function outlinedCircles(centers: [number, number][], color: [number, number, number]): RawPixelData {
@@ -73,6 +73,24 @@ describe('touching MoonBoard hold outlines', () => {
     const pixels = outlinedCircles(centers as [number, number][], color as [number, number, number]);
     const holds = detectHoldsFromPixelData(pixels, { x: 0, y: 0, width: pixels.width, height: pixels.height });
     expect(holds.map((hold) => hold.coordinate).sort()).toEqual(expected);
+    expect(holds).toHaveLength(expected.length);
     expect(holds.every((hold) => hold.type === role)).toBe(true);
+  });
+
+  it('keeps near-miss outlines separate at 1.4 cells of center spacing', () => {
+    const pixels = outlinedCircles(
+      [
+        [330, 870],
+        [414, 870],
+      ],
+      [0, 255, 0],
+    );
+    const centers = findCircleCenters(pixels);
+    expect(centers.map(({ x, y }) => [x, y])).toEqual([
+      [330, 870],
+      [414, 870],
+    ]);
+    expect(centers).toHaveLength(2);
+    expect(centers.every((center) => center.type === 'start')).toBe(true);
   });
 });

--- a/packages/moonboard-ocr/src/board-profiles.ts
+++ b/packages/moonboard-ocr/src/board-profiles.ts
@@ -1,0 +1,35 @@
+import type { GridCoordinate } from './types';
+
+/** Upstream holdsetup IDs, not Boardsesh layout IDs. Never infer a setup from holds. */
+export const BOARD_PROFILES = {
+  1: { name: 'MoonBoard 2016', rows: 18 },
+  15: { name: 'MoonBoard Masters 2017', rows: 18 },
+  17: { name: 'MoonBoard Masters 2019', rows: 18 },
+  19: { name: 'Mini MoonBoard 2020', rows: 12 },
+  21: { name: 'MoonBoard 2024', rows: 18 },
+  22: { name: 'Mini MoonBoard 2025', rows: 12 },
+  23: { name: 'MoonBoard 2010', rows: 18 },
+} as const;
+
+export type HoldSetup = keyof typeof BOARD_PROFILES;
+export type GridRows = 12 | 18;
+
+export function boardRows(holdsetup: HoldSetup = 21): GridRows {
+  if (!Object.hasOwn(BOARD_PROFILES, holdsetup)) throw new Error('Unsupported MoonBoard holdsetup');
+  return BOARD_PROFILES[holdsetup].rows;
+}
+
+const positions = (rows: GridRows) => {
+  const result: Partial<Record<GridCoordinate, { x: number; y: number }>> = {};
+  for (let column = 0; column < 11; column++) {
+    for (let row = 1; row <= rows; row++) {
+      result[`${String.fromCharCode(65 + column)}${row}` as GridCoordinate] = {
+        x: (column + 0.5) / 11,
+        y: (rows - row + 0.5) / rows,
+      };
+    }
+  }
+  return result;
+};
+
+export const GRID_POSITIONS_BY_ROWS = { 12: positions(12), 18: positions(18) };

--- a/packages/moonboard-ocr/src/browser.ts
+++ b/packages/moonboard-ocr/src/browser.ts
@@ -22,7 +22,10 @@
 
 import { CanvasImageProcessor } from './image-processor/canvas-processor';
 // Import from parser-core to avoid pulling in sharp via parser.ts
-import { parseWithProcessor, deduplicateClimbs } from './parser-core';
+import { parseWithProcessor, deduplicateClimbs, type ParseOptions } from './parser-core';
+export type { ParseOptions } from './parser-core';
+export { BOARD_PROFILES } from './board-profiles';
+export type { HoldSetup, GridRows } from './board-profiles';
 import type { ParseResult, MoonBoardClimb, DetectedHold, GridCoordinate, HoldType } from './types';
 
 // Re-export types for consumers
@@ -34,10 +37,10 @@ export type { ParseResult, MoonBoardClimb, DetectedHold, GridCoordinate, HoldTyp
  * @param image - A File or Blob containing the screenshot image
  * @returns ParseResult containing the extracted climb data or error
  */
-export async function parseScreenshot(image: File | Blob): Promise<ParseResult> {
+export async function parseScreenshot(image: File | Blob, options: ParseOptions = {}): Promise<ParseResult> {
   const processor = new CanvasImageProcessor();
   await processor.load(image);
-  return parseWithProcessor(processor);
+  return parseWithProcessor(processor, options);
 }
 
 /**
@@ -50,6 +53,7 @@ export async function parseScreenshot(image: File | Blob): Promise<ParseResult> 
 export async function parseMultipleScreenshots(
   images: Array<File | Blob>,
   onProgress?: (current: number, total: number, name: string) => void,
+  options: ParseOptions = {},
 ): Promise<{ climbs: MoonBoardClimb[]; errors: Array<{ name: string; error: string }> }> {
   const climbs: MoonBoardClimb[] = [];
   const errors: Array<{ name: string; error: string }> = [];
@@ -60,7 +64,7 @@ export async function parseMultipleScreenshots(
     onProgress?.(i + 1, images.length, name);
 
     try {
-      const result = await parseScreenshot(image);
+      const result = await parseScreenshot(image, options);
       if (result.success && result.climb) {
         climbs.push(result.climb);
       } else {

--- a/packages/moonboard-ocr/src/cli.ts
+++ b/packages/moonboard-ocr/src/cli.ts
@@ -1,10 +1,24 @@
 #!/usr/bin/env node
 
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import fs from 'fs/promises';
 import path from 'path';
 import { parseScreenshot, parseMultipleScreenshots, deduplicateClimbs } from './parser';
 import type { MoonBoardClimb } from './types';
+import { boardRows, type HoldSetup } from './board-profiles';
+
+const setupOption = () =>
+  new Option('--holdsetup <id>', 'Upstream MoonBoard setup ID (not Boardsesh layout ID)')
+    .argParser((value) => {
+      const id = Number(value) as HoldSetup;
+      boardRows(id);
+      return id;
+    })
+    .default(21);
+const profileOption = () =>
+  new Option('--screenshot-profile <profile>', 'Validated screenshot layout')
+    .choices(['legacy-ios', 'android-pixel8pro-1.3.68'])
+    .default('legacy-ios');
 
 /**
  * Check if a file is an image based on extension
@@ -25,6 +39,8 @@ program
   .description('Parse MoonBoard screenshot(s) and extract climb data')
   .option('-o, --output <file>', 'Output JSON file', 'climbs.json')
   .option('--no-dedupe', 'Skip deduplication of climbs')
+  .addOption(setupOption())
+  .addOption(profileOption())
   .action(async (input: string, options) => {
     try {
       const inputPath = path.resolve(input);
@@ -56,9 +72,13 @@ program
 
       // Parse all images
       console.info('Parsing screenshots...');
-      const { climbs, errors } = await parseMultipleScreenshots(imagePaths, (current, total, file) => {
-        process.stdout.write(`\rProcessing: ${current}/${total} - ${file}`);
-      });
+      const { climbs, errors } = await parseMultipleScreenshots(
+        imagePaths,
+        (current, total, file) => {
+          process.stdout.write(`\rProcessing: ${current}/${total} - ${file}`);
+        },
+        { holdsetup: options.holdsetup, screenshotProfile: options.screenshotProfile },
+      );
       console.info(''); // New line after progress
 
       // Report errors
@@ -119,12 +139,17 @@ program
 program
   .command('test <image>')
   .description('Test parsing a single image and show detailed output')
-  .action(async (image: string) => {
+  .addOption(setupOption())
+  .addOption(profileOption())
+  .action(async (image: string, options) => {
     try {
       const imagePath = path.resolve(image);
       console.info(`Testing: ${imagePath}\n`);
 
-      const result = await parseScreenshot(imagePath);
+      const result = await parseScreenshot(imagePath, {
+        holdsetup: options.holdsetup,
+        screenshotProfile: options.screenshotProfile,
+      });
 
       if (result.success && result.climb) {
         console.info('=== Parsed Climb Data ===');

--- a/packages/moonboard-ocr/src/core/holds.ts
+++ b/packages/moonboard-ocr/src/core/holds.ts
@@ -94,6 +94,8 @@ export function classifyPixelColor(
   if (palette === 'android') {
     if (Math.hypot(r - 255, g, b) < 35) return 'finish';
     if (Math.hypot(r, g - 255, b) < 35) return 'start';
+    // Blue spans #2961ff and #0066ff ring pixels (~41 RGB units apart).
+    // Its wider tolerance deliberately retains both observed shades.
     if (Math.hypot(r - 41, g - 97, b - 255) < 50) return 'hand';
     return null;
   }
@@ -220,12 +222,11 @@ function enclosedCircleCenters(
         count++;
         sumX += pixel.x;
         sumY += pixel.y;
-        stack.push(
-          { x: pixel.x + 1, y: pixel.y },
-          { x: pixel.x - 1, y: pixel.y },
-          { x: pixel.x, y: pixel.y + 1 },
-          { x: pixel.x, y: pixel.y - 1 },
-        );
+        // Do not allocate neighbors outside the component's bounding box.
+        if (pixel.x < right) stack.push({ x: pixel.x + 1, y: pixel.y });
+        if (pixel.x > left) stack.push({ x: pixel.x - 1, y: pixel.y });
+        if (pixel.y < bottom) stack.push({ x: pixel.x, y: pixel.y + 1 });
+        if (pixel.y > top) stack.push({ x: pixel.x, y: pixel.y - 1 });
       }
       // Reject the exterior and tiny lenses enclosed where two rings overlap.
       if (!touchesEdge && count >= cellWidth * cellHeight * 0.15) {
@@ -281,7 +282,7 @@ export function findCircleCenters(
         const enclosed = enclosedCircleCenters(component, width, width / 11, height / rows);
         // The helper currently returns zero or >=2 centers. Keep the >=2 guard
         // explicit: one interior must not replace the ordinary centroid path.
-        if (enclosed.length > 1) {
+        if (enclosed.length >= 2) {
           circles.push(
             ...enclosed.map((center) => ({
               ...center,

--- a/packages/moonboard-ocr/src/core/holds.ts
+++ b/packages/moonboard-ocr/src/core/holds.ts
@@ -176,7 +176,9 @@ function enclosedCircleCenters(
     bottom = Math.max(bottom, pixel.y);
     outline.add(pixel.y * imageWidth + pixel.x);
   }
-  // Keep the existing centroid path for ordinary individual circles.
+  // Keep the centroid path only when BOTH dimensions fit an individual circle.
+  // A horizontal pair expands width alone; a vertical pair expands height alone.
+  // Either dimension reaching 1.4 cells must therefore reach the interior scan.
   if (right - left < cellWidth * 1.4 && bottom - top < cellHeight * 1.4) return [];
 
   const visited = new Set<number>();
@@ -255,6 +257,8 @@ export function findCircleCenters(pixelData: RawPixelData): CircleCenter[] {
 
       if (component.length >= minPixels) {
         const enclosed = enclosedCircleCenters(component, width, width / 11, height / 18);
+        // The helper currently returns zero or >=2 centers. Keep the >=2 guard
+        // explicit: one interior must not replace the ordinary centroid path.
         if (enclosed.length > 1) {
           circles.push(
             ...enclosed.map((center) => ({

--- a/packages/moonboard-ocr/src/core/holds.ts
+++ b/packages/moonboard-ocr/src/core/holds.ts
@@ -85,7 +85,10 @@ export function classifyPixelColor(r: number, g: number, b: number): HoldType | 
   // Also matches rendered color ~RGB(225, 82, 64)
   const redDist = Math.sqrt(Math.pow(r - 244, 2) + Math.pow(g - 67, 2) + Math.pow(b - 54, 2));
   const redDist2 = Math.sqrt(Math.pow(r - 225, 2) + Math.pow(g - 82, 2) + Math.pow(b - 64, 2));
-  if (redDist < 50 || redDist2 < 50) {
+  // Stock Android Moon Climbing 1.3.68 renders saturated RGB circles. Keep
+  // the iOS palette too; screenshots from both platforms feed this package.
+  const androidRedDist = Math.sqrt(Math.pow(r - 255, 2) + Math.pow(g, 2) + Math.pow(b, 2));
+  if (redDist < 50 || redDist2 < 50 || androidRedDist < 35) {
     return 'finish';
   }
 
@@ -101,7 +104,8 @@ export function classifyPixelColor(r: number, g: number, b: number): HoldType | 
   // Actual rendered: ~RGB(85, 171, 103) or ~RGB(100, 160, 80)
   const greenDist1 = Math.sqrt(Math.pow(r - 76, 2) + Math.pow(g - 175, 2) + Math.pow(b - 80, 2));
   const greenDist2 = Math.sqrt(Math.pow(r - 100, 2) + Math.pow(g - 160, 2) + Math.pow(b - 80, 2));
-  if ((greenDist1 < 40 || greenDist2 < 40) && g > r && g > b) {
+  const androidGreenDist = Math.sqrt(Math.pow(r, 2) + Math.pow(g - 255, 2) + Math.pow(b, 2));
+  if ((greenDist1 < 40 || greenDist2 < 40 || androidGreenDist < 35) && g > r && g > b) {
     return 'start';
   }
 

--- a/packages/moonboard-ocr/src/core/holds.ts
+++ b/packages/moonboard-ocr/src/core/holds.ts
@@ -1,4 +1,5 @@
-import { type HoldType, type GridCoordinate, type DetectedHold, GRID_POSITIONS } from '../types';
+import { type HoldType, type GridCoordinate, type DetectedHold } from '../types';
+import { GRID_POSITIONS_BY_ROWS, type GridRows } from '../board-profiles';
 import type { RawPixelData, ImageRegion } from '../image-processor/types';
 
 type CircleCenter = {
@@ -7,6 +8,8 @@ type CircleCenter = {
   type: HoldType;
   pixelCount: number;
 };
+
+export type HoldPalette = 'combined' | 'android';
 
 /**
  * Check if a pixel is the MoonBoard yellow color.
@@ -79,7 +82,21 @@ export function detectBoardRegion(pixelData: RawPixelData): ImageRegion | null {
  * - BLUE circles (#2961ff) = HAND holds (intermediate)
  * - GREEN circles (#4caf50) = START holds (bottom of climb)
  */
-export function classifyPixelColor(r: number, g: number, b: number): HoldType | null {
+export function classifyPixelColor(
+  r: number,
+  g: number,
+  b: number,
+  palette: HoldPalette = 'combined',
+): HoldType | null {
+  // Android rings are saturated; the broader iOS reds also match the red
+  // plastic holds on Masters 2017. A declared Android profile must not use
+  // those legacy color tolerances to classify the underlying board artwork.
+  if (palette === 'android') {
+    if (Math.hypot(r - 255, g, b) < 35) return 'finish';
+    if (Math.hypot(r, g - 255, b) < 35) return 'start';
+    if (Math.hypot(r - 41, g - 97, b - 255) < 50) return 'hand';
+    return null;
+  }
   // Red circle (FINISH holds) - top of climb
   // Exact color: #f44336 = RGB(244, 67, 54)
   // Also matches rendered color ~RGB(225, 82, 64)
@@ -124,6 +141,7 @@ function floodFill(
   startY: number,
   targetType: HoldType,
   visited: Set<number>,
+  palette: HoldPalette,
 ): { x: number; y: number }[] {
   const pixels: { x: number; y: number }[] = [];
   const stack: { x: number; y: number }[] = [{ x: startX, y: startY }];
@@ -141,7 +159,7 @@ function floodFill(
     const g = data[pixelIdx + 1];
     const b = data[pixelIdx + 2];
 
-    const pixelType = classifyPixelColor(r, g, b);
+    const pixelType = classifyPixelColor(r, g, b, palette);
     if (pixelType !== targetType) continue;
 
     visited.add(idx);
@@ -229,7 +247,11 @@ function enclosedCircleCenters(
  * Find centers of colored circles using flood-fill connected components.
  * Works with 4-channel RGBA data.
  */
-export function findCircleCenters(pixelData: RawPixelData): CircleCenter[] {
+export function findCircleCenters(
+  pixelData: RawPixelData,
+  rows: GridRows = 18,
+  palette: HoldPalette = 'combined',
+): CircleCenter[] {
   const { data, width, height, channels } = pixelData;
   const visited = new Set<number>();
   const circles: CircleCenter[] = [];
@@ -237,7 +259,7 @@ export function findCircleCenters(pixelData: RawPixelData): CircleCenter[] {
   // Minimum pixels to be considered a valid circle (filters noise).
   // Scale with image resolution: 5% of average cell area (11 cols x 18 rows).
   // For 1097x1764 (1290 phone): ~489, for 992x1595 (1206 phone): ~399
-  const minPixels = Math.max(100, Math.round(((width * height) / (11 * 18)) * 0.05));
+  const minPixels = Math.max(100, Math.round(((width * height) / (11 * rows)) * 0.05));
 
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
@@ -249,14 +271,14 @@ export function findCircleCenters(pixelData: RawPixelData): CircleCenter[] {
       const g = data[pixelIdx + 1];
       const b = data[pixelIdx + 2];
 
-      const holdType = classifyPixelColor(r, g, b);
+      const holdType = classifyPixelColor(r, g, b, palette);
       if (!holdType) continue;
 
       // Flood fill to find all connected pixels of same type
-      const component = floodFill(data, width, height, channels, x, y, holdType, visited);
+      const component = floodFill(data, width, height, channels, x, y, holdType, visited, palette);
 
       if (component.length >= minPixels) {
-        const enclosed = enclosedCircleCenters(component, width, width / 11, height / 18);
+        const enclosed = enclosedCircleCenters(component, width, width / 11, height / rows);
         // The helper currently returns zero or >=2 centers. Keep the >=2 guard
         // explicit: one interior must not replace the ordinary centroid path.
         if (enclosed.length > 1) {
@@ -293,11 +315,15 @@ export function findCircleCenters(pixelData: RawPixelData): CircleCenter[] {
 /**
  * Find the nearest grid coordinate to a relative position.
  */
-export function findNearestGridPosition(relX: number, relY: number): { coordinate: GridCoordinate; distance: number } {
+export function findNearestGridPosition(
+  relX: number,
+  relY: number,
+  rows: GridRows = 18,
+): { coordinate: GridCoordinate; distance: number } {
   let nearestCoord: GridCoordinate = 'A1';
   let minDistance = Infinity;
 
-  for (const [coord, pos] of Object.entries(GRID_POSITIONS)) {
+  for (const [coord, pos] of Object.entries(GRID_POSITIONS_BY_ROWS[rows])) {
     const dx = relX - pos.x;
     const dy = relY - pos.y;
     const distance = Math.sqrt(dx * dx + dy * dy);
@@ -318,6 +344,7 @@ export function mapCirclesToHolds(
   circles: CircleCenter[],
   boardRegion: ImageRegion,
   pixelDataDimensions: { width: number; height: number },
+  rows: GridRows = 18,
 ): DetectedHold[] {
   return circles
     .map((circle) => {
@@ -326,7 +353,7 @@ export function mapCirclesToHolds(
       const relY = circle.y / pixelDataDimensions.height;
 
       // Find nearest grid position
-      const { coordinate, distance } = findNearestGridPosition(relX, relY);
+      const { coordinate, distance } = findNearestGridPosition(relX, relY, rows);
 
       // Calculate confidence based on distance (closer = higher confidence)
       // Max reasonable distance is ~0.05 (half a cell width)
@@ -416,10 +443,20 @@ export function detectBenchmarkCircle(pixelData: RawPixelData): boolean {
 /**
  * Detect holds from raw pixel data of the board region.
  */
-export function detectHoldsFromPixelData(pixelData: RawPixelData, boardRegion: ImageRegion): DetectedHold[] {
-  const circles = findCircleCenters(pixelData);
-  return mapCirclesToHolds(circles, boardRegion, {
-    width: pixelData.width,
-    height: pixelData.height,
-  });
+export function detectHoldsFromPixelData(
+  pixelData: RawPixelData,
+  boardRegion: ImageRegion,
+  rows: GridRows = 18,
+  palette: HoldPalette = 'combined',
+): DetectedHold[] {
+  const circles = findCircleCenters(pixelData, rows, palette);
+  return mapCirclesToHolds(
+    circles,
+    boardRegion,
+    {
+      width: pixelData.width,
+      height: pixelData.height,
+    },
+    rows,
+  );
 }

--- a/packages/moonboard-ocr/src/core/holds.ts
+++ b/packages/moonboard-ocr/src/core/holds.ts
@@ -157,6 +157,72 @@ function floodFill(
   return pixels;
 }
 
+/** Separate touching outlines by their enclosed interiors, not a shared centroid. */
+function enclosedCircleCenters(
+  component: { x: number; y: number }[],
+  imageWidth: number,
+  cellWidth: number,
+  cellHeight: number,
+): { x: number; y: number }[] {
+  let left = Infinity,
+    right = -Infinity,
+    top = Infinity,
+    bottom = -Infinity;
+  const outline = new Set<number>();
+  for (const pixel of component) {
+    left = Math.min(left, pixel.x);
+    right = Math.max(right, pixel.x);
+    top = Math.min(top, pixel.y);
+    bottom = Math.max(bottom, pixel.y);
+    outline.add(pixel.y * imageWidth + pixel.x);
+  }
+  // Keep the existing centroid path for ordinary individual circles.
+  if (right - left < cellWidth * 1.4 && bottom - top < cellHeight * 1.4) return [];
+
+  const visited = new Set<number>();
+  const centers: { x: number; y: number }[] = [];
+  for (let y = top; y <= bottom; y++) {
+    for (let x = left; x <= right; x++) {
+      const index = y * imageWidth + x;
+      if (outline.has(index) || visited.has(index)) continue;
+      const stack = [{ x, y }];
+      let touchesEdge = false,
+        count = 0,
+        sumX = 0,
+        sumY = 0;
+      while (stack.length > 0) {
+        const pixel = stack.pop()!;
+        if (pixel.x < left || pixel.x > right || pixel.y < top || pixel.y > bottom) continue;
+        const pixelIndex = pixel.y * imageWidth + pixel.x;
+        if (outline.has(pixelIndex) || visited.has(pixelIndex)) continue;
+        visited.add(pixelIndex);
+        touchesEdge ||= pixel.x === left || pixel.x === right || pixel.y === top || pixel.y === bottom;
+        count++;
+        sumX += pixel.x;
+        sumY += pixel.y;
+        stack.push(
+          { x: pixel.x + 1, y: pixel.y },
+          { x: pixel.x - 1, y: pixel.y },
+          { x: pixel.x, y: pixel.y + 1 },
+          { x: pixel.x, y: pixel.y - 1 },
+        );
+      }
+      // Reject the exterior and tiny lenses enclosed where two rings overlap.
+      if (!touchesEdge && count >= cellWidth * cellHeight * 0.15) {
+        const center = { x: Math.round(sumX / count), y: Math.round(sumY / count) };
+        const column = center.x / cellWidth - 0.5;
+        const row = center.y / cellHeight - 0.5;
+        // Four touching rings can enclose a gap halfway between BOTH axes.
+        // Allow calibration drift on one axis (older iOS crops have it).
+        if (Math.abs(column - Math.round(column)) < 0.35 || Math.abs(row - Math.round(row)) < 0.35) {
+          centers.push(center);
+        }
+      }
+    }
+  }
+  return centers.length >= 2 ? centers : [];
+}
+
 /**
  * Find centers of colored circles using flood-fill connected components.
  * Works with 4-channel RGBA data.
@@ -188,6 +254,17 @@ export function findCircleCenters(pixelData: RawPixelData): CircleCenter[] {
       const component = floodFill(data, width, height, channels, x, y, holdType, visited);
 
       if (component.length >= minPixels) {
+        const enclosed = enclosedCircleCenters(component, width, width / 11, height / 18);
+        if (enclosed.length > 1) {
+          circles.push(
+            ...enclosed.map((center) => ({
+              ...center,
+              type: holdType,
+              pixelCount: Math.round(component.length / enclosed.length),
+            })),
+          );
+          continue;
+        }
         // Calculate center of mass
         let sumX = 0,
           sumY = 0;

--- a/packages/moonboard-ocr/src/core/holds.ts
+++ b/packages/moonboard-ocr/src/core/holds.ts
@@ -427,7 +427,10 @@ export function mapCirclesToHolds(
  * The MoonBoard benchmark indicator is a ~47x47 golden circle in the header.
  * Color samples: RGB(211,175,88), RGB(214,165,62), RGB(229,168,88)
  */
-function isOrangePixel(r: number, g: number, b: number): boolean {
+function isOrangePixel(r: number, g: number, b: number, style: 'legacy-ios' | 'android'): boolean {
+  // Android 1.3.68 uses bright gold, with compression spreading its blue
+  // channel from near zero into the muted-gold range. Keep both connected.
+  if (style === 'android') return r >= 180 && g >= 130 && g <= 215 && b <= 110 && r > g && g > b;
   return r >= 180 && r <= 255 && g >= 130 && g <= 210 && b >= 20 && b <= 100 && r > g && g > b;
 }
 
@@ -438,7 +441,10 @@ function isOrangePixel(r: number, g: number, b: number): boolean {
  * ~48x48px). This avoids false negatives when star ratings or other small
  * orange UI elements are present in the same header region.
  */
-export function detectBenchmarkCircle(pixelData: RawPixelData): boolean {
+export function detectBenchmarkCircle(
+  pixelData: RawPixelData,
+  style: 'legacy-ios' | 'android' = 'legacy-ios',
+): boolean {
   const { data, width, height, channels } = pixelData;
   const visited = new Set<number>();
 
@@ -448,7 +454,7 @@ export function detectBenchmarkCircle(pixelData: RawPixelData): boolean {
       if (visited.has(idx)) continue;
 
       const pixelIdx = idx * channels;
-      if (!isOrangePixel(data[pixelIdx], data[pixelIdx + 1], data[pixelIdx + 2])) continue;
+      if (!isOrangePixel(data[pixelIdx], data[pixelIdx + 1], data[pixelIdx + 2], style)) continue;
 
       // Flood-fill this orange component
       let count = 0;
@@ -464,7 +470,7 @@ export function detectBenchmarkCircle(pixelData: RawPixelData): boolean {
         const vi = p.y * width + p.x;
         if (visited.has(vi)) continue;
         const pi = vi * channels;
-        if (!isOrangePixel(data[pi], data[pi + 1], data[pi + 2])) continue;
+        if (!isOrangePixel(data[pi], data[pi + 1], data[pi + 2], style)) continue;
         visited.add(vi);
         count++;
         if (p.x < minX) minX = p.x;

--- a/packages/moonboard-ocr/src/core/holds.ts
+++ b/packages/moonboard-ocr/src/core/holds.ts
@@ -180,10 +180,12 @@ function floodFill(
 /** Separate touching outlines by their enclosed interiors, not a shared centroid. */
 function enclosedCircleCenters(
   component: { x: number; y: number }[],
-  imageWidth: number,
+  pixelData: RawPixelData,
   cellWidth: number,
   cellHeight: number,
+  palette: HoldPalette,
 ): { x: number; y: number }[] {
+  const { width: imageWidth, data, channels } = pixelData;
   let left = Infinity,
     right = -Infinity,
     top = Infinity,
@@ -201,35 +203,84 @@ function enclosedCircleCenters(
   // Either dimension reaching 1.4 cells must therefore reach the interior scan.
   if (right - left < cellWidth * 1.4 && bottom - top < cellHeight * 1.4) return [];
 
+  // A differently colored ring can paint over part of this outline. Treat all
+  // marker colors as barriers so that overlap does not open an otherwise closed
+  // interior. Only scan this merged component's small bounding box.
+  const markerPixels = new Set(outline);
+  for (let y = top; y <= bottom; y++) {
+    for (let x = left; x <= right; x++) {
+      const index = y * imageWidth + x;
+      const offset = index * channels;
+      if (!markerPixels.has(index) && classifyPixelColor(data[offset], data[offset + 1], data[offset + 2], palette)) {
+        markerPixels.add(index);
+      }
+    }
+  }
+  // Blended pixels at a red/blue overlap can fall outside both palettes. Seal
+  // one-pixel seams locally, without widening the color tolerance over plastic.
+  const thicken = (pixels: Set<number>): Set<number> => {
+    const result = new Set<number>();
+    for (const index of pixels) {
+      const centerX = index % imageWidth;
+      const centerY = Math.floor(index / imageWidth);
+      for (let y = Math.max(top, centerY - 1); y <= Math.min(bottom, centerY + 1); y++) {
+        for (let x = Math.max(left, centerX - 1); x <= Math.min(right, centerX + 1); x++) {
+          result.add(y * imageWidth + x);
+        }
+      }
+    }
+    return result;
+  };
+  const barriers = thicken(markerPixels);
+  const ownBarriers = thicken(outline);
+
   const visited = new Set<number>();
   const centers: { x: number; y: number }[] = [];
   for (let y = top; y <= bottom; y++) {
     for (let x = left; x <= right; x++) {
       const index = y * imageWidth + x;
-      if (outline.has(index) || visited.has(index)) continue;
-      const stack = [{ x, y }];
+      if (barriers.has(index) || visited.has(index)) continue;
+      const stack = [index];
+      visited.add(index);
       let touchesEdge = false,
         count = 0,
         sumX = 0,
-        sumY = 0;
+        sumY = 0,
+        boundaryEdges = 0,
+        ownBoundaryEdges = 0;
       while (stack.length > 0) {
-        const pixel = stack.pop()!;
-        if (pixel.x < left || pixel.x > right || pixel.y < top || pixel.y > bottom) continue;
-        const pixelIndex = pixel.y * imageWidth + pixel.x;
-        if (outline.has(pixelIndex) || visited.has(pixelIndex)) continue;
-        visited.add(pixelIndex);
-        touchesEdge ||= pixel.x === left || pixel.x === right || pixel.y === top || pixel.y === bottom;
+        const pixelIndex = stack.pop()!;
+        const pixelX = pixelIndex % imageWidth;
+        const pixelY = Math.floor(pixelIndex / imageWidth);
+        touchesEdge ||= pixelX === left || pixelX === right || pixelY === top || pixelY === bottom;
         count++;
-        sumX += pixel.x;
-        sumY += pixel.y;
-        // Do not allocate neighbors outside the component's bounding box.
-        if (pixel.x < right) stack.push({ x: pixel.x + 1, y: pixel.y });
-        if (pixel.x > left) stack.push({ x: pixel.x - 1, y: pixel.y });
-        if (pixel.y < bottom) stack.push({ x: pixel.x, y: pixel.y + 1 });
-        if (pixel.y > top) stack.push({ x: pixel.x, y: pixel.y - 1 });
+        sumX += pixelX;
+        sumY += pixelY;
+        const neighbors: number[] = [];
+        if (pixelX < right) neighbors.push(pixelIndex + 1);
+        if (pixelX > left) neighbors.push(pixelIndex - 1);
+        if (pixelY < bottom) neighbors.push(pixelIndex + imageWidth);
+        if (pixelY > top) neighbors.push(pixelIndex - imageWidth);
+        for (const neighbor of neighbors) {
+          if (barriers.has(neighbor)) {
+            boundaryEdges++;
+            if (ownBarriers.has(neighbor)) ownBoundaryEdges++;
+          } else if (!visited.has(neighbor)) {
+            visited.add(neighbor);
+            stack.push(neighbor);
+          }
+        }
       }
-      // Reject the exterior and tiny lenses enclosed where two rings overlap.
-      if (!touchesEdge && count >= cellWidth * cellHeight * 0.15) {
+      // Reject the exterior, tiny overlap lenses, and multi-cell empty gaps.
+      // Single-ring interiors fit about one cell; allow a 20% crop-area margin.
+      // An unrelated ring inside the bounding box must not acquire this role:
+      // most of an accepted interior's boundary must belong to this component.
+      if (
+        !touchesEdge &&
+        count >= cellWidth * cellHeight * 0.15 &&
+        count <= cellWidth * cellHeight * 1.2 &&
+        ownBoundaryEdges > boundaryEdges / 2
+      ) {
         const center = { x: Math.round(sumX / count), y: Math.round(sumY / count) };
         const column = center.x / cellWidth - 0.5;
         const row = center.y / cellHeight - 0.5;
@@ -279,7 +330,7 @@ export function findCircleCenters(
       const component = floodFill(data, width, height, channels, x, y, holdType, visited, palette);
 
       if (component.length >= minPixels) {
-        const enclosed = enclosedCircleCenters(component, width, width / 11, height / rows);
+        const enclosed = enclosedCircleCenters(component, pixelData, width / 11, height / rows, palette);
         // The helper currently returns zero or >=2 centers. Keep the >=2 guard
         // explicit: one interior must not replace the ordinary centroid path.
         if (enclosed.length >= 2) {

--- a/packages/moonboard-ocr/src/core/ocr.ts
+++ b/packages/moonboard-ocr/src/core/ocr.ts
@@ -106,8 +106,12 @@ export function parseHeaderText(lines: string[]): OcrResult {
   // Try to find climb name (usually first meaningful line)
   // Collect candidate lines and pick the best one
   const nameCandidates: string[] = [];
+  const setterLineIndex = lines.findIndex((line) => /set\s+by\s+/i.test(line));
+  // Rating stars and repeat counts below the setter can resemble long uppercase
+  // names. Only the title area is eligible when the metadata boundary is known.
+  const titleLines = setterLineIndex >= 0 ? lines.slice(0, setterLineIndex) : lines;
 
-  for (const line of lines) {
+  for (const line of titleLines) {
     // Skip lines that look like metadata
     if (
       line.toLowerCase().includes('set by') ||
@@ -125,7 +129,7 @@ export function parseHeaderText(lines: string[]): OcrResult {
     // Remove heart emoji and OCR artifacts, trim
     const cleaned = line
       .replace(/♡|❤️|🤍|©|®/gu, '') // Remove heart, copyright symbols
-      .replace(/\s*[QO@()&]+\s*$/i, '') // Remove trailing Q/O/@/()/& (OCR error for heart/icons)
+      .replace(/\s+[QO@()&]+\s*$/i, '') // A separate icon token, never letters within a real name
       .replace(/^\d+[)\]]\s*/, '') // Remove leading numbers like "0)"
       .replace(/^[yl]\s+/i, '') // Remove leading y/l (OCR artifacts)
       .trim();
@@ -144,13 +148,14 @@ export function parseHeaderText(lines: string[]): OcrResult {
   // Pick the best candidate (prefer longer names, all-caps is common for climb names)
   if (nameCandidates.length > 0) {
     // Sort by: prefer all-caps, then by length
-    nameCandidates.sort((a, b) => {
-      const aAllCaps = a === a.toUpperCase();
-      const bAllCaps = b === b.toUpperCase();
-      if (aAllCaps && !bAllCaps) return -1;
-      if (!aAllCaps && bAllCaps) return 1;
-      return b.length - a.length; // Longer names first
-    });
+    if (setterLineIndex >= 0)
+      nameCandidates.sort((a, b) => {
+        const aAllCaps = a === a.toUpperCase();
+        const bAllCaps = b === b.toUpperCase();
+        if (aAllCaps && !bAllCaps) return -1;
+        if (!aAllCaps && bAllCaps) return 1;
+        return b.length - a.length; // Longer names first
+      });
     name = nameCandidates[0];
 
     // Clean up trailing "8" or "B" which may come from heart icon or benchmark indicator
@@ -174,16 +179,19 @@ export function parseHeaderText(lines: string[]): OcrResult {
     }
   }
 
-  // Find grades
-  for (const line of lines) {
-    // Format: "Grade: User 8A/V11/ Setter 8A/V11"
-    const gradeMatch = line.match(/grade[:\s]+user\s+([^\s/]+(?:\/[^\s/]+)?)\s*[/|]\s*setter\s+([^\s]+)/i);
-    if (gradeMatch) {
-      userGrade = gradeMatch[1].trim();
-      setterGrade = gradeMatch[2].trim();
-      break;
+  // Explicit labels take precedence. A setter-only grade is not a community
+  // grade, and a missing setter grade must not be filled from the community.
+  const gradeLines = setterLineIndex >= 0 ? lines.slice(setterLineIndex + 1) : lines;
+  const hasGradeLabels = gradeLines.some((line) => /\b(?:user|setter)\b/i.test(line));
+  for (const line of gradeLines) {
+    for (const match of line.matchAll(/\b(user|setter)\s+([3-9][ABC]?\+?(?:\/V\d+)?)/gi)) {
+      if (match[1].toLowerCase() === 'user' && !userGrade) userGrade = match[2];
+      if (match[1].toLowerCase() === 'setter' && !setterGrade) setterGrade = match[2];
     }
-    // Alternative: just look for grade patterns
+  }
+  // Preserve the legacy unlabelled grade-order fallback only when neither label
+  // survived OCR. Never let it overwrite or infer an explicitly labelled role.
+  for (const line of hasGradeLabels ? [] : gradeLines) {
     const simpleGradeMatch = line.match(/(\d[ABC]?\+?\/V\d+)/gi);
     if (simpleGradeMatch && simpleGradeMatch.length >= 1) {
       if (!userGrade) userGrade = simpleGradeMatch[0];
@@ -204,7 +212,7 @@ export function parseHeaderText(lines: string[]): OcrResult {
     setter: setter || 'Unknown',
     angle,
     userGrade: userGrade || 'Unknown',
-    setterGrade: setterGrade || userGrade || 'Unknown',
+    setterGrade: setterGrade || 'Unknown',
     isBenchmark,
     warnings,
   };

--- a/packages/moonboard-ocr/src/core/ocr.ts
+++ b/packages/moonboard-ocr/src/core/ocr.ts
@@ -184,7 +184,14 @@ export function parseHeaderText(lines: string[]): OcrResult {
   const gradeLines = setterLineIndex >= 0 ? lines.slice(setterLineIndex + 1) : lines;
   const hasGradeLabels = gradeLines.some((line) => /\b(?:user|setter)\b/i.test(line));
   for (const line of gradeLines) {
-    for (const match of line.matchAll(/\b(user|setter)\s+([3-9][ABC]?\+?(?:\/V\d+)?)/gi)) {
+    // Compressed Android plus signs can acquire a preceding dash. Only repair
+    // this observed Font/V-grade form; never silently accept a malformed prefix.
+    const normalized = line.replace(/([3-9][ABC])-\+(?=\/V\d+\b)/gi, '$1+');
+    if (normalized !== line) warnings.push('Normalized OCR dash before grade plus');
+    // A slash after the V grade can separate the legacy iOS Setter field.
+    for (const match of normalized.matchAll(
+      /\b(user|setter)\s+([3-9][ABC]?\+?(?:\/V\d+)?)(?![A-Z0-9+-]|\/(?!\s*(?:Setter\b|$)))/gi,
+    )) {
       if (match[1].toLowerCase() === 'user' && !userGrade) userGrade = match[2];
       if (match[1].toLowerCase() === 'setter' && !setterGrade) setterGrade = match[2];
     }

--- a/packages/moonboard-ocr/src/core/regions.ts
+++ b/packages/moonboard-ocr/src/core/regions.ts
@@ -12,7 +12,9 @@ export type ImageRegions = {
  * includes labels). Reject other geometries instead of silently mislabeling holds.
  */
 export function calculateAndroidRegions(width: number, height: number, rows: GridRows): ImageRegions {
-  if (width !== 1008 || height !== 2244) throw new Error('Unvalidated Android screenshot dimensions');
+  if (width !== 1008 || height !== 2244) {
+    throw new Error('Unvalidated Android screenshot dimensions: expected 1008x2244');
+  }
   return {
     header: { x: 0, y: 247, width, height: 202 },
     board: { x: 107, y: rows === 12 ? 786 : 560, width: 853, height: rows === 12 ? 931 : 1396 },

--- a/packages/moonboard-ocr/src/core/regions.ts
+++ b/packages/moonboard-ocr/src/core/regions.ts
@@ -1,9 +1,23 @@
 import type { ImageRegion } from '../image-processor/types';
+import type { GridRows } from '../board-profiles';
 
 export type ImageRegions = {
   header: ImageRegion;
   board: ImageRegion;
 };
+
+/** Observed stock Android 1.3.68 on a Pixel 8 Pro at 1008×2244.
+ * Mini boards are centered with additional vertical space, not stretched to 18
+ * rows. These bounds describe cell edges, not the yellow artwork (which also
+ * includes labels). Reject other geometries instead of silently mislabeling holds.
+ */
+export function calculateAndroidRegions(width: number, height: number, rows: GridRows): ImageRegions {
+  if (width !== 1008 || height !== 2244) throw new Error('Unvalidated Android screenshot dimensions');
+  return {
+    header: { x: 0, y: 247, width, height: 202 },
+    board: { x: 107, y: rows === 12 ? 786 : 560, width: 853, height: rows === 12 ? 931 : 1396 },
+  };
+}
 
 /**
  * Calculate header and board regions based on image dimensions.

--- a/packages/moonboard-ocr/src/index.ts
+++ b/packages/moonboard-ocr/src/index.ts
@@ -17,6 +17,9 @@
 
 // Main parsing functions
 export { parseScreenshot, parseMultipleScreenshots, parseWithProcessor, deduplicateClimbs } from './parser';
+export type { ParseOptions } from './parser';
+export { BOARD_PROFILES } from './board-profiles';
+export type { HoldSetup, GridRows } from './board-profiles';
 
 // Image processor for advanced use cases
 export { SharpImageProcessor } from './image-processor/sharp-processor';

--- a/packages/moonboard-ocr/src/parser-core.ts
+++ b/packages/moonboard-ocr/src/parser-core.ts
@@ -57,7 +57,7 @@ export async function parseWithProcessor(processor: ImageProcessor, options: Par
 
     // Extract header for OCR and benchmark detection
     const headerPixels = await processor.extractRegion(regions.header);
-    const isBenchmark = detectBenchmarkCircle(headerPixels);
+    const isBenchmark = detectBenchmarkCircle(headerPixels, android ? 'android' : 'legacy-ios');
 
     const ocrImageData = await processor.extractForOCR(regions.header);
     const ocrResult = await runOCR(ocrImageData, options);

--- a/packages/moonboard-ocr/src/parser-core.ts
+++ b/packages/moonboard-ocr/src/parser-core.ts
@@ -8,10 +8,16 @@
 import type { ImageProcessor } from './image-processor/types';
 import { runOCR, type OcrOptions } from './core/ocr';
 import { detectHoldsFromPixelData, detectBoardRegion, detectBenchmarkCircle } from './core/holds';
-import { calculateRegions, calculateRegionsFromDetectedBoard } from './core/regions';
+import { calculateRegions, calculateRegionsFromDetectedBoard, calculateAndroidRegions } from './core/regions';
+import { boardRows, type HoldSetup } from './board-profiles';
 import type { MoonBoardClimb, ParseResult, GridCoordinate } from './types';
 
-export type ParseOptions = OcrOptions;
+export type ParseOptions = OcrOptions & {
+  /** Upstream setup ID. Defaults to the original full-size 2024 parser. */
+  holdsetup?: HoldSetup;
+  /** Explicitly opt into calibrated Android geometry; legacy iOS remains default. */
+  screenshotProfile?: 'legacy-ios' | 'android-pixel8pro-1.3.68';
+};
 
 /**
  * Parse a MoonBoard screenshot using the provided ImageProcessor.
@@ -26,17 +32,25 @@ export async function parseWithProcessor(processor: ImageProcessor, options: Par
 
   try {
     const metadata = processor.getMetadata();
+    const rows = boardRows(options.holdsetup);
+    const android = options.screenshotProfile === 'android-pixel8pro-1.3.68';
+    if (options.screenshotProfile && !android && options.screenshotProfile !== 'legacy-ios') {
+      throw new Error('Unsupported screenshot profile');
+    }
+    if (rows === 12 && !android) throw new Error('Mini screenshots require a validated Android profile');
 
     // Try auto-detecting the board via yellow pixel analysis
     const fullPixelData = await processor.extractFullImage();
     const yellowRegion = detectBoardRegion(fullPixelData);
 
-    const regions = yellowRegion
-      ? calculateRegionsFromDetectedBoard(yellowRegion, metadata.width, metadata.height)
-      : (() => {
-          warnings.push('Could not auto-detect board region, using proportional fallback');
-          return calculateRegions(metadata.width, metadata.height);
-        })();
+    const regions = android
+      ? calculateAndroidRegions(metadata.width, metadata.height, rows)
+      : yellowRegion
+        ? calculateRegionsFromDetectedBoard(yellowRegion, metadata.width, metadata.height)
+        : (() => {
+            warnings.push('Could not auto-detect board region, using proportional fallback');
+            return calculateRegions(metadata.width, metadata.height);
+          })();
 
     // Extract header for OCR and benchmark detection
     const headerPixels = await processor.extractRegion(regions.header);
@@ -48,7 +62,7 @@ export async function parseWithProcessor(processor: ImageProcessor, options: Par
 
     // Extract board region for hold detection
     const boardPixels = await processor.extractRegion(regions.board);
-    const detectedHolds = detectHoldsFromPixelData(boardPixels, regions.board);
+    const detectedHolds = detectHoldsFromPixelData(boardPixels, regions.board, rows, android ? 'android' : 'combined');
 
     // Group holds by type
     const startHolds: GridCoordinate[] = [];

--- a/packages/moonboard-ocr/src/parser-core.ts
+++ b/packages/moonboard-ocr/src/parser-core.ts
@@ -38,6 +38,9 @@ export async function parseWithProcessor(processor: ImageProcessor, options: Par
       throw new Error('Unsupported screenshot profile');
     }
     if (rows === 12 && !android) throw new Error('Mini screenshots require a validated Android profile');
+    if (!android && options.holdsetup !== undefined && options.holdsetup !== 21) {
+      throw new Error('This setup requires a validated Android screenshot profile');
+    }
 
     // Try auto-detecting the board via yellow pixel analysis
     const fullPixelData = await processor.extractFullImage();

--- a/packages/moonboard-ocr/src/parser.ts
+++ b/packages/moonboard-ocr/src/parser.ts
@@ -30,6 +30,7 @@ export async function parseScreenshot(imagePath: string, options: ParseOptions =
 export async function parseMultipleScreenshots(
   imagePaths: string[],
   onProgress?: (current: number, total: number, file: string) => void,
+  options: ParseOptions = {},
 ): Promise<{ climbs: MoonBoardClimb[]; errors: Array<{ file: string; error: string }> }> {
   const climbs: MoonBoardClimb[] = [];
   const errors: Array<{ file: string; error: string }> = [];
@@ -38,7 +39,7 @@ export async function parseMultipleScreenshots(
     const imagePath = imagePaths[i];
     onProgress?.(i + 1, imagePaths.length, path.basename(imagePath));
 
-    const result = await parseScreenshot(imagePath);
+    const result = await parseScreenshot(imagePath, options);
     if (result.success && result.climb) {
       climbs.push(result.climb);
     } else {

--- a/packages/moonboard-ocr/src/types.ts
+++ b/packages/moonboard-ocr/src/types.ts
@@ -1,4 +1,5 @@
-// Grid coordinates for MoonBoard 2024
+// Grid coordinates shared by all MoonBoards. Mini profiles validate a 12-row
+// subset at runtime; full-size profiles retain all 18 rows.
 // Columns: A-K (11 columns)
 // Rows: 1-18 (bottom to top)
 export type Column = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K';

--- a/packages/moonboard-ocr/src/types.ts
+++ b/packages/moonboard-ocr/src/types.ts
@@ -117,6 +117,8 @@ export const GRID_CONFIG = {
  * Relative grid positions for each hold coordinate.
  * Values are 0-1 representing percentage of board width/height.
  * Positions are at cell centers to match the original cell-based detection.
+ * Legacy 18-row export retained for compatibility. For board-aware code use
+ * GRID_POSITIONS_BY_ROWS[boardRows(holdsetup)] from board-profiles instead.
  *
  * For 11 columns: cell width = 1/11, centers at (colIdx + 0.5) / 11
  * For 18 rows: cell height = 1/18, centers at (rowIdx + 0.5) / 18


### PR DESCRIPTION
## Summary

Add explicit Android profiles for all seven MoonBoard setups: 2010, 2016, Masters 2017, Masters 2019, 2024, Mini 2020 and Mini 2025. Both Minis use 12-row grids and their own crop. Node, browser and CLI APIs accept upstream setup IDs and the opt-in `android-pixel8pro-1.3.68` profile. Unsupported dimensions and uncalibrated non-2024 iOS setups fail closed. The web upload UI still defaults to legacy iOS/2024; this is not automatic board recognition.

Real-device proof: Pixel 8 Pro, stock Android 16, Moon Climbing 1.3.68 (368), 1008×2244, macOS 26.6.2. Separate calibration matched 14 climbs / 119 hold-role pairs across all seven boards. The fixed 1,000-reference sample captured 954 climbs, retaining 46 unmatched searches without substitution. Corrected re-evaluation matched **954/954 climbs and 7,409/7,409 hold-role pairs**, compared with baseline 953/954 and 7,408/7,409. Benchmark detection improved **3/31 → 31/31**, with zero false positives among 923 negative references.

The sample uses fresh official-app screenshots and old structured API references, compared through the existing catalog importer's pure mapping. No database is connected, no catalog is emitted, and no tick/edit/post/BLE action is performed. Private screenshots, raw hierarchies and account data are not published. These are **post-hoc corrected results**, not an independent holdout claim or full-catalog acceptance.

Corrections exposed by the app/reference comparison:

- Profile-specific saturated marker colours avoid mistaking Masters 2017 red plastic for finish rings.
- Separate touching ring interiors; preserve a hand ring occluded by another marker colour and a narrow antialias seam. Synthetic tests cover horizontal/vertical overlaps and phantom interior gaps. Earlier iOS fixture corrections restored 24 visually verified rings in 21 images.
- Accept compressed bright-gold Android benchmark badges without combining separate rating stars. Legacy iOS badge detection is unchanged.
- Use the setter line as the title boundary, keep explicit user/setter grades independent, and preserve missing grades. Repair the observed `6B-+/V4` OCR artifact without copying the community grade, with a warning.

Raw OCR name matches improved **628/954 → 805/954**; setter names remain **911/954**. Text is still imperfect and public accessibility labels remain the appropriate separate metadata source. Name scoring ignores case, grade scoring uses Font grades and treats `Unknown` as missing. The angle's default 40° is not counted as recognition accuracy. Beta links were demonstrated separately on a small sample, not validated across these 1,000 references.

The first 155 captures, overlapping-hold/badge examples and three grade-artifact references were used for development. Baseline and intermediate results remain preserved, images are hash-verified, and corrected analyses use new source fingerprints. Detailed per-board results, exact invocation and reliability limits: [OCR_VALIDATION.md](https://github.com/boardsesh/moonboard-scraper/blob/feat/usb-auth-renewal/OCR_VALIDATION.md), collector draft https://github.com/boardsesh/moonboard-scraper/pull/2.

Review follow-ups address checked dimension messages, documented blue tolerance and legacy grid exports, CLI option coverage, barely-touching rings, an explicit two-center guard, and bounded interior-neighbour allocation.

Validation: **187 OCR tests**, **53 catalog mapping/batch tests**, scoped `vp check`, OCR package typecheck and full `vp run typecheck` pass. This does not prove renewable API authentication, 24-hour unattended operation, complete enumeration, stable upstream identity, or a first database import. No production schedule is enabled.

Review follow-up documents and tests the existing single-centroid fallback when a damaged pair has only one enclosed interior; this is a known limitation, not claimed two-hold recovery. Red-plastic test painting now runs outside the ring loops. The README explains the legacy grade separator and requires new calibration for other Android dimensions rather than an unsafe iOS-profile workaround. These tests/docs leave the 954-image parser fingerprint unchanged.

## Release Notes

Local screenshot tools support all seven Android MoonBoard layouts, including both Minis, and keep touching holds separate.

## Test plan

1. CI green.
2. Read the validation report; confirm coverage gaps remain visible.

## Risk

Risk: 3/5 — changes shared hold/text detection; real comparisons and synthetic regressions pass, but automatic import stays disabled.
