### PR TITLE
feat(web): build plans admin queue, sitemap shard and launch order (build plans 10/10)

### DIFF
--- a/docs/cnc-packs.md
+++ b/docs/cnc-packs.md
@@ -747,6 +747,117 @@ Order timestamps are formatted with `createOrderDateFormatter`, which pins
 two runtimes in two zones; without the pin the same instant prints as two
 different clock times and React reports a hydration mismatch.
 
+## The admin queue
+
+`/admin/build-plans` lists every order, newest first, behind the same
+`checkAdmin` gate as the rest of `/admin`. It is the operator's view of the
+three fields `CncOrder` withholds from the buyer — the licensee email, the
+attempts spent, and the generator's real error — plus a Regenerate button on any
+`ready` or `failed` order.
+
+It is **not** behind the `cnc-packs` flag, on purpose. The flag decides whether
+the shop is open to the public; orders that already exist still have to be
+supportable if it is turned back off, and an operator locked out of the queue by
+a rollout percentage is exactly the wrong failure.
+
+Behind it, `Query.adminCncOrders(status, limit, cursor)` (`requireAdmin`,
+60/min on its own bucket, 25 rows by default and 100 at most). Keyset
+paginated on `(created_at, id)` rather than offset paginated: purchases land at
+the front of this list while somebody is paging through it, and an offset would
+show a row twice or skip one. A cursor that does not decode starts at the top
+rather than erroring — it is an opaque token an operator can only have got from
+us, and a first page is a more useful answer to a truncated paste than a
+failure.
+
+No index backs that ordering yet. `cnc_orders` holds one row per sale, so the
+sort is over a small table; an index added before there is volume to justify it
+is a write cost paid for a guess.
+
+## Launch
+
+The flag is off and the pages are `noindex` because the manufacturing licence
+ships marked DRAFT pending an Australian IP review — not because the code is
+unfinished. Launch is therefore mostly owner actions, in this order. Steps 1-5
+can all be done before anything is visible to anyone.
+
+1. **Stripe.** Create the two AUD prices (personal, commercial single-build) and
+   put their ids in `STRIPE_PRICE_CNC_PERSONAL` / `STRIPE_PRICE_CNC_COMMERCIAL`.
+   Enable Stripe Tax with the AU GST registration. Add the webhook endpoint at
+   `https://<backend>/api/cnc/stripe/webhook` for `checkout.session.completed`,
+   `checkout.session.async_payment_succeeded`,
+   `checkout.session.async_payment_failed`, `checkout.session.expired` and
+   `charge.refunded`, and set its signing secret as `STRIPE_WEBHOOK_SECRET`.
+   Set the Terms-of-Service URL on the Checkout branding settings to
+   `https://www.boardsesh.com/build-plans/licence` — Checkout collects the
+   licence acceptance against that URL, so it has to resolve before the first
+   real sale even though the page is still `noindex`.
+2. **Railway worker.** Create the `cnc-worker` service from
+   `ghcr.io/boardsesh/boardsesh-cnc-worker:production`, healthcheck `/health`,
+   `drainingSeconds` at least one job's length. Set its env:
+   `BOARDSESH_BACKEND_URL`, `CNC_WORKER_SECRET`, `CNC_WORKER_ID`
+   (`$RAILWAY_REPLICA_ID`), `FINGERPRINT_SECRET`, the `PRIVATE_*` bucket
+   credentials, `WORKER_CONCURRENCY`, `POLL_INTERVAL_S`, `SENTRY_DSN`.
+3. **Backend env.** Set `CNC_WORKER_URL` (private networking), the same
+   `CNC_WORKER_SECRET` the worker got, and `CNC_DOWNLOAD_TOKEN_SECRET`. Every
+   one of these fails closed, so a missed variable is a refusal rather than a
+   silent half-working shop — see the Environment table above.
+4. **Lawyer sign-off.** The Australian IP review of the licence text and of the
+   Kilter-derived engrave layer. This is the actual gate; everything else is
+   reversible and this is not.
+5. **Review a printed A3 set.** Generate one pack per size, print the A3 PDFs,
+   and check the dimensions against the built wall. The generator's goldens
+   prove it did not change; they do not prove it was right the first time.
+6. **Flip `cnc-packs` in PostHog.** Ramp it rather than jumping to 100% — the
+   pages, the sitemap shard and the footer link all read the same flag, so a
+   percentage rollout is also how the first real checkouts are throttled.
+   `FEATURE_FLAG_OVERRIDES=cnc-packs=false` on the web service is the kill
+   switch if something goes wrong; it does not need a deploy.
+
+Then, and only once the flag has been at 100% for long enough to trust,
+**a follow-up PR retires the gate**. Not part of the launch itself — pinning
+the dashboard to 100% and leaving the code alone would keep a PostHog round trip
+in front of every render of a page that is now public, and would keep it failing
+closed when PostHog is down. Following `docs/feature-flags.md`, that PR:
+
+- drops `requireCncPacksFlag()` and its `notFound()` from the four
+  `/build-plans*` routes, and removes `CNC_PACKS_FLAG` from
+  `packages/web/app/flags.ts` and `SERVER_FEATURE_FLAG_KEYS`;
+- swaps `createNoIndexMetadata` for `createPageMetadata` with a `path` on
+  `/build-plans` and `/build-plans/licence`, which is what emits the canonical
+  and the four-locale `alternates.languages` hreflang block. `/build-plans/orders`
+  and `/build-plans/orders/[licenceId]` stay `noindex` — they are per-buyer
+  utility pages;
+- replaces the flag read in `build-plans-entries.ts` with the plain list, so the
+  sitemap shard publishes unconditionally, and adds `/build-plans/licence` to it
+  (a unit test refuses any listed path with no `page.tsx` behind it);
+- rewrites the gate's tests as "this route renders" rather than deleting them;
+- archives the `cnc-packs` flag in the PostHog dashboard.
+
+The order matters in one place only: **do not remove the flag before the licence
+page exists and the lawyer has signed it off.** The gate is the only thing
+keeping a DRAFT licence out of Google.
+
+### Follow-ups, not built
+
+Four things that are deliberately out of the v1 scope, in the order they are
+likely to be wanted:
+
+- **Art asset orphan sweep.** An upload that never reached checkout stays in the
+  bucket forever. Bounded today by the 20-an-hour rate limit and the 5 MB cap;
+  the design and the three things it has to get right are under "Orphan sweep
+  (not built)" above.
+- **PNG artwork.** `POST /api/cnc/art` already accepts and sniffs a PNG, so the
+  whole storage and cleanup path is exercised — but the generator's tracer is
+  v2, so `png` is absent from `CncArtworkRules.allowedKinds` and an order naming
+  a PNG asset is refused with `CNC_INVALID_CONFIG`. Adding it is a generator
+  change plus one entry in that list.
+- **10-build pack credits.** Today the 10-build tier is a `mailto:` on the
+  pricing page. Doing it properly means a credit balance that is not an order
+  row — one payment, ten licences drawn down over months — which is a second
+  table and a second state machine, not a third tier in `catalog.ts`.
+- **OEM licensing.** Also `mailto:` today, and probably always negotiated rather
+  than self-serve.
+
 ## Local end-to-end
 
 ```

--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -16,7 +16,7 @@ Two kinds of shard:
 
 |                   | fixed (`SHARD_REGISTRY`)                           | paged (`PAGED_SHARD_REGISTRY`)                   |
 | ----------------- | -------------------------------------------------- | ------------------------------------------------ |
-| members           | `static`, `boards`, `gyms`, `setters`, `playlists` | `climbs` when enabled                            |
+| members           | `static`, `boards`, `gyms`, `setters`, `playlists`, `build-plans` | `climbs` when enabled             |
 | file              | one `/sitemaps/<id>.xml`                           | `/sitemaps/climbs/1.xml … N.xml`                 |
 | index asks it for | the whole item list                                | `summary()` only — count + newest timestamp      |
 | N comes from      | —                                                  | `ceil(itemCount / urlsPerShard)` at request time |
@@ -24,6 +24,29 @@ Two kinds of shard:
 `N` is derived from the summary on every request, never from the filesystem: Next has
 no partial dynamic segments, so a `climbs-1.xml` shape would hardcode today's page
 count into the directory tree.
+
+## The build-plans shard
+
+`/sitemaps/build-plans.xml` is the shop's own shard, and it is the one whose
+contents are decided by a **PostHog feature flag** rather than by a query.
+`buildBuildPlansEntries` reads the server flag `cnc-packs` (with
+`allowAnonymous: true`, since a crawler is nobody) and returns an empty list
+while it is off, which is the state the shard ships in — the manufacturing
+licence is marked DRAFT until an Australian IP lawyer signs it off.
+
+So the shard is declared `expectsUrls: false`, alongside `gyms` and `setters`:
+empty is a legitimate answer here, and failing closed would 503 a shard for
+being in its intended pre-launch state. Flipping the flag to 100% publishes the
+URLs on the next crawl with no deploy.
+
+The pages are genuinely translated copy, not translated chrome over shared data,
+so this shard takes the registry's default `all-locales` expansion and keeps its
+hreflang cluster — unlike `boards` and `setters`, which cross-canonicalise.
+
+`/build-plans/orders` and `/build-plans/orders/[licenceId]` are never listed:
+per-buyer utility pages behind a login. `/build-plans/licence` belongs in the
+shard and joins it in the PR that adds the page; a unit test fails on any listed
+path with no `page.tsx` behind it, so the list cannot advertise a 404.
 
 ## The climb sitemap switch
 

--- a/packages/backend/src/graphql/resolvers/cnc-packs/__tests__/queries.test.ts
+++ b/packages/backend/src/graphql/resolvers/cnc-packs/__tests__/queries.test.ts
@@ -15,9 +15,10 @@ vi.mock('../../shared/helpers', async (importOriginal) => ({
   applyRateLimit: vi.fn(async () => {}),
 }));
 
-const { listOrdersForUserMock, getOrderByLicenceIdMock } = vi.hoisted(() => ({
+const { listOrdersForUserMock, getOrderByLicenceIdMock, listOrdersForAdminMock } = vi.hoisted(() => ({
   listOrdersForUserMock: vi.fn(),
   getOrderByLicenceIdMock: vi.fn(),
+  listOrdersForAdminMock: vi.fn(),
 }));
 
 // `toPublicOrder` is kept real: it is the function that strips the fingerprint
@@ -27,7 +28,14 @@ vi.mock('../../../../services/cnc/orders', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../../services/cnc/orders')>()),
   listOrdersForUser: listOrdersForUserMock,
   getOrderByLicenceId: getOrderByLicenceIdMock,
+  listOrdersForAdmin: listOrdersForAdminMock,
 }));
+
+// The admin gate reads community_roles. Stubbed so these tests are about what
+// the resolver does on either side of it, not about the role query — every
+// admin test below sets the mock's verdict explicitly.
+const { requireAdminMock } = vi.hoisted(() => ({ requireAdminMock: vi.fn(async () => {}) }));
+vi.mock('../../social/roles', () => ({ requireAdmin: requireAdminMock }));
 
 const { fetchLayoutMock } = vi.hoisted(() => ({ fetchLayoutMock: vi.fn() }));
 
@@ -133,6 +141,9 @@ function makeOrder(overrides: Partial<CncOrder> = {}): CncOrder {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Back to "allowed" for every test, so the one that makes it reject cannot
+  // leak its verdict into whatever runs next.
+  requireAdminMock.mockResolvedValue(undefined);
 });
 
 describe('cncCatalog', () => {
@@ -445,5 +456,121 @@ describe('cncOrder', () => {
     await cncPackQueries.cncOrder(undefined, { licenceId: 'BS-CNC-ABC234' }, authCtx(OWNER_ID));
 
     expect(applyRateLimitMock).toHaveBeenCalledWith(authCtx(OWNER_ID), 60, 'cncOrder');
+  });
+});
+
+describe('adminCncOrders', () => {
+  const adminCtx = () => authCtx('user-admin');
+
+  function page(orders: CncOrder[], hasMore = false) {
+    return { orders, hasMore };
+  }
+
+  it('refuses a caller who is not an admin, before reading any order', async () => {
+    requireAdminMock.mockRejectedValue(new Error('Admin role required for this operation'));
+
+    await expect(cncPackQueries.adminCncOrders(undefined, {}, authCtx(OTHER_ID))).rejects.toThrow(/Admin role/);
+
+    // The gate runs first: a refused caller costs neither a query nor a slot in
+    // the rate-limit bucket.
+    expect(listOrdersForAdminMock).not.toHaveBeenCalled();
+    expect(applyRateLimitMock).not.toHaveBeenCalled();
+  });
+
+  it('publishes the three fields the buyer never sees', async () => {
+    listOrdersForAdminMock.mockResolvedValue(
+      page([makeOrder({ status: 'failed', attempts: 3, lastError: 'ezdxf: SEAM_TOO_CLOSE_TO_HOLE at panel 2' })]),
+    );
+
+    const result = await cncPackQueries.adminCncOrders(undefined, {}, adminCtx());
+    const [entry] = result.orders;
+
+    expect(entry.licenseeEmail).toBe('marco@example.com');
+    expect(entry.attempts).toBe(3);
+    expect(entry.lastError).toBe('ezdxf: SEAM_TOO_CLOSE_TO_HOLE at panel 2');
+  });
+
+  it('still redacts everything the buyer-facing shape redacts', async () => {
+    listOrdersForAdminMock.mockResolvedValue(page([makeOrder({ status: 'failed', lastError: 'internal detail' })]));
+
+    const result = await cncPackQueries.adminCncOrders(undefined, {}, adminCtx());
+    const [entry] = result.orders;
+
+    // The nested order is the buyer's own view, unchanged — the fingerprint
+    // manifest and the claim token stay gone, and the buyer's `errorMessage` is
+    // still the fixed public string rather than `lastError`.
+    expect(JSON.stringify(entry.order)).not.toContain('never-publish-me');
+    expect(JSON.stringify(entry.order)).not.toContain('claim-token-secret');
+    expect(entry.order.errorMessage).not.toContain('internal detail');
+  });
+
+  it('passes the status filter through and defaults to 25 rows', async () => {
+    listOrdersForAdminMock.mockResolvedValue(page([]));
+
+    await cncPackQueries.adminCncOrders(undefined, { status: 'failed' }, adminCtx());
+
+    expect(listOrdersForAdminMock).toHaveBeenCalledWith({ status: 'failed', limit: 25, after: null });
+  });
+
+  it('clamps an oversized limit instead of rejecting it', async () => {
+    listOrdersForAdminMock.mockResolvedValue(page([]));
+
+    await cncPackQueries.adminCncOrders(undefined, { limit: 5000 }, adminCtx());
+
+    expect(listOrdersForAdminMock).toHaveBeenCalledWith({ status: null, limit: 100, after: null });
+  });
+
+  it('clamps a zero or negative limit up to one row', async () => {
+    listOrdersForAdminMock.mockResolvedValue(page([]));
+
+    await cncPackQueries.adminCncOrders(undefined, { limit: 0 }, adminCtx());
+
+    expect(listOrdersForAdminMock).toHaveBeenCalledWith({ status: null, limit: 1, after: null });
+  });
+
+  it('hands back a cursor only when there is another page', async () => {
+    listOrdersForAdminMock.mockResolvedValue(page([makeOrder()], false));
+
+    const lastPage = await cncPackQueries.adminCncOrders(undefined, {}, adminCtx());
+
+    expect(lastPage.hasMore).toBe(false);
+    expect(lastPage.cursor).toBeNull();
+  });
+
+  it('pages forward from the last row of the previous page', async () => {
+    const older = makeOrder({ id: 7, createdAt: new Date('2026-08-30T00:00:00.000Z') });
+    listOrdersForAdminMock.mockResolvedValue(page([makeOrder(), older], true));
+
+    const first = await cncPackQueries.adminCncOrders(undefined, { limit: 2 }, adminCtx());
+    expect(first.hasMore).toBe(true);
+    expect(first.cursor).toBeTruthy();
+
+    listOrdersForAdminMock.mockResolvedValue(page([]));
+    await cncPackQueries.adminCncOrders(undefined, { limit: 2, cursor: first.cursor }, adminCtx());
+
+    // The cursor names the LAST row of the page just served, so the next page
+    // starts strictly after it — an offset would have skipped or repeated rows
+    // as new orders landed at the front.
+    expect(listOrdersForAdminMock).toHaveBeenLastCalledWith({
+      status: null,
+      limit: 2,
+      after: { createdAt: older.createdAt, id: 7 },
+    });
+  });
+
+  it('starts at the top for a cursor it cannot read, rather than serving an empty page', async () => {
+    listOrdersForAdminMock.mockResolvedValue(page([]));
+
+    await cncPackQueries.adminCncOrders(undefined, { cursor: 'not-a-cursor' }, adminCtx());
+
+    expect(listOrdersForAdminMock).toHaveBeenCalledWith({ status: null, limit: 25, after: null });
+  });
+
+  it('meters the read at 60/min on a bucket of its own', async () => {
+    listOrdersForAdminMock.mockResolvedValue(page([]));
+
+    await cncPackQueries.adminCncOrders(undefined, {}, adminCtx());
+
+    expect(applyRateLimitMock).toHaveBeenCalledWith(adminCtx(), 60, 'adminCncOrders');
   });
 });

--- a/packages/backend/src/graphql/resolvers/cnc-packs/order-mapper.ts
+++ b/packages/backend/src/graphql/resolvers/cnc-packs/order-mapper.ts
@@ -58,3 +58,27 @@ export function toGraphQLOrder(order: CncOrder) {
     errorMessage: publicOrder.status === 'failed' ? CNC_PUBLIC_FAILURE_MESSAGE : null,
   };
 }
+
+/**
+ * One order row as the GraphQL `CncAdminOrder` type.
+ *
+ * Built on `toGraphQLOrder` rather than beside it: the buyer's shape is the
+ * same object an administrator sees, and the three admin-only fields sit
+ * alongside it instead of being spliced in. So a field that is redacted for the
+ * buyer stays redacted here too, and only what this function names explicitly
+ * is added back.
+ *
+ * The three it names are the operator's whole job. `licenseeEmail` is who to
+ * write to (buyer-typed, and often not the account holder), `attempts` says how
+ * much of the retry budget a stuck order has left, and `lastError` is the
+ * generator's real message — the thing a regenerate decision is made on, and
+ * the thing the buyer is deliberately never shown.
+ */
+export function toGraphQLAdminOrder(order: CncOrder) {
+  return {
+    order: toGraphQLOrder(order),
+    licenseeEmail: order.licenseeEmail,
+    attempts: order.attempts,
+    lastError: order.lastError,
+  };
+}

--- a/packages/backend/src/graphql/resolvers/cnc-packs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/cnc-packs/queries.ts
@@ -8,7 +8,8 @@ import {
   CNC_DEFAULT_ARTWORK_FONT,
   type CncCatalogEntry,
 } from '../../../services/cnc/catalog';
-import { getOrderByLicenceId, listOrdersForUser } from '../../../services/cnc/orders';
+import { getOrderByLicenceId, listOrdersForAdmin, listOrdersForUser } from '../../../services/cnc/orders';
+import type { CncOrderStatus } from '../../../services/cnc/order-state';
 import {
   CncConfigMappingError,
   CncWorkerUnavailableError,
@@ -24,8 +25,10 @@ import {
   CNC_MIN_ARTWORK_WIDTH_MM,
   CncLicenceIdSchema,
 } from '../../../validation/schemas';
+import { decodeCursor, encodeCursor } from '../../../utils/feed-cursor';
+import { requireAdmin } from '../social/roles';
 import { CNC_WORKER_UNAVAILABLE_CODE, invalidConfigError, resolveCncConfig } from './config';
-import { toGraphQLOrder } from './order-mapper';
+import { toGraphQLAdminOrder, toGraphQLOrder } from './order-mapper';
 
 /**
  * Read side of CNC build packs: what is on sale, what a configuration looks
@@ -68,6 +71,19 @@ const RATE_LIMIT_CNC_READ = 60;
 const RATE_LIMIT_CNC_CATALOG_OP = 'cncCatalog';
 const RATE_LIMIT_MY_CNC_ORDERS_OP = 'myCncOrders';
 const RATE_LIMIT_CNC_ORDER_OP = 'cncOrder';
+const RATE_LIMIT_ADMIN_CNC_ORDERS_OP = 'adminCncOrders';
+
+/** Rows per admin page when the caller does not say. One screenful of table. */
+const ADMIN_ORDERS_DEFAULT_LIMIT = 25;
+
+/**
+ * Ceiling on rows per admin page.
+ *
+ * Clamped rather than rejected: an operator asking for 500 wants "more", not an
+ * error, and the page they get back carries a cursor for the rest. The number
+ * bounds one response, not what an administrator may eventually read.
+ */
+const ADMIN_ORDERS_MAX_LIMIT = 100;
 
 type GraphQLManufacturingOption = {
   key: string;
@@ -275,5 +291,49 @@ export const cncPackQueries = {
     const order = await getOrderByLicenceId(validLicenceId);
     if (!order || order.userId !== userId) return null;
     return toGraphQLOrder(order);
+  },
+
+  /**
+   * Every buyer's orders, newest first. Admin only.
+   *
+   * The one query that reads across users, and the reason `/admin/build-plans`
+   * exists: when a pack fails, somebody has to see whose it was, what the
+   * generator actually said, and how much of the retry budget is left, none of
+   * which the buyer's own view carries.
+   *
+   * A bad cursor is treated as "start at the top" rather than as an error. It
+   * is an opaque token an operator can only have got from us, so the realistic
+   * ways to hold a broken one are a truncated copy-paste or a link from an old
+   * page shape — and a first page is a more useful answer to both than a
+   * failure.
+   */
+  adminCncOrders: async (
+    _: unknown,
+    { status, limit, cursor }: { status?: CncOrderStatus | null; limit?: number | null; cursor?: string | null },
+    ctx: ConnectionContext,
+  ) => {
+    await requireAdmin(ctx);
+    await applyRateLimit(ctx, RATE_LIMIT_CNC_READ, RATE_LIMIT_ADMIN_CNC_ORDERS_OP);
+
+    const pageSize = Math.min(Math.max(limit ?? ADMIN_ORDERS_DEFAULT_LIMIT, 1), ADMIN_ORDERS_MAX_LIMIT);
+    const decoded = cursor ? decodeCursor(cursor) : null;
+    const after = decoded ? { createdAt: new Date(decoded.createdAt), id: decoded.id } : null;
+    // A cursor whose timestamp does not parse would turn every keyset
+    // comparison into NULL and silently return an empty page — worse than
+    // starting over, because it reads as "no orders" rather than "bad cursor".
+    const validAfter = after && Number.isFinite(after.createdAt.getTime()) ? after : null;
+
+    const { orders, hasMore } = await listOrdersForAdmin({
+      status: status ?? null,
+      limit: pageSize,
+      after: validAfter,
+    });
+    const lastOrder = orders.at(-1);
+
+    return {
+      orders: orders.map(toGraphQLAdminOrder),
+      hasMore,
+      cursor: hasMore && lastOrder ? encodeCursor(lastOrder.createdAt, lastOrder.id) : null,
+    };
   },
 };

--- a/packages/backend/src/services/cnc/orders.ts
+++ b/packages/backend/src/services/cnc/orders.ts
@@ -177,6 +177,71 @@ export async function attachCheckoutSession(orderId: number, sessionId: string):
   return order ?? null;
 }
 
+/**
+ * Where a keyset page starts: the last row of the previous page.
+ *
+ * Both halves are needed. `created_at` alone is not unique — two checkouts in
+ * the same millisecond are ordinary once a wall goes on sale from two devices —
+ * and a cursor on it alone would either repeat that pair forever or skip one of
+ * them depending on which way the comparison leans.
+ */
+export type CncOrderCursor = { createdAt: Date; id: number };
+
+export type ListOrdersForAdminOptions = {
+  /** One status bucket, or every status when omitted. */
+  status?: CncOrderStatus | null;
+  /** Rows to return. The caller clamps; this is not a place to guess a ceiling. */
+  limit: number;
+  /** Start strictly after this row in `(created_at desc, id desc)` order. */
+  after?: CncOrderCursor | null;
+};
+
+/**
+ * Every buyer's orders for the admin list, newest first, one keyset page at a
+ * time.
+ *
+ * Keyset and not offset because the list grows at the front: a purchase landing
+ * while an operator pages through would shift every later offset by one and
+ * show them a row twice. `(created_at, id)` is the sort key, so the cursor is
+ * the last row of the page rather than a count of rows already seen.
+ *
+ * One row past `limit` is fetched and dropped, which is how `hasMore` is
+ * answered without a second `COUNT(*)` over the whole table.
+ *
+ * No index backs this ordering today, deliberately: `cnc_orders` holds one row
+ * per sale, the sort is over the whole (small) table, and an index added before
+ * there is a volume to justify it is a write cost paid for a guess. Revisit
+ * when the table passes a few thousand rows.
+ */
+export async function listOrdersForAdmin({
+  status,
+  limit,
+  after,
+}: ListOrdersForAdminOptions): Promise<{ orders: CncOrder[]; hasMore: boolean }> {
+  const statusFilter = status ? [eq(cncOrders.status, status)] : [];
+  // `(created_at, id) < (t, i)` written out, because drizzle has no row-value
+  // comparison helper and the raw form would be the one place in this file
+  // reaching for `sql` without needing to.
+  const keysetFilter = after
+    ? [
+        or(
+          lt(cncOrders.createdAt, after.createdAt),
+          and(eq(cncOrders.createdAt, after.createdAt), lt(cncOrders.id, after.id)),
+        ),
+      ]
+    : [];
+
+  const rows = await db
+    .select()
+    .from(cncOrders)
+    .where(and(...statusFilter, ...keysetFilter))
+    .orderBy(desc(cncOrders.createdAt), desc(cncOrders.id))
+    .limit(limit + 1);
+
+  const hasMore = rows.length > limit;
+  return { orders: hasMore ? rows.slice(0, limit) : rows, hasMore };
+}
+
 /** A buyer's orders, newest first. Served by `cnc_orders_user_created_idx`. */
 export async function listOrdersForUser(userId: string): Promise<CncOrder[]> {
   return db.select().from(cncOrders).where(eq(cncOrders.userId, userId)).orderBy(desc(cncOrders.createdAt));

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -5576,6 +5576,47 @@ type CncCheckoutSession {
 }
 
 """
+One order as an administrator sees it: the buyer's own view, plus the three
+fields that view deliberately withholds.
+
+A wrapper rather than a flattened copy of `CncOrder`. The buyer's shape is
+built by exactly one mapper, and re-listing its twenty-odd fields here is how
+a field redacted on one path ends up published on the other. Nesting keeps
+this type down to what is genuinely admin-only.
+"""
+type CncAdminOrder {
+  "Exactly what the buyer sees, from the same mapper, so the two cannot drift."
+  order: CncOrder!
+  """
+  Where the licence and the download link were sent.
+
+  Buyer-typed free text rather than the account email — a pack is often bought
+  for a client or a teammate — so this is the address support has to reply to,
+  and it is a large part of why this query exists at all.
+  """
+  licenseeEmail: String
+  "Generation attempts spent. Three is the budget; a `failed` row sitting at three has run out of them."
+  attempts: Int!
+  "The generator's real error, verbatim. The buyer only ever sees a fixed public message."
+  lastError: String
+}
+
+"""
+A page of orders for the admin list, newest first.
+
+Keyset paginated rather than offset paginated: orders arrive at the front of
+this list while an administrator is reading it, and an offset would show a row
+twice or skip one.
+"""
+type CncOrderConnection {
+  orders: [CncAdminOrder!]!
+  "True when there is another page. Pass `cursor` to fetch it."
+  hasMore: Boolean!
+  "Opaque cursor for the next page, or null at the end of the list."
+  cursor: String
+}
+
+"""
 Verdict on a configuration's artwork, from the generator itself rather than
 the browser's live-feedback maths. `collisions` carries one entry per
 offending item with the panel and the reason.
@@ -6566,6 +6607,18 @@ type Query {
   order, it never grants access to it. Requires authentication.
   """
   cncOrder(licenceId: String!): CncOrder
+
+  """
+  Every buyer's orders, newest first — the list behind `/admin/build-plans`.
+  Admin only.
+
+  Carries the three fields `CncOrder` withholds (licensee email, attempts,
+  the generator's real error), because those are what an operator needs to
+  answer "whose pack is this, why did it fail, and who do I write to". Filter
+  with `status` to work one bucket at a time; `limit` defaults to 25 and
+  is capped at 100, and `cursor` comes from the previous page.
+  """
+  adminCncOrders(status: CncOrderStatus, limit: Int, cursor: String): CncOrderConnection!
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1329,6 +1329,33 @@ export type ClimbStatsHistoryEntry = {
 };
 
 /**
+ * One order as an administrator sees it: the buyer's own view, plus the three
+ * fields that view deliberately withholds.
+ *
+ * A wrapper rather than a flattened copy of `CncOrder`. The buyer's shape is
+ * built by exactly one mapper, and re-listing its twenty-odd fields here is how
+ * a field redacted on one path ends up published on the other. Nesting keeps
+ * this type down to what is genuinely admin-only.
+ */
+export type CncAdminOrder = {
+  __typename?: 'CncAdminOrder';
+  /** Generation attempts spent. Three is the budget; a `failed` row sitting at three has run out of them. */
+  attempts: Scalars['Int']['output'];
+  /** The generator's real error, verbatim. The buyer only ever sees a fixed public message. */
+  lastError?: Maybe<Scalars['String']['output']>;
+  /**
+   * Where the licence and the download link were sent.
+   *
+   * Buyer-typed free text rather than the account email — a pack is often bought
+   * for a client or a teammate — so this is the address support has to reply to,
+   * and it is a large part of why this query exists at all.
+   */
+  licenseeEmail?: Maybe<Scalars['String']['output']>;
+  /** Exactly what the buyer sees, from the same mapper, so the two cannot drift. */
+  order: CncOrder;
+};
+
+/**
  * One piece of custom artwork. Exactly one of `assetId` (an uploaded SVG) or
  * `text` (a routed label) must be set.
  */
@@ -1573,6 +1600,22 @@ export type CncOrder = {
   status: CncOrderStatus;
   tier: CncLicenceTier;
   zipSizeBytes?: Maybe<Scalars['Int']['output']>;
+};
+
+/**
+ * A page of orders for the admin list, newest first.
+ *
+ * Keyset paginated rather than offset paginated: orders arrive at the front of
+ * this list while an administrator is reading it, and an offset would show a row
+ * twice or skip one.
+ */
+export type CncOrderConnection = {
+  __typename?: 'CncOrderConnection';
+  /** Opaque cursor for the next page, or null at the end of the list. */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** True when there is another page. Pass `cursor` to fetch it. */
+  hasMore: Scalars['Boolean']['output'];
+  orders: Array<CncAdminOrder>;
 };
 
 /**
@@ -5435,6 +5478,17 @@ export type Query = {
    */
   adminAppFeedback: AdminAppFeedbackResult;
   /**
+   * Every buyer's orders, newest first — the list behind `/admin/build-plans`.
+   * Admin only.
+   *
+   * Carries the three fields `CncOrder` withholds (licensee email, attempts,
+   * the generator's real error), because those are what an operator needs to
+   * answer "whose pack is this, why did it fail, and who do I write to". Filter
+   * with `status` to work one bucket at a time; `limit` defaults to 25 and
+   * is capped at 100, and `cursor` comes from the previous page.
+   */
+  adminCncOrders: CncOrderConnection;
+  /**
    * Get all current user's playlists across boards/layouts, paginated.
    * Optional boardType/layoutId filter. Requires authentication.
    */
@@ -6080,6 +6134,13 @@ export type QueryActivityFeedArgs = {
 /** Root query type for all read operations. */
 export type QueryAdminAppFeedbackArgs = {
   input?: InputMaybe<AdminAppFeedbackInput>;
+};
+
+/** Root query type for all read operations. */
+export type QueryAdminCncOrdersArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  status?: InputMaybe<CncOrderStatus>;
 };
 
 /** Root query type for all read operations. */
@@ -9146,6 +9207,7 @@ export type ResolversTypes = ResolversObject<{
   ClimbStatsForAngle: ResolverTypeWrapper<ClimbStatsForAngle>;
   ClimbStatsForClimb: ResolverTypeWrapper<ClimbStatsForClimb>;
   ClimbStatsHistoryEntry: ResolverTypeWrapper<ClimbStatsHistoryEntry>;
+  CncAdminOrder: ResolverTypeWrapper<CncAdminOrder>;
   CncArtworkInput: CncArtworkInput;
   CncArtworkKind: CncArtworkKind;
   CncArtworkMode: CncArtworkMode;
@@ -9159,6 +9221,7 @@ export type ResolversTypes = ResolversObject<{
   CncLicenceTier: CncLicenceTier;
   CncManufacturingOption: ResolverTypeWrapper<CncManufacturingOption>;
   CncOrder: ResolverTypeWrapper<CncOrder>;
+  CncOrderConnection: ResolverTypeWrapper<CncOrderConnection>;
   CncOrderStatus: CncOrderStatus;
   CncPlacementInput: CncPlacementInput;
   CncTierPrice: ResolverTypeWrapper<CncTierPrice>;
@@ -9560,6 +9623,7 @@ export type ResolversParentTypes = ResolversObject<{
   ClimbStatsForAngle: ClimbStatsForAngle;
   ClimbStatsForClimb: ClimbStatsForClimb;
   ClimbStatsHistoryEntry: ClimbStatsHistoryEntry;
+  CncAdminOrder: CncAdminOrder;
   CncArtworkInput: CncArtworkInput;
   CncArtworkRules: CncArtworkRules;
   CncArtworkValidation: CncArtworkValidation;
@@ -9570,6 +9634,7 @@ export type ResolversParentTypes = ResolversObject<{
   CncDownloadGrant: CncDownloadGrant;
   CncManufacturingOption: CncManufacturingOption;
   CncOrder: CncOrder;
+  CncOrderConnection: CncOrderConnection;
   CncPlacementInput: CncPlacementInput;
   CncTierPrice: CncTierPrice;
   Comment: Comment;
@@ -10556,6 +10621,17 @@ export type ClimbStatsHistoryEntryResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type CncAdminOrderResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['CncAdminOrder'] = ResolversParentTypes['CncAdminOrder'],
+> = ResolversObject<{
+  attempts?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  lastError?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  licenseeEmail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  order?: Resolver<ResolversTypes['CncOrder'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type CncArtworkRulesResolvers<
   ContextType = ConnectionContext,
   ParentType extends ResolversParentTypes['CncArtworkRules'] = ResolversParentTypes['CncArtworkRules'],
@@ -10659,6 +10735,16 @@ export type CncOrderResolvers<
   status?: Resolver<ResolversTypes['CncOrderStatus'], ParentType, ContextType>;
   tier?: Resolver<ResolversTypes['CncLicenceTier'], ParentType, ContextType>;
   zipSizeBytes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type CncOrderConnectionResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['CncOrderConnection'] = ResolversParentTypes['CncOrderConnection'],
+> = ResolversObject<{
+  cursor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  hasMore?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  orders?: Resolver<Array<ResolversTypes['CncAdminOrder']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -12769,6 +12855,12 @@ export type QueryResolvers<
     ContextType,
     Partial<QueryAdminAppFeedbackArgs>
   >;
+  adminCncOrders?: Resolver<
+    ResolversTypes['CncOrderConnection'],
+    ParentType,
+    ContextType,
+    Partial<QueryAdminCncOrdersArgs>
+  >;
   allUserPlaylists?: Resolver<
     ResolversTypes['AllUserPlaylistsResult'],
     ParentType,
@@ -14600,6 +14692,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   ClimbStatsForAngle?: ClimbStatsForAngleResolvers<ContextType>;
   ClimbStatsForClimb?: ClimbStatsForClimbResolvers<ContextType>;
   ClimbStatsHistoryEntry?: ClimbStatsHistoryEntryResolvers<ContextType>;
+  CncAdminOrder?: CncAdminOrderResolvers<ContextType>;
   CncArtworkRules?: CncArtworkRulesResolvers<ContextType>;
   CncArtworkValidation?: CncArtworkValidationResolvers<ContextType>;
   CncCatalog?: CncCatalogResolvers<ContextType>;
@@ -14608,6 +14701,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   CncDownloadGrant?: CncDownloadGrantResolvers<ContextType>;
   CncManufacturingOption?: CncManufacturingOptionResolvers<ContextType>;
   CncOrder?: CncOrderResolvers<ContextType>;
+  CncOrderConnection?: CncOrderConnectionResolvers<ContextType>;
   CncTierPrice?: CncTierPriceResolvers<ContextType>;
   Comment?: CommentResolvers<ContextType>;
   CommentAdded?: CommentAddedResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/cnc-packs.ts
+++ b/packages/shared-schema/src/schema/cnc-packs.ts
@@ -290,6 +290,47 @@ export const cncPacksTypeDefs = /* GraphQL */ `
   }
 
   """
+  One order as an administrator sees it: the buyer's own view, plus the three
+  fields that view deliberately withholds.
+
+  A wrapper rather than a flattened copy of \`CncOrder\`. The buyer's shape is
+  built by exactly one mapper, and re-listing its twenty-odd fields here is how
+  a field redacted on one path ends up published on the other. Nesting keeps
+  this type down to what is genuinely admin-only.
+  """
+  type CncAdminOrder {
+    "Exactly what the buyer sees, from the same mapper, so the two cannot drift."
+    order: CncOrder!
+    """
+    Where the licence and the download link were sent.
+
+    Buyer-typed free text rather than the account email — a pack is often bought
+    for a client or a teammate — so this is the address support has to reply to,
+    and it is a large part of why this query exists at all.
+    """
+    licenseeEmail: String
+    "Generation attempts spent. Three is the budget; a \`failed\` row sitting at three has run out of them."
+    attempts: Int!
+    "The generator's real error, verbatim. The buyer only ever sees a fixed public message."
+    lastError: String
+  }
+
+  """
+  A page of orders for the admin list, newest first.
+
+  Keyset paginated rather than offset paginated: orders arrive at the front of
+  this list while an administrator is reading it, and an offset would show a row
+  twice or skip one.
+  """
+  type CncOrderConnection {
+    orders: [CncAdminOrder!]!
+    "True when there is another page. Pass \`cursor\` to fetch it."
+    hasMore: Boolean!
+    "Opaque cursor for the next page, or null at the end of the list."
+    cursor: String
+  }
+
+  """
   Verdict on a configuration's artwork, from the generator itself rather than
   the browser's live-feedback maths. \`collisions\` carries one entry per
   offending item with the panel and the reason.

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -963,5 +963,17 @@ export const queriesTypeDefs = /* GraphQL */ `
     order, it never grants access to it. Requires authentication.
     """
     cncOrder(licenceId: String!): CncOrder
