### PR TITLE
feat(mobile): pin a board, and put the one you're on first

### DIFF
--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -89,6 +89,7 @@ import { AnalyticsScreenTracker } from '../src/components/analytics/AnalyticsScr
 import { ImageCacheTabSweeper } from '../src/components/ImageCacheTabSweeper';
 import { AnalyticsGymProperties } from '../src/components/analytics/AnalyticsGymProperties';
 import { AnalyticsPersonProperties } from '../src/components/analytics/AnalyticsPersonProperties';
+import { BoardOpenRecorder } from '../src/components/board-activity/BoardOpenRecorder';
 import { OtaUpdateTracker } from '../src/components/analytics/OtaUpdateTracker';
 import { InstallReferrerTracker } from '../src/components/analytics/InstallReferrerTracker';
 import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
@@ -588,6 +589,8 @@ function RootLayout() {
                           <AnalyticsPersonProperties />
                           {/* Stamps the active board's gym on every event. Null render. */}
                           <AnalyticsGymProperties />
+                          {/* Records board opens, which order "Your boards". Null render. */}
+                          <BoardOpenRecorder />
                           <ConnectionSettingsProvider>
                             <ToastProvider>
                               <ClimbActionsDataWrapper>

--- a/packages/mobile/app/boards/__tests__/index-board-actions.test.tsx
+++ b/packages/mobile/app/boards/__tests__/index-board-actions.test.tsx
@@ -7,19 +7,21 @@
 // that a picker opened mid-session must still switch boards when the identity
 // lookup fails.
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import type { UserBoard } from '@boardsesh/shared-schema';
 
 type Children = { children?: ReactNode };
 type ButtonProps = { title: string; onPress?: () => void };
-type CarouselItem = { key: string; title: string; isViewerOwner?: boolean };
+type CarouselItem = { key: string; title: string; isViewerOwner?: boolean; isPinned?: boolean };
 type CarouselProps = {
   items: CarouselItem[];
   onSelect: (item: CarouselItem) => void;
   actionFor?: (item: CarouselItem) => string | null;
   actionLabelFor?: (item: CarouselItem) => string;
   onAction?: (item: CarouselItem) => void;
+  onTogglePin?: (item: CarouselItem) => void;
+  pinLabelFor?: (item: CarouselItem) => string;
   isEditing?: boolean;
   pendingActionKey?: string | null;
 };
@@ -30,6 +32,12 @@ const setActiveBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined)
 const clearActiveBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const deleteBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const unfollowBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const pinBoardMock = vi.hoisted(() => vi.fn());
+// The screen passes usePinBoard an onPinError callback; capturing it is how the
+// rollback-on-failure path gets exercised without a real mutation.
+const pinBoardOptions = vi.hoisted(() => ({
+  last: null as { onPinError?: (boardUuid: string, error: unknown) => void } | null,
+}));
 const confirmMock = vi.hoisted(() => vi.fn().mockResolvedValue(true));
 const forgetOfflineBoardMock = vi.hoisted(() => vi.fn());
 // The last props the carousel was handed, so ownership can be asserted on the
