### PR TITLE
fix(mobile): stop a long summary squeezing the section title to zero width

### DIFF
--- a/packages/mobile/src/components/CollapsibleSection.tsx
+++ b/packages/mobile/src/components/CollapsibleSection.tsx
@@ -242,19 +242,14 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
-  // Sized by its own text (basis auto), shrinking only once the summary has
-  // nothing left to give. `flex: 1` here is what broke the collapsed Logbook
-  // header: it sets flexBasis 0, so a summary wider than the row put the row
-  // into negative free space, which Yoga distributes by (shrink factor x base
-  // size) — the title's base being 0 meant it absorbed none of that shrink and
-  // stayed 0 wide, wrapping "Logbook" one letter per line down the card.
+  // Basis auto, never `flex: 1`: with basis 0 an overlong summary took all of
+  // the row's negative free space (Yoga shrinks by factor x base size), leaving
+  // the title 0 wide and wrapping "Logbook" one letter per line.
   title: {
     flexShrink: 1,
   },
-  // Takes the row's spare width instead of its own text width (basis 0), so a
-  // long summary can never squeeze the title: it ellipsizes into whatever is
-  // left over. Right-aligned to sit against the chevron, as when the title
-  // still grew into the gap.
+  // Basis 0, so the summary ellipsizes into the spare width instead of
+  // squeezing the title. Right-aligned against the chevron, as before.
   summary: {
     opacity: 0.55,
     flexGrow: 1,

--- a/packages/mobile/src/components/CollapsibleSection.tsx
+++ b/packages/mobile/src/components/CollapsibleSection.tsx
@@ -242,12 +242,26 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
+  // Sized by its own text (basis auto), shrinking only once the summary has
+  // nothing left to give. `flex: 1` here is what broke the collapsed Logbook
+  // header: it sets flexBasis 0, so a summary wider than the row put the row
+  // into negative free space, which Yoga distributes by (shrink factor x base
+  // size) — the title's base being 0 meant it absorbed none of that shrink and
+  // stayed 0 wide, wrapping "Logbook" one letter per line down the card.
   title: {
-    flex: 1,
+    flexShrink: 1,
   },
+  // Takes the row's spare width instead of its own text width (basis 0), so a
+  // long summary can never squeeze the title: it ellipsizes into whatever is
+  // left over. Right-aligned to sit against the chevron, as when the title
+  // still grew into the gap.
   summary: {
     opacity: 0.55,
+    flexGrow: 1,
+    flexBasis: 0,
     flexShrink: 1,
+    textAlign: 'right',
+    marginLeft: spacing[2],
     marginRight: spacing[2],
   },
   content: {

--- a/packages/mobile/src/components/__tests__/collapsible-section-header-layout.test.tsx
+++ b/packages/mobile/src/components/__tests__/collapsible-section-header-layout.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// Yoga doesn't run under the test renderer, so this file asserts the flexbox
+// CONTRACT of the collapsed header rather than measured pixels. The contract is
+// what broke: a summary wider than the row ("40° · not tried yet · sent at 3
+// angles · tried at 45°") drove the row into negative free space, which Yoga
+// distributes by (shrink factor x flex base size). The title's `flex: 1` gave it
+// a base size of 0, so it absorbed none of that shrink and stayed 0 wide —
+// "Logbook" then wrapped one letter per line down the side of the card.
+
+type StyleProp = Record<string, unknown> | Array<Record<string, unknown> | undefined | false> | undefined;
+
+function flattenStyle(style: StyleProp): Record<string, unknown> {
+  if (!style) return {};
+  if (Array.isArray(style)) return Object.assign({}, ...style.map((entry) => (entry ? flattenStyle(entry) : {})));
+  return style;
+}
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: vi.fn(async () => null),
+    setItem: vi.fn(async () => undefined),
+    removeItem: vi.fn(async () => undefined),
+  },
+}));
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
+    createElement('button', { onClick: () => onPress?.() }, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+}));
+vi.mock('react-native-reanimated', () => ({
+  default: { View: ({ children }: { children?: ReactNode }) => createElement('div', null, children) },
+  useSharedValue: (value: number) => ({ value }),
+  useAnimatedStyle: (factory: () => Record<string, unknown>) => factory(),
+  withTiming: (value: number) => value,
+}));
+// Forwards the resolved style so the assertions can read the flex contract off
+// the rendered title/summary instead of reaching into module-private styles.
+vi.mock('../Text', () => ({
+  Text: ({ children, style }: { children?: ReactNode; style?: StyleProp }) =>
+    createElement('span', { 'data-style': JSON.stringify(flattenStyle(style)) }, children),
+}));
+vi.mock('../Icon', () => ({ Icon: () => createElement('i', null) }));
+vi.mock('../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
+
+const TITLE = 'Logbook';
+const LONG_SUMMARY = '40° · not tried yet · sent at 3 angles · tried at 45°';
+
+async function renderHeader() {
+  const { CollapsibleSection } = await import('../CollapsibleSection');
+  const { container } = render(
+    <CollapsibleSection title={TITLE} summary={LONG_SUMMARY}>
+      <div>SECTION_BODY</div>
+    </CollapsibleSection>,
+  );
+  const spans = Array.from(container.querySelectorAll('span'));
+  const styleOf = (text: string) => {
+    const node = spans.find((span) => span.textContent === text);
+    if (!node) throw new Error(`No <span> rendered for ${JSON.stringify(text)}`);
+    return JSON.parse(node.getAttribute('data-style') ?? '{}') as Record<string, unknown>;
+  };
+  return { title: styleOf(TITLE), summary: styleOf(LONG_SUMMARY) };
+}
+
+describe('CollapsibleSection collapsed header layout', () => {
+  it('sizes the title by its own text so a long summary cannot shrink it to zero', async () => {
+    const { title } = await renderHeader();
+
+    // `flex: 1` and a literal `flexBasis: 0` both zero the base size, which is
+    // exactly what let the summary starve the title.
+    expect(title.flex).toBeUndefined();
+    expect(title.flexBasis).not.toBe(0);
+    expect(title.flexGrow).not.toBe(1);
+    expect(title.flexShrink).toBe(1);
+  });
+
+  it('gives the summary the spare width instead of its own text width', async () => {
+    const { summary } = await renderHeader();
+
+    // Base size 0 means the summary never contributes to the row's overflow —
+    // it grows into what's left and ellipsizes there (numberOfLines={1}).
+    expect(summary.flexBasis).toBe(0);
+    expect(summary.flexGrow).toBe(1);
+    expect(summary.flexShrink).toBe(1);
+  });
+});

--- a/packages/mobile/src/components/__tests__/collapsible-section-header-layout.test.tsx
+++ b/packages/mobile/src/components/__tests__/collapsible-section-header-layout.test.tsx
@@ -68,11 +68,12 @@ describe('CollapsibleSection collapsed header layout', () => {
   it('sizes the title by its own text so a long summary cannot shrink it to zero', async () => {
     const { title } = await renderHeader();
 
-    // `flex: 1` and a literal `flexBasis: 0` both zero the base size, which is
-    // exactly what let the summary starve the title.
+    // `flex` (any value) and an explicit `flexBasis` both take the base size
+    // away from the text, which is what let the summary starve the title.
+    // `flexGrow` unset keeps the spare width with the summary.
     expect(title.flex).toBeUndefined();
-    expect(title.flexBasis).not.toBe(0);
-    expect(title.flexGrow).not.toBe(1);
+    expect(title.flexBasis).toBeUndefined();
+    expect(title.flexGrow).toBeUndefined();
     expect(title.flexShrink).toBe(1);
   });
 

--- a/packages/mobile/src/components/__tests__/collapsible-section-header-layout.test.tsx
+++ b/packages/mobile/src/components/__tests__/collapsible-section-header-layout.test.tsx
@@ -3,13 +3,9 @@ import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
-// Yoga doesn't run under the test renderer, so this file asserts the flexbox
-// CONTRACT of the collapsed header rather than measured pixels. The contract is
-// what broke: a summary wider than the row ("40° · not tried yet · sent at 3
-// angles · tried at 45°") drove the row into negative free space, which Yoga
-// distributes by (shrink factor x flex base size). The title's `flex: 1` gave it
-// a base size of 0, so it absorbed none of that shrink and stayed 0 wide —
-// "Logbook" then wrapped one letter per line down the side of the card.
+// Yoga doesn't run under the test renderer, so these assert the header's flex
+// CONTRACT rather than measured pixels — the title's `flex: 1` (basis 0) let a
+// long summary take all the shrink and wrap "Logbook" one letter per line.
 
 type StyleProp = Record<string, unknown> | Array<Record<string, unknown> | undefined | false> | undefined;
 


### PR DESCRIPTION
## Summary

The play drawer's collapsed Logbook header could render "Logbook" one letter per line down the side of the card whenever the summary next to it got long — e.g. `40° · not tried yet · sent at 3 angles · tried at 45°`.

`CollapsibleSection`'s title carried `flex: 1`, which sets `flexBasis: 0`. A summary wider than the row puts the row into negative free space, and Yoga distributes that shrink by (shrink factor × flex base size). With a base size of 0 the title absorbed none of the shrink, kept a width of ~0, and its text wrapped per character while the summary rendered at full width.

The fix swaps the two roles:

- title sizes to its own text (`flexShrink: 1`, basis auto) and shrinks only when it alone overflows the row.
- summary takes the row's spare width (`flexBasis: 0`, `flexGrow: 1`) and ellipsizes into it (it already had `numberOfLines={1}`), right-aligned against the chevron so the header looks unchanged when everything fits.

Any collapsed section with a summary was exposed to this — Logbook, Boardsesh grade, the logbook filter sheet's Refine/Advanced sections, open drafts, the generator tuning card, the import result rows — so all of them get the fix.

Author-side verification: `vp run test:mobile` (810 files / 8372 tests, green), `vp run typecheck:mobile`, `vp check` (0 errors). The new test in `collapsible-section-header-layout.test.tsx` fails on the old `flex: 1` style and passes on the new one, so it guards the regression rather than just describing the current code.

## Release Notes

- Long climb summaries no longer squash the Logbook heading into a column of single letters

## Test plan

1. Open a climb you've tried at several angles.
2. Collapse the Logbook section on that climb.
3. Header reads "Logbook" on one line.
4. Summary sits right of it, cut with "…" if long.
5. Tap the header — it still expands and collapses.

## Risk

Risk: 2/5 — one flexbox style on a shared section header, covered by tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VhTWmox4dX5keyzoVaHFR

---
_Generated by [Claude Code](https://claude.ai/code/session_019VhTWmox4dX5keyzoVaHFR)_