### PR TITLE
feat(backend): give every notification a destination and board art

### DIFF
--- a/packages/backend/src/__tests__/notifications.test.ts
+++ b/packages/backend/src/__tests__/notifications.test.ts
@@ -4,7 +4,16 @@ import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { socialNotificationQueries, socialNotificationMutations } from '../graphql/resolvers/social/notifications';
 
 // All mock variables must be inside vi.hoisted() to avoid "Cannot access before initialization" errors
-const { mockExecute, mockSelect, mockFrom, mockWhere, mockSet, mockReturning, mockUpdate } = vi.hoisted(() => {
+const {
+  mockExecute,
+  mockSelect,
+  mockFrom,
+  mockWhere,
+  mockSet,
+  mockReturning,
+  mockUpdate,
+  mockBatchEnrichUserProfiles,
+} = vi.hoisted(() => {
   const mockFrom = vi.fn();
   const mockWhere = vi.fn();
   const mockSet = vi.fn();
@@ -22,7 +31,18 @@ const { mockExecute, mockSelect, mockFrom, mockWhere, mockSet, mockReturning, mo
   mockSet.mockReturnValue({ where: mockWhere });
   mockWhere.mockReturnValue({ returning: mockReturning });
 
-  return { mockExecute, mockSelect, mockFrom, mockWhere, mockSet, mockReturning, mockUpdate };
+  const mockBatchEnrichUserProfiles = vi.fn();
+
+  return {
+    mockExecute,
+    mockSelect,
+    mockFrom,
+    mockWhere,
+    mockSet,
+    mockReturning,
+    mockUpdate,
+    mockBatchEnrichUserProfiles,
+  };
 });
 
 vi.mock('../db/client', () => ({
@@ -47,6 +67,10 @@ vi.mock('../utils/rate-limiter', () => ({
 
 vi.mock('../utils/redis-rate-limiter', () => ({
   checkRateLimitRedis: vi.fn(),
+}));
+
+vi.mock('../graphql/resolvers/social/helpers', () => ({
+  batchEnrichUserProfiles: mockBatchEnrichUserProfiles,
 }));
 
 function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
@@ -344,5 +368,248 @@ describe('markGroupNotificationsRead mutation', () => {
     const count = await socialNotificationMutations.markGroupNotificationsRead(null, { type: 'new_follower' }, ctx);
 
     expect(count).toBe(2);
+  });
+});
+
+// ============================================
+// groupedNotifications enrichment
+// ============================================
+
+/** A `board_climbs` row shaped like NOTIFICATION_CLIMB_COLUMNS selects it. */
+function makeClimbRow(overrides: Record<string, unknown> = {}) {
+  return {
+    uuid: 'climb-1',
+    name: 'Blue Ridge',
+    boardType: 'kilter',
+    setterUsername: 'setter1',
+    layoutId: 8,
+    angle: 40,
+    frames: 'p1080r12p1122r13',
+    compatibleSizeIds: [17, 18],
+    ...overrides,
+  };
+}
+
+/** One grouped row off the CTE, with the fields every branch reads. */
+function makeGroupRow(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'new_climb',
+    entityType: 'climb',
+    entityId: 'climb-1',
+    actorCount: '1',
+    latestUuid: 'notif-1',
+    latestCreatedAt: new Date('2024-01-15T12:00:00Z'),
+    allRead: false,
+    commentBody: null,
+    actorIds: ['user-a'],
+    actorDisplayNames: ['Alice'],
+    actorAvatarUrls: [null],
+    totalGroupCount: '1',
+    ...overrides,
+  };
+}
+
+/** Queue one `db.select().from().where()` result, in call order. */
+function queueSelect(rows: unknown[]) {
+  mockFrom.mockReturnValueOnce({ where: vi.fn().mockResolvedValueOnce(rows) });
+}
+
+describe('groupedNotifications enrichment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelect.mockReturnValue({ from: mockFrom });
+    mockFrom.mockReturnThis();
+  });
+
+  it('gives a climb row the frames and sizes a thumbnail needs', async () => {
+    const ctx = makeCtx();
+    mockExecute.mockResolvedValueOnce([makeGroupRow()]);
+    queueSelect([makeClimbRow()]); // climbs
+    queueSelect([{ count: 0 }]); // unread count
+
+    const [group] = (await socialNotificationQueries.groupedNotifications(null, {}, ctx)).groups;
+
+    expect(group.climbUuid).toBe('climb-1');
+    expect(group.climbName).toBe('Blue Ridge');
+    expect(group.climbLayoutId).toBe(8);
+    expect(group.climbFrames).toBe('p1080r12p1122r13');
+    expect(group.climbCompatibleSizeIds).toEqual([17, 18]);
+  });
+
+  it('resolves a comment on an ascent to its thread AND its climb', async () => {
+    const ctx = makeCtx();
+    mockExecute.mockResolvedValueOnce([
+      makeGroupRow({ type: 'comment_on_tick', entityType: 'tick', entityId: 'tick-9' }),
+    ]);
+    queueSelect([{ uuid: 'tick-9', climbUuid: 'climb-1', boardType: 'kilter' }]); // ticks
+    queueSelect([makeClimbRow()]); // climbs
+    queueSelect([{ count: 0 }]); // unread count
+
+    const [group] = (await socialNotificationQueries.groupedNotifications(null, {}, ctx)).groups;
+
+    expect(group.threadEntityType).toBe('tick');
+    expect(group.threadEntityId).toBe('tick-9');
+    // The climb rides along so the row can draw board art like a climb row.
+    expect(group.climbUuid).toBe('climb-1');
+    expect(group.climbFrames).toBe('p1080r12p1122r13');
+  });
+
+  it('resolves a vote on a comment to the thread the comment lives in', async () => {
+    const ctx = makeCtx();
+    mockExecute.mockResolvedValueOnce([
+      makeGroupRow({ type: 'vote_on_comment', entityType: 'comment', entityId: 'comment-3' }),
+    ]);
+    queueSelect([{ uuid: 'comment-3', entityType: 'session', entityId: 'session-7' }]); // comments
+    queueSelect([{ count: 0 }]); // unread count
+
+    const [group] = (await socialNotificationQueries.groupedNotifications(null, {}, ctx)).groups;
+
+    // The thread is the session the comment sits under, NOT the comment uuid.
+    expect(group.threadEntityType).toBe('session');
+    expect(group.threadEntityId).toBe('session-7');
+  });
+
+  it('chains a vote on an ascent comment all the way to the climb', async () => {
+    const ctx = makeCtx();
+    mockExecute.mockResolvedValueOnce([
+      makeGroupRow({ type: 'vote_on_comment', entityType: 'comment', entityId: 'comment-3' }),
+    ]);
+    queueSelect([{ uuid: 'comment-3', entityType: 'tick', entityId: 'tick-9' }]); // comments
+    queueSelect([{ uuid: 'tick-9', climbUuid: 'climb-1', boardType: 'kilter' }]); // ticks
+    queueSelect([makeClimbRow()]); // climbs
+    queueSelect([{ count: 0 }]); // unread count
+
+    const [group] = (await socialNotificationQueries.groupedNotifications(null, {}, ctx)).groups;
+
+    expect(group.threadEntityType).toBe('tick');
+    expect(group.threadEntityId).toBe('tick-9');
+    expect(group.climbUuid).toBe('climb-1');
+  });
+
+  it('leaves a follower row without a thread or a climb', async () => {
+    const ctx = makeCtx();
+    mockExecute.mockResolvedValueOnce([makeGroupRow({ type: 'new_follower', entityType: null, entityId: 'user-123' })]);
+    queueSelect([{ count: 0 }]); // unread count
+
+    const [group] = (await socialNotificationQueries.groupedNotifications(null, {}, ctx)).groups;
+
+    expect(group.threadEntityId).toBeUndefined();
+    expect(group.climbUuid).toBeUndefined();
+    expect(group.climbFrames).toBeUndefined();
+  });
+});
+
+// ============================================
+// notificationActors
+// ============================================
+
+describe('notificationActors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelect.mockReturnValue({ from: mockFrom });
+    mockFrom.mockReturnThis();
+  });
+
+  /** Queue the grouped-actor query's chain: from().where().groupBy().orderBy().limit().offset(). */
+  function queueActorPage(rows: unknown[]) {
+    mockFrom.mockReturnValueOnce({
+      where: vi.fn().mockReturnValue({
+        groupBy: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({ offset: vi.fn().mockResolvedValue(rows) }),
+          }),
+        }),
+      }),
+    });
+  }
+
+  it('requires authentication', async () => {
+    const ctx = makeCtx({ isAuthenticated: false });
+    await expect(
+      socialNotificationQueries.notificationActors(null, { input: { type: 'new_follower' } }, ctx),
+    ).rejects.toThrow('Authentication required');
+  });
+
+  it('rejects a limit above the cap', async () => {
+    const ctx = makeCtx();
+    await expect(
+      socialNotificationQueries.notificationActors(null, { input: { type: 'new_follower', limit: 999 } }, ctx),
+    ).rejects.toThrow();
+  });
+
+  it('rejects a type that is not a notification type', async () => {
+    const ctx = makeCtx();
+    await expect(
+      socialNotificationQueries.notificationActors(null, { input: { type: 'not_a_type' } }, ctx),
+    ).rejects.toThrow();
+  });
+
+  it('returns actors newest-first with follow state', async () => {
+    const ctx = makeCtx();
+    queueSelect([{ count: 5 }]); // distinct actor count
+    queueActorPage([{ actorId: 'user-b' }, { actorId: 'user-a' }]);
+    // Identities come back in whatever order Postgres likes — reversed here on
+    // purpose, so the assertion proves the result follows the actor order.
+    mockFrom.mockReturnValueOnce({
+      leftJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([
+          { id: 'user-a', userName: 'Alice', userImage: null, displayName: null, avatarUrl: 'a.png' },
+          { id: 'user-b', userName: null, userImage: 'b-fallback.png', displayName: 'Bob', avatarUrl: null },
+        ]),
+      }),
+    });
+    mockBatchEnrichUserProfiles.mockResolvedValueOnce(
+      new Map([
+        ['user-a', { followerCount: 3, followingCount: 1, isFollowedByMe: false }],
+        ['user-b', { followerCount: 9, followingCount: 4, isFollowedByMe: true }],
+      ]),
+    );
+
+    const result = await socialNotificationQueries.notificationActors(
+      null,
+      { input: { type: 'new_follower', limit: 2 } },
+      ctx,
+    );
+
+    expect(result.users.map((user) => user.id)).toEqual(['user-b', 'user-a']);
+    expect(result.users[0]).toMatchObject({ displayName: 'Bob', avatarUrl: 'b-fallback.png', isFollowedByMe: true });
+    expect(result.users[1]).toMatchObject({ displayName: 'Alice', avatarUrl: 'a.png', isFollowedByMe: false });
+    expect(result.totalCount).toBe(5);
+    expect(result.hasMore).toBe(true);
+    expect(mockBatchEnrichUserProfiles).toHaveBeenCalledWith(['user-b', 'user-a'], 'user-123');
+  });
+
+  it('drops an actor whose account is gone rather than emitting a blank row', async () => {
+    const ctx = makeCtx();
+    queueSelect([{ count: 2 }]);
+    queueActorPage([{ actorId: 'user-a' }, { actorId: 'deleted-user' }]);
+    mockFrom.mockReturnValueOnce({
+      leftJoin: vi.fn().mockReturnValue({
+        where: vi
+          .fn()
+          .mockResolvedValue([
+            { id: 'user-a', userName: 'Alice', userImage: null, displayName: null, avatarUrl: null },
+          ]),
+      }),
+    });
+    mockBatchEnrichUserProfiles.mockResolvedValueOnce(new Map());
+
+    const result = await socialNotificationQueries.notificationActors(null, { input: { type: 'new_follower' } }, ctx);
+
+    expect(result.users).toHaveLength(1);
+    expect(result.users[0].id).toBe('user-a');
+    // hasMore counts the page the DB returned, not the rows that survived.
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('short-circuits without touching the identity fetch when the group is empty', async () => {
+    const ctx = makeCtx();
+    queueSelect([{ count: 0 }]);
+    queueActorPage([]);
+
+    const result = await socialNotificationQueries.notificationActors(null, { input: { type: 'new_follower' } }, ctx);
+
+    expect(result).toEqual({ users: [], totalCount: 0, hasMore: false });
+    expect(mockBatchEnrichUserProfiles).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/events/index.ts
+++ b/packages/backend/src/events/index.ts
@@ -19,6 +19,9 @@ import { isNoMatchClimb } from '../graphql/resolvers/shared/helpers';
 import { logger } from '../utils/logger';
 import { climbStatsJoinConditions, resolvedClimbAngleSql } from '../db/queries/util/climb-stats-join';
 
+/** The values `notifications.entity_type` actually accepts, for the guard below. */
+const SOCIAL_ENTITY_TYPES = new Set<string>(dbSchema.socialEntityTypeEnum.enumValues);
+
 export const eventBroker = new EventBroker();
 
 /**
@@ -284,13 +287,21 @@ async function createInlineNotification(event: SocialEvent): Promise<void> {
       .limit(1);
     if (existing) return;
 
+    // `follow.created` carries entityType 'user', which is NOT a member of the
+    // social_entity_type enum — passing it through threw on insert and the catch
+    // below swallowed it, so a follow made no notification at all whenever Redis
+    // was down. The worker path already passes null here.
+    const entityType = SOCIAL_ENTITY_TYPES.has(event.entityType)
+      ? (event.entityType as dbSchema.SocialEntityType)
+      : null;
+
     const uuid = crypto.randomUUID();
     await db.insert(dbSchema.notifications).values({
       uuid,
       recipientId,
       actorId: event.actorId,
       type: notificationType,
-      entityType: event.entityType as dbSchema.SocialEntityType,
+      entityType,
       entityId: event.entityId,
     });
 
@@ -314,7 +325,7 @@ async function createInlineNotification(event: SocialEvent): Promise<void> {
         actorId: event.actorId,
         actorDisplayName: actor?.displayName || actor?.name || undefined,
         actorAvatarUrl: actor?.avatarUrl || actor?.image || undefined,
-        entityType: event.entityType as dbSchema.SocialEntityType,
+        entityType,
         entityId: event.entityId,
         isRead: false,
         createdAt: new Date().toISOString(),

--- a/packages/backend/src/graphql/resolvers/social/notifications.ts
+++ b/packages/backend/src/graphql/resolvers/social/notifications.ts
@@ -4,7 +4,8 @@ import { executeRows } from '@boardsesh/db/client';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
-import { GroupedNotificationsInputSchema } from '../../../validation/schemas';
+import { GroupedNotificationsInputSchema, NotificationActorsInputSchema } from '../../../validation/schemas';
+import { batchEnrichUserProfiles } from './helpers';
 import { pubsub } from '../../../pubsub/index';
 import { createAsyncIterator } from '../shared/async-iterators';
 
@@ -40,6 +41,8 @@ const NOTIFICATION_CLIMB_COLUMNS = {
   setterUsername: dbSchema.boardClimbs.setterUsername,
   layoutId: dbSchema.boardClimbs.layoutId,
   angle: dbSchema.boardClimbs.angle,
+  frames: dbSchema.boardClimbs.frames,
+  compatibleSizeIds: dbSchema.boardClimbs.compatibleSizeIds,
 } as const;
 
 type NotificationClimb = {
@@ -49,6 +52,15 @@ type NotificationClimb = {
   setterUsername: string | null;
   layoutId: number;
   angle: number | null;
+  frames: string | null;
+  compatibleSizeIds: number[] | null;
+};
+
+type ClimbBoardFields = {
+  climbLayoutId?: number;
+  climbAngle?: number;
+  climbFrames?: string;
+  climbCompatibleSizeIds?: number[];
 };
 
 /**
@@ -56,10 +68,17 @@ type NotificationClimb = {
  * `board_climbs` (most climbs carry none), so it stays `undefined` rather than
  * collapsing to 0 — clients fall back to the reader's own board angle, which is
  * a better guess than flat.
+ *
+ * `frames` + `compatibleSizeIds` ride along so a row can draw the board art
+ * without a follow-up climb query per row. The size list is not decoration:
+ * boards that number holds independently per size (Woods) render a completely
+ * different climb on the layout's default size — see docs/board-art-geometry.md.
  */
-function applyClimbBoardFields(group: { climbLayoutId?: number; climbAngle?: number }, climb: NotificationClimb): void {
+function applyClimbBoardFields(group: ClimbBoardFields, climb: NotificationClimb): void {
   group.climbLayoutId = climb.layoutId;
   group.climbAngle = climb.angle ?? undefined;
+  group.climbFrames = climb.frames ?? undefined;
+  group.climbCompatibleSizeIds = climb.compatibleSizeIds ?? undefined;
 }
 
 function truncateCommentBody(commentBody: string | null): string | undefined {
@@ -252,6 +271,10 @@ export const socialNotificationQueries = {
         boardType: undefined as string | undefined,
         climbLayoutId: undefined as number | undefined,
         climbAngle: undefined as number | undefined,
+        climbFrames: undefined as string | undefined,
+        climbCompatibleSizeIds: undefined as number[] | undefined,
+        threadEntityType: undefined as string | undefined,
+        threadEntityId: undefined as string | undefined,
         proposalUuid: undefined as string | undefined,
         setterUsername: undefined as string | undefined,
         gymName: undefined as string | undefined,
@@ -264,11 +287,16 @@ export const socialNotificationQueries = {
     // Enrich groups with climb/proposal data (batched to avoid N+1)
     const proposalTypes = ['proposal_created', 'proposal_approved', 'proposal_rejected', 'proposal_vote'];
     const climbTypes = ['new_climb', 'new_climb_global'];
+    // The types that hang off a comment thread. Clients open the thread for
+    // these rather than a climb, so they need `threadEntityType`/`threadEntityId`.
+    const threadTypes = ['comment_reply', 'comment_on_tick', 'comment_on_climb', 'vote_on_tick', 'vote_on_comment'];
 
     // Collect entity IDs by type
     const climbEntityIds: string[] = [];
     const proposalEntityIds: string[] = [];
     const gymEntityIds: string[] = [];
+    const commentEntityIds: string[] = [];
+    const tickEntityIds: string[] = [];
     for (const group of groups) {
       if (!group.entityId) continue;
       if (group.type === 'new_climbs_synced' || climbTypes.includes(group.type)) {
@@ -277,6 +305,49 @@ export const socialNotificationQueries = {
         proposalEntityIds.push(group.entityId);
       } else if (group.type === 'gym_claim_approved') {
         gymEntityIds.push(group.entityId);
+      } else if (threadTypes.includes(group.type)) {
+        // A vote on a comment names the COMMENT; the thread it lives in is the
+        // comment's own entity, one hop away. Every other thread type already
+        // names the commented-on entity.
+        if (group.entityType === 'comment') commentEntityIds.push(group.entityId);
+        else if (group.entityType === 'tick') tickEntityIds.push(group.entityId);
+      }
+    }
+
+    // Batch-fetch the thread behind a voted-on comment. Three sequential batched
+    // lookups follow (comment → thread → climb), each one `inArray` over at most
+    // `limit` groups rather than a query per row.
+    const commentThreadMap = new Map<string, { entityType: string; entityId: string }>();
+    if (commentEntityIds.length > 0) {
+      const commentRows = await db
+        .select({
+          uuid: dbSchema.comments.uuid,
+          entityType: dbSchema.comments.entityType,
+          entityId: dbSchema.comments.entityId,
+        })
+        .from(dbSchema.comments)
+        .where(inArray(dbSchema.comments.uuid, commentEntityIds));
+      for (const row of commentRows) {
+        commentThreadMap.set(row.uuid, { entityType: row.entityType, entityId: row.entityId });
+        if (row.entityType === 'tick') tickEntityIds.push(row.entityId);
+      }
+    }
+
+    // Batch-fetch the climb behind a tick, so a row about someone's ascent can
+    // draw the same board art as a climb row.
+    const tickClimbMap = new Map<string, { climbUuid: string; boardType: string }>();
+    if (tickEntityIds.length > 0) {
+      const tickRows = await db
+        .select({
+          uuid: dbSchema.boardseshTicks.uuid,
+          climbUuid: dbSchema.boardseshTicks.climbUuid,
+          boardType: dbSchema.boardseshTicks.boardType,
+        })
+        .from(dbSchema.boardseshTicks)
+        .where(inArray(dbSchema.boardseshTicks.uuid, [...new Set(tickEntityIds)]));
+      for (const row of tickRows) {
+        tickClimbMap.set(row.uuid, { climbUuid: row.climbUuid, boardType: row.boardType });
+        climbEntityIds.push(row.climbUuid);
       }
     }
 
@@ -372,6 +443,28 @@ export const socialNotificationQueries = {
           group.climbName = climb?.name ?? undefined;
           if (climb) applyClimbBoardFields(group, climb);
         }
+      } else if (threadTypes.includes(group.type)) {
+        const thread =
+          group.entityType === 'comment'
+            ? commentThreadMap.get(group.entityId)
+            : group.entityType
+              ? { entityType: group.entityType, entityId: group.entityId }
+              : undefined;
+        if (!thread) continue;
+
+        group.threadEntityType = thread.entityType;
+        group.threadEntityId = thread.entityId;
+
+        // An ascent's thread carries the climb it was logged on, which is what
+        // lets these rows draw board art like a climb row does.
+        if (thread.entityType !== 'tick') continue;
+        const tick = tickClimbMap.get(thread.entityId);
+        if (!tick) continue;
+        group.climbUuid = tick.climbUuid;
+        group.boardType = tick.boardType;
+        const climb = climbMap.get(tick.climbUuid);
+        group.climbName = climb?.name ?? undefined;
+        if (climb) applyClimbBoardFields(group, climb);
       }
     }
 
@@ -400,6 +493,94 @@ export const socialNotificationQueries = {
       .where(and(eq(dbSchema.notifications.recipientId, userId), isNull(dbSchema.notifications.readAt)));
 
     return Number(result[0]?.count || 0);
+  },
+
+  /**
+   * Every distinct actor behind one notification group, newest first.
+   *
+   * `groupedNotifications` caps `actors` at three, so "Sarah and 4 others
+   * started following you" can't show the other four. The group key is the same
+   * (type, entity_type, entity_id) triple that resolver groups by, and the
+   * `notifications_dedup_idx (actor_id, recipient_id, type, entity_id)` index
+   * covers the lookup.
+   *
+   * Scoped to the caller's own notifications — the recipient predicate is the
+   * whole authorisation story, so there is nothing to leak by passing another
+   * user's entity id.
+   */
+  notificationActors: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
+    requireAuthenticated(ctx);
+    const { type, entityType, entityId, limit, offset } = validateInput(NotificationActorsInputSchema, input, 'input');
+    const userId = ctx.userId!;
+
+    // `IS NOT DISTINCT FROM` rather than `=`: `new_follower` carries a null
+    // entity_type, and `= NULL` matches nothing.
+    const groupPredicate = and(
+      eq(dbSchema.notifications.recipientId, userId),
+      sql`${dbSchema.notifications.type} = ${type}`,
+      sql`${dbSchema.notifications.entityType} IS NOT DISTINCT FROM ${entityType ?? null}`,
+      sql`${dbSchema.notifications.entityId} IS NOT DISTINCT FROM ${entityId ?? null}`,
+      // `actor_id` is ON DELETE SET NULL, so a deleted account leaves an
+      // actor-less row. The grouped resolver drops those too.
+      sql`${dbSchema.notifications.actorId} IS NOT NULL`,
+    );
+
+    const [totalRow] = await db
+      .select({ count: sql<number>`count(DISTINCT ${dbSchema.notifications.actorId})` })
+      .from(dbSchema.notifications)
+      .where(groupPredicate);
+    const totalCount = Number(totalRow?.count ?? 0);
+
+    const actorRows = await db
+      .select({
+        actorId: sql<string>`${dbSchema.notifications.actorId}`,
+        latestCreatedAt: sql<Date>`max(${dbSchema.notifications.createdAt})`,
+      })
+      .from(dbSchema.notifications)
+      .where(groupPredicate)
+      .groupBy(dbSchema.notifications.actorId)
+      .orderBy(sql`max(${dbSchema.notifications.createdAt}) DESC`)
+      .limit(limit)
+      .offset(offset);
+
+    const actorIds = actorRows.map((row) => row.actorId);
+    if (actorIds.length === 0) return { users: [], totalCount, hasMore: false };
+
+    const [identityRows, enrichments] = await Promise.all([
+      db
+        .select({
+          id: dbSchema.users.id,
+          userName: dbSchema.users.name,
+          userImage: dbSchema.users.image,
+          displayName: dbSchema.userProfiles.displayName,
+          avatarUrl: dbSchema.userProfiles.avatarUrl,
+        })
+        .from(dbSchema.users)
+        .leftJoin(dbSchema.userProfiles, eq(dbSchema.userProfiles.userId, dbSchema.users.id))
+        .where(inArray(dbSchema.users.id, actorIds)),
+      batchEnrichUserProfiles(actorIds, userId),
+    ]);
+
+    const identities = new Map(identityRows.map((row) => [row.id, row]));
+    // Ordered by `actorIds`, not by the identity fetch — the newest-first order
+    // is the point, and a join comes back in whatever order Postgres likes.
+    const users = actorIds.flatMap((actorId) => {
+      const identity = identities.get(actorId);
+      if (!identity) return [];
+      const enrichment = enrichments.get(actorId);
+      return [
+        {
+          id: actorId,
+          displayName: identity.displayName || identity.userName || undefined,
+          avatarUrl: identity.avatarUrl || identity.userImage || undefined,
+          followerCount: enrichment?.followerCount ?? 0,
+          followingCount: enrichment?.followingCount ?? 0,
+          isFollowedByMe: enrichment?.isFollowedByMe ?? false,
+        },
+      ];
+    });
+
+    return { users, totalCount, hasMore: offset + actorRows.length < totalCount };
   },
 };
 

--- a/packages/backend/src/validation/schemas/feeds.ts
+++ b/packages/backend/src/validation/schemas/feeds.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { notificationTypeEnum, socialEntityTypeEnum } from '@boardsesh/db/schema';
 
 /**
  * Activity feed input validation schema
@@ -26,5 +27,19 @@ export const GlobalCommentFeedInputSchema = z.object({
  */
 export const GroupedNotificationsInputSchema = z.object({
   limit: z.number().int().min(1).max(50).optional().default(20),
+  offset: z.number().int().min(0).optional().default(0),
+});
+
+/**
+ * Actors behind one notification group. The (type, entityType, entityId) triple
+ * is the same key `groupedNotifications` groups by; the client passes back the
+ * fields off the row it tapped, so `entityType`/`entityId` are nullable exactly
+ * where a notification carries none (`new_follower` sets no entity type).
+ */
+export const NotificationActorsInputSchema = z.object({
+  type: z.enum(notificationTypeEnum.enumValues),
+  entityType: z.enum(socialEntityTypeEnum.enumValues).optional().nullable(),
+  entityId: z.string().max(100).optional().nullable(),
+  limit: z.number().int().min(1).max(50).optional().default(30),
   offset: z.number().int().min(0).optional().default(0),
 });

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -3891,6 +3891,26 @@ type GroupedNotification {
   climbs that carry no angle; clients fall back to the reader's own board.
   """
   climbAngle: Int
+  """
+  The climb's hold frames, so a row can draw the board art without a second
+  round trip. Present wherever climbUuid is.
+  """
+  climbFrames: String
+  """
+  Sizes the climb fits. Boards whose sizes number holds independently (Woods)
+  render a COMPLETELY different climb on the layout's default size, so a client
+  drawing the art needs this to pick the right one.
+  """
+  climbCompatibleSizeIds: [Int!]
+  """
+  The comment thread this notification belongs to, when it has one. For a
+  comment or a vote on a comment that is the commented-on entity (a tick, a
+  session, a playlist climb) rather than the comment itself, so a client can
+  open the thread directly.
+  """
+  threadEntityType: SocialEntityType
+  "ID of the entity named by threadEntityType."
+  threadEntityId: String
   "Proposal UUID (for deep-linking to a specific proposal)"
   proposalUuid: String
   "Setter username (for new_climbs_synced notifications)"
@@ -3915,6 +3935,25 @@ type GroupedNotificationConnection {
   unreadCount: Int!
   "Whether more groups are available"
   hasMore: Boolean!
+}
+
+"""
+Input for listing the distinct actors behind one notification group — the
+people in "Sarah and 4 others started following you". The triple is the same
+one groupedNotifications groups by, so a client passes back the fields off the
+row it tapped.
+"""
+input NotificationActorsInput {
+  "Notification type of the group"
+  type: NotificationType!
+  "Entity type of the group (null for types that carry none, like new_follower)"
+  entityType: SocialEntityType
+  "Entity ID of the group"
+  entityId: String
+  "Maximum number of actors to return"
+  limit: Int
+  "Number of actors to skip"
+  offset: Int
 }
 
 """
@@ -6033,6 +6072,16 @@ type Query {
   Get unread notification count for the current user.
   """
   unreadNotificationCount: Int!
+
+  """
+  Get every distinct actor behind one notification group, newest first.
+  A grouped row only carries the first three actors, so this is how a client
+  shows all of them — the follow-back list behind "Sarah and 4 others started
+  following you". Returns FollowConnection because PublicUserProfile already
+  carries isFollowedByMe, which is what a follow-back list needs.
+  Requires authentication; scoped to the caller's own notifications.
+  """
+  notificationActors(input: NotificationActorsInput!): FollowConnection!
 
   # ============================================
   # Community Proposals Queries

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -2415,6 +2415,17 @@ export type GroupedNotification = {
    */
   climbAngle?: Maybe<Scalars['Int']['output']>;
   /**
+   * Sizes the climb fits. Boards whose sizes number holds independently (Woods)
+   * render a COMPLETELY different climb on the layout's default size, so a client
+   * drawing the art needs this to pick the right one.
+   */
+  climbCompatibleSizeIds?: Maybe<Array<Scalars['Int']['output']>>;
+  /**
+   * The climb's hold frames, so a row can draw the board art without a second
+   * round trip. Present wherever climbUuid is.
+   */
+  climbFrames?: Maybe<Scalars['String']['output']>;
+  /**
    * Layout the climb was set on. Clients need this to build a board URL that
    * actually resolves: the climb query filters on layoutId, so guessing the
    * board's first layout misses every Kilter Homewall / Tension Board 2 climb.
@@ -2440,6 +2451,15 @@ export type GroupedNotification = {
   proposalUuid?: Maybe<Scalars['String']['output']>;
   /** Setter username (for new_climbs_synced notifications) */
   setterUsername?: Maybe<Scalars['String']['output']>;
+  /** ID of the entity named by threadEntityType. */
+  threadEntityId?: Maybe<Scalars['String']['output']>;
+  /**
+   * The comment thread this notification belongs to, when it has one. For a
+   * comment or a vote on a comment that is the commented-on entity (a tick, a
+   * session, a playlist climb) rather than the comment itself, so a client can
+   * open the thread directly.
+   */
+  threadEntityType?: Maybe<SocialEntityType>;
   /** Type of notification */
   type: NotificationType;
   /** UUID of the most recent notification in the group */
@@ -4564,6 +4584,25 @@ export type Notification = {
   uuid: Scalars['ID']['output'];
 };
 
+/**
+ * Input for listing the distinct actors behind one notification group — the
+ * people in "Sarah and 4 others started following you". The triple is the same
+ * one groupedNotifications groups by, so a client passes back the fields off the
+ * row it tapped.
+ */
+export type NotificationActorsInput = {
+  /** Entity ID of the group */
+  entityId?: InputMaybe<Scalars['String']['input']>;
+  /** Entity type of the group (null for types that carry none, like new_follower) */
+  entityType?: InputMaybe<SocialEntityType>;
+  /** Maximum number of actors to return */
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  /** Number of actors to skip */
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  /** Notification type of the group */
+  type: NotificationType;
+};
+
 /** Paginated list of notifications with counts. */
 export type NotificationConnection = {
   __typename?: 'NotificationConnection';
@@ -5432,6 +5471,15 @@ export type Query = {
   nearbySessions: Array<DiscoverableSession>;
   /** Get a feed of newly created climbs for a board type and layout. */
   newClimbFeed: NewClimbFeedResult;
+  /**
+   * Get every distinct actor behind one notification group, newest first.
+   * A grouped row only carries the first three actors, so this is how a client
+   * shows all of them — the follow-back list behind "Sarah and 4 others started
+   * following you". Returns FollowConnection because PublicUserProfile already
+   * carries isFollowedByMe, which is what a follow-back list needs.
+   * Requires authentication; scoped to the caller's own notifications.
+   */
+  notificationActors: FollowConnection;
   /** Get notifications for the current user. */
   notifications: NotificationConnection;
   /**
@@ -6025,6 +6073,11 @@ export type QueryNearbySessionsArgs = {
 /** Root query type for all read operations. */
 export type QueryNewClimbFeedArgs = {
   input: NewClimbFeedInput;
+};
+
+/** Root query type for all read operations. */
+export type QueryNotificationActorsArgs = {
+  input: NotificationActorsInput;
 };
 
 /** Root query type for all read operations. */
@@ -8897,6 +8950,7 @@ export type ResolversTypes = ResolversObject<{
   NewClimbSubscription: ResolverTypeWrapper<NewClimbSubscription>;
   NewClimbSubscriptionInput: NewClimbSubscriptionInput;
   Notification: ResolverTypeWrapper<Notification>;
+  NotificationActorsInput: NotificationActorsInput;
   NotificationConnection: ResolverTypeWrapper<NotificationConnection>;
   NotificationEvent: ResolverTypeWrapper<NotificationEvent>;
   NotificationType: NotificationType;
@@ -9277,6 +9331,7 @@ export type ResolversParentTypes = ResolversObject<{
   NewClimbSubscription: NewClimbSubscription;
   NewClimbSubscriptionInput: NewClimbSubscriptionInput;
   Notification: Notification;
+  NotificationActorsInput: NotificationActorsInput;
   NotificationConnection: NotificationConnection;
   NotificationEvent: NotificationEvent;
   OrphanGym: OrphanGym;
@@ -10589,6 +10644,8 @@ export type GroupedNotificationResolvers<
   actors?: Resolver<Array<ResolversTypes['GroupedNotificationActor']>, ParentType, ContextType>;
   boardType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   climbAngle?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  climbCompatibleSizeIds?: Resolver<Maybe<Array<ResolversTypes['Int']>>, ParentType, ContextType>;
+  climbFrames?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   climbLayoutId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   climbName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   climbUuid?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -10600,6 +10657,8 @@ export type GroupedNotificationResolvers<
   isRead?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   proposalUuid?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   setterUsername?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  threadEntityId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  threadEntityType?: Resolver<Maybe<ResolversTypes['SocialEntityType']>, ParentType, ContextType>;
   type?: Resolver<ResolversTypes['NotificationType'], ParentType, ContextType>;
   uuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -12552,6 +12611,12 @@ export type QueryResolvers<
     ParentType,
     ContextType,
     RequireFields<QueryNewClimbFeedArgs, 'input'>
+  >;
+  notificationActors?: Resolver<
+    ResolversTypes['FollowConnection'],
+    ParentType,
+    ContextType,
+    RequireFields<QueryNotificationActorsArgs, 'input'>
   >;
   notifications?: Resolver<
     ResolversTypes['NotificationConnection'],

--- a/packages/shared-schema/src/schema/notifications.ts
+++ b/packages/shared-schema/src/schema/notifications.ts
@@ -117,6 +117,26 @@ export const notificationsTypeDefs = /* GraphQL */ `
     climbs that carry no angle; clients fall back to the reader's own board.
     """
     climbAngle: Int
+    """
+    The climb's hold frames, so a row can draw the board art without a second
+    round trip. Present wherever climbUuid is.
+    """
+    climbFrames: String
+    """
+    Sizes the climb fits. Boards whose sizes number holds independently (Woods)
+    render a COMPLETELY different climb on the layout's default size, so a client
+    drawing the art needs this to pick the right one.
+    """
+    climbCompatibleSizeIds: [Int!]
+    """
+    The comment thread this notification belongs to, when it has one. For a
+    comment or a vote on a comment that is the commented-on entity (a tick, a
+    session, a playlist climb) rather than the comment itself, so a client can
+    open the thread directly.
+    """
+    threadEntityType: SocialEntityType
+    "ID of the entity named by threadEntityType."
+    threadEntityId: String
     "Proposal UUID (for deep-linking to a specific proposal)"
     proposalUuid: String
     "Setter username (for new_climbs_synced notifications)"
@@ -141,6 +161,25 @@ export const notificationsTypeDefs = /* GraphQL */ `
     unreadCount: Int!
     "Whether more groups are available"
     hasMore: Boolean!
+  }
+
+  """
+  Input for listing the distinct actors behind one notification group — the
+  people in "Sarah and 4 others started following you". The triple is the same
+  one groupedNotifications groups by, so a client passes back the fields off the
+  row it tapped.
+  """
+  input NotificationActorsInput {
+    "Notification type of the group"
+    type: NotificationType!
+    "Entity type of the group (null for types that carry none, like new_follower)"
+    entityType: SocialEntityType
+    "Entity ID of the group"
+    entityId: String
+    "Maximum number of actors to return"
+    limit: Int
+    "Number of actors to skip"
+    offset: Int
   }
 
   """

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -748,6 +748,16 @@ export const queriesTypeDefs = /* GraphQL */ `
     """
     unreadNotificationCount: Int!
 
+    """
+    Get every distinct actor behind one notification group, newest first.
+    A grouped row only carries the first three actors, so this is how a client
+    shows all of them — the follow-back list behind "Sarah and 4 others started
+    following you". Returns FollowConnection because PublicUserProfile already
+    carries isFollowedByMe, which is what a follow-back list needs.
+    Requires authentication; scoped to the caller's own notifications.
+    """
+    notificationActors(input: NotificationActorsInput!): FollowConnection!
+
     # ============================================
     # Community Proposals Queries
     # ============================================

--- a/packages/shared-schema/src/types/notifications.ts
+++ b/packages/shared-schema/src/types/notifications.ts
@@ -65,6 +65,13 @@ export type GroupedNotification = {
   climbLayoutId?: number | null;
   /** Angle the climb was set at, when the setter fixed one (often null). */
   climbAngle?: number | null;
+  /** The climb's hold frames, so a row can draw the board art with no second round trip. */
+  climbFrames?: string | null;
+  /** Sizes the climb fits — Woods numbers holds per size, so the default size draws a different climb. */
+  climbCompatibleSizeIds?: number[] | null;
+  /** The commented-on entity behind a comment/vote row, so a client can open the thread. */
+  threadEntityType?: SocialEntityType | null;
+  threadEntityId?: string | null;
   proposalUuid?: string | null;
   setterUsername?: string | null;
   /** Gym name (for gym_claim_approved notifications). */

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -2412,6 +2412,17 @@ export type GroupedNotification = {
    */
   climbAngle?: Maybe<Scalars['Int']['output']>;
   /**
+   * Sizes the climb fits. Boards whose sizes number holds independently (Woods)
+   * render a COMPLETELY different climb on the layout's default size, so a client
+   * drawing the art needs this to pick the right one.
+   */
+  climbCompatibleSizeIds?: Maybe<Array<Scalars['Int']['output']>>;
+  /**
+   * The climb's hold frames, so a row can draw the board art without a second
+   * round trip. Present wherever climbUuid is.
+   */
+  climbFrames?: Maybe<Scalars['String']['output']>;
+  /**
    * Layout the climb was set on. Clients need this to build a board URL that
    * actually resolves: the climb query filters on layoutId, so guessing the
    * board's first layout misses every Kilter Homewall / Tension Board 2 climb.
@@ -2437,6 +2448,15 @@ export type GroupedNotification = {
   proposalUuid?: Maybe<Scalars['String']['output']>;
   /** Setter username (for new_climbs_synced notifications) */
   setterUsername?: Maybe<Scalars['String']['output']>;
+  /** ID of the entity named by threadEntityType. */
+  threadEntityId?: Maybe<Scalars['String']['output']>;
+  /**
+   * The comment thread this notification belongs to, when it has one. For a
+   * comment or a vote on a comment that is the commented-on entity (a tick, a
+   * session, a playlist climb) rather than the comment itself, so a client can
+   * open the thread directly.
+   */
+  threadEntityType?: Maybe<SocialEntityType>;
   /** Type of notification */
   type: NotificationType;
   /** UUID of the most recent notification in the group */
@@ -4561,6 +4581,25 @@ export type Notification = {
   uuid: Scalars['ID']['output'];
 };
 
+/**
+ * Input for listing the distinct actors behind one notification group — the
+ * people in "Sarah and 4 others started following you". The triple is the same
+ * one groupedNotifications groups by, so a client passes back the fields off the
+ * row it tapped.
+ */
+export type NotificationActorsInput = {
+  /** Entity ID of the group */
+  entityId?: InputMaybe<Scalars['String']['input']>;
+  /** Entity type of the group (null for types that carry none, like new_follower) */
+  entityType?: InputMaybe<SocialEntityType>;
+  /** Maximum number of actors to return */
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  /** Number of actors to skip */
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  /** Notification type of the group */
+  type: NotificationType;
+};
+
 /** Paginated list of notifications with counts. */
 export type NotificationConnection = {
   __typename?: 'NotificationConnection';
@@ -5429,6 +5468,15 @@ export type Query = {
   nearbySessions: Array<DiscoverableSession>;
   /** Get a feed of newly created climbs for a board type and layout. */
   newClimbFeed: NewClimbFeedResult;
+  /**
+   * Get every distinct actor behind one notification group, newest first.
+   * A grouped row only carries the first three actors, so this is how a client
+   * shows all of them — the follow-back list behind "Sarah and 4 others started
+   * following you". Returns FollowConnection because PublicUserProfile already
+   * carries isFollowedByMe, which is what a follow-back list needs.
+   * Requires authentication; scoped to the caller's own notifications.
+   */
+  notificationActors: FollowConnection;
   /** Get notifications for the current user. */
   notifications: NotificationConnection;
   /**
@@ -6022,6 +6070,11 @@ export type QueryNearbySessionsArgs = {
 /** Root query type for all read operations. */
 export type QueryNewClimbFeedArgs = {
   input: NewClimbFeedInput;
+};
+
+/** Root query type for all read operations. */
+export type QueryNotificationActorsArgs = {
+  input: NotificationActorsInput;
 };
 
 /** Root query type for all read operations. */


### PR DESCRIPTION
## Summary

Backend half of making every mobile notification pressable. Ships alone, ahead of the mobile PR, because `production-deploy.yml` and `mobile-ota-production.yml` race on a push to `main` and the OTA wins — a client asking for a field the deployed backend doesn't know fails GraphQL document validation for the whole document. API first, client second.

Five notification types dead-end on mobile today (a comment or a like on your ascent, a reply, a like on your comment): the grouped resolver only enriches climb, proposal and gym rows, so the client's climb branch — its sole fallback — has nothing to route on. Rows about a climb also carry no art; the payload has a climb uuid but no frames.

Adds to `GroupedNotification`:

- **`climbFrames`** + **`climbCompatibleSizeIds`** — so a row can draw the same board thumbnail the climbs list draws, with no follow-up query per row. The size list is load-bearing, not decoration: Woods numbers holds independently per size, so the layout default renders a *different* climb (`docs/board-art-geometry.md`).
- **`threadEntityType`** / **`threadEntityId`** — the comment thread a comment/vote row belongs to. A vote on a comment names the *comment*, so the resolver walks one hop to the entity the comment sits under.

And one query:

- **`notificationActors(input)`** — the people behind "Sarah and 4 others started following you". A group only carries its first three actors, so the rest are unreachable. Returns `FollowConnection`, reusing `PublicUserProfile` because it already carries `isFollowedByMe`, which is exactly what a follow-back list needs. Scoped to the caller's own notifications; the recipient predicate is the whole authorisation story.

Ascent rows now resolve their tick's climb too, which is what lets a comment or a like on your send draw board art. Three sequential batched lookups (comment → thread → climb), each one `inArray` over at most a page of groups, so the existing no-N+1 shape holds — no new per-row query.

Also fixes the inline (no-Redis) notification path, which passed `follow.created`'s `entityType: 'user'` straight into a `social_entity_type` column: the insert threw and the `catch` swallowed it, so a follow produced no notification at all whenever Redis was down. The worker path already passed `null`.

**Author-side verification:** `vp run typecheck` clean; `vp test run --project backend` → 4296 passing, 5 failing files all pre-existing and untouched by this change (3 worker-DB init flakes — `CONNECT_TIMEOUT localhost:5433`, missing `boardsesh_backend_test_w6`; `qa-verdicts` hitting a missing `device_model` column; a stale `github-qa` heading assertion). The 30 tests in `notifications.test.ts` pass, and the new guards were mutation-tested: dropping the `climbFrames` copy, skipping the comment→parent hop, and returning identity order instead of newest-first each turned exactly the intended tests red.

Mobile consumer follows in a second PR.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 3/5 — backend resolver plus an additive schema change; no migration, no writes, and every new field is nullable, so an older client that doesn't request them is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaBF6eEAz23MpFTDYtUP3R