+
+    """
+    Every buyer's orders, newest first — the list behind \`/admin/build-plans\`.
+    Admin only.
+
+    Carries the three fields \`CncOrder\` withholds (licensee email, attempts,
+    the generator's real error), because those are what an operator needs to
+    answer "whose pack is this, why did it fail, and who do I write to". Filter
+    with \`status\` to work one bucket at a time; \`limit\` defaults to 25 and
+    is capped at 100, and \`cursor\` comes from the previous page.
+    """
+    adminCncOrders(status: CncOrderStatus, limit: Int, cursor: String): CncOrderConnection!
   }
 `;

--- a/packages/shared-schema/src/types/cnc-packs.ts
+++ b/packages/shared-schema/src/types/cnc-packs.ts
@@ -155,6 +155,32 @@ export type CncOrder = {
   errorMessage: string | null;
 };
 
+/**
+ * One order as an administrator sees it: the buyer's view plus the three fields
+ * that view withholds.
+ *
+ * Nested rather than flattened for the same reason the SDL nests it — one
+ * mapper builds the buyer's shape, and a second copy of its field list is how a
+ * redaction stops applying on one of the two paths.
+ */
+export type CncAdminOrder = {
+  order: CncOrder;
+  /** Buyer-typed, not the account email. Where the licence and download link went. */
+  licenseeEmail: string | null;
+  /** Attempts spent against the three-attempt budget. */
+  attempts: number;
+  /** The generator's real error. Never shown to the buyer. */
+  lastError: string | null;
+};
+
+/** One keyset-paginated page of the admin order list, newest first. */
+export type CncOrderConnection = {
+  orders: CncAdminOrder[];
+  hasMore: boolean;
+  /** Feed back as `cursor` for the next page; null at the end of the list. */
+  cursor: string | null;
+};
+
 /** The generator's verdict on a configuration's artwork. `collisions` lists one entry per offending item. */
 export type CncArtworkValidation = {
   ok: boolean;

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1326,6 +1326,33 @@ export type ClimbStatsHistoryEntry = {
 };
 
 /**
+ * One order as an administrator sees it: the buyer's own view, plus the three
+ * fields that view deliberately withholds.
+ *
+ * A wrapper rather than a flattened copy of `CncOrder`. The buyer's shape is
+ * built by exactly one mapper, and re-listing its twenty-odd fields here is how
+ * a field redacted on one path ends up published on the other. Nesting keeps
+ * this type down to what is genuinely admin-only.
+ */
+export type CncAdminOrder = {
+  __typename?: 'CncAdminOrder';
+  /** Generation attempts spent. Three is the budget; a `failed` row sitting at three has run out of them. */
+  attempts: Scalars['Int']['output'];
+  /** The generator's real error, verbatim. The buyer only ever sees a fixed public message. */
+  lastError?: Maybe<Scalars['String']['output']>;
+  /**
+   * Where the licence and the download link were sent.
+   *
+   * Buyer-typed free text rather than the account email — a pack is often bought
+   * for a client or a teammate — so this is the address support has to reply to,
+   * and it is a large part of why this query exists at all.
+   */
+  licenseeEmail?: Maybe<Scalars['String']['output']>;
+  /** Exactly what the buyer sees, from the same mapper, so the two cannot drift. */
+  order: CncOrder;
+};
+
+/**
  * One piece of custom artwork. Exactly one of `assetId` (an uploaded SVG) or
  * `text` (a routed label) must be set.
  */
@@ -1570,6 +1597,22 @@ export type CncOrder = {
   status: CncOrderStatus;
   tier: CncLicenceTier;
   zipSizeBytes?: Maybe<Scalars['Int']['output']>;
+};
+
+/**
+ * A page of orders for the admin list, newest first.
+ *
+ * Keyset paginated rather than offset paginated: orders arrive at the front of
+ * this list while an administrator is reading it, and an offset would show a row
+ * twice or skip one.
+ */
+export type CncOrderConnection = {
+  __typename?: 'CncOrderConnection';
+  /** Opaque cursor for the next page, or null at the end of the list. */
+  cursor?: Maybe<Scalars['String']['output']>;
+  /** True when there is another page. Pass `cursor` to fetch it. */
+  hasMore: Scalars['Boolean']['output'];
+  orders: Array<CncAdminOrder>;
 };
 
 /**
@@ -5432,6 +5475,17 @@ export type Query = {
    */
   adminAppFeedback: AdminAppFeedbackResult;
   /**
+   * Every buyer's orders, newest first — the list behind `/admin/build-plans`.
+   * Admin only.
+   *
+   * Carries the three fields `CncOrder` withholds (licensee email, attempts,
+   * the generator's real error), because those are what an operator needs to
+   * answer "whose pack is this, why did it fail, and who do I write to". Filter
+   * with `status` to work one bucket at a time; `limit` defaults to 25 and
+   * is capped at 100, and `cursor` comes from the previous page.
+   */
+  adminCncOrders: CncOrderConnection;
+  /**
    * Get all current user's playlists across boards/layouts, paginated.
    * Optional boardType/layoutId filter. Requires authentication.
    */
@@ -6077,6 +6131,13 @@ export type QueryActivityFeedArgs = {
 /** Root query type for all read operations. */
 export type QueryAdminAppFeedbackArgs = {
   input?: InputMaybe<AdminAppFeedbackInput>;
+};
+
+/** Root query type for all read operations. */
+export type QueryAdminCncOrdersArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  status?: InputMaybe<CncOrderStatus>;
 };
 
 /** Root query type for all read operations. */

--- a/packages/shared/graphql/src/operations/cnc-packs.ts
+++ b/packages/shared/graphql/src/operations/cnc-packs.ts
@@ -6,6 +6,8 @@ import type {
   CncCheckoutSession,
   CncDownloadGrant,
   CncOrder,
+  CncOrderConnection,
+  CncOrderStatus,
   CreateCncCheckoutSessionInput,
 } from '@boardsesh/shared-schema';
 
@@ -125,6 +127,30 @@ export const GET_CNC_ORDER = gql`
   }
 `;
 
+/**
+ * Admin only: every buyer's orders, newest first.
+ *
+ * Selects the buyer's fields through the same fragment the buyer's own queries
+ * use, so the admin table and the buyer's order page can never disagree about
+ * one order — plus the three fields only an operator is shown.
+ */
+export const ADMIN_CNC_ORDERS = gql`
+  query AdminCncOrders($status: CncOrderStatus, $limit: Int, $cursor: String) {
+    adminCncOrders(status: $status, limit: $limit, cursor: $cursor) {
+      orders {
+        order {
+          ${CNC_ORDER_FIELDS}
+        }
+        licenseeEmail
+        attempts
+        lastError
+      }
+      hasMore
+      cursor
+    }
+  }
+`;
+
 // ============================================
 // CNC build pack mutations
 // ============================================
@@ -211,6 +237,19 @@ export type GetCncOrderQueryVariables = {
 
 export type GetCncOrderQueryResponse = {
   cncOrder: CncOrder | null;
+};
+
+export type AdminCncOrdersQueryVariables = {
+  /** One status bucket, or every status when omitted. */
+  status?: CncOrderStatus | null;
+  /** Defaults to 25 server-side, clamped to 100. */
+  limit?: number | null;
+  /** The previous page's `cursor`. */
+  cursor?: string | null;
+};
+
+export type AdminCncOrdersQueryResponse = {
+  adminCncOrders: CncOrderConnection;
 };
 
 export type ValidateCncArtworkMutationVariables = {

--- a/packages/shared/i18n/locales/de/admin.json
+++ b/packages/shared/i18n/locales/de/admin.json
@@ -25,7 +25,44 @@
     "gymClaims": "Hallen-Ansprüche",
     "feedback": "Bug-Reports",
     "gymDuplicates": "Doppelte Hallen",
-    "locationSync": "Standort-Sync-Sperren"
+    "locationSync": "Standort-Sync-Sperren",
+    "buildPlans": "Baupaket-Bestellungen"
+  },
+  "buildPlans": {
+    "title": "Baupaket-Bestellungen",
+    "subtitle": "Alle Bestellungen, die neueste zuerst. Lies den Fehler des Generators und stell das Paket wieder in die Warteschlange.",
+    "backToAdmin": "Zurück zum Admin-Panel",
+    "statusFilter": {
+      "all": "Alle"
+    },
+    "table": {
+      "licence": "Lizenz",
+      "licensee": "Lizenznehmer*in",
+      "tier": "Tarif",
+      "wall": "Wand",
+      "status": "Status",
+      "attempts": "Versuche",
+      "created": "Erstellt",
+      "actions": "Aktionen"
+    },
+    "actions": {
+      "regenerate": "Neu erzeugen"
+    },
+    "confirm": {
+      "title": "Dieses Paket neu erzeugen?",
+      "body": "{{licenceId}} wird unter derselben Lizenz-ID neu erzeugt und ersetzt die Datei, die Käufer*innen herunterladen. Die bezahlte Lizenz bleibt bestehen.",
+      "cancel": "So lassen",
+      "confirm": "Neu erzeugen"
+    },
+    "snackbar": {
+      "regenerated": "Wieder in der Warteschlange",
+      "regenerateFailed": "Das Paket ließ sich nicht neu einreihen"
+    },
+    "empty": "Keine Bestellung passt zu diesen Filtern.",
+    "error": "Die Bestellungen ließen sich nicht laden.",
+    "retry": "Nochmal versuchen",
+    "loadMore": "Mehr laden",
+    "unknown": "Nicht angegeben"
   },
   "feedback": {
     "title": "Bug-Reports & Feedback",

--- a/packages/shared/i18n/locales/en-US/admin.json
+++ b/packages/shared/i18n/locales/en-US/admin.json
@@ -25,7 +25,44 @@
     "gymClaims": "Gym claims",
     "feedback": "Bug reports",
     "gymDuplicates": "Duplicate gyms",
-    "locationSync": "Location sync freezes"
+    "locationSync": "Location sync freezes",
+    "buildPlans": "Build-pack orders"
+  },
+  "buildPlans": {
+    "title": "Build-pack orders",
+    "subtitle": "Every order, newest first. Read the generator's error, then requeue the pack.",
+    "backToAdmin": "Back to admin",
+    "statusFilter": {
+      "all": "All"
+    },
+    "table": {
+      "licence": "Licence",
+      "licensee": "Licensee",
+      "tier": "Tier",
+      "wall": "Wall",
+      "status": "Status",
+      "attempts": "Attempts",
+      "created": "Created",
+      "actions": "Actions"
+    },
+    "actions": {
+      "regenerate": "Regenerate"
+    },
+    "confirm": {
+      "title": "Rebuild this pack?",
+      "body": "{{licenceId}} is rebuilt under the same licence id and replaces the file the buyer downloads. They keep the licence they paid for.",
+      "cancel": "Keep it as it is",
+      "confirm": "Rebuild it"
+    },
+    "snackbar": {
+      "regenerated": "Back in the queue",
+      "regenerateFailed": "Couldn't requeue that pack"
+    },
+    "empty": "No orders match these filters.",
+    "error": "Couldn't load orders.",
+    "retry": "Retry",
+    "loadMore": "Load more",
+    "unknown": "Not given"
   },
   "feedback": {
     "title": "Bug reports & feedback",

--- a/packages/shared/i18n/locales/es/admin.json
+++ b/packages/shared/i18n/locales/es/admin.json
@@ -138,7 +138,44 @@
     "gymClaims": "Reclamaciones de rocódromos",
     "feedback": "Reportes de errores",
     "gymDuplicates": "Rocódromos duplicados",
-    "locationSync": "Bloqueos de sincronización de ubicaciones"
+    "locationSync": "Bloqueos de sincronización de ubicaciones",
+    "buildPlans": "Pedidos de packs de construcción"
+  },
+  "buildPlans": {
+    "title": "Pedidos de packs de construcción",
+    "subtitle": "Todos los pedidos, del más reciente al más antiguo. Lee el error del generador y vuelve a encolar el pack.",
+    "backToAdmin": "Volver al panel",
+    "statusFilter": {
+      "all": "Todos"
+    },
+    "table": {
+      "licence": "Licencia",
+      "licensee": "Titular",
+      "tier": "Tarifa",
+      "wall": "Muro",
+      "status": "Estado",
+      "attempts": "Intentos",
+      "created": "Creado",
+      "actions": "Acciones"
+    },
+    "actions": {
+      "regenerate": "Regenerar"
+    },
+    "confirm": {
+      "title": "¿Volver a generar este pack?",
+      "body": "{{licenceId}} se vuelve a generar con el mismo id de licencia y sustituye al archivo que descarga el comprador. Conserva la licencia que pagó.",
+      "cancel": "Dejarlo como está",
+      "confirm": "Volver a generar"
+    },
+    "snackbar": {
+      "regenerated": "De vuelta en la cola",
+      "regenerateFailed": "No se pudo volver a encolar ese pack"
+    },
+    "empty": "Ningún pedido coincide con estos filtros.",
+    "error": "No se pudieron cargar los pedidos.",
+    "retry": "Reintentar",
+    "loadMore": "Cargar más",
+    "unknown": "No indicado"
   },
   "feedback": {
     "title": "Errores y comentarios",

--- a/packages/shared/i18n/locales/fr/admin.json
+++ b/packages/shared/i18n/locales/fr/admin.json
@@ -25,7 +25,44 @@
     "gymClaims": "Revendications de salles",
     "feedback": "Rapports de bugs",
     "gymDuplicates": "Salles en double",
-    "locationSync": "Gels de synchronisation des lieux"
+    "locationSync": "Gels de synchronisation des lieux",
+    "buildPlans": "Commandes de packs de construction"
+  },
+  "buildPlans": {
+    "title": "Commandes de packs de construction",
+    "subtitle": "Toutes les commandes, la plus récente en premier. Lisez l’erreur du générateur, puis remettez le pack dans la file.",
+    "backToAdmin": "Retour à l’administration",
+    "statusFilter": {
+      "all": "Toutes"
+    },
+    "table": {
+      "licence": "Licence",
+      "licensee": "Titulaire",
+      "tier": "Formule",
+      "wall": "Mur",
+      "status": "Statut",
+      "attempts": "Tentatives",
+      "created": "Créée le",
+      "actions": "Actions"
+    },
+    "actions": {
+      "regenerate": "Régénérer"
+    },
+    "confirm": {
+      "title": "Régénérer ce pack ?",
+      "body": "{{licenceId}} est régénéré avec le même identifiant de licence et remplace le fichier téléchargé par l’acheteur. Il garde la licence qu’il a payée.",
+      "cancel": "Le laisser tel quel",
+      "confirm": "Régénérer"
+    },
+    "snackbar": {
+      "regenerated": "De retour dans la file",
+      "regenerateFailed": "Impossible de remettre ce pack dans la file"
+    },
+    "empty": "Aucune commande ne correspond à ces filtres.",
+    "error": "Impossible de charger les commandes.",
+    "retry": "Réessayer",
+    "loadMore": "Charger plus",
+    "unknown": "Non renseigné"
   },
   "feedback": {
     "title": "Bugs et retours",

--- a/packages/shared/i18n/locales/fr/admin.json
+++ b/packages/shared/i18n/locales/fr/admin.json
@@ -41,7 +41,7 @@
       "tier": "Formule",
       "wall": "Mur",
       "status": "Statut",
-      "attempts": "Tentatives",
+      "attempts": "Essais",
       "created": "Créée le",
       "actions": "Actions"
     },

--- a/packages/web/app/admin/build-plans/page.tsx
+++ b/packages/web/app/admin/build-plans/page.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import MuiLink from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
+import BuildPlansPanel from '@/app/components/admin/build-plans-panel';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import I18nProvider from '@/app/components/providers/i18n-provider';
+import { fetchCncCatalog } from '@/app/build-plans/build-plans-page';
+import { checkAdmin } from '@/app/lib/admin/check-admin';
+import { getLocale } from '@/app/lib/i18n/get-locale';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { themeTokens } from '@/app/theme/theme-config';
+
+/**
+ * Every build-pack order, for support and for requeueing a failed pack.
+ *
+ * Server-rendered so admin access is enforced before any markup ships, matching
+ * the rest of `/admin`. `adminCncOrders` and `regenerateCncPack` are both
+ * `requireAdmin` on the backend, so this gate is defence in depth — but it is
+ * also what stops a non-admin seeing a table of other people's email addresses
+ * flash up before the query is refused.
+ *
+ * Deliberately NOT behind the `cnc-packs` flag. The flag decides whether the
+ * shop is open to the public; orders that already exist still have to be
+ * supportable if it is turned back off, and an operator locked out of the queue
+ * by a rollout percentage is exactly the wrong failure. `/admin` is noindex
+ * through the layout's `createNoIndexMetadata`, so nothing here is indexable
+ * either way.
+ *
+ * The catalogue is fetched here rather than in the panel: it is the same cached,
+ * public read the shop page makes, and it is only used to turn a size id into a
+ * wall label.
+ */
+export const dynamic = 'force-dynamic';
+
+export default async function AdminBuildPlansPage() {
+  const access = await checkAdmin();
+  const locale = await getLocale();
+  const { t } = await getServerTranslation('admin');
+
+  if (!access.authenticated) {
+    return (
+      <I18nProvider locale={locale} namespaces={['common', 'admin', 'cnc']}>
+        <Container maxWidth="lg" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+          <Alert severity="warning">{t('auth.signInRequired')}</Alert>
+        </Container>
+      </I18nProvider>
+    );
+  }
+
+  if (!access.isAdmin) {
+    return (
+      <I18nProvider locale={locale} namespaces={['common', 'admin', 'cnc']}>
+        <Container maxWidth="lg" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+          <Alert severity="error">{t(access.boardScopedOnly ? 'auth.boardScopedNoAccess' : 'auth.noAccess')}</Alert>
+        </Container>
+      </I18nProvider>
+    );
+  }
+
+  const catalog = await fetchCncCatalog();
+
+  return (
+    <I18nProvider locale={locale} namespaces={['common', 'admin', 'cnc']}>
+      <Container maxWidth="lg" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+        <Typography variant="h5" sx={{ fontWeight: 700, mb: 1, color: themeTokens.neutral[800] }}>
+          {t('buildPlans.title')}
+        </Typography>
+        <Typography variant="body2" sx={{ mb: 2, color: themeTokens.neutral[600] }}>
+          {t('buildPlans.subtitle')}
+        </Typography>
+        <Box sx={{ mb: 3 }}>
+          <MuiLink component={LocaleLink} href="/admin" underline="hover" sx={{ color: themeTokens.colors.primary }}>
+            {t('buildPlans.backToAdmin')}
+          </MuiLink>
+        </Box>
+        <BuildPlansPanel catalog={catalog} locale={locale} />
+      </Container>
+    </I18nProvider>
+  );
+}

--- a/packages/web/app/admin/page.tsx
+++ b/packages/web/app/admin/page.tsx
@@ -108,6 +108,14 @@ export default function AdminPage() {
         </MuiLink>
         <MuiLink
           component={LocaleLink}
+          href="/admin/build-plans"
+          underline="hover"
+          sx={{ color: themeTokens.colors.primary }}
+        >
+          {t('nav.buildPlans')}
+        </MuiLink>
+        <MuiLink
+          component={LocaleLink}
           href="/admin/location-sync"
           underline="hover"
           sx={{ color: themeTokens.colors.primary }}

--- a/packages/web/app/components/admin/__tests__/build-plans-panel.test.tsx
+++ b/packages/web/app/components/admin/__tests__/build-plans-panel.test.tsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { CncAdminOrder, CncOrder, CncOrderStatus } from '@boardsesh/shared-schema';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import BuildPlansPanel from '../build-plans-panel';
+
+const mockRequest = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (namespace?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(namespace, key, options),
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'admin-token' }),
+}));
+
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@boardsesh/graphql/operations/cnc-packs', () => ({
+  ADMIN_CNC_ORDERS: 'ADMIN_CNC_ORDERS',
+  REGENERATE_CNC_PACK: 'REGENERATE_CNC_PACK',
+}));
+
+function makeOrder(overrides: Partial<CncOrder> = {}): CncOrder {
+  return {
+    id: '1',
+    licenceId: 'BS-CNC-ABC234',
+    tier: 'personal',
+    status: 'ready',
+    boardName: 'kilter',
+    layoutId: 8,
+    sizeId: 25,
+    setIds: '26,27,28,29',
+    options: {},
+    artwork: [],
+    licenseeName: 'Marco',
+    customerSiteName: null,
+    amountCents: 14900,
+    currency: 'AUD',
+    createdAt: '2026-09-01T00:00:00.000Z',
+    paidAt: '2026-09-01T00:01:00.000Z',
+    generatedAt: '2026-09-01T00:04:00.000Z',
+    zipSizeBytes: 4_500_000,
+    downloadCount: 0,
+    lastDownloadedAt: null,
+    errorMessage: null,
+    ...overrides,
+  };
+}
+
+function makeEntry(overrides: Partial<CncAdminOrder> = {}, orderOverrides: Partial<CncOrder> = {}): CncAdminOrder {
+  return {
+    order: makeOrder(orderOverrides),
+    licenseeEmail: 'marco@example.com',
+    attempts: 1,
+    lastError: null,
+    ...overrides,
+  };
+}
+
+function page(orders: CncAdminOrder[], { hasMore = false, cursor = null as string | null } = {}) {
+  return { adminCncOrders: { orders, hasMore, cursor } };
+}
+
+function renderPanel() {
+  return render(<BuildPlansPanel catalog={null} locale="en-US" />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('BuildPlansPanel', () => {
+  it('shows the three fields the buyer never sees', async () => {
+    mockRequest.mockResolvedValue(
+      page([makeEntry({ attempts: 3, lastError: 'ezdxf: PANEL_EXCEEDS_SHEET on panel 2' }, { status: 'failed' })]),
+    );
+
+    renderPanel();
+
+    // The whole reason the screen exists: who to write to, how much budget is
+    // left, and what actually went wrong.
+    expect(await screen.findByText('marco@example.com')).toBeDefined();
+    expect(screen.getByText('3')).toBeDefined();
+    expect(screen.getByText('ezdxf: PANEL_EXCEEDS_SHEET on panel 2')).toBeDefined();
+  });
+
+  it('offers Regenerate on a failed order', async () => {
+    mockRequest.mockResolvedValue(page([makeEntry({}, { status: 'failed' })]));
+
+    renderPanel();
+
+    expect(await screen.findByRole('button', { name: 'Regenerate' })).toBeDefined();
+  });
+
+  it.each<CncOrderStatus>(['pending_payment', 'queued', 'generating', 'cancelled', 'refunded'])(
+    'offers no Regenerate on a %s order',
+    async (status) => {
+      // The resolver refuses these transitions anyway; the button is hidden so
+      // an operator is never offered an action that can only fail.
+      mockRequest.mockResolvedValue(page([makeEntry({}, { status })]));
+
+      renderPanel();
+
+      await screen.findByText('BS-CNC-ABC234');
+      expect(screen.queryByRole('button', { name: 'Regenerate' })).toBeNull();
+    },
+  );
+
+  it('confirms by licence id before requeueing, and does nothing if you back out', async () => {
+    mockRequest.mockResolvedValue(page([makeEntry({}, { status: 'failed' })]));
+
+    renderPanel();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Regenerate' }));
+    expect(await screen.findByText(/BS-CNC-ABC234 is rebuilt under the same licence id/)).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Keep it as it is' }));
+
+    // One call: the initial list. The mutation never went out.
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
+  });
+
+  it('requeues on confirm and clears the row of its spent attempts and error', async () => {
+    mockRequest.mockResolvedValueOnce(
+      page([makeEntry({ attempts: 3, lastError: 'ezdxf: PANEL_EXCEEDS_SHEET on panel 2' }, { status: 'failed' })]),
+    );
+
+    renderPanel();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Regenerate' }));
+    mockRequest.mockResolvedValueOnce({ regenerateCncPack: makeOrder({ status: 'queued' }) });
+    fireEvent.click(screen.getByRole('button', { name: 'Rebuild it' }));
+
+    expect(await screen.findByText('In the queue')).toBeDefined();
+    // A requeue resets the attempt budget and clears the previous error — a row
+    // still showing "3" and the old message would read as a fresh failure.
+    await waitFor(() => expect(screen.queryByText('ezdxf: PANEL_EXCEEDS_SHEET on panel 2')).toBeNull());
+    expect(screen.getByText('0')).toBeDefined();
+  });
+
+  it('sends the status filter and asks for the first page again when it changes', async () => {
+    mockRequest.mockResolvedValue(page([]));
+
+    renderPanel();
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
+    expect(mockRequest).toHaveBeenLastCalledWith('ADMIN_CNC_ORDERS', { status: null, limit: 50, cursor: null });
+
+    fireEvent.click(screen.getByText('Did not build'));
+
+    // A new filter starts over: a cursor from the unfiltered list means nothing
+    // in the filtered one.
+    await waitFor(() =>
+      expect(mockRequest).toHaveBeenLastCalledWith('ADMIN_CNC_ORDERS', { status: 'failed', limit: 50, cursor: null }),
+    );
+  });
+
+  it('appends the next page rather than replacing the one on screen', async () => {
+    mockRequest.mockResolvedValueOnce(page([makeEntry()], { hasMore: true, cursor: 'cursor-1' }));
+
+    renderPanel();
+    await screen.findByText('BS-CNC-ABC234');
+
+    mockRequest.mockResolvedValueOnce(page([makeEntry({}, { licenceId: 'BS-CNC-XYZ789' })]));
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+
+    expect(await screen.findByText('BS-CNC-XYZ789')).toBeDefined();
+    // The first page is still there — this is a growing list, not a pager.
+    expect(screen.getByText('BS-CNC-ABC234')).toBeDefined();
+    expect(mockRequest).toHaveBeenLastCalledWith('ADMIN_CNC_ORDERS', { status: null, limit: 50, cursor: 'cursor-1' });
+  });
+
+  it('offers a retry rather than an empty table when the query fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockRequest.mockRejectedValueOnce(new Error('backend unreachable'));
+
+    renderPanel();
+
+    expect(await screen.findByText("Couldn't load orders.")).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeDefined();
+  });
+});

--- a/packages/web/app/components/admin/__tests__/build-plans-panel.test.tsx
+++ b/packages/web/app/components/admin/__tests__/build-plans-panel.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import type { CncAdminOrder, CncOrder, CncOrderStatus } from '@boardsesh/shared-schema';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 import BuildPlansPanel from '../build-plans-panel';
@@ -127,7 +127,7 @@ describe('BuildPlansPanel', () => {
     await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
   });
 
-  it('requeues on confirm and clears the row of its spent attempts and error', async () => {
+  it('requeues on confirm and re-reads the queue for the row it cannot know', async () => {
     mockRequest.mockResolvedValueOnce(
       page([makeEntry({ attempts: 3, lastError: 'ezdxf: PANEL_EXCEEDS_SHEET on panel 2' }, { status: 'failed' })]),
     );
@@ -135,14 +135,26 @@ describe('BuildPlansPanel', () => {
     renderPanel();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Regenerate' }));
+    // The mutation answers with a plain order: no attempt count, no last error.
     mockRequest.mockResolvedValueOnce({ regenerateCncPack: makeOrder({ status: 'queued' }) });
+    mockRequest.mockResolvedValueOnce(page([makeEntry({ attempts: 0 }, { status: 'queued' })]));
     fireEvent.click(screen.getByRole('button', { name: 'Rebuild it' }));
 
-    expect(await screen.findByText('In the queue')).toBeDefined();
-    // A requeue resets the attempt budget and clears the previous error — a row
-    // still showing "3" and the old message would read as a fresh failure.
-    await waitFor(() => expect(screen.queryByText('ezdxf: PANEL_EXCEEDS_SHEET on panel 2')).toBeNull());
-    expect(screen.getByText('0')).toBeDefined();
+    // So the row's two admin-only columns come from a re-read of the queue once
+    // the mutation resolves — a row still showing "3" and the old message would
+    // read as a fresh failure.
+    await waitFor(() =>
+      expect(mockRequest).toHaveBeenLastCalledWith('ADMIN_CNC_ORDERS', { status: null, limit: 50, cursor: null }),
+    );
+    expect(mockRequest).toHaveBeenCalledTimes(3);
+    // Scoped to the row: "In the queue" is also one of the status filter chips.
+    await waitFor(() => {
+      const row = screen.getByText('BS-CNC-ABC234').closest('tr') as HTMLElement | null;
+      expect(row).not.toBeNull();
+      expect(within(row as HTMLElement).getByText('In the queue')).toBeDefined();
+      expect(within(row as HTMLElement).getByText('0')).toBeDefined();
+    });
+    expect(screen.queryByText('ezdxf: PANEL_EXCEEDS_SHEET on panel 2')).toBeNull();
   });
 
   it('sends the status filter and asks for the first page again when it changes', async () => {

--- a/packages/web/app/components/admin/build-plans-panel.tsx
+++ b/packages/web/app/components/admin/build-plans-panel.tsx
@@ -142,27 +142,14 @@ export default function BuildPlansPanel({ catalog, locale }: { catalog: CncCatal
     async (entry: CncAdminOrder) => {
       if (!token) return;
       setPendingLicenceId(entry.order.licenceId);
+      let requeued = false;
       try {
         const client = createGraphQLHttpClient(token);
-        const result = await client.request<RegenerateCncPackMutationResponse, RegenerateCncPackMutationVariables>(
+        await client.request<RegenerateCncPackMutationResponse, RegenerateCncPackMutationVariables>(
           REGENERATE_CNC_PACK,
           { licenceId: entry.order.licenceId },
         );
-        const requeued = result.regenerateCncPack;
-        // Patch the one row rather than refetching the page. The sort is by
-        // creation so nothing would move, but a refetch would throw away the
-        // operator's scroll position in the middle of triage — and the
-        // resolver has already told us the row's new state.
-        setEntries((previous) =>
-          previous.map((candidate) =>
-            candidate.order.licenceId === requeued.licenceId
-              ? // A requeue resets the attempt budget and clears the error, and
-                // the admin fields are not on the mutation's payload, so they
-                // are mirrored here from what the transition is defined to do.
-                { ...candidate, order: requeued, attempts: 0, lastError: null }
-              : candidate,
-          ),
-        );
+        requeued = true;
         setSnackbar(t('buildPlans.snackbar.regenerated'));
       } catch (error) {
         console.error('[BuildPlansPanel] Regenerate failed:', error);
@@ -171,8 +158,16 @@ export default function BuildPlansPanel({ catalog, locale }: { catalog: CncCatal
         setPendingLicenceId(null);
         setConfirming(null);
       }
+      // The mutation answers with a `CncOrder`, which carries neither the
+      // attempt count nor the last generator error — the two columns an
+      // operator is on this screen for. Re-read the queue rather than guess at
+      // them, or the row keeps showing a spent budget and a stale error next to
+      // a pack that is already building again.
+      if (requeued) {
+        await fetchOrders(null);
+      }
     },
-    [token, t],
+    [token, t, fetchOrders],
   );
 
   const filters: StatusFilter[] = ['all', ...STATUS_ORDER];

--- a/packages/web/app/components/admin/build-plans-panel.tsx
+++ b/packages/web/app/components/admin/build-plans-panel.tsx
@@ -1,0 +1,357 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import MuiLink from '@mui/material/Link';
+import Paper from '@mui/material/Paper';
+import Snackbar from '@mui/material/Snackbar';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+import { getBoardDisplayName } from '@boardsesh/climb-actions';
+import {
+  ADMIN_CNC_ORDERS,
+  REGENERATE_CNC_PACK,
+  type AdminCncOrdersQueryResponse,
+  type AdminCncOrdersQueryVariables,
+  type RegenerateCncPackMutationResponse,
+  type RegenerateCncPackMutationVariables,
+} from '@boardsesh/graphql/operations/cnc-packs';
+import type { CncAdminOrder, CncCatalog, CncOrderStatus } from '@boardsesh/shared-schema';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { createOrderDateFormatter } from '@/app/build-plans/format-date';
+import { orderStatusChipColor, wallLabel } from '@/app/build-plans/order-display';
+
+/**
+ * The operator's view of every build-pack order.
+ *
+ * It exists for the one job the buyer's own order page cannot do: when a pack
+ * fails, somebody has to see whose it was, what the generator actually said,
+ * and whether the retry budget is spent — then requeue it. Everything else on
+ * this screen is context for that decision.
+ *
+ * Status colour and wall label are imported from the buyer-facing
+ * `app/build-plans/order-display.ts` rather than restated, so a status cannot
+ * read green here and grey on the page the buyer is looking at while support is
+ * on the phone with them.
+ */
+
+const PAGE_SIZE = 50;
+const COLUMN_COUNT = 8;
+
+/**
+ * The statuses worth filtering to, in lifecycle order.
+ *
+ * `pending_payment` and `cancelled` are on the list because "did this checkout
+ * ever complete" is a real support question, even though neither ever reaches
+ * the generator.
+ */
+const STATUS_ORDER: CncOrderStatus[] = [
+  'pending_payment',
+  'queued',
+  'generating',
+  'ready',
+  'failed',
+  'cancelled',
+  'refunded',
+];
+
+/** Only a generated or failed pack can be rebuilt; the resolver enforces the same rule. */
+const REGENERATABLE: ReadonlySet<CncOrderStatus> = new Set<CncOrderStatus>(['ready', 'failed']);
+
+type StatusFilter = CncOrderStatus | 'all';
+type Translate = ReturnType<typeof useTranslation>['t'];
+
+/**
+ * Status wording comes from the buyer's own `cnc` catalogue rather than a
+ * second admin copy: one phrase per status, wherever it is shown.
+ */
+function statusLabel(tCnc: Translate, status: CncOrderStatus): string {
+  // i18n-keep cnc:status.pending_payment
+  return tCnc(`status.${status}`);
+}
+
+export default function BuildPlansPanel({ catalog, locale }: { catalog: CncCatalog | null; locale: string }) {
+  const { t } = useTranslation('admin');
+  const { t: tCnc } = useTranslation('cnc');
+  const { token } = useWsAuthToken();
+
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [entries, setEntries] = useState<CncAdminOrder[]>([]);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+  const [confirming, setConfirming] = useState<CncAdminOrder | null>(null);
+  const [pendingLicenceId, setPendingLicenceId] = useState<string | null>(null);
+  const [snackbar, setSnackbar] = useState('');
+
+  const dateFormat = useMemo(
+    () => createOrderDateFormatter(locale, { dateStyle: 'medium', timeStyle: 'short' }),
+    [locale],
+  );
+
+  const fetchOrders = useCallback(
+    async (nextCursor: string | null) => {
+      if (!token) return;
+      setLoading(true);
+      setFailed(false);
+      try {
+        const client = createGraphQLHttpClient(token);
+        const result = await client.request<AdminCncOrdersQueryResponse, AdminCncOrdersQueryVariables>(
+          ADMIN_CNC_ORDERS,
+          { status: statusFilter === 'all' ? null : statusFilter, limit: PAGE_SIZE, cursor: nextCursor },
+        );
+        const page = result.adminCncOrders;
+        // A cursor means "append". The first page of a new filter passes null,
+        // so there is no separate reset flag to get wrong.
+        setEntries((previous) => (nextCursor ? [...previous, ...page.orders] : page.orders));
+        setCursor(page.cursor);
+        setHasMore(page.hasMore);
+      } catch (error) {
+        console.error('[BuildPlansPanel] Failed to fetch orders:', error);
+        setFailed(true);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [token, statusFilter],
+  );
+
+  useEffect(() => {
+    void fetchOrders(null);
+  }, [fetchOrders]);
+
+  const regenerate = useCallback(
+    async (entry: CncAdminOrder) => {
+      if (!token) return;
+      setPendingLicenceId(entry.order.licenceId);
+      try {
+        const client = createGraphQLHttpClient(token);
+        const result = await client.request<RegenerateCncPackMutationResponse, RegenerateCncPackMutationVariables>(
+          REGENERATE_CNC_PACK,
+          { licenceId: entry.order.licenceId },
+        );
+        const requeued = result.regenerateCncPack;
+        // Patch the one row rather than refetching the page. The sort is by
+        // creation so nothing would move, but a refetch would throw away the
+        // operator's scroll position in the middle of triage — and the
+        // resolver has already told us the row's new state.
+        setEntries((previous) =>
+          previous.map((candidate) =>
+            candidate.order.licenceId === requeued.licenceId
+              ? // A requeue resets the attempt budget and clears the error, and
+                // the admin fields are not on the mutation's payload, so they
+                // are mirrored here from what the transition is defined to do.
+                { ...candidate, order: requeued, attempts: 0, lastError: null }
+              : candidate,
+          ),
+        );
+        setSnackbar(t('buildPlans.snackbar.regenerated'));
+      } catch (error) {
+        console.error('[BuildPlansPanel] Regenerate failed:', error);
+        setSnackbar(t('buildPlans.snackbar.regenerateFailed'));
+      } finally {
+        setPendingLicenceId(null);
+        setConfirming(null);
+      }
+    },
+    [token, t],
+  );
+
+  const filters: StatusFilter[] = ['all', ...STATUS_ORDER];
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center', mb: 2 }}>
+        {filters.map((option) => (
+          <Chip
+            key={option}
+            label={option === 'all' ? t('buildPlans.statusFilter.all') : statusLabel(tCnc, option)}
+            size="small"
+            variant={statusFilter === option ? 'filled' : 'outlined'}
+            color={statusFilter === option ? 'primary' : 'default'}
+            onClick={() => setStatusFilter(option)}
+            sx={{ cursor: 'pointer' }}
+          />
+        ))}
+      </Box>
+
+      {failed && (
+        <Alert
+          severity="error"
+          sx={{ mb: 2 }}
+          action={
+            <Button color="inherit" size="small" onClick={() => fetchOrders(null)} sx={{ textTransform: 'none' }}>
+              {t('buildPlans.retry')}
+            </Button>
+          }
+        >
+          {t('buildPlans.error')}
+        </Alert>
+      )}
+
+      <TableContainer component={Paper} variant="outlined">
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>{t('buildPlans.table.licence')}</TableCell>
+              <TableCell>{t('buildPlans.table.licensee')}</TableCell>
+              <TableCell>{t('buildPlans.table.tier')}</TableCell>
+              <TableCell>{t('buildPlans.table.wall')}</TableCell>
+              <TableCell>{t('buildPlans.table.status')}</TableCell>
+              <TableCell align="right">{t('buildPlans.table.attempts')}</TableCell>
+              <TableCell>{t('buildPlans.table.created')}</TableCell>
+              <TableCell>{t('buildPlans.table.actions')}</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {entries.map((entry) => (
+              <React.Fragment key={entry.order.licenceId}>
+                <TableRow hover>
+                  <TableCell>
+                    <MuiLink
+                      component={LocaleLink}
+                      href={`/build-plans/orders/${entry.order.licenceId}`}
+                      underline="hover"
+                      sx={{ color: 'var(--color-primary)', fontFamily: 'monospace' }}
+                    >
+                      {entry.order.licenceId}
+                    </MuiLink>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2">{entry.order.licenseeName ?? t('buildPlans.unknown')}</Typography>
+                    <Typography variant="caption" sx={{ color: 'var(--neutral-500)', wordBreak: 'break-all' }}>
+                      {entry.licenseeEmail ?? t('buildPlans.unknown')}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    {entry.order.tier === 'personal'
+                      ? tCnc('tiers.personal.name')
+                      : /* i18n-keep cnc:tiers.commercial.name */ tCnc('tiers.commercial.name')}
+                  </TableCell>
+                  <TableCell>
+                    {`${getBoardDisplayName(entry.order.boardName)} ${wallLabel(catalog, entry.order)}`}
+                  </TableCell>
+                  <TableCell>
+                    <Chip
+                      size="small"
+                      color={orderStatusChipColor(entry.order.status)}
+                      label={statusLabel(tCnc, entry.order.status)}
+                    />
+                  </TableCell>
+                  <TableCell align="right">{entry.attempts}</TableCell>
+                  <TableCell>{dateFormat.format(new Date(entry.order.createdAt))}</TableCell>
+                  <TableCell>
+                    {REGENERATABLE.has(entry.order.status) && (
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        disabled={pendingLicenceId === entry.order.licenceId}
+                        onClick={() => setConfirming(entry)}
+                        sx={{ textTransform: 'none' }}
+                      >
+                        {t('buildPlans.actions.regenerate')}
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
+
+                {/*
+                  The generator's real error gets its own full-width row under
+                  the order it belongs to. These messages carry module names and
+                  config keys and run to a couple of hundred characters; folded
+                  into an eight-column row they either truncate the only useful
+                  part or wreck the table.
+                */}
+                {entry.lastError && (
+                  <TableRow>
+                    <TableCell colSpan={COLUMN_COUNT} sx={{ borderTop: 0, pt: 0 }}>
+                      <Typography
+                        variant="caption"
+                        component="pre"
+                        sx={{ m: 0, color: 'var(--color-error)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+                      >
+                        {entry.lastError}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </React.Fragment>
+            ))}
+
+            {entries.length === 0 && !loading && (
+              <TableRow>
+                <TableCell colSpan={COLUMN_COUNT}>
+                  <Typography variant="body2" sx={{ color: 'var(--neutral-500)', py: 2 }}>
+                    {t('buildPlans.empty')}
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 2, mt: 2 }}>
+        {loading && <CircularProgress size={20} />}
+        {hasMore && !loading && (
+          <Button onClick={() => fetchOrders(cursor)} sx={{ textTransform: 'none' }}>
+            {t('buildPlans.loadMore')}
+          </Button>
+        )}
+      </Box>
+
+      {/*
+        Regenerating overwrites the zip the buyer may already have downloaded,
+        under the same licence id — recoverable, but not something to trigger by
+        misclicking a row, so it is confirmed by licence id first.
+      */}
+      <Dialog open={confirming !== null} onClose={() => setConfirming(null)}>
+        <DialogTitle>{t('buildPlans.confirm.title')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {t('buildPlans.confirm.body', { licenceId: confirming?.order.licenceId ?? '' })}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirming(null)} sx={{ textTransform: 'none' }}>
+            {t('buildPlans.confirm.cancel')}
+          </Button>
+          <Button
+            variant="contained"
+            disabled={pendingLicenceId !== null}
+            onClick={() => confirming && regenerate(confirming)}
+            sx={{ textTransform: 'none' }}
+          >
+            {t('buildPlans.confirm.confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={snackbar !== ''}
+        autoHideDuration={4000}
+        onClose={() => setSnackbar('')}
+        message={snackbar}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      />
+    </Box>
+  );
+}

--- a/packages/web/app/lib/seo/sitemap/__tests__/build-plans-entries.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/build-plans-entries.test.ts
@@ -1,0 +1,77 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+
+const { getServerFeatureFlagMock } = vi.hoisted(() => ({ getServerFeatureFlagMock: vi.fn() }));
+vi.mock('@/app/lib/feature-flags/server-feature-flag', () => ({
+  getServerFeatureFlag: getServerFeatureFlagMock,
+}));
+
+const { BUILD_PLANS_ENTRIES, buildBuildPlansEntries } = await import('../build-plans-entries');
+
+const APP_ROOT = join(import.meta.dirname, '..', '..', '..', '..');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('buildBuildPlansEntries', () => {
+  it('lists nothing while cnc-packs is off', async () => {
+    getServerFeatureFlagMock.mockResolvedValue(false);
+
+    await expect(buildBuildPlansEntries()).resolves.toEqual([]);
+  });
+
+  it('lists the shop once cnc-packs is on', async () => {
+    getServerFeatureFlagMock.mockResolvedValue(true);
+
+    const items = await buildBuildPlansEntries();
+
+    expect(items.map((item) => item.path)).toContain('/build-plans');
+  });
+
+  it('evaluates the flag for anonymous visitors', async () => {
+    // Without `allowAnonymous` the flag resolves `no-distinct-id` for a crawler
+    // — which has no person behind it — and the shard would stay empty however
+    // the PostHog rollout is configured. That failure is invisible: the shard
+    // still answers 200 with a valid empty urlset.
+    getServerFeatureFlagMock.mockResolvedValue(true);
+
+    await buildBuildPlansEntries();
+
+    expect(getServerFeatureFlagMock).toHaveBeenCalledWith('cnc-packs', {
+      distinctId: null,
+      allowAnonymous: true,
+    });
+  });
+
+  it('hands back a copy, so a caller that sorts it cannot rewrite the constant', async () => {
+    getServerFeatureFlagMock.mockResolvedValue(true);
+
+    const items = await buildBuildPlansEntries();
+    items.length = 0;
+
+    expect(BUILD_PLANS_ENTRIES.length).toBeGreaterThan(0);
+  });
+
+  it('lists no path without a page behind it', () => {
+    // The failure this exists for: `/build-plans/licence` is planned, its page
+    // is not written yet, and adding the URL here before the route would ask
+    // Google to crawl a 404 the moment the flag flips.
+    for (const item of BUILD_PLANS_ENTRIES) {
+      const routeDirectory = join(APP_ROOT, item.path.replace(/^\//, ''));
+      expect(existsSync(join(routeDirectory, 'page.tsx')), `${item.path} has no page.tsx`).toBe(true);
+    }
+  });
+
+  it('stamps a real edit date rather than the current time', () => {
+    // `new Date()` here would claim every page changed on every crawl and
+    // destroy the freshness signal — the same rule `static-entries.ts` follows.
+    for (const item of BUILD_PLANS_ENTRIES) {
+      expect(item.lastModified).toBeInstanceOf(Date);
+      expect(item.lastModified!.getTime()).toBeLessThan(Date.now());
+    }
+  });
+});

--- a/packages/web/app/lib/seo/sitemap/__tests__/shard-registry.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/shard-registry.test.ts
@@ -48,6 +48,12 @@ vi.mock('../climb-store', () => ({
   buildClimbShardPage: async () => ({ items: [], totalItems: 0 }),
   fetchStoredClimbPageLastmods: async () => [],
 }));
+// The build-plans shard asks PostHog whether `cnc-packs` is on. Stubbed off,
+// which is both the shipping state and the state that makes the shard's
+// `expectsUrls: false` matter.
+vi.mock('@/app/lib/feature-flags/server-feature-flag', () => ({
+  getServerFeatureFlag: async () => false,
+}));
 
 const { PAGED_SHARD_REGISTRY, SHARD_REGISTRY } = await import('../shard-registry');
 
@@ -103,7 +109,28 @@ describe('SHARD_REGISTRY', () => {
       playlists: false,
       gyms: false,
       setters: false,
+      // `build-plans` ships empty on purpose: the shop is behind the
+      // `cnc-packs` flag and has nothing to list until it flips. Failing closed
+      // there would 503 a shard for being in its intended pre-launch state.
+      'build-plans': false,
     });
+  });
+
+  it('publishes nothing from the build-plans shard while cnc-packs is off', async () => {
+    // The whole contract of the flag gate: the shard exists, is routed, and is
+    // listed in this registry from the day it is written — and Google is told
+    // about none of it until the flag opens the shop.
+    const buildPlans = SHARD_REGISTRY.find((shard) => shard.id === 'build-plans');
+    expect(buildPlans).toBeDefined();
+    await expect(buildPlans!.build()).resolves.toEqual([]);
+  });
+
+  it('fans the build-plans pages out to every locale', () => {
+    // The counter-assertion to the board-content carve-out. `/build-plans` is
+    // genuinely translated copy, not translated chrome over shared data, so it
+    // takes the default `all-locales` expansion and keeps its hreflang cluster.
+    const buildPlans = SHARD_REGISTRY.find((shard) => shard.id === 'build-plans');
+    expect(buildPlans?.expansion).toBeUndefined();
   });
 
   it('marks the paged climbs shard as expecting URLs on the shard route', () => {

--- a/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
@@ -28,7 +28,7 @@ const KILTER_CONFIG: PopularBoardConfig = {
 const boardConfigs = vi.hoisted(() => ({ shouldThrow: false, empty: false, hang: false, delayMs: 0 }));
 const playlistRows = vi.hoisted(() => ({ count: 1, uuidLength: 0, shouldThrow: false, hang: false, delayMs: 0 }));
 const climbSummary = vi.hoisted(() => ({ itemCount: 25_000, shouldThrow: false, hang: false, delayMs: 0 }));
-/** `static`, `gyms` and `setters` are pure builders — flags let the full index fail, or stall, at once. */
+/** `static`, `gyms`, `setters` and `build-plans` are pure builders — flags let the full index fail, or stall, at once. */
 const pureBuilders = vi.hoisted(() => ({ shouldThrow: false, hang: false, delayMs: 0 }));
 
 /** Never settles: the failure mode a try/catch cannot see. */
@@ -73,7 +73,7 @@ vi.mock('../playlist-query', () => ({
 }));
 
 /**
- * The registry wraps these three in `async () => build()`, so handing back a
+ * The registry wraps these four in `async () => build()`, so handing back a
  * pending or delayed promise is what a hung/slow I/O call looks like from the
  * index's side once it awaits — the cast is the price of faking that through a
  * sync signature.
@@ -103,6 +103,13 @@ vi.mock('../setter-entries', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../setter-entries')>();
   return { ...actual, buildSetterEntries: () => pureBuilder(actual.buildSetterEntries) };
 });
+// Declared-empty like gyms and setters while `cnc-packs` is off, and stubbed
+// here rather than by mocking the flag module underneath it: the real builder's
+// only I/O is that PostHog call, and routing the stub through `pureBuilder`
+// keeps `build-plans` in the throw and stall scenarios below with the others.
+vi.mock('../build-plans-entries', () => ({
+  buildBuildPlansEntries: () => pureBuilder(() => []),
+}));
 
 vi.mock('../climb-store', () => ({
   fetchClimbShardSummary: async () => {
@@ -258,7 +265,7 @@ describe('buildSitemapIndexXml', () => {
     // indistinguishable from here, so the omission is logged rather than silent.
     expect(xml).not.toContain('/sitemaps/gyms.xml');
     expect(xml).not.toContain('/sitemaps/setters.xml');
-    expect(warnings.join(' ')).toContain('gyms, setters');
+    expect(warnings.join(' ')).toContain('gyms, setters, build-plans');
     // An empty shard is not a degradation: nothing failed, so the response keeps
     // the full cache window.
     expect(degradedShards).toEqual([]);
@@ -371,13 +378,13 @@ describe('buildSitemapIndexXml', () => {
 
     expect(response.status).toBe(503);
     expect(response.headers.get('cache-control')).toBe('no-store');
-    expect(errors.join(' ')).toContain('6 of 6 builders failed');
+    expect(errors.join(' ')).toContain('7 of 7 builders failed');
   });
 
   it('serves the rest of the index when a builder never settles', async () => {
     // The case a try/catch cannot see: a builder that stalls rather than
-    // rejecting holds the request to the platform timeout, which 5xxes all six
-    // shards. `fetchPlaylistSitemapRows` has no bound of its own, so this is not
+    // rejecting holds the request to the platform timeout, which 5xxes every
+    // shard. `fetchPlaylistSitemapRows` has no bound of its own, so this is not
     // hypothetical.
     vi.useFakeTimers();
     boardConfigs.hang = true;
@@ -395,7 +402,7 @@ describe('buildSitemapIndexXml', () => {
     expect(errors.join(' ')).toContain(`exceeded its ${SHARD_DEADLINE_MS}ms deadline`);
   });
 
-  it('keeps every shard when all six are slow but each is inside its own deadline', async () => {
+  it('keeps every shard when they are all slow but each is inside its own deadline', async () => {
     // The walk is bounded by max(builder), not sum(builder). An earlier draft
     // sequenced the shards under a shared 8s budget, which made this exact case
     // drop `playlists` — last in the registry, so the deterministic victim —

--- a/packages/web/app/lib/seo/sitemap/build-plans-entries.ts
+++ b/packages/web/app/lib/seo/sitemap/build-plans-entries.ts
@@ -1,0 +1,51 @@
+import 'server-only';
+import { CNC_PACKS_FLAG } from '@/app/flags';
+import { getServerFeatureFlag } from '@/app/lib/feature-flags/server-feature-flag';
+import type { SitemapItem } from './entries';
+
+/**
+ * The `/build-plans` shard: the shop's own indexable pages.
+ *
+ * A search surface, not a utility one — people look for "kilter homewall CNC
+ * plans" and "climbing wall panel DXF" — so the pages are translated content
+ * that fans out to all four locales like `/about` and `/legal` do, and the
+ * shard takes the registry's default `all-locales` expansion.
+ *
+ * Hardcoded dates, same convention as `static-entries.ts`: bump the date when
+ * the copy actually changes rather than letting `new Date()` claim a fresh edit
+ * on every crawl.
+ *
+ * `/build-plans/orders` and `/build-plans/orders/[licenceId]` are deliberately
+ * absent. They are per-buyer utility pages behind a login, they carry a licence
+ * id in the URL, and listing them would ask Google to crawl a surface it can
+ * only ever be redirected away from.
+ *
+ * `/build-plans/licence` belongs here too and is not listed yet, because the
+ * page does not exist yet — the manufacturing licence ships marked DRAFT and
+ * its own PR has not landed. Add it in the PR that adds the route; the guard
+ * test beside this file fails on any path here without a `page.tsx` behind it,
+ * so the list cannot start advertising a 404.
+ */
+export const BUILD_PLANS_ENTRIES: readonly SitemapItem[] = [
+  { path: '/build-plans', changeFrequency: 'monthly', priority: 0.7, lastModified: new Date('2026-09-06') },
+];
+
+/**
+ * The shard's items — empty while `cnc-packs` is off.
+ *
+ * The shard is declared `expectsUrls: false` precisely so this can answer
+ * nothing without 503ing: before launch there is no shop, so an empty
+ * `<urlset>` is the truth rather than a regressed builder. That is also why the
+ * gate is here and not a hardcoded list edit at launch — the flag flip alone
+ * publishes the URLs, with no deploy and no second thing to remember.
+ *
+ * `allowAnonymous: true` is load-bearing for exactly the reason it is on the
+ * pages: a crawler is nobody, so without the opt-in this resolves
+ * `no-distinct-id` and the shard would stay empty however the PostHog rollout
+ * is set. Fails closed like every other flag read — an unreachable PostHog
+ * withholds the URLs rather than publishing a surface that 404s.
+ */
+export async function buildBuildPlansEntries(): Promise<SitemapItem[]> {
+  const enabled = await getServerFeatureFlag(CNC_PACKS_FLAG, { distinctId: null, allowAnonymous: true });
+  return enabled ? [...BUILD_PLANS_ENTRIES] : [];
+}

--- a/packages/web/app/lib/seo/sitemap/shard-registry.ts
+++ b/packages/web/app/lib/seo/sitemap/shard-registry.ts
@@ -2,6 +2,7 @@ import 'server-only';
 import { absoluteUrl } from '@/app/lib/seo/base-url';
 import { getBoardsShardConfigsOrThrow } from './board-config-source';
 import { boardConfigsToItems } from './board-entries';
+import { buildBuildPlansEntries } from './build-plans-entries';
 import { climbSitemapsEnabled } from './climb-sitemaps-enabled';
 import { buildClimbShardPage, fetchClimbShardSummary, fetchStoredClimbPageLastmods } from './climb-store';
 import {
@@ -27,7 +28,7 @@ import {
   type SitemapUrlEntry,
 } from './sitemap-xml';
 
-export type ShardId = 'static' | 'boards' | 'gyms' | 'setters' | 'playlists';
+export type ShardId = 'static' | 'boards' | 'gyms' | 'setters' | 'playlists' | 'build-plans';
 
 export type SitemapShard = {
   id: ShardId;
@@ -93,6 +94,18 @@ export const SHARD_REGISTRY: readonly SitemapShard[] = [
     path: '/sitemaps/playlists.xml',
     expectsUrls: false,
     build: async () => playlistRowsToItems(await fetchPlaylistSitemapRows()),
+  },
+  {
+    id: 'build-plans',
+    path: '/sitemaps/build-plans.xml',
+    // Empty while the `cnc-packs` flag is off, which is the state this shard
+    // ships in: there is no shop to advertise until the manufacturing licence
+    // clears its legal review. That is a declared-empty shard like gyms and
+    // setters, not a builder that broke, so it must answer an empty
+    // `<urlset>` rather than 503. It starts publishing on the flag flip, with
+    // no deploy — see `build-plans-entries.ts`.
+    expectsUrls: false,
+    build: () => buildBuildPlansEntries(),
   },
 ];
 

--- a/packages/web/app/sitemaps/build-plans.xml/route.ts
+++ b/packages/web/app/sitemaps/build-plans.xml/route.ts
@@ -1,0 +1,11 @@
+import { shardRouteHandler } from '@/app/lib/seo/sitemap/shard-registry';
+
+// Kept out of the build-time prerender pass for the same reason as the index:
+// the shard builders read at request time — this one reads the `cnc-packs`
+// feature flag, whose whole point is that flipping it in PostHog publishes the
+// URLs without a deploy.
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<Response> {
+  return shardRouteHandler('build-plans');
+}


### PR DESCRIPTION
## Summary

Build plans (CNC packs) slice 10 of 10: the admin queue, the sitemap shard and the launch order. Stacked on #5180.

- `adminCncOrders` query (admin only, keyset pagination) and an `/admin/build-plans` page: every order with licensee, tier, wall, status, attempts and last error, a status filter, and a confirmed Regenerate for ready or failed orders.
- A `build-plans` sitemap shard that emits `/build-plans` in all locales once the `cnc-packs` flag is on and nothing before. `/build-plans/licence` is added when #5170 (slice 6, stacked on #5168) lands.
- `docs/cnc-packs.md` "Launch": the owner actions in order (Stripe prices, Stripe Tax, webhook and Terms URL; Railway worker service and env; backend env vars; lawyer sign-off; printed A3 review of the size snapshots; flip the flag), then the separate flag-retirement PR (drop the gate, real metadata with hreflang, unconditional shard, archive the flag). Follow-ups not built: art asset orphan sweep, PNG artwork, 10-build credits, OEM.

Merge order for the series: #5164 → #5165 → #5167 → #5168 → #5172 → #5177 → #5181 → #5180 → this; #5170 any time after #5168.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — admin-only page and a flag-gated sitemap shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBHWJfrtZ29m47uCvX5yQC
