### PR TITLE
docs(web): name what the setter head-concurrency test hangs off

### DIFF
--- a/packages/web/app/setter/[setter_username]/__tests__/setter-page-ssr.test.tsx
+++ b/packages/web/app/setter/[setter_username]/__tests__/setter-page-ssr.test.tsx
@@ -33,6 +33,13 @@ const ogSummary = vi.hoisted(() => ({
  * so `view:start` lands before `og:end`. Sequenced awaits cannot produce that
  * order no matter how fast either read is, so the assertion is about the code's
  * shape rather than about timing.
+ *
+ * `view:*` is stamped by the `getSetterPageData` stub, one layer below the
+ * `setterPageHasCrawlableClimb` the head actually calls — that call reaches
+ * this stub through `getSetterPageView`. It is the closest seam a stub can sit
+ * on, and it is a real dependency of the assertion: route the head's second
+ * read around `getSetterPageData` and no `view:*` event is stamped at all,
+ * which is what the presence checks in the test below exist to catch.
  */
 const readOrder = vi.hoisted(() => ({ events: [] as string[] }));
 

--- a/packages/web/app/setter/[setter_username]/page.tsx
+++ b/packages/web/app/setter/[setter_username]/page.tsx
@@ -113,9 +113,9 @@ export async function generateMetadata({ params, searchParams }: SetterPageProps
   // one condition emitting different signals is how they drift apart.
   if (isFrontDoorPageOutOfRange(resolvedSearchParams.page)) notFound();
 
-  const page = parseFrontDoorPage(resolvedSearchParams.page);
-
   try {
+    const page = parseFrontDoorPage(resolvedSearchParams.page);
+
     // Started together, not one after the other. The second read is not
     // conditional on the first in any way that saves a query: the page body
     // resolves `getSetterPageView` on every request, the 404 included, so


### PR DESCRIPTION
## Summary

Two review notes from #5184 that landed after it merged. Neither changes behaviour.

**The concurrency test never stated its coupling.** It stamps its `view:*` events from the `getSetterPageData` stub, one layer below the `setterPageHasCrawlableClimb` the head actually calls — the call reaches the stub through `getSetterPageView`. That is the closest seam a stub can sit on, and it is a real dependency of the assertion: route the head's second read around `getSetterPageData` and no `view:*` event is stamped at all. The presence checks already catch that, but the failure read as an ordering mystery rather than as the coupling breaking. The comment now names it.

**`parseFrontDoorPage` moves back inside the `try`,** next to the two reads that consume `page`. #5184 lifted it out to compute `page` before the `Promise.all`; inside the block, adjacent to its only consumers, reads better. Neither position can catch anything the other does not — the function is total for its parameter type: `Number()` over a `string | string[] | number | undefined`, a `Number.isFinite` guard, then `Math.max`, `Math.trunc` and `Math.min`, with no throwing branch.

Author-side verification: setter tests green (29), and the branch was restarted from the post-merge `main` rather than stacked on #5184's merged history.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — one comment and one statement moved within a function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZsJBk5fp3NwiZaQWkDarf

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZsJBk5fp3NwiZaQWkDarf)_