### PR TITLE
fix(web): read the setter follow state as the signed-in viewer, not anonymously

### DIFF
--- a/packages/web/app/setter/[setter_username]/__tests__/setter-follow-island.test.tsx
+++ b/packages/web/app/setter/[setter_username]/__tests__/setter-follow-island.test.tsx
@@ -4,10 +4,23 @@ import { render, screen, waitFor } from '@testing-library/react';
 
 const graphqlRequest = vi.hoisted(() => vi.fn());
 const sessionState = vi.hoisted(() => ({
-  value: { data: { authToken: 'token' }, status: 'authenticated' } as { data: unknown; status: string },
+  value: { data: {}, status: 'authenticated' } as { data: unknown; status: string },
 }));
+/**
+ * The token comes from `useWsAuthToken`, the same hook `FollowButton` writes
+ * with — NOT off the session, which never carries one.
+ */
+const wsAuthState = vi.hoisted(() => ({ token: 'token' as string | null }));
 
 vi.mock('next-auth/react', () => ({ useSession: () => sessionState.value }));
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: (enabled = true) => ({
+    token: enabled ? wsAuthState.token : null,
+    isAuthenticated: enabled && wsAuthState.token !== null,
+    isLoading: false,
+    error: null,
+  }),
+}));
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en-US' } }),
 }));
@@ -46,5 +59,24 @@ describe('the setter follow island', () => {
     // The count is a server-resolved prop, so it survives the failure whole.
     expect(screen.getByText(/^7/)).toBeTruthy();
     consoleError.mockRestore();
+  });
+
+  it("drops the previous viewer's follow state when the token changes", async () => {
+    // Sign out and back in as somebody else and this effect re-runs. Without
+    // the reset the button keeps rendering the LAST viewer's answer, and
+    // "Following" shown to a stranger is the expensive direction: the toggle
+    // sends UNFOLLOW from that state and takes the count down.
+    graphqlRequest.mockResolvedValue({ setterProfile: { isFollowedByMe: true, followerCount: 42 } });
+    wsAuthState.token = 'token-viewer-a';
+
+    const { rerender } = render(<SetterFollowIsland username="marco" initialFollowerCount={3} />);
+    await waitFor(() => expect(screen.getByRole('button')).toBeTruthy());
+
+    // Viewer B's read never resolves, so anything on screen is left over from A.
+    graphqlRequest.mockReturnValue(new Promise(() => {}));
+    wsAuthState.token = 'token-viewer-b';
+    rerender(<SetterFollowIsland username="marco" initialFollowerCount={3} />);
+
+    await waitFor(() => expect(screen.queryByRole('button')).toBeNull());
   });
 });

--- a/packages/web/app/setter/[setter_username]/__tests__/setter-follow-island.test.tsx
+++ b/packages/web/app/setter/[setter_username]/__tests__/setter-follow-island.test.tsx
@@ -31,15 +31,19 @@ describe('the setter follow island', () => {
     await waitFor(() => expect(screen.getByText(/^42/)).toBeTruthy());
   });
 