@@ -111,6 +119,9 @@ vi.mock('react-i18next', () => ({
         'mobile.emptyTitle': 'No boards yet',
         'mobile.emptySubtitle': 'Search for a board to get started',
         'myBoards.title': 'Manage boards',
+        'mobile.discovery.pinAria': 'Pin {{name}}',
+        'mobile.discovery.unpinAria': 'Unpin {{name}}',
+        'mobile.discovery.pinError': "Couldn't update your pinned boards",
       };
       const template = map[key] ?? key;
       return options?.name === undefined ? template : template.replace('{{name}}', options.name);
@@ -147,6 +158,10 @@ vi.mock('../../../src/lib/graphql/hooks', () => ({
     isPending: state.unfollowPending !== null,
     variables: state.unfollowPending ?? undefined,
   }),
+  usePinBoard: (options?: { onPinError?: (boardUuid: string, error: unknown) => void }) => {
+    pinBoardOptions.last = options ?? null;
+    return { mutate: pinBoardMock };
+  },
 }));
 
 vi.mock('../../../src/lib/graphql/use-active-board', () => ({
@@ -261,6 +276,64 @@ beforeEach(() => {
   state.unfollowPending = null;
 });
 
+describe('the pin toggle', () => {
+  it('pins a board that is not pinned yet', () => {
+    render(createElement(BoardSelection));
+    carouselProps.last?.onTogglePin?.({ key: 'gym', title: 'High Point Orlando', isPinned: false });
+    expect(pinBoardMock).toHaveBeenCalledWith({ boardUuid: 'gym', pinned: true });
+  });
+
+  it('unpins one that is', () => {
+    state.myBoards = [{ ...myWall, isPinnedByMe: true }, gymBoard];
+    render(createElement(BoardSelection));
+    const pinned = carouselProps.last?.items.find((item) => item.key === 'mine');
+    expect(pinned?.isPinned).toBe(true);
+    carouselProps.last?.onTogglePin?.(pinned!);
+    expect(pinBoardMock).toHaveBeenCalledWith({ boardUuid: 'mine', pinned: false });
+  });
+
+  // The regression this whole optimistic design exists for: the glyph flips at
+  // once, but the carousel must NOT reorder, or the card slides out from under
+  // the finger that just tapped it. The reorder lands on the next open.
+  it('flips the glyph immediately without moving the card', () => {
+    render(createElement(BoardSelection));
+    const before = carouselProps.last?.items.map((item) => item.key);
+    expect(carouselProps.last?.items.find((item) => item.key === 'gym')?.isPinned).toBe(false);
+
+    act(() => {
+      carouselProps.last?.onTogglePin?.({ key: 'gym', title: 'High Point Orlando', isPinned: false });
+    });
+
+    expect(carouselProps.last?.items.find((item) => item.key === 'gym')?.isPinned).toBe(true);
+    expect(carouselProps.last?.items.map((item) => item.key)).toEqual(before);
+  });
+
+  it('puts the glyph back and says so when the pin fails', () => {
+    render(createElement(BoardSelection));
+    act(() => {
+      carouselProps.last?.onTogglePin?.({ key: 'gym', title: 'High Point Orlando', isPinned: false });
+    });
+    expect(carouselProps.last?.items.find((item) => item.key === 'gym')?.isPinned).toBe(true);
+
+    act(() => {
+      pinBoardOptions.last?.onPinError?.('gym', new Error('offline'));
+    });
+
+    expect(carouselProps.last?.items.find((item) => item.key === 'gym')?.isPinned).toBe(false);
+    expect(toastMock.showToast).toHaveBeenCalledWith("Couldn't update your pinned boards", 'error');
+  });
+
+  it('labels the toggle for a screen reader, both ways round', () => {
+    render(createElement(BoardSelection));
+    expect(carouselProps.last?.pinLabelFor?.({ key: 'gym', title: 'High Point Orlando', isPinned: false })).toBe(
+      'Pin High Point Orlando',
+    );
+    expect(carouselProps.last?.pinLabelFor?.({ key: 'gym', title: 'High Point Orlando', isPinned: true })).toBe(
+      'Unpin High Point Orlando',
+    );
+  });
+});
+
 describe('the per-card ownership action', () => {
   it('opens the edit form for a board the viewer owns', () => {
     render(createElement(BoardSelection));
@@ -287,10 +360,29 @@ describe('the per-card ownership action', () => {
     ]);
   });
 
-  it('leads with the boards the viewer owns', () => {
+  // The screen no longer re-partitions by ownership: myBoards arrives ordered by
+  // pin, then by when the climber last opened each board (#4884). Re-sorting
+  // here would file a pinned gym board behind a wall they own and never touch.
+  it('keeps the order the server sent', () => {
     state.myBoards = [gymBoard, myWall];
     render(createElement(BoardSelection));
+    expect(carouselProps.last?.items.map((item) => item.key)).toEqual(['gym', 'mine']);
+  });
+
+  // The one thing the server cannot order, because it lives in AsyncStorage on
+  // this device.
+  it('hoists the active board to the front', () => {
+    state.myBoards = [gymBoard, myWall];
+    state.activeBoard = { uuid: 'mine' };
+    render(createElement(BoardSelection));
     expect(carouselProps.last?.items.map((item) => item.key)).toEqual(['mine', 'gym']);
+  });
+
+  it('never injects a stored active board the list does not contain', () => {
+    state.myBoards = [gymBoard, myWall];
+    state.activeBoard = { uuid: 'a-board-that-was-deleted' };
+    render(createElement(BoardSelection));
+    expect(carouselProps.last?.items.map((item) => item.key)).toEqual(['gym', 'mine']);
   });
 
   it('labels the action for a screen reader', () => {

--- a/packages/mobile/app/boards/__tests__/index-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/index-offline.test.tsx
@@ -123,6 +123,7 @@ vi.mock('../../../src/lib/graphql/hooks', () => ({
   useProfile: () => ({ data: { id: 'me' } }),
   useDeleteBoard: () => ({ mutateAsync: vi.fn(), isPending: false, variables: undefined }),
   useUnfollowBoard: () => ({ mutateAsync: vi.fn(), isPending: false, variables: undefined }),
+  usePinBoard: () => ({ mutate: vi.fn() }),
 }));
 
 vi.mock('../../../src/lib/graphql/use-active-board', () => ({

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -11,6 +11,7 @@ import {
   useProfile,
   useDeleteBoard,
   useUnfollowBoard,
+  usePinBoard,
 } from '../../src/lib/graphql/hooks';
 import { useActiveBoard, useClearActiveBoard } from '../../src/lib/graphql/use-active-board';
 import { useDeviceLocation } from '../../src/lib/use-device-location';
@@ -29,7 +30,7 @@ import { BluetoothQuickstartSheet } from '../../src/components/board-discovery/B
 import { userBoardsToItems, popularConfigToItem } from '../../src/components/board-discovery/board-items';
 import {
   boardCardAction,
-  sortViewerOwnedFirst,
+  hoistActiveBoard,
   type BoardCardAction,
 } from '../../src/components/board-discovery/board-card-actions';
 import { offlineBoardRows } from '../../src/components/board-discovery/offline-board-items';
@@ -99,6 +100,25 @@ export default function BoardSelection() {
   // `presentation: 'modal'` route, so it cannot survive a dismiss: every one of
   // the twelve places that open this picker gets it switched off.
   const [isEditingBoards, setIsEditingBoards] = useState(false);
+
+  // Pins the climber toggled since this modal opened, so the glyph flips under
+  // the finger without waiting for a refetch. Deliberately does NOT reorder: the
+  // pin mutation invalidates `myBoards` with `refetchType: 'none'`, so the new
+  // order lands the next time the picker is opened rather than sliding the card
+  // out from under the tap that made it.
+  const [pinnedOverrides, setPinnedOverrides] = useState<ReadonlyMap<string, boolean>>(() => new Map());
+  const pinBoard = usePinBoard({
+    onPinError: (boardUuid) => {
+      // Put the glyph back where the server still has it.
+      setPinnedOverrides((previous) => {
+        const next = new Map(previous);
+        next.delete(boardUuid);
+        return next;
+      });
+      showToast(t('mobile.discovery.pinError'), 'error');
+    },
+  });
+  const pinBoardMutate = pinBoard.mutate;
 
   const {
     data: boardConnection,
@@ -172,17 +192,20 @@ export default function BoardSelection() {
   // Only the user's OWN boards carry a download state.
   const boardOfflineState = useBoardOfflineState();
   const myBoardItems = useMemo(
-    // Viewer-owned first (the server's `desc(isOwned)` means "a real wall", not
-    // "yours"), and `currentUserId` stamps `isViewerOwner` once per list build so
-    // no row ever scans back into `myBoards` for it.
+    // The server now orders these: pinned first, then by when you last opened
+    // the board, then never-opened by when you added it (#4884). All this adds
+    // is the board you're on, which the server cannot know — it lives in
+    // AsyncStorage on this device. `currentUserId` stamps `isViewerOwner` once
+    // per list build so no row ever scans back into `myBoards` for it.
     () =>
       userBoardsToItems(
-        sortViewerOwnedFirst(myBoards, currentUserId),
+        hoistActiveBoard(myBoards, activeBoard?.uuid),
         activeBoard?.uuid,
         boardOfflineState,
         currentUserId,
+        pinnedOverrides,
       ),
-    [myBoards, activeBoard?.uuid, boardOfflineState, currentUserId],
+    [myBoards, activeBoard?.uuid, boardOfflineState, currentUserId, pinnedOverrides],
   );
   const nearbyItems = useMemo(
     () => userBoardsToItems(nearby?.boards ?? [], activeBoard?.uuid),
@@ -387,6 +410,27 @@ export default function BoardSelection() {
       ? (unfollowBoard.variables ?? null)
       : null;
 
+  const onTogglePin = useCallback(
+    (item: DiscoveryBoardItem) => {
+      const nextPinned = !item.isPinned;
+      setPinnedOverrides((previous) => {
+        const next = new Map(previous);
+        next.set(item.key, nextPinned);
+        return next;
+      });
+      pinBoardMutate({ boardUuid: item.key, pinned: nextPinned });
+    },
+    [pinBoardMutate],
+  );
+
+  const pinLabelFor = useCallback(
+    (item: DiscoveryBoardItem) =>
+      item.isPinned
+        ? t('mobile.discovery.unpinAria', { name: item.title })
+        : t('mobile.discovery.pinAria', { name: item.title }),
+    [t],
+  );
+
   // Gates the Edit/Done toggle AND the whole per-card action slot. Onboarding is
   // the reason the two share a predicate: the first screen a new account ever
   // sees must not carry a board action of any kind, and gating only the toggle
@@ -394,6 +438,11 @@ export default function BoardSelection() {
   // with no resolvable identity, and offline — where every action behind it is a
   // network mutation.
   const canEditBoards = myBoardItems.length > 0 && currentUserId !== undefined && !isLocalOnly && !fromOnboarding;
+  // Same family of gates as canEditBoards, minus the identity requirement: a pin
+  // is the viewer's own state and does not depend on knowing who owns the board.
+  // Offline is still out — the mutation could not reach the server — and so is
+  // onboarding, whose first screen carries no board controls at all.
+  const canPinBoards = !isLocalOnly && !fromOnboarding && isAuthenticated;
   useEffect(() => {
     if (isEditingBoards && !canEditBoards) setIsEditingBoards(false);
   }, [isEditingBoards, canEditBoards]);
@@ -445,6 +494,8 @@ export default function BoardSelection() {
           onAction={canEditBoards ? onMyBoardAction : undefined}
           deleteActionTitle={t('mobile.manage.deleteConfirm')}
           unfollowActionTitle={t('mobile.manage.unfollowConfirm')}
+          onTogglePin={canPinBoards ? onTogglePin : undefined}
+          pinLabelFor={pinLabelFor}
           isEditing={isEditingBoards}
           pendingActionKey={pendingActionKey}
         />

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -495,7 +495,9 @@ export default function BoardSelection() {
           deleteActionTitle={t('mobile.manage.deleteConfirm')}
           unfollowActionTitle={t('mobile.manage.unfollowConfirm')}
           onTogglePin={canPinBoards ? onTogglePin : undefined}
-          pinLabelFor={pinLabelFor}
+          // Gated with its handler: the card ignores a label it has no control
+          // for, but the carousel would still resolve one per row.
+          pinLabelFor={canPinBoards ? pinLabelFor : undefined}
           isEditing={isEditingBoards}
           pendingActionKey={pendingActionKey}
         />

--- a/packages/mobile/src/components/board-activity/BoardOpenRecorder.tsx
+++ b/packages/mobile/src/components/board-activity/BoardOpenRecorder.tsx
@@ -1,0 +1,65 @@
+// Records "this climber opened this board" — the recency half of the
+// "Your boards" ordering (#4884). Mounted once at the app root; renders null.
+//
+// Why one root-level watcher instead of instrumenting the activation paths:
+// `useActivateBoard` is the funnel for the picker, the builder and onboarding,
+// but a BLE connect, a deep link, the cross-board add gate, the drawer host, the
+// queue provider, the gym list and the board editor all call `useSetActiveBoard`
+// directly. Instrumenting the setter is wrong in the other direction — the angle
+// controls rewrite the active board for an ANGLE change, which is not a board
+// open. Watching the active board's UUID catches every real switch and nothing
+// else: an angle rewrite keeps the same uuid.
+
+import { useEffect } from 'react';
+import { useActiveBoard } from '../../lib/graphql/use-active-board';
+import { useRecordBoardOpened } from '../../lib/graphql/hooks';
+import { useAuth } from '../../providers/auth-provider';
+import { useStoredUserId } from '../../hooks/use-current-user-id';
+
+/**
+ * The last (user, board) pair recorded, at module scope rather than in a ref.
+ *
+ * A ref resets when the component remounts — which Fast Refresh and an OTA
+ * reload both do — and would re-record the same board. Keyed by user as well as
+ * board so two accounts on one device cannot dedupe against each other.
+ */
+let lastRecordedKey: string | null = null;
+
+/** Test seam: the module-level dedupe outlives a test's render tree. */
+export function resetBoardOpenRecorderForTests(): void {
+  lastRecordedKey = null;
+}
+
+export function BoardOpenRecorder(): null {
+  const { isAuthenticated } = useAuth();
+  const { data: activeBoard, isPending } = useActiveBoard();
+  const { userId } = useStoredUserId(isAuthenticated);
+  const recordBoardOpened = useRecordBoardOpened();
+
+  // The uuid scalar, never the board object: the query hands back a fresh object
+  // identity on every refetch and on every angle write.
+  const boardUuid = activeBoard?.uuid ?? null;
+  const record = recordBoardOpened.mutate;
+
+  useEffect(() => {
+    // `data` is undefined while the AsyncStorage read is in flight; treating
+    // that tick as "no board" would fire again the moment it resolves.
+    if (isPending) return;
+    if (!isAuthenticated || boardUuid == null || userId == null) return;
+    // Screenshot builds drive the active board themselves to stage captures.
+    // Recording those would reorder the store-shot account's board list between
+    // runs. Inlined so it dead-strips from normal builds.
+    if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1') return;
+
+    const key = `${userId}:${boardUuid}`;
+    if (lastRecordedKey === key) return;
+    lastRecordedKey = key;
+
+    // Fire-and-forget. Offline this simply fails, and that is the right
+    // outcome: an ordering nicety must never produce a toast, a retry storm or
+    // a Sentry entry. The next open on a live connection records it.
+    record(boardUuid, { onError: () => {} });
+  }, [isPending, isAuthenticated, boardUuid, userId, record]);
+
+  return null;
+}

--- a/packages/mobile/src/components/board-activity/__tests__/board-open-recorder.test.tsx
+++ b/packages/mobile/src/components/board-activity/__tests__/board-open-recorder.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { createElement } from 'react';
+
+const recordMock = vi.hoisted(() => vi.fn());
+const state = vi.hoisted(() => ({
+  activeBoard: undefined as { uuid: string; angle?: number } | undefined,
+  isPending: false,
+  isAuthenticated: true,
+  userId: 'user-1' as string | undefined,
+}));
+
+vi.mock('../../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: state.activeBoard, isPending: state.isPending }),
+}));
+
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useRecordBoardOpened: () => ({ mutate: recordMock }),
+}));
+
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: state.isAuthenticated }),
+}));
+
+vi.mock('../../../hooks/use-current-user-id', () => ({
+  useStoredUserId: () => ({ userId: state.userId }),
+}));
+
+const { BoardOpenRecorder, resetBoardOpenRecorderForTests } = await import('../BoardOpenRecorder');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetBoardOpenRecorderForTests();
+  state.activeBoard = { uuid: 'board-a' };
+  state.isPending = false;
+  state.isAuthenticated = true;
+  state.userId = 'user-1';
+});
+
+afterEach(cleanup);
+
+describe('BoardOpenRecorder', () => {
+  it('records the board that is already active on a cold start', () => {
+    render(createElement(BoardOpenRecorder));
+    expect(recordMock).toHaveBeenCalledWith('board-a', expect.anything());
+  });
+
+  it('records again when the climber switches board', () => {
+    const { rerender } = render(createElement(BoardOpenRecorder));
+    expect(recordMock).toHaveBeenCalledTimes(1);
+
+    state.activeBoard = { uuid: 'board-b' };
+    rerender(createElement(BoardOpenRecorder));
+    expect(recordMock).toHaveBeenCalledTimes(2);
+    expect(recordMock).toHaveBeenLastCalledWith('board-b', expect.anything());
+  });
+
+  // The reason this watches the uuid rather than living in useSetActiveBoard:
+  // the angle controls rewrite the active board for an angle change, handing
+  // back a NEW object with the SAME uuid. That is not a board open.
+  it('stays silent when only the angle changed', () => {
+    const { rerender } = render(createElement(BoardOpenRecorder));
+    expect(recordMock).toHaveBeenCalledTimes(1);
+
+    state.activeBoard = { uuid: 'board-a', angle: 45 };
+    rerender(createElement(BoardOpenRecorder));
+    expect(recordMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for the stored board to resolve', () => {
+    state.isPending = true;
+    state.activeBoard = undefined;
+    const { rerender } = render(createElement(BoardOpenRecorder));
+    expect(recordMock).not.toHaveBeenCalled();
+
+    state.isPending = false;
+    state.activeBoard = { uuid: 'board-a' };
+    rerender(createElement(BoardOpenRecorder));
+    expect(recordMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('records nothing when signed out', () => {
+    state.isAuthenticated = false;
+    render(createElement(BoardOpenRecorder));
+    expect(recordMock).not.toHaveBeenCalled();
+  });
+
+  it('records nothing with no board', () => {
+    state.activeBoard = undefined;
+    render(createElement(BoardOpenRecorder));
+    expect(recordMock).not.toHaveBeenCalled();
+  });
+
+  // Fast Refresh and an OTA reload both remount this. A useRef would forget and
+  // re-record; the dedupe is at module scope precisely so it does not.
+  it('does not re-record the same board across a remount', () => {
+    const first = render(createElement(BoardOpenRecorder));
+    expect(recordMock).toHaveBeenCalledTimes(1);
+    first.unmount();
+
+    render(createElement(BoardOpenRecorder));
+    expect(recordMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Two accounts on one device must not dedupe against each other.
+  it('records the same board again for a different user', () => {
+    const { rerender } = render(createElement(BoardOpenRecorder));
+    expect(recordMock).toHaveBeenCalledTimes(1);
+
+    state.userId = 'user-2';
+    rerender(createElement(BoardOpenRecorder));
+    expect(recordMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/mobile/src/components/board-discovery/BoardCarousel.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardCarousel.tsx
@@ -66,9 +66,14 @@ export function BoardCarousel({
   pendingActionKey = null,
   contentStyle,
 }: BoardCarouselProps) {
-  // One object per (isEditing, pendingActionKey) pair rather than per render, so
-  // FlashList only invalidates its cells when something actually changed.
-  const extraData = useMemo(() => ({ isEditing, pendingActionKey }), [isEditing, pendingActionKey]);
+  // The card state that lives OUTSIDE the item, so FlashList knows when a
+  // recycled cell is stale. `isPinned` is not here on purpose — it rides on the
+  // item, so the data diff already catches it. Whether pinning is offered at all
+  // does not: the host drops `onTogglePin` when the climber goes offline, and
+  // that has to invalidate the cells too or the pill lingers on recycled cards.
+  // One object per distinct combination rather than per render.
+  const canPin = onTogglePin !== undefined;
+  const extraData = useMemo(() => ({ isEditing, pendingActionKey, canPin }), [isEditing, pendingActionKey, canPin]);
 
   const renderItem = useCallback(
     ({ item }: { item: DiscoveryBoardItem }) => {

--- a/packages/mobile/src/components/board-discovery/BoardCarousel.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardCarousel.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { type ViewStyle } from 'react-native';
 import { SnapCarousel } from '../SnapCarousel';
 import type { BoardCardAction } from './board-card-actions';
@@ -26,6 +26,13 @@ type BoardCarouselProps = {
    */
   deleteActionTitle?: string;
   unfollowActionTitle?: string;
+  /**
+   * Toggle a board's pin. Only "Your boards" passes one; the card renders no pin
+   * control without it. Memoize it, like `downloadLabelFor`.
+   */
+  onTogglePin?: (item: DiscoveryBoardItem) => void;
+  /** Per-item screen-reader label for the pin toggle. Memoize it. */
+  pinLabelFor?: (item: DiscoveryBoardItem) => string;
   /** "Your boards" is in Edit mode. A scalar, so toggling leaves item identities alone. */
   isEditing?: boolean;
   /**
@@ -53,10 +60,16 @@ export function BoardCarousel({
   onAction,
   deleteActionTitle,
   unfollowActionTitle,
+  onTogglePin,
+  pinLabelFor,
   isEditing = false,
   pendingActionKey = null,
   contentStyle,
 }: BoardCarouselProps) {
+  // One object per (isEditing, pendingActionKey) pair rather than per render, so
+  // FlashList only invalidates its cells when something actually changed.
+  const extraData = useMemo(() => ({ isEditing, pendingActionKey }), [isEditing, pendingActionKey]);
+
   const renderItem = useCallback(
     ({ item }: { item: DiscoveryBoardItem }) => {
       const action = actionFor?.(item) ?? null;
@@ -72,6 +85,8 @@ export function BoardCarousel({
           actionTitle={
             action === 'delete' ? deleteActionTitle : action === 'unfollow' ? unfollowActionTitle : undefined
           }
+          onTogglePin={onTogglePin}
+          pinLabel={pinLabelFor?.(item)}
           isEditing={isEditing}
           isActionPending={pendingActionKey === item.key}
         />
@@ -86,6 +101,8 @@ export function BoardCarousel({
       onAction,
       deleteActionTitle,
       unfollowActionTitle,
+      onTogglePin,
+      pinLabelFor,
       isEditing,
       pendingActionKey,
     ],
@@ -97,6 +114,11 @@ export function BoardCarousel({
       cardWidth={DISCOVERY_CARD_WIDTH}
       renderItem={renderItem}
       keyExtractor={keyExtractor}
+      // The card's interactive state — Edit mode, the in-flight action, and now
+      // the pin — lives outside the item for the first two, so FlashList has to
+      // be told when a recycled cell is stale. Without it a pin tap can leave
+      // the neighbouring recycled card showing the old glyph.
+      extraData={extraData}
       contentStyle={contentStyle}
     />
   );

--- a/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
@@ -530,13 +530,11 @@ const styles = StyleSheet.create({
     ...overlayPill,
     right: spacing[2],
   },
-  // Same slot as distanceBadge; square rather than text-width, since it holds a
-  // single glyph.
+  // Shares the distance pill's slot and its exact geometry — the two never
+  // appear together, so they should read as the same object in the same place.
   pinBadge: {
     ...overlayPill,
     right: spacing[2],
-    paddingHorizontal: spacing[2],
-    paddingVertical: 3,
   },
   title: {
     fontWeight: '600',

--- a/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
@@ -335,7 +335,8 @@ export const BoardDiscoveryCard = memo(function BoardDiscoveryCard({
             style={styles.offlineBadge}
             // The glyph is a 26pt disc inside a 168pt card, so widen the touch
             // area rather than the visual: 26 + 2 × 9 lands exactly on the 44pt
-            // floor. The two corner rects sit 82pt apart and never overlap.
+            // floor. The three corner rects sit 80pt apart on each axis and
+            // never overlap.
             hitSlop={CORNER_BADGE_HIT_SLOP}
           >
             <Icon name="offline.download" size={15} color={brandColors.primaryFill} />
@@ -377,22 +378,26 @@ export const BoardDiscoveryCard = memo(function BoardDiscoveryCard({
           </View>
         ) : null}
 
-        {/* The pin lives in the distance pill's slot. A board can't be both a
-            proximity result and one of yours to pin, but guard anyway so the two
-            can never stack. */}
+        {/* The pin is a corner disc, not an overlay pill: it is a BUTTON, and the
+            two other buttons on this thumb are white discs. Pinned inverts the
+            same disc (violet fill, white glyph) rather than changing its shape,
+            so on/off reads without the control drifting out of the family.
+            It still yields the bottom-right slot to the distance pill — a board
+            can't be both a proximity result and one of yours to pin, but guard
+            anyway so the two can never stack. */}
         {onTogglePin && item.distanceMeters == null ? (
           <Pressable
             onPress={handleTogglePin}
             accessibilityRole="button"
             accessibilityState={{ selected: item.isPinned === true }}
             accessibilityLabel={pinLabel}
-            style={styles.pinBadge}
+            style={[styles.pinBadge, item.isPinned ? { backgroundColor: brandColors.primaryFill } : null]}
             hitSlop={CORNER_BADGE_HIT_SLOP}
           >
             <Icon
               name={item.isPinned ? 'pin.fill' : 'pin'}
-              size={13}
-              color={item.isPinned ? brandColors.primaryFill : overlays.onScrim}
+              size={15}
+              color={item.isPinned ? brandColors.onPrimary : brandColors.primaryFill}
             />
           </Pressable>
         ) : null}
@@ -456,18 +461,21 @@ export const BoardDiscoveryCard = memo(function BoardDiscoveryCard({
   );
 });
 
-// Shared geometry for the two top-corner discs and the two bottom overlay pills.
-// Only the horizontal edge differs, so the corner budget stays literally two
-// circles and two pills — never four circles, never a destructive one.
+// Shared geometry for the corner discs and the bottom overlay pills. Only the
+// edges differ, so every tappable glyph on the thumb is the same 26pt circle and
+// every status strip is the same pill — never a disc that is almost a disc.
 //
-// The bottom-right pill is shared, not duplicated: it carries the distance on
-// Near you and the pin toggle in "Your boards" (#4884). Those two never coexist
-// — `distanceMeters` is only set by proximity queries, and the pin control is
-// only handed to the saved-boards carousel — and the card asserts it by
-// rendering the pin solely when distance is absent.
+// Discs are for BUTTONS (download, edit, pin); pills are for STATUS (active,
+// distance). That split is why the pin left the pill family in #5179: QA read a
+// wide dark pill sitting under two white circles as a different kind of thing.
+//
+// The bottom-right slot is shared, not duplicated: the distance pill takes it on
+// Near you, the pin disc in "Your boards" (#4884). Those two never coexist —
+// `distanceMeters` is only set by proximity queries, and the pin control is only
+// handed to the saved-boards carousel — and the card asserts it by rendering the
+// pin solely when distance is absent.
 const cornerBadge = {
   position: 'absolute',
-  top: CORNER_BADGE_INSET,
   width: CORNER_BADGE_SIZE,
   height: CORNER_BADGE_SIZE,
   borderRadius: borderRadius.full,
@@ -516,10 +524,12 @@ const styles = StyleSheet.create({
   },
   offlineBadge: {
     ...cornerBadge,
+    top: CORNER_BADGE_INSET,
     left: CORNER_BADGE_INSET,
   },
   actionBadge: {
     ...cornerBadge,
+    top: CORNER_BADGE_INSET,
     right: CORNER_BADGE_INSET,
   },
   activeBadge: {
@@ -530,11 +540,14 @@ const styles = StyleSheet.create({
     ...overlayPill,
     right: spacing[2],
   },
-  // Shares the distance pill's slot and its exact geometry — the two never
-  // appear together, so they should read as the same object in the same place.
+  // Same disc as the download and edit buttons, on the free bottom corner. The
+  // inset doubles as the hitSlop for the same reason it does up top: `thumb`
+  // clips a child's touch rect on Android, so 26 + 2 × 9 lands the 44pt square
+  // exactly on the bottom edge — 80pt clear of the edit disc's rect above it.
   pinBadge: {
-    ...overlayPill,
-    right: spacing[2],
+    ...cornerBadge,
+    bottom: CORNER_BADGE_INSET,
+    right: CORNER_BADGE_INSET,
   },
   title: {
     fontWeight: '600',

--- a/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
@@ -52,6 +52,12 @@ export type DiscoveryBoardItem = {
    */
   isViewerOwner?: boolean;
   /**
+   * Whether the viewer pinned this board to the front of their list. Only the
+   * "Your boards" carousel renders a control for it; elsewhere it is unset and
+   * the slot stays empty.
+   */
+  isPinned?: boolean;
+  /**
    * Offline download state for this board's scope. Absent on cards that cannot
    * be downloaded as a board (popular configs — see `popularConfigToItem`).
    */
@@ -83,6 +89,7 @@ const CORNER_BADGE_INSET = CORNER_BADGE_HIT_SLOP;
 /** Custom accessibility action names for the card's nested buttons. */
 const BOARD_ACTION_NAME = 'boardAction';
 const DOWNLOAD_ACTION_NAME = 'download';
+const PIN_ACTION_NAME = 'pin';
 
 /** Distance badge copy: metres under 1km, one-decimal km above. */
 function formatDistance(meters: number): string {
@@ -124,6 +131,15 @@ type BoardDiscoveryCardProps = {
   isEditing?: boolean;
   /** A delete/unfollow targeting THIS card is in flight. */
   isActionPending?: boolean;
+  /**
+   * Toggle this board's pin. Passed only by the "Your boards" carousel — every
+   * other surface omits it, which is what suppresses the control entirely
+   * (Near you, Popular, onboarding, and the offline branch, where the mutation
+   * could not reach the server anyway).
+   */
+  onTogglePin?: (item: DiscoveryBoardItem) => void;
+  /** Screen-reader label for the pin toggle (pinAria / unpinAria). */
+  pinLabel?: string;
 };
 
 /**
@@ -144,6 +160,8 @@ export const BoardDiscoveryCard = memo(function BoardDiscoveryCard({
   actionTitle,
   isEditing = false,
   isActionPending = false,
+  onTogglePin,
+  pinLabel,
 }: BoardDiscoveryCardProps) {
   const { t } = useTranslation('boards');
   const { systemColors, brandColors, radii } = useTheme();
@@ -178,6 +196,9 @@ export const BoardDiscoveryCard = memo(function BoardDiscoveryCard({
   const showFollowingBadge = !isEditing && action === 'unfollow';
   const showEditAction = isEditing && (action === 'delete' || action === 'unfollow') && onAction !== undefined;
   const canDownload = item.offlineState === 'off' && onDownload !== undefined;
+  // Mirrors the render guard below, so the rotor never publishes an action the
+  // touch surface does not offer.
+  const canPin = onTogglePin !== undefined && item.distanceMeters == null;
 
   const handleAction = useCallback(() => {
     onAction?.(item);
@@ -199,6 +220,11 @@ export const BoardDiscoveryCard = memo(function BoardDiscoveryCard({
     onPress(item);
   }, [onPress, item]);
 
+  const handleTogglePin = useCallback(() => {
+    hapticLight();
+    onTogglePin?.(item);
+  }, [onTogglePin, item]);
+
   // The outer Pressable sets `accessible` by default, so on iOS UIKit treats the
   // card as a leaf and VoiceOver never reaches the corner glyphs. Publish each
   // nested button as a labelled custom action instead — the same shape
@@ -210,8 +236,9 @@ export const BoardDiscoveryCard = memo(function BoardDiscoveryCard({
     const nested: AccessibilityActionInfo[] = [];
     if (hasBoardAction && actionLabel !== undefined) nested.push({ name: BOARD_ACTION_NAME, label: actionLabel });
     if (canDownload && downloadLabel !== undefined) nested.push({ name: DOWNLOAD_ACTION_NAME, label: downloadLabel });
+    if (canPin && pinLabel !== undefined) nested.push({ name: PIN_ACTION_NAME, label: pinLabel });
     return nested.length > 0 ? rowAccessibilityActionsWith(...nested) : ACTIVATE_ACCESSIBILITY_ACTIONS;
-  }, [hasBoardAction, actionLabel, canDownload, downloadLabel]);
+  }, [hasBoardAction, actionLabel, canDownload, downloadLabel, canPin, pinLabel]);
 
   const handleAccessibilityAction = useCallback(
     (event: AccessibilityActionEvent) => {
@@ -221,8 +248,9 @@ export const BoardDiscoveryCard = memo(function BoardDiscoveryCard({
       // keeps its haptic when it is reached from the rotor.
       if (actionName === BOARD_ACTION_NAME) (showEditAction ? handleEditAction : handleAction)();
       if (actionName === DOWNLOAD_ACTION_NAME) handleDownload();
+      if (actionName === PIN_ACTION_NAME) handleTogglePin();
     },
-    [isEditing, showEditAction, handlePress, handleAction, handleEditAction, handleDownload],
+    [isEditing, showEditAction, handlePress, handleAction, handleEditAction, handleDownload, handleTogglePin],
   );
 
   const activeLabel = t('mobile.discovery.activeBadge');
@@ -236,7 +264,14 @@ export const BoardDiscoveryCard = memo(function BoardDiscoveryCard({
       : item.isViewerOwner
         ? t('mobile.discovery.ownedBadgeAria')
         : t('mobile.discovery.followingBadgeAria');
-  const accessibilityLabel = [item.title, item.subtitle, item.isActive ? activeLabel : null, ownershipLabel]
+  const pinnedLabel = canPin && item.isPinned ? t('mobile.discovery.pinnedBadgeAria') : null;
+  const accessibilityLabel = [
+    item.title,
+    item.subtitle,
+    item.isActive ? activeLabel : null,
+    ownershipLabel,
+    pinnedLabel,
+  ]
     .filter((part): part is string => typeof part === 'string' && part.length > 0)
     .join(', ');
 
@@ -342,6 +377,26 @@ export const BoardDiscoveryCard = memo(function BoardDiscoveryCard({
           </View>
         ) : null}
 
+        {/* The pin lives in the distance pill's slot. A board can't be both a
+            proximity result and one of yours to pin, but guard anyway so the two
+            can never stack. */}
+        {onTogglePin && item.distanceMeters == null ? (
+          <Pressable
+            onPress={handleTogglePin}
+            accessibilityRole="button"
+            accessibilityState={{ selected: item.isPinned === true }}
+            accessibilityLabel={pinLabel}
+            style={styles.pinBadge}
+            hitSlop={CORNER_BADGE_HIT_SLOP}
+          >
+            <Icon
+              name={item.isPinned ? 'pin.fill' : 'pin'}
+              size={13}
+              color={item.isPinned ? brandColors.primaryFill : overlays.onScrim}
+            />
+          </Pressable>
+        ) : null}
+
         {item.distanceMeters != null ? (
           <View style={styles.distanceBadge}>
             <Icon name="location" size={11} color={overlays.onScrim} />
@@ -404,6 +459,12 @@ export const BoardDiscoveryCard = memo(function BoardDiscoveryCard({
 // Shared geometry for the two top-corner discs and the two bottom overlay pills.
 // Only the horizontal edge differs, so the corner budget stays literally two
 // circles and two pills — never four circles, never a destructive one.
+//
+// The bottom-right pill is shared, not duplicated: it carries the distance on
+// Near you and the pin toggle in "Your boards" (#4884). Those two never coexist
+// — `distanceMeters` is only set by proximity queries, and the pin control is
+// only handed to the saved-boards carousel — and the card asserts it by
+// rendering the pin solely when distance is absent.
 const cornerBadge = {
   position: 'absolute',
   top: CORNER_BADGE_INSET,
@@ -468,6 +529,14 @@ const styles = StyleSheet.create({
   distanceBadge: {
     ...overlayPill,
     right: spacing[2],
+  },
+  // Same slot as distanceBadge; square rather than text-width, since it holds a
+  // single glyph.
+  pinBadge: {
+    ...overlayPill,
+    right: spacing[2],
+    paddingHorizontal: spacing[2],
+    paddingVertical: 3,
   },
   title: {
     fontWeight: '600',

--- a/packages/mobile/src/components/board-discovery/__tests__/board-card-actions.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-card-actions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { UserBoard } from '@boardsesh/shared-schema';
-import { boardCardAction, sortViewerOwnedFirst, type BoardCardAction } from '../board-card-actions';
+import { boardCardAction, sortViewerOwnedFirst, hoistActiveBoard, type BoardCardAction } from '../board-card-actions';
 
 const board = (overrides: Partial<UserBoard> & { uuid: string }): UserBoard =>
   ({
@@ -79,5 +79,38 @@ describe('sortViewerOwnedFirst', () => {
     const snapshotFollowed = board({ uuid: 'snapshot-followed', ownerId: undefined, isOwned: false });
     const sorted = sortViewerOwnedFirst([snapshotFollowed, snapshotMine], 'me');
     expect(sorted.map((entry) => entry.uuid)).toEqual(['snapshot-mine', 'snapshot-followed']);
+  });
+});
+
+describe('hoistActiveBoard', () => {
+  const mine = board({ uuid: 'mine', ownerId: 'me' });
+  const gym = board({ uuid: 'gym', ownerId: 'someone-else' });
+  const otherGym = board({ uuid: 'other-gym', ownerId: 'someone-else' });
+
+  it('moves the active board to the front, keeping everything else in order', () => {
+    const hoisted = hoistActiveBoard([gym, mine, otherGym], 'mine');
+    expect(hoisted.map((entry) => entry.uuid)).toEqual(['mine', 'gym', 'other-gym']);
+  });
+
+  it('leaves the order alone when the active board already leads', () => {
+    const hoisted = hoistActiveBoard([mine, gym], 'mine');
+    expect(hoisted.map((entry) => entry.uuid)).toEqual(['mine', 'gym']);
+  });
+
+  it('leaves the order alone with no active board', () => {
+    expect(hoistActiveBoard([gym, mine], undefined).map((entry) => entry.uuid)).toEqual(['gym', 'mine']);
+    expect(hoistActiveBoard([gym, mine], null).map((entry) => entry.uuid)).toEqual(['gym', 'mine']);
+  });
+
+  // Hoist-only: a stored board the server no longer lists must not conjure a card.
+  it('injects nothing when the active board is not in the list', () => {
+    const hoisted = hoistActiveBoard([gym, mine], 'deleted-board');
+    expect(hoisted.map((entry) => entry.uuid)).toEqual(['gym', 'mine']);
+  });
+
+  it('never duplicates the active board', () => {
+    const hoisted = hoistActiveBoard([gym, mine, otherGym], 'gym');
+    expect(hoisted.filter((entry) => entry.uuid === 'gym')).toHaveLength(1);
+    expect(hoisted).toHaveLength(3);
   });
 });

--- a/packages/mobile/src/components/board-discovery/__tests__/board-discovery-card.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-discovery-card.test.tsx
@@ -113,7 +113,7 @@ vi.mock('../../../theme/colors', () => ({ withAlpha: (color: string, alpha: numb
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
     systemColors: { tertiaryBackground: '#eee', separator: '#ccc', tertiaryLabel: '#999', secondaryLabel: '#888' },
-    brandColors: { primary: '#6D28D9', primaryFill: '#6D28D9', error: '#C81E1E' },
+    brandColors: { primary: '#6D28D9', primaryFill: '#6D28D9', onPrimary: '#FFFFFF', error: '#C81E1E' },
     radii: { button: 10 },
   }),
 }));
@@ -180,12 +180,27 @@ const item: DiscoveryBoardItem = {
   title: 'Tension 8x10',
 };
 
-function edgeKeys(element: Element | null): string[] {
+function styleOf(element: Element | null): Record<string, unknown> {
   const raw = element?.getAttribute('data-style');
-  if (raw === null || raw === undefined) return [];
+  if (raw === null || raw === undefined) return {};
   const parsed: unknown = JSON.parse(raw);
-  const style = (Array.isArray(parsed) ? Object.assign({}, ...parsed) : parsed) as Record<string, unknown>;
+  // A Pressable's style can be an array (base + a state override); flatten it the
+  // way RN would so an assertion reads the value that actually renders.
+  return (Array.isArray(parsed) ? Object.assign({}, ...parsed.filter((entry) => entry !== null)) : parsed) as Record<
+    string,
+    unknown
+  >;
+}
+
+function edgeKeys(element: Element | null): string[] {
+  const style = styleOf(element);
   return ['top', 'bottom', 'left', 'right'].filter((edge) => style[edge] !== undefined);
+}
+
+/** The disc geometry every tappable corner glyph shares (#5179). */
+function discShape(element: Element | null): Record<string, unknown> {
+  const { width, height, borderRadius } = styleOf(element);
+  return { width, height, borderRadius };
 }
 
 function resetCapture() {
@@ -498,9 +513,8 @@ describe('BoardDiscoveryCard pin toggle', () => {
   });
 
   it('takes the bottom-right slot, and yields it to the distance pill', () => {
-    // The card's stated corner budget is two circles and two pills. The pin
-    // shares the distance pill's slot rather than adding a fifth, so a Near-you
-    // board must never render both.
+    // The pin takes the bottom-right slot rather than adding a fifth corner, so a
+    // Near-you board must never render both it and the distance pill.
     const { container } = render(
       createElement(BoardDiscoveryCard, {
         item: { ...item, isPinned: true },
@@ -509,8 +523,8 @@ describe('BoardDiscoveryCard pin toggle', () => {
         pinLabel: 'Unpin Tension 8x10',
       }),
     );
-    const pinPill = container.querySelector('[data-icon="pin.fill"]')!.parentElement;
-    expect(edgeKeys(pinPill)).toEqual(['bottom', 'right']);
+    const pinDisc = container.querySelector('[data-icon="pin.fill"]')!.parentElement;
+    expect(edgeKeys(pinDisc)).toEqual(['bottom', 'right']);
 
     resetCapture();
     const withDistance = render(
@@ -523,6 +537,65 @@ describe('BoardDiscoveryCard pin toggle', () => {
     );
     expect(withDistance.container.querySelector('[data-icon="pin.fill"]')).toBeNull();
     expect(withDistance.container.querySelector('[data-icon="location"]')).not.toBeNull();
+  });
+
+  // QA declined #5179 on exactly this: a wide dark pill under two white circles
+  // reads as a different kind of control. The pin is a BUTTON, so it wears the
+  // button shape — and pinning inverts that disc instead of reshaping it.
+  it('wears the same disc as the download and edit buttons', () => {
+    const { container } = render(
+      createElement(BoardDiscoveryCard, {
+        item: { ...item, offlineState: 'off' },
+        onPress: vi.fn(),
+        onDownload: vi.fn(),
+        downloadLabel: 'Download Tension 8x10',
+        action: 'edit',
+        onAction: vi.fn(),
+        actionLabel: 'Edit Tension 8x10',
+        onTogglePin: vi.fn(),
+        pinLabel: 'Pin Tension 8x10',
+      }),
+    );
+    const downloadDisc = container.querySelector('[data-icon="offline.download"]')!.parentElement;
+    const editDisc = container.querySelector('[data-icon="edit"]')!.parentElement;
+    const pinDisc = container.querySelector('[data-icon="pin"]')!.parentElement;
+
+    expect(discShape(pinDisc)).toEqual(discShape(downloadDisc));
+    expect(discShape(pinDisc)).toEqual(discShape(editDisc));
+    // Unpinned it is indistinguishable from its two neighbours: same white fill.
+    expect(styleOf(pinDisc).backgroundColor).toBe(styleOf(editDisc).backgroundColor);
+  });
+
+  it('inverts the disc when pinned rather than changing its shape', () => {
+    const { container } = render(
+      createElement(BoardDiscoveryCard, {
+        item: { ...item, offlineState: 'off' },
+        onPress: vi.fn(),
+        onDownload: vi.fn(),
+        downloadLabel: 'Download Tension 8x10',
+        onTogglePin: vi.fn(),
+        pinLabel: 'Pin Tension 8x10',
+      }),
+    );
+    const restingFill = styleOf(container.querySelector('[data-icon="pin"]')!.parentElement).backgroundColor;
+
+    resetCapture();
+    const pinned = render(
+      createElement(BoardDiscoveryCard, {
+        item: { ...item, offlineState: 'off', isPinned: true },
+        onPress: vi.fn(),
+        onDownload: vi.fn(),
+        downloadLabel: 'Download Tension 8x10',
+        onTogglePin: vi.fn(),
+        pinLabel: 'Unpin Tension 8x10',
+      }),
+    );
+    const pinnedDisc = pinned.container.querySelector('[data-icon="pin.fill"]')!.parentElement;
+    const downloadDisc = pinned.container.querySelector('[data-icon="offline.download"]')!.parentElement;
+
+    // The fill flips, the geometry does not.
+    expect(styleOf(pinnedDisc).backgroundColor).not.toBe(restingFill);
+    expect(discShape(pinnedDisc)).toEqual(discShape(downloadDisc));
   });
 
   it('toggles from a tap and from the accessibility rotor', () => {

--- a/packages/mobile/src/components/board-discovery/__tests__/board-discovery-card.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-discovery-card.test.tsx
@@ -461,6 +461,108 @@ describe('BoardDiscoveryCard corner budget', () => {
   });
 });
 
+describe('BoardDiscoveryCard pin toggle', () => {
+  afterEach(resetCapture);
+
+  it('renders no pin control unless the host passes a handler', () => {
+    // Near you, Popular, onboarding and the offline branch all omit it; the
+    // absent handler is the gate, so there is nothing to talk past.
+    const { container } = render(
+      createElement(BoardDiscoveryCard, { item: { ...item, isPinned: false }, onPress: vi.fn() }),
+    );
+    expect(container.querySelector('[data-icon="pin"]')).toBeNull();
+    expect(container.querySelector('[data-icon="pin.fill"]')).toBeNull();
+  });
+
+  it('shows an outline pin when unpinned and a filled one when pinned', () => {
+    const { container, rerender } = render(
+      createElement(BoardDiscoveryCard, {
+        item: { ...item, isPinned: false },
+        onPress: vi.fn(),
+        onTogglePin: vi.fn(),
+        pinLabel: 'Pin Tension 8x10',
+      }),
+    );
+    expect(container.querySelector('[data-icon="pin"]')).not.toBeNull();
+    expect(container.querySelector('[data-icon="pin.fill"]')).toBeNull();
+
+    rerender(
+      createElement(BoardDiscoveryCard, {
+        item: { ...item, isPinned: true },
+        onPress: vi.fn(),
+        onTogglePin: vi.fn(),
+        pinLabel: 'Unpin Tension 8x10',
+      }),
+    );
+    expect(container.querySelector('[data-icon="pin.fill"]')).not.toBeNull();
+  });
+
+  it('takes the bottom-right slot, and yields it to the distance pill', () => {
+    // The card's stated corner budget is two circles and two pills. The pin
+    // shares the distance pill's slot rather than adding a fifth, so a Near-you
+    // board must never render both.
+    const { container } = render(
+      createElement(BoardDiscoveryCard, {
+        item: { ...item, isPinned: true },
+        onPress: vi.fn(),
+        onTogglePin: vi.fn(),
+        pinLabel: 'Unpin Tension 8x10',
+      }),
+    );
+    const pinPill = container.querySelector('[data-icon="pin.fill"]')!.parentElement;
+    expect(edgeKeys(pinPill)).toEqual(['bottom', 'right']);
+
+    resetCapture();
+    const withDistance = render(
+      createElement(BoardDiscoveryCard, {
+        item: { ...item, isPinned: true, distanceMeters: 320 },
+        onPress: vi.fn(),
+        onTogglePin: vi.fn(),
+        pinLabel: 'Unpin Tension 8x10',
+      }),
+    );
+    expect(withDistance.container.querySelector('[data-icon="pin.fill"]')).toBeNull();
+    expect(withDistance.container.querySelector('[data-icon="location"]')).not.toBeNull();
+  });
+
+  it('toggles from a tap and from the accessibility rotor', () => {
+    const onTogglePin = vi.fn();
+    const onPress = vi.fn();
+    const { container } = render(
+      createElement(BoardDiscoveryCard, {
+        item: { ...item, isPinned: false },
+        onPress,
+        onTogglePin,
+        pinLabel: 'Pin Tension 8x10',
+      }),
+    );
+
+    fireEvent.click(container.querySelector('[data-icon="pin"]')!.parentElement!);
+    expect(onTogglePin).toHaveBeenCalledWith({ ...item, isPinned: false });
+    // Tapping the pin must not also activate the board underneath it.
+    expect(onPress).not.toHaveBeenCalled();
+
+    const dispatch = cardRootProps.last?.onAccessibilityAction as (event: {
+      nativeEvent: { actionName: string };
+    }) => void;
+    dispatch({ nativeEvent: { actionName: 'pin' } });
+    expect(onTogglePin).toHaveBeenCalledTimes(2);
+  });
+
+  it('publishes the pin as a custom action, since the card is a leaf to VoiceOver', () => {
+    render(
+      createElement(BoardDiscoveryCard, {
+        item: { ...item, isPinned: false },
+        onPress: vi.fn(),
+        onTogglePin: vi.fn(),
+        pinLabel: 'Pin Tension 8x10',
+      }),
+    );
+    const actions = cardRootProps.last?.accessibilityActions as Array<{ name: string; label?: string }>;
+    expect(actions.some((action) => action.name === 'pin' && action.label === 'Pin Tension 8x10')).toBe(true);
+  });
+});
+
 describe('BoardDiscoveryCard accessibility', () => {
   afterEach(resetCapture);
 

--- a/packages/mobile/src/components/board-discovery/__tests__/board-items.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-items.test.ts
@@ -210,3 +210,30 @@ describe('offline state on discovery items', () => {
     expect(item?.key.startsWith('popular:')).toBe(true);
   });
 });
+
+describe('pin state', () => {
+  it('takes the pin from the board by default', () => {
+    const pinned = { ...board, isPinnedByMe: true } as unknown as UserBoard;
+    expect(userBoardToItem(pinned)?.isPinned).toBe(true);
+    expect(userBoardToItem(board)?.isPinned).toBe(false);
+  });
+
+  // An offline snapshot written before the field existed carries no answer; the
+  // card must read "not pinned" rather than undefined.
+  it('reads a board with no pin field as unpinned', () => {
+    const legacy = { ...board } as Record<string, unknown>;
+    delete legacy.isPinnedByMe;
+    expect(userBoardToItem(legacy as unknown as UserBoard)?.isPinned).toBe(false);
+  });
+
+  it('lets an optimistic override win over the server answer', () => {
+    const overrides = new Map([['b-1', true]]);
+    const [item] = userBoardsToItems([board], null, undefined, undefined, overrides);
+    expect(item.isPinned).toBe(true);
+
+    const unpinning = new Map([['b-1', false]]);
+    const pinnedBoard = { ...board, isPinnedByMe: true } as unknown as UserBoard;
+    const [flipped] = userBoardsToItems([pinnedBoard], null, undefined, undefined, unpinning);
+    expect(flipped.isPinned).toBe(false);
+  });
+});

--- a/packages/mobile/src/components/board-discovery/board-card-actions.ts
+++ b/packages/mobile/src/components/board-discovery/board-card-actions.ts
@@ -42,11 +42,15 @@ export function boardCardAction({ isViewerOwner, isEditing }: BoardCardActionInp
  * Viewer-owned boards first, followed boards after, each group keeping its
  * incoming order.
  *
- * The server orders `myBoards` by `desc(userBoards.isOwned)`, but that column
- * means "a real user-owned wall", not "owned by the viewer" — so a gym board the
- * viewer merely follows can lead the carousel. Returns the input order unchanged
- * when there is no identity to compare against, because guessing would file the
- * user's own wall behind boards they follow.
+ * Used by onboarding only. The board picker deliberately does NOT use this any
+ * more: `myBoards` now orders by pin, then by when you last opened the board
+ * (#4884), and re-partitioning by ownership on top of that would file a pinned
+ * gym board behind a wall you own and have never touched. Onboarding has no
+ * usage history to order by, so ownership is still the best signal there.
+ *
+ * Returns the input order unchanged when there is no identity to compare
+ * against, because guessing would file the user's own wall behind boards they
+ * follow.
  */
 export function sortViewerOwnedFirst(boards: readonly UserBoard[], currentUserId: string | undefined): UserBoard[] {
   if (currentUserId === undefined) return [...boards];
@@ -56,4 +60,19 @@ export function sortViewerOwnedFirst(boards: readonly UserBoard[], currentUserId
     (boardIsOwnedBy(board, currentUserId) ? owned : followed).push(board);
   }
   return [...owned, ...followed];
+}
+
+/**
+ * The active board first, everything else in the order the server gave.
+ *
+ * The server cannot do this itself: the active board lives in AsyncStorage on
+ * the device, so `myBoards` has never heard of it. Hoist-only — a board that is
+ * not in the list is never injected, so a stale stored board cannot conjure a
+ * card. Mirrors what the offline branch already does in `offline-board-items`.
+ */
+export function hoistActiveBoard(boards: readonly UserBoard[], activeUuid: string | null | undefined): UserBoard[] {
+  if (activeUuid == null) return [...boards];
+  const active = boards.find((board) => board.uuid === activeUuid);
+  if (!active) return [...boards];
+  return [active, ...boards.filter((board) => board.uuid !== activeUuid)];
 }

--- a/packages/mobile/src/components/board-discovery/board-items.ts
+++ b/packages/mobile/src/components/board-discovery/board-items.ts
@@ -30,6 +30,12 @@ export function userBoardToItem(
    * than offering to unfollow the user's own wall.
    */
   currentUserId?: string,
+  /**
+   * Whether this board is pinned, when the caller has an optimistic override for
+   * it. Defaults to the server's `isPinnedByMe`; the picker passes an override
+   * so a just-tapped pin flips instantly without waiting for a refetch.
+   */
+  isPinnedOverride?: boolean,
 ): DiscoveryBoardItem | null {
   const boardName = toBoardName(board.boardType);
   if (boardName === null) return null;
@@ -44,6 +50,7 @@ export function userBoardToItem(
     distanceMeters: board.distanceMeters ?? undefined,
     isActive: activeUuid != null && board.uuid === activeUuid,
     isViewerOwner: currentUserId === undefined ? undefined : boardIsOwnedBy(board, currentUserId),
+    isPinned: isPinnedOverride ?? board.isPinnedByMe ?? false,
     offlineState,
   };
 }
@@ -58,13 +65,21 @@ export function userBoardsToItems(
   activeUuid?: string | null,
   offlineStateFor?: (board: UserBoard) => BoardDownloadState,
   currentUserId?: string,
+  /** Uuids the user just toggled, pending the next fetch. See `userBoardToItem`. */
+  pinnedOverrides?: ReadonlyMap<string, boolean>,
 ): DiscoveryBoardItem[] {
   // Only boards that actually render take part: a board dropped for an
   // unsupported type must not push its neighbour into a disambiguation the user
   // can see no reason for.
   const rendered: { item: DiscoveryBoardItem; board: UserBoard }[] = [];
   for (const board of boards) {
-    const item = userBoardToItem(board, activeUuid, offlineStateFor?.(board), currentUserId);
+    const item = userBoardToItem(
+      board,
+      activeUuid,
+      offlineStateFor?.(board),
+      currentUserId,
+      pinnedOverrides?.get(board.uuid),
+    );
     if (item !== null) rendered.push({ item, board });
   }
   const subtitles = disambiguateBoardSubtitles(rendered.map((entry) => entry.board));

--- a/packages/mobile/src/components/board-discovery/manage-items.ts
+++ b/packages/mobile/src/components/board-discovery/manage-items.ts
@@ -27,9 +27,11 @@ export function boardIsOwnedBy(board: UserBoard, currentUserId: string | undefin
  * Split `boards` (owned + followed, as `myBoards` returns them) into a flat item
  * array: an owned group then a followed group, each preceded by a header that's
  * omitted when the group is empty. Owned = `boardIsOwnedBy`.
- * `myBoards` already orders owned-first, so this is a single pass; the caller
- * supplies the localized header titles. Each board carries precomputed
- * `isOwned`/`isActive` so the row never scans for them.
+ * The partition is this function's own: `myBoards` orders by pin and recency
+ * (#4884), not owned-first, so the two groups are built here in a single pass.
+ * Within each group the server's order is kept. The caller supplies the
+ * localized header titles. Each board carries precomputed `isOwned`/`isActive`
+ * so the row never scans for them.
  */
 export function buildManageItems(
   boards: readonly UserBoard[],

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-pin-board.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-pin-board.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PIN_BOARD, UNPIN_BOARD } from '@boardsesh/graphql/operations/boards';
+
+// Two fast taps on one card fire pin and then unpin as two independent requests.
+// Nothing in HTTP promises they reach the server in that order, and the loser is
+// the server: it can settle on "pinned" while the card's local override says
+// otherwise, and the disagreement survives until the picker is next opened. The
+// mutation runs in a scope so the second toggle waits for the first to settle,
+// which is what these tests hold — the ordering, not the option that buys it.
+
+const requestMock = vi.fn();
+vi.mock('../../client', () => ({
+  getHttpClient: () => ({ request: requestMock }),
+}));
+
+// The hooks barrel re-exports siblings that transitively pull in react-native /
+// expo-router. usePinBoard is pure React Query and touches none of them, so stub
+// the heavy re-exports so the barrel parses under the node SSR transform.
+vi.mock('react-native', () => ({}));
+vi.mock('../use-infinite-search-climbs', () => ({ useInfiniteSearchClimbs: vi.fn() }));
+vi.mock('../use-beta-link-preview', () => ({ useBetaLinkPreview: vi.fn() }));
+vi.mock('../use-mobile-climb-actions-data', () => ({ useMobileClimbActionsData: vi.fn() }));
+vi.mock('../use-you-data', () => ({
+  useAllBoardsTicks: vi.fn(),
+  useUserProfileStats: vi.fn(),
+  useUserClimbPercentile: vi.fn(),
+  useUserAscentsFeed: vi.fn(),
+  useSessionGroupedFeed: vi.fn(),
+}));
+vi.mock('../use-you-profile-data', () => ({ useYouProfileData: vi.fn() }));
+vi.mock('../use-social', () => ({
+  useVote: vi.fn(),
+  useBulkVoteSummaries: vi.fn(),
+  useComments: vi.fn(),
+  useAddComment: vi.fn(),
+}));
+vi.mock('../use-session-detail', () => ({ useSessionDetail: vi.fn(), useSessionPreview: vi.fn() }));
+vi.mock('../use-integrations', () => ({
+  useIntegrationStatuses: vi.fn(),
+  useDisconnectIntegration: vi.fn(),
+  useSetIntegrationAutoSync: vi.fn(),
+  useSyncSessionToIntegration: vi.fn(),
+}));
+
+import { usePinBoard } from '../index';
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, Wrapper };
+}
+
+/** A request mock whose responses are released by hand, one at a time. */
+function deferredRequests() {
+  const releases: Array<() => void> = [];
+  requestMock.mockImplementation(
+    (document: string) =>
+      new Promise((resolve) => {
+        releases.push(() => resolve(document === PIN_BOARD ? { pinBoard: true } : { unpinBoard: true }));
+      }),
+  );
+  return releases;
+}
+
+/** Which mutation document each call sent, in the order the client saw them. */
+function sentDocuments(): string[] {
+  return requestMock.mock.calls.map((call) => (call[0] === PIN_BOARD ? 'PIN' : 'UNPIN'));
+}
+
+describe('usePinBoard', () => {
+  beforeEach(() => {
+    requestMock.mockReset();
+  });
+
+  it('holds the second toggle until the first settles', async () => {
+    const releases = deferredRequests();
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => usePinBoard(), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.mutate({ boardUuid: 'board-1', pinned: true });
+      result.current.mutate({ boardUuid: 'board-1', pinned: false });
+    });
+
+    // The unpin has NOT reached the client: it is queued behind the pin, so the
+    // server can never see the pair inverted.
+    await waitFor(() => expect(requestMock).toHaveBeenCalledTimes(1));
+    expect(sentDocuments()).toEqual(['PIN']);
+
+    act(() => releases[0]());
+
+    await waitFor(() => expect(requestMock).toHaveBeenCalledTimes(2));
+    expect(sentDocuments()).toEqual(['PIN', 'UNPIN']);
+  });
+
+  it('sends both toggles, in the order the climber tapped them', async () => {
+    const releases = deferredRequests();
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => usePinBoard(), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.mutate({ boardUuid: 'board-1', pinned: true });
+      result.current.mutate({ boardUuid: 'board-1', pinned: false });
+    });
+
+    await waitFor(() => expect(releases).toHaveLength(1));
+    act(() => releases[0]());
+    await waitFor(() => expect(releases).toHaveLength(2));
+    act(() => releases[1]());
+
+    // Serializing must not swallow a tap: an `isPending` guard in the handler
+    // would leave the board pinned when the climber asked for unpinned.
+    await waitFor(() => expect(sentDocuments()).toEqual(['PIN', 'UNPIN']));
+    expect(requestMock.mock.calls[1][1]).toEqual({ input: { boardUuid: 'board-1' } });
+    expect(requestMock.mock.calls[1][0]).toBe(UNPIN_BOARD);
+  });
+
+  it('reports the failing board to onPinError so the glyph can go back', async () => {
+    requestMock.mockRejectedValue(new Error('offline'));
+    const onPinError = vi.fn();
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => usePinBoard({ onPinError }), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.mutate({ boardUuid: 'board-9', pinned: true });
+    });
+
+    await waitFor(() => expect(onPinError).toHaveBeenCalledTimes(1));
+    expect(onPinError.mock.calls[0][0]).toBe('board-9');
+  });
+});

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -80,11 +80,17 @@ import {
   DELETE_BOARD,
   FOLLOW_BOARD,
   UNFOLLOW_BOARD,
+  PIN_BOARD,
+  UNPIN_BOARD,
+  RECORD_BOARD_OPENED,
   GET_BOARD_BY_SLUG,
   type UpdateBoardMutationResponse,
   type DeleteBoardMutationResponse,
   type FollowBoardMutationResponse,
   type UnfollowBoardMutationResponse,
+  type PinBoardMutationResponse,
+  type UnpinBoardMutationResponse,
+  type RecordBoardOpenedMutationResponse,
   type GetBoardBySlugQueryResponse,
 } from '@boardsesh/graphql/operations/boards';
 import { getHttpClient } from '../client';
@@ -756,6 +762,57 @@ export function useUnfollowBoard() {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['myBoards'] });
+    },
+  });
+}
+
+/**
+ * Pin or unpin a board, which floats it to the front of "Your boards" (#4884).
+ *
+ * `refetchType: 'none'` is the whole point of the invalidation here: it marks
+ * the list stale WITHOUT refetching the mounted observer. A plain invalidate
+ * refetches immediately, the server returns the new order, and the card the
+ * climber's finger is still on slides out from under it. Marking stale instead
+ * means the reorder lands the next time the picker is opened.
+ */
+export function usePinBoard(options?: { onPinError?: (boardUuid: string, error: unknown) => void }) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ boardUuid, pinned }: { boardUuid: string; pinned: boolean }) => {
+      if (pinned) {
+        const response = await getHttpClient().request<PinBoardMutationResponse>(PIN_BOARD, {
+          input: { boardUuid },
+        });
+        return response.pinBoard;
+      }
+      const response = await getHttpClient().request<UnpinBoardMutationResponse>(UNPIN_BOARD, {
+        input: { boardUuid },
+      });
+      return response.unpinBoard;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['myBoards'], refetchType: 'none' });
+    },
+    // Config-level, so a rejected pin still surfaces after the modal is
+    // dismissed (same reasoning as useFollowBoard).
+    onError: (error, variables) => {
+      options?.onPinError?.(variables.boardUuid, error);
+    },
+  });
+}
+
+/**
+ * Record that the climber opened this board — the recency half of the
+ * "Your boards" ordering. Fire-and-forget: no invalidation (the ordering it
+ * feeds is read on the next open, not now) and no retry.
+ */
+export function useRecordBoardOpened() {
+  return useMutation({
+    mutationFn: async (boardUuid: string) => {
+      const response = await getHttpClient().request<RecordBoardOpenedMutationResponse>(RECORD_BOARD_OPENED, {
+        input: { boardUuid },
+      });
+      return response.recordBoardOpened;
     },
   });
 }

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -778,6 +778,14 @@ export function useUnfollowBoard() {
 export function usePinBoard(options?: { onPinError?: (boardUuid: string, error: unknown) => void }) {
   const queryClient = useQueryClient();
   return useMutation({
+    // Serialize every pin toggle behind one scope. Two fast taps on the same
+    // card fire pin-then-unpin as two independent requests, and nothing stops
+    // the server answering them out of order — leaving it pinned while the glyph
+    // says otherwise until the next picker open. A scope makes the second wait
+    // for the first to settle, so arrival order is dispatch order. Deliberately
+    // not a `isPending` guard in the handler: that drops the tap the climber
+    // meant, and puts a churning value in `onTogglePin`'s deps.
+    scope: { id: 'pin-board' },
     mutationFn: async ({ boardUuid, pinned }: { boardUuid: string; pinned: boolean }) => {
       if (pinned) {
         const response = await getHttpClient().request<PinBoardMutationResponse>(PIN_BOARD, {

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -75,6 +75,7 @@ const BOARD_FIELDS = `
   serialNumber
   timerName
   canEdit
+  isPinnedByMe
 `;
 
 const CLIMB_SEARCH_FIELDS = `

--- a/packages/mobile/src/lib/screenshot-board-selection.ts
+++ b/packages/mobile/src/lib/screenshot-board-selection.ts
@@ -3,12 +3,14 @@ import { SCREENSHOT_BOARDS } from './screenshot-mode';
 /**
  * Which of the account's boards a screenshot slot renders.
  *
- * Position alone can't answer that: `myBoards` comes back ordered
- * `isOwned DESC, createdAt DESC`, so `boards[0]` is "the newest board I own" and
- * shifts under the capture every time the account follows or adds a wall — which
- * is how a MoonBoard ended up as the wall in the App Store hero shots. The
- * capture asks for boards by name instead (`SCREENSHOT_BOARDS`), and only falls
- * back to a position when nothing matches.
+ * Position alone can't answer that: `myBoards` orders by pin, then by when the
+ * account last opened each board (#4884), so `boards[0]` shifts under the
+ * capture whenever the account uses, pins, follows or adds a wall — which is how
+ * a MoonBoard ended up as the wall in the App Store hero shots. (The recorder
+ * that writes those timestamps is itself gated off in screenshot builds, but the
+ * ordering still moves with pins and follows.) The capture asks for boards by
+ * name instead (`SCREENSHOT_BOARDS`), and only falls back to a position when
+ * nothing matches.
  *
  * Screenshot-only: every caller reaches this from an inlined
  * `EXPO_PUBLIC_SCREENSHOT_MODE === '1'` branch, so it dead-strips from normal

--- a/packages/shared/graphql/src/operations/boards.ts
+++ b/packages/shared/graphql/src/operations/boards.ts
@@ -346,6 +346,13 @@ export type PinBoardMutationResponse = {
   pinBoard: boolean;
 };
 
+// Same input as PinBoard — UNPIN_BOARD declares `$input: PinBoardInput!` — but
+// spelled out so the pair matches Follow/Unfollow above and a caller can name
+// the mutation it is actually sending.
+export type UnpinBoardMutationVariables = {
+  input: PinBoardInput;
+};
+
 export type UnpinBoardMutationResponse = {
   unpinBoard: boolean;
 };

--- a/packages/shared/graphql/src/operations/boards.ts
+++ b/packages/shared/graphql/src/operations/boards.ts
@@ -212,6 +212,24 @@ export const UNFOLLOW_BOARD = gql`
   }
 `;
 
+export const PIN_BOARD = gql`
+  mutation PinBoard($input: PinBoardInput!) {
+    pinBoard(input: $input)
+  }
+`;
+
+export const UNPIN_BOARD = gql`
+  mutation UnpinBoard($input: PinBoardInput!) {
+    unpinBoard(input: $input)
+  }
+`;
+
+export const RECORD_BOARD_OPENED = gql`
+  mutation RecordBoardOpened($input: RecordBoardOpenedInput!) {
+    recordBoardOpened(input: $input)
+  }
+`;
+
 export const RECORD_BOARD_SERIAL = gql`
   mutation RecordBoardSerial($input: RecordBoardSerialInput!) {
     recordBoardSerial(input: $input) {
@@ -314,6 +332,34 @@ export type UnfollowBoardMutationVariables = {
 
 export type UnfollowBoardMutationResponse = {
   unfollowBoard: boolean;
+};
+
+export type PinBoardInput = {
+  boardUuid: string;
+};
+
+export type PinBoardMutationVariables = {
+  input: PinBoardInput;
+};
+
+export type PinBoardMutationResponse = {
+  pinBoard: boolean;
+};
+
+export type UnpinBoardMutationResponse = {
+  unpinBoard: boolean;
+};
+
+export type RecordBoardOpenedInput = {
+  boardUuid: string;
+};
+
+export type RecordBoardOpenedMutationVariables = {
+  input: RecordBoardOpenedInput;
+};
+
+export type RecordBoardOpenedMutationResponse = {
+  recordBoardOpened: boolean;
 };
 
 export type GetPopularBoardConfigsQueryVariables = {

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -93,7 +93,11 @@
       "create": "Board anlegen",
       "createTile": "Erstellen",
       "followed": "{{name}} zu deinen Boards hinzugefügt",
-      "followError": "{{name}} ließ sich nicht zu deinen Boards hinzufügen"
+      "followError": "{{name}} ließ sich nicht zu deinen Boards hinzufügen",
+      "pinAria": "{{name}} anpinnen",
+      "unpinAria": "{{name}} abpinnen",
+      "pinnedBadgeAria": "Angepinnt",
+      "pinError": "Deine angepinnten Boards ließen sich nicht aktualisieren"
     },
     "create": {
       "screenTitle": "Richte dein Board ein",

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -93,7 +93,11 @@
       "create": "Create board",
       "createTile": "Create",
       "followed": "Added {{name}} to your boards",
-      "followError": "Couldn't add {{name}} to your boards"
+      "followError": "Couldn't add {{name}} to your boards",
+      "pinAria": "Pin {{name}}",
+      "unpinAria": "Unpin {{name}}",
+      "pinnedBadgeAria": "Pinned",
+      "pinError": "Couldn't update your pinned boards"
     },
     "create": {
       "screenTitle": "Set up your board",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -93,7 +93,11 @@
       "create": "Crear plafón",
       "createTile": "Crear",
       "followed": "{{name}} añadido a tus plafones",
-      "followError": "No se pudo añadir {{name}} a tus plafones"
+      "followError": "No se pudo añadir {{name}} a tus plafones",
+      "pinAria": "Fijar {{name}}",
+      "unpinAria": "Desfijar {{name}}",
+      "pinnedBadgeAria": "Fijado",
+      "pinError": "No se pudieron actualizar tus plafones fijados"
     },
     "create": {
       "screenTitle": "Configura tu plafón",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -93,7 +93,11 @@
       "create": "Créer une board",
       "createTile": "Créer",
       "followed": "{{name}} ajoutée à tes boards",
-      "followError": "Impossible d'ajouter {{name}} à tes boards"
+      "followError": "Impossible d'ajouter {{name}} à tes boards",
+      "pinAria": "Épingler {{name}}",
+      "unpinAria": "Désépingler {{name}}",
+      "pinnedBadgeAria": "Épinglée",
+      "pinError": "Impossible de mettre à jour tes boards épinglées"
     },
     "create": {
       "screenTitle": "Configure ta board",


### PR DESCRIPTION
## Summary

The client half of #4884. Follows #5155 (backend, merged), which shipped the API this needs. Splitting them was the point: both deploy workflows fire on push to `main` and the OTA beats the backend rollout, so an app asking for `isPinnedByMe` against a backend that lacks it would fail GraphQL document validation and take down the board picker.

**Recording an open is one root-level watcher on the active board's uuid**, not instrumentation on the activation paths. `useActivateBoard` is the funnel for the picker, the builder and onboarding, but a BLE connect, a deep link, the cross-board gate, the drawer host, the queue provider, the gym list and the board editor all set the active board directly. Instrumenting the setter is wrong the other way: the angle controls rewrite the active board for an *angle* change, which is not a board open. Watching the uuid catches every real switch and nothing else, because an angle rewrite keeps the same uuid.

The dedupe key lives at module scope rather than in a `useRef` — Fast Refresh and an OTA reload both remount the component, and a ref would forget and re-record. Keyed by user too, so two accounts on one device can't dedupe against each other. It's gated off in screenshot builds, which drive the active board themselves to stage captures.

**The picker stops re-sorting by ownership.** That partition fought the new order: it filed a pinned gym board behind a wall you own and never touch. All the client adds now is hoisting the board you're on, which the server can't know because it lives in AsyncStorage on the device. `sortViewerOwnedFirst` stays for onboarding, which has no usage history to order by.

**The pin shares the distance pill's slot** rather than adding a fifth corner badge, which `BoardDiscoveryCard` documents as out of budget ("two circles and two pills, never four circles"). The two can never collide — distance is only set by proximity queries, and the pin is only handed to the saved-boards carousel — and the card asserts it by rendering the pin only when distance is absent. The comment stating the invariant was updated in the same diff.

**Tapping the pin flips the glyph at once but does not reorder.** A card must not slide out from under the finger that tapped it, so the mutation invalidates `myBoards` with `refetchType: 'none'` and the new order lands on the next open of the picker.

### Verification

- `vp run typecheck` clean; `vp check` 0 errors; `vp run check:mobile-bundle` OK.
- `vp run test:mobile` — 798 files, 8293 tests, all passing.
- i18n parity (`--project i18n`) green: pin strings in all four locales, reusing the vocabulary already established for playlist pins (es *Fijar*/*Desfijar*, fr *Épingler*/*Épinglée* — feminine, matching the existing "Ta board" — de *anpinnen*/*abpinnen*).
- Mutation-tested the two guards that matter: making the picker reorder optimistically fails "flips the glyph immediately without moving the card", and keying the recorder on the angle fails "stays silent when only the angle changed". Nothing else broke in either case.

Closes #4884.

## Release Notes

- Your boards now lead with the one you're on, then the boards you use most
- Pin a board to keep it at the front, however long it's been

## Test plan

1. Change board → tap a board → reopen the picker.
2. That board now leads the row.
3. Pin is round, matching the two buttons above it.
4. Tap the pin → that disc turns violet.
5. Force-quit, relaunch, reopen → pinned board sits second.

## Risk

Risk: 3/5 — board picker ordering plus a new per-card control and a root-level effect. JS-only, so it rides OTA. The API it depends on is already on `main` via #5155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBmPStSju5LtZ42vvLVzRP