-  it('keeps the server count when the profile read fails', async () => {
+  it('keeps the server count and shows no button when the profile read fails', async () => {
     graphqlRequest.mockRejectedValue(new Error('offline'));
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     render(<SetterFollowIsland username="marco" initialFollowerCount={7} />);
 
-    // The button still appears (a signed-in climber must not lose the
-    // affordance), and the count does not blank or reset to zero.
-    await waitFor(() => expect(screen.getByRole('button')).toBeTruthy());
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+
+    // No button, because the failed read cannot say whether this viewer already
+    // follows. It used to fall back to "Follow", and a follower who clicked it
+    // moved the count to 8 without changing anything on the server.
+    expect(screen.queryByRole('button')).toBeNull();
+    // The count is a server-resolved prop, so it survives the failure whole.
     expect(screen.getByText(/^7/)).toBeTruthy();
     consoleError.mockRestore();
   });

--- a/packages/web/app/setter/[setter_username]/__tests__/setter-page-ssr.test.tsx
+++ b/packages/web/app/setter/[setter_username]/__tests__/setter-page-ssr.test.tsx
@@ -25,6 +25,17 @@ const ogSummary = vi.hoisted(() => ({
   calls: 0,
 }));
 
+/**
+ * Which of the head's two reads started when.
+ *
+ * Both stubs below suspend once before they resolve, which is the whole trick:
+ * a `Promise.all` calls both functions before either can get past that await,
+ * so `view:start` lands before `og:end`. Sequenced awaits cannot produce that
+ * order no matter how fast either read is, so the assertion is about the code's
+ * shape rather than about timing.
+ */
+const readOrder = vi.hoisted(() => ({ events: [] as string[] }));
+
 vi.mock('server-only', () => ({}));
 vi.mock('@/app/lib/db/db', () => ({ dbz: {}, dbzRead: {}, sql: {}, executeRows: async () => [] }));
 
@@ -39,7 +50,12 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('../server-setter-data', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../server-setter-data')>()),
-  getSetterPageData: async () => setterData.value,
+  getSetterPageData: async () => {
+    readOrder.events.push('view:start');
+    await Promise.resolve();
+    readOrder.events.push('view:end');
+    return setterData.value;
+  },
 }));
 
 vi.mock('@/app/lib/server-popular-configs', () => ({
@@ -64,6 +80,9 @@ vi.mock('@/app/lib/server-popular-configs', () => ({
 vi.mock('@/app/lib/seo/dynamic-og-data', () => ({
   getSetterOgSummary: async () => {
     ogSummary.calls += 1;
+    readOrder.events.push('og:start');
+    await Promise.resolve();
+    readOrder.events.push('og:end');
     return ogSummary.value;
   },
 }));
@@ -198,6 +217,7 @@ beforeEach(() => {
   notFoundCalls.count = 0;
   ogSummary.value = { displayName: 'Marco', version: 'v1' };
   ogSummary.calls = 0;
+  readOrder.events = [];
 });
 
 describe('the setter front door, server-rendered', () => {
@@ -345,6 +365,18 @@ describe('the setter front door, as a crawler reads its head', () => {
 
     expect(notFoundCalls.count).toBe(before + 1);
     expect(ogSummary.calls).toBe(0);
+  });
+
+  it('starts both of its reads at once rather than one after the other', async () => {
+    // The OG summary and the page view are two independent queries, and the
+    // early return between them saves neither: the body resolves the page view
+    // on every request, the 404 path included. Awaiting them in sequence only
+    // added a round trip to the head of every cold request.
+    setterData.value = pageData([{ uuid: 'a'.repeat(32), name: 'First Climb' }]);
+
+    await metadataFor();
+
+    expect(readOrder.events.indexOf('view:start')).toBeLessThan(readOrder.events.indexOf('og:end'));
   });
 
   it('serves a setter whose name contains a percent sign instead of 500ing on it', async () => {

--- a/packages/web/app/setter/[setter_username]/__tests__/setter-page-ssr.test.tsx
+++ b/packages/web/app/setter/[setter_username]/__tests__/setter-page-ssr.test.tsx
@@ -103,6 +103,11 @@ vi.mock('../setter-share-button', () => ({ default: () => null }));
 // point of the assertion below is that moving it there kept it in the server
 // HTML. Only its session read is stubbed.
 vi.mock('next-auth/react', () => ({ useSession: () => ({ data: null, status: 'unauthenticated' }) }));
+// `useWsAuthToken` is a React Query hook and this render has no provider. The
+// stub answers as it does for the anonymous crawler this test is about.
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: null, isAuthenticated: false, isLoading: false, error: null }),
+}));
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en-US' } }),
 }));

--- a/packages/web/app/setter/[setter_username]/__tests__/setter-page-ssr.test.tsx
+++ b/packages/web/app/setter/[setter_username]/__tests__/setter-page-ssr.test.tsx
@@ -381,7 +381,15 @@ describe('the setter front door, as a crawler reads its head', () => {
 
     await metadataFor();
 
-    expect(readOrder.events.indexOf('view:start')).toBeLessThan(readOrder.events.indexOf('og:end'));
+    const viewStart = readOrder.events.indexOf('view:start');
+    const ogEnd = readOrder.events.indexOf('og:end');
+    // Presence first, and not as ceremony: `indexOf` answers -1 for an event
+    // that never happened, and -1 satisfies the ordering check against any real
+    // index. A refactor that stopped this path reaching `getSetterPageData` at
+    // all would otherwise turn this test green by removing what it measures.
+    expect(viewStart).toBeGreaterThan(-1);
+    expect(ogEnd).toBeGreaterThan(-1);
+    expect(viewStart).toBeLessThan(ogEnd);
   });
 
   it('serves a setter whose name contains a percent sign instead of 500ing on it', async () => {

--- a/packages/web/app/setter/[setter_username]/page.tsx
+++ b/packages/web/app/setter/[setter_username]/page.tsx
@@ -113,9 +113,36 @@ export async function generateMetadata({ params, searchParams }: SetterPageProps
   // one condition emitting different signals is how they drift apart.
   if (isFrontDoorPageOutOfRange(resolvedSearchParams.page)) notFound();
 
-  try {
-    const summary = await getSetterOgSummary(username);
+  const page = parseFrontDoorPage(resolvedSearchParams.page);
 
+  try {
+    // Started together, not one after the other. The second read is not
+    // conditional on the first in any way that saves a query: the page body
+    // resolves `getSetterPageView` on every request, the 404 included, so
+    // returning early below only moves that query later into the same request
+    // rather than avoiding it. Awaiting them in sequence bought nothing and
+    // cost the head a second serial round trip on every cold request.
+    //
+    // Safe as a `Promise.all`: `setterPageHasCrawlableClimb` swallows its own
+    // failures, so only `getSetterOgSummary` can reject, and the `catch` below
+    // is what handles it.
+    const [summary, hasCrawlableClimb] = await Promise.all([
+      getSetterOgSummary(username),
+      setterPageHasCrawlableClimb(username, page),
+    ]);
+
+    // Noindex metadata rather than `notFound()`, and the asymmetry with the
+    // page-range check above is deliberate: that check reads the URL, this one
+    // reads a query. The body 404s on its own read of the same rule
+    // (`getSetterPageView` → `getSetterPageData`) and a 404 discards this
+    // metadata entirely, so a crawler sees one signal either way. Leaving the
+    // 404 to the body means the two queries disagreeing costs a noindexed 200
+    // on a setter who does have visible climbs, rather than a 404 on one.
+    //
+    // They agree today because both spell one rule — `is_listed = true AND
+    // is_draft = false` on `board_climbs` — as the `has_visible_climb` EXISTS
+    // in `getSetterOgSummary` and as `visibleSetterClimbsWhere` in
+    // `server-setter-data.ts`. Change one and change the other.
     if (!summary) {
       return createNoIndexMetadata({
         title: t('metadata.setter.fallbackTitle'),
@@ -127,7 +154,6 @@ export async function generateMetadata({ params, searchParams }: SetterPageProps
     }
 
     const displayName = summary.displayName;
-    const page = parseFrontDoorPage(resolvedSearchParams.page);
     const { path, robots } = resolveListPageIndexation({ cleanPath, page, searchParams: resolvedSearchParams });
     // The shared doctrine cannot see this one: a setter every one of whose
     // climbs sits on a configuration `resolveClimbSitemapGroups` does not
@@ -136,7 +162,7 @@ export async function generateMetadata({ params, searchParams }: SetterPageProps
     // image. `/sitemaps/setters` already refuses to submit them (linkable AND
     // ≥3 climbs); this stops the ones a share link or an OG card surfaces from
     // being indexed as content either.
-    const linklessPage = !(await setterPageHasCrawlableClimb(username, page));
+    const linklessPage = !hasCrawlableClimb;
 
     return createBoardContentPageMetadata({
       title: t('metadata.setter.title', { name: displayName }),

--- a/packages/web/app/setter/[setter_username]/setter-follow-island.tsx
+++ b/packages/web/app/setter/[setter_username]/setter-follow-island.tsx
@@ -5,6 +5,7 @@ import Box from '@mui/material/Box';
 import { useSession } from 'next-auth/react';
 import { useTranslation } from 'react-i18next';
 import FollowButton from '@/app/components/ui/follow-button';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import {
   GET_SETTER_PROFILE,
@@ -40,16 +41,33 @@ type SetterFollowIslandProps = {
  * server, and `initialFollowerCount` is a server-resolved prop.
  */
 export default function SetterFollowIsland({ username, initialFollowerCount }: SetterFollowIslandProps) {
-  const { data: session, status } = useSession();
+  const { status } = useSession();
   const { t } = useTranslation('profile');
+  // The credential the button WRITES with, so the read and the write speak for
+  // the same viewer: `useFollowToggle` takes its token from here too. This read
+  // used to cast the session to `{ authToken?: string }`, a field NextAuth's
+  // `session` callback never sets and `Session` never declares — so it resolved
+  // to `undefined`, every request went out anonymous, and `isFollowedByMe` came
+  // back the way it does for a stranger. A follower was shown "Follow".
+  //
+  // `enabled` keeps an anonymous visitor paying nothing, which is the rule this
+  // island exists to keep: no session, no token fetch, no follow-state read,
+  // and `FollowButton` renders null regardless.
+  const { token: authToken } = useWsAuthToken(status === 'authenticated');
   const [isFollowing, setIsFollowing] = useState<boolean | null>(null);
   const [followerCount, setFollowerCount] = useState(initialFollowerCount);
 
   useEffect(() => {
-    if (status !== 'authenticated') return;
+    // Whose answer this is matters. Signing out, signing back in as somebody
+    // else and routing to another setter all re-run this effect, and state kept
+    // from the last run renders the PREVIOUS viewer's button. "Following" shown
+    // to a stranger is the expensive direction: `useFollowToggle` sends
+    // UNFOLLOW from that state and takes the count down.
+    setIsFollowing(null);
+
+    if (!authToken) return;
 
     let cancelled = false;
-    const authToken = (session as { authToken?: string } | null)?.authToken ?? null;
 
     void createGraphQLHttpClient(authToken)
       .request<GetSetterProfileQueryResponse, GetSetterProfileQueryVariables>(GET_SETTER_PROFILE, {
@@ -80,7 +98,7 @@ export default function SetterFollowIsland({ username, initialFollowerCount }: S
     return () => {
       cancelled = true;
     };
-  }, [status, session, username]);
+  }, [authToken, username]);
 
   // The COUNT renders unconditionally — including in the server pass, since a
   // client component's first render happens on the server — so the crawlable

--- a/packages/web/app/setter/[setter_username]/setter-follow-island.tsx
+++ b/packages/web/app/setter/[setter_username]/setter-follow-island.tsx
@@ -68,10 +68,13 @@ export default function SetterFollowIsland({ username, initialFollowerCount }: S
       })
       .catch((error: unknown) => {
         console.error('Failed to read setter follow state:', error);
-        // Show the button rather than hiding it. A signed-in climber on a flaky
-        // connection losing the affordance entirely is worse than one who has
-        // to click twice; the mutation is idempotent from the server's side.
-        if (!cancelled) setIsFollowing(false);
+        // Leave the state unknown, which renders no button — the same rule the
+        // pending state follows, for the same reason. Falling back to `false`
+        // showed "Follow" to a climber who already follows this setter, and the
+        // click that follows is not merely a redundant mutation: `FollowButton`
+        // reports it through `onFollowChange`, so the count below ticks up to a
+        // number this setter does not have. Losing the affordance until a
+        // reload is the smaller cost.
       });
 
     return () => {
@@ -81,10 +84,11 @@ export default function SetterFollowIsland({ username, initialFollowerCount }: S
 
   // The COUNT renders unconditionally — including in the server pass, since a
   // client component's first render happens on the server — so the crawlable
-  // HTML still carries it. Only the button waits: until the state is known it
-  // is not rendered at all rather than rendered as "Follow", because a signed-in
-  // follower briefly told they don't follow this setter will click it and
-  // unfollow them.
+  // HTML still carries it. Only the button waits, and `null` means waiting
+  // whether the read is still in flight or has failed: a button is worth
+  // rendering only once it can name the viewer's real state, since one shown as
+  // "Follow" to somebody who already follows costs a click that inflates the
+  // count rather than changing anything.
   return (
     <Box sx={countSx}>
       <span>


### PR DESCRIPTION
## Summary

Follow-ups from review on #4577, which has already merged, plus two bugs that verifying the review feedback turned up.

**The follow-state read was always anonymous.** `SetterFollowIsland` took its credential from `(session as { authToken?: string }).authToken`, and nothing puts `authToken` on a NextAuth session here: the `session` callback in `app/lib/auth/auth-options.ts` sets `authSessionId`, `user.id`, `user.image` and `user.name`, the `Session` augmentation in `app/lib/auth/types.ts` declares no such field, and the GraphQL client sends no cookies cross-origin. The cast resolved to `undefined` on every render, so `isFollowedByMe` answered the way it does for a stranger and a real follower was shown "Follow". It now reads the token from `useWsAuthToken` — the same hook `useFollowToggle` writes with — so the read and the write speak for one viewer. Passing `enabled` keeps an anonymous visitor paying nothing: no session, no token fetch, no read.

**A resolved follow state outlived its viewer.** `isFollowing` was never reset, so signing out and back in as somebody else, or routing to another setter, left the previous viewer's button on screen. A stale `true` is the expensive direction: it renders "Following" for a stranger, and `useFollowToggle` sends UNFOLLOW from that state and takes the count down. The effect now clears the state on every run before it reads. (Raised by Codex; thread resolved.)

**The error path no longer guesses.** The failed read used to fall back to `isFollowing = false`, which shows "Follow" to a climber who already follows. That click is not merely a redundant mutation — `FollowButton` reports it through `onFollowChange`, so the hero count ticks up to a number the setter does not have. The state now stays `null`, which renders no button, matching the rule the pending state already followed.

**The head's two reads start together.** `generateMetadata` awaited `getSetterOgSummary` and then `setterPageHasCrawlableClimb`. The early return between them saves no query: the page body resolves `getSetterPageView` on every request, the 404 path included, so returning early only moved that query later into the same request. `Promise.all` drops one serial round trip from every cold request without adding a query to any path. Safe because `setterPageHasCrawlableClimb` swallows its own failures, so only the OG summary can reject and the existing `catch` still handles it.

**One point was documentation.** `generateMetadata` returns noindex metadata for an unknown setter rather than calling `notFound()` the way the page-range check above it does. The asymmetry is deliberate — the range check reads the URL, this one reads a query, and leaving the 404 to the body means a disagreement between the two queries costs a noindexed 200 on a setter who does have climbs rather than a 404 on one. The comment now says that, and names both copies of the `is_listed AND NOT is_draft` rule so a change to one finds the other.

Author-side verification: full web suite green (386 files, 4485 tests), `typecheck:web` clean, `vp check` back to the same 2 errors and 348 warnings a clean `main` checkout reports, all in unrelated files. Both new tests were confirmed to fail against the code they pin — the concurrency test against sequential awaits, the viewer-change test against the unreset effect.

## Release Notes

- Following a setter now shows the right button: if you already follow them, it says Following instead of asking you to follow again.
- The follower count no longer drifts when the page loads on a bad connection.

## Test plan

1. Sign in, open a setter page you already follow.
2. Button reads Following, not Follow.
3. Tap it — button flips, count drops one.
4. Reload — button and count still match.

## Risk

Risk: 2/5 — one web client island plus metadata sequencing, both covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZsJBk5fp3NwiZaQWkDarf