### PR TITLE
feat(backend): add the inferred-session backfill script

### DIFF
--- a/docs/inferred-sessions-backfill.md
+++ b/docs/inferred-sessions-backfill.md
@@ -18,7 +18,8 @@ the script does not authorize running `--apply` against production.
 - The backfill refuses every window requiring a merge or emptied-session removal.
   Existing session comments, votes, and edits need a separate reviewed repair.
   All modes that plan also reject moving a tick out of its explicit session or
-  processing a clipped window. Failures roll back that window, log the user ID,
+  processing a clipped window. Ordinary live tick writes instead skip clipped
+  inference so climbers can still log their tick. Failures roll back that window, log the user ID,
   continue with later users, and produce exit code 1.
 - `--delay-ms` pauses between windows for apply/simulation and between users for
   inventory. `--limit` limits users, not windows. `--user` explicitly processes one
@@ -32,16 +33,25 @@ same-day window fix. Re-measure counts and timing; they are not rollout gates.
 
 ## Target and executable
 
-Use the production **backend** service, not web or OTA. The GitHub `Production`
-environment's `RAILWAY_BACKEND_SERVICE_ID` currently identifies
-`5912f97f-aa1e-4274-8fbf-eed5da0dceb9`. Verify its owning project and production
-environment in Railway before connecting. Do not assume the repository variable
-`RAILWAY_PROJECT_ID` identifies this project: it is also used by OTA tooling.
+The read-only Railway API preflight on 2026-09-07 confirmed these targets:
+
+| Target | Name | ID |
+| --- | --- | --- |
+| Project | boardsesh | afceee45-0af1-46b3-abbe-8b9094c23bc6 |
+| Environment | production | 8cd7204e-8ba4-4790-bb64-6a150971eacd |
+| Backend | boardsesh-backend | 5912f97f-aa1e-4274-8fbf-eed5da0dceb9 |
+| Database | PostGIS - PROD | 648faad6-ed14-4c51-8297-94179f8a237b |
+
+The backend points at `postgis.railway.internal:5432/railway` and has
+`INFERRED_SESSIONS_ENABLED=true`. Use the backend's injected connection inside
+Railway. The API preflight succeeded through the HTTP client after the Railway CLI
+timed out; no service configuration was changed.
 
 After the PR is merged and deployed, open a backend shell with explicit targets:
 
 ```sh
-railway ssh --project "$BACKFILL_PROJECT_ID" --environment "$BACKFILL_ENVIRONMENT_ID" \
+railway ssh --project afceee45-0af1-46b3-abbe-8b9094c23bc6 \
+  --environment 8cd7204e-8ba4-4790-bb64-6a150971eacd \
   --service 5912f97f-aa1e-4274-8fbf-eed5da0dceb9
 ```
 
@@ -154,3 +164,30 @@ Disabling `INFERRED_SESSIONS_ENABLED` stops ordinary reconciliation but does not
 undo committed backfill assignments. There is no destructive undo command here.
 If grouping is wrong, stop, preserve logs and the backup, and review a targeted
 repair or recovery separately. Never delete inferred sessions as an ad-hoc rollback.
+
+
+## Recorded read-only preflight, 2026-09-07
+
+The corrected script was sampled against production with read-only transactions:
+459,745 total ticks; 436,163 unassigned ticks; 2,530 eligible users.
+
+The selected canary has 487 ticks and 55 explicit sessions. The first simulation
+caught the planner moving a tick between explicit sessions in the same timing run.
+The planner now preserves assigned ticks and attaches only loose ticks to the
+nearest eligible explicit session. A repeated read-only simulation completed:
+
+| Measure | Result |
+| --- | --- |
+| Reconciliation windows | 48 |
+| New inferred sessions planned | 5 |
+| Explicit-assigned groups / ticks | 56 / 476 |
+| Merges / emptied sessions / failures | 0 / 0 / 0 |
+| New-session tick count p50 / max | 2 / 4 |
+
+The 56 groups can refer to 55 explicit sessions: multiple timing runs can belong
+to the same explicit session. This is not a count of new explicit sessions.
+No production writes were made. A canary apply and its repeat remain approval
+steps after merge and deployment.
+
+PostgreSQL also emitted a pre-existing collation-version mismatch notice during
+this read. No collation, index, or database changes were made as part of this task.

--- a/docs/inferred-sessions-backfill.md
+++ b/docs/inferred-sessions-backfill.md
@@ -186,8 +186,35 @@ nearest eligible explicit session. A repeated read-only simulation completed:
 
 The 56 groups can refer to 55 explicit sessions: multiple timing runs can belong
 to the same explicit session. This is not a count of new explicit sessions.
-No production writes were made. A canary apply and its repeat remain approval
-steps after merge and deployment.
+No production writes were made during this read-only preflight. The subsequent
+authorized execution is recorded below.
 
 PostgreSQL also emitted a pre-existing collation-version mismatch notice during
 this read. No collation, index, or database changes were made as part of this task.
+
+## Authorized execution, 2026-09-07
+
+The operator explicitly authorized running the reviewed local revision
+`87f7fbcc0e7359f9c5feaaa19572f2b6d7a4140a` before merge. A native Railway backup
+was created at `2026-09-06T23:16:54.101Z`, ID
+`10d445c1-73d7-45c6-ad9c-1a60cce894bd`.
+
+The canary created five sessions and assigned all 34 loose ticks, preserving its
+487 ticks. Repeating the apply created zero sessions and left the complete
+tick-to-session assignment checksum unchanged. A ten-climber batch then created
+82 sessions across 104 windows with zero failures.
+
+A read-only audit covered all 87 generated sessions and their 559 member ticks:
+zero empty sessions, incorrect owners, invalid anchors, timestamp mismatches, or
+lifecycle mismatches. Replanning all 1,250 ticks across these 11 climbers proposed
+zero creations, merges, removals, or reassignments, with no missing or duplicate
+planned ticks. Production-wide dangling-assignment and invalid-inferred-session
+counts remained zero. These were database checks; no visual app QA was performed.
+
+After explicit full-fleet approval, a single process started at
+`2026-09-06T23:49:14.875038Z` for the remaining 2,519 eligible climbers. It uses
+the public database connection with a 50 ms delay between windows and retains
+progress logs for recovery. Completion and final fleet integrity have not yet
+been confirmed. The process uses the already-loaded revision above; subsequent
+PR edits do not update that running process. Its timestamp centers already use
+`parseClimbedAt`; the later UTC fix concerns the live save/update/delete callers.

--- a/docs/inferred-sessions-backfill.md
+++ b/docs/inferred-sessions-backfill.md
@@ -7,7 +7,9 @@ the script does not authorize running `--apply` against production.
 
 - No flags: inventory eligible users and reconciliation windows. This does not
   predict the number of sessions. A window includes complete UTC days plus runs
-  connected across midnight, and can produce several sessions.
+  connected across midnight, and can produce several sessions. These are read
+  windows only: automatic groups always split at gaps over eight hours. Exactly
+  eight hours stays connected; existing explicit assignments remain fixed.
 - `--simulate`: use the live planner in a read-only, repeatable-read transaction
   per window. Reports new sessions, runs assigned to explicit sessions, merges,
   emptied sessions, and new-session size/duration. Explicit-assignment totals
@@ -29,7 +31,7 @@ the script does not authorize running `--apply` against production.
   inclusive and uses the database's user-ID ordering.
 
 The older production figures in the original PR body were measured before the
-same-day window fix. Re-measure counts and timing; they are not rollout gates.
+eight-hour grouping rule. Re-measure counts and timing; they are not rollout gates.
 
 ## Target and executable
 
@@ -112,8 +114,8 @@ First run one reviewed canary:
 node --import tsx src/scripts/backfill-inferred-sessions.ts --user "$BACKFILL_USER_ID" --apply --delay-ms 50 --progress-every 1
 ```
 
-Inspect that climber's Sessions and logbook: every tick appears, same-day loose
-ticks join the expected session, and existing session edits and comments remain.
+Inspect that climber's Sessions and logbook: every tick appears, gaps over eight
+hours separate automatic groups, and existing session edits and comments remain.
 Re-run the same canary command: it should create zero sessions and preserve IDs.
 If both passes succeed, proceed with a bounded batch, then the fleet:
 
@@ -212,9 +214,38 @@ planned ticks. Production-wide dangling-assignment and invalid-inferred-session
 counts remained zero. These were database checks; no visual app QA was performed.
 
 After explicit full-fleet approval, a single process started at
-`2026-09-06T23:49:14.875038Z` for the remaining 2,519 eligible climbers. It uses
-the public database connection with a 50 ms delay between windows and retains
-progress logs for recovery. Completion and final fleet integrity have not yet
-been confirmed. The process uses the already-loaded revision above; subsequent
-PR edits do not update that running process. Its timestamp centers already use
-`parseClimbedAt`; the later UTC fix concerns the live save/update/delete callers.
+`2026-09-06T23:49:14.875038Z` for the remaining 2,519 eligible climbers. It was
+stopped at `2026-09-07T00:34:56.756892Z` after the operator identified that UTC-day
+absorption could join an evening session to the following local morning. Completed
+windows remain committed; the unfinished transaction rolled back. The snapshot at
+pause had 428,393 unassigned ticks and 2,504 eligible climbers.
+
+A move to Railway's private database network was prepared and a read-only canary
+completed there. No Railway apply worker started. The temporary SSH key was revoked
+and its local private key removed. The backfill remains paused for the eight-hour
+policy change and an audit of already-written assignments. The previous audit
+validated storage and consistency with the former algorithm; it did not establish
+that its same-UTC-day assumptions reflected separate visits to the wall.
+
+### Eight-hour audit before resuming
+
+At `2026-09-07T01:34:31.113Z`, a read-only audit covered the 27 climbers present
+in operator logs plus four other owners of recently created inferred sessions:
+31 climbers, 14,435 ticks, and 726 inferred sessions created since the preflight.
+This includes concurrent live inference; the 726 are not all backfill creations.
+
+Four recent inferred sessions contain gaps over eight hours. Replanning complete
+histories proposes four inferred-session merges, zero emptied sessions, and 43
+already-assigned inferred ticks changing destination across three climbers. It
+also proposes 564 new sessions, including groups from 5,388 still-unassigned ticks;
+those new-session totals are not solely repairs.
+
+The audit found zero empty recent sessions, ownership errors, invalid anchors,
+timestamp/lifecycle mismatches, moved explicit ticks, missing/duplicate planned
+ticks, or prospective inferred gaps over eight hours. Applying the plan in memory
+and reconciling it again proposed zero further changes. No production repair was
+written. Merge/removal guards remain enabled pending a reviewed repair.
+
+Ticks already absorbed into explicit sessions have no assignment provenance, so
+this audit cannot distinguish those from deliberately assigned members. Existing
+explicit assignments remain fixed under the approved policy.

--- a/docs/inferred-sessions-backfill.md
+++ b/docs/inferred-sessions-backfill.md
@@ -1,0 +1,156 @@
+# Inferred-session backfill
+
+PR #5194 supplies a manual backfill; nothing schedules it. Preparing or deploying
+the script does not authorize running `--apply` against production.
+
+## Behaviour
+
+- No flags: inventory eligible users and reconciliation windows. This does not
+  predict the number of sessions. A window includes complete UTC days plus runs
+  connected across midnight, and can produce several sessions.
+- `--simulate`: use the live planner in a read-only, repeatable-read transaction
+  per window. Reports new sessions, runs assigned to explicit sessions, merges,
+  emptied sessions, and new-session size/duration. Explicit-assignment totals
+  include ticks already assigned there; they are not counts of newly moved ticks.
+- `--apply`: use the same planner in a serializable transaction per window. Counts
+  newly inserted sessions only after commit. The flag enables inference only in
+  this process; it does not change the backend service's feature flag.
+- The backfill refuses every window requiring a merge or emptied-session removal.
+  Existing session comments, votes, and edits need a separate reviewed repair.
+  All modes that plan also reject moving a tick out of its explicit session or
+  processing a clipped window. Failures roll back that window, log the user ID,
+  continue with later users, and produce exit code 1.
+- `--delay-ms` pauses between windows for apply/simulation and between users for
+  inventory. `--limit` limits users, not windows. `--user` explicitly processes one
+  user's complete history, including already-assigned ticks.
+- Fleet selection includes only users with unassigned ticks. It is not a repair
+  sweep for users whose ticks are all assigned incorrectly. `--resume-from` is
+  inclusive and uses the database's user-ID ordering.
+
+The older production figures in the original PR body were measured before the
+same-day window fix. Re-measure counts and timing; they are not rollout gates.
+
+## Target and executable
+
+Use the production **backend** service, not web or OTA. The GitHub `Production`
+environment's `RAILWAY_BACKEND_SERVICE_ID` currently identifies
+`5912f97f-aa1e-4274-8fbf-eed5da0dceb9`. Verify its owning project and production
+environment in Railway before connecting. Do not assume the repository variable
+`RAILWAY_PROJECT_ID` identifies this project: it is also used by OTA tooling.
+
+After the PR is merged and deployed, open a backend shell with explicit targets:
+
+```sh
+railway ssh --project "$BACKFILL_PROJECT_ID" --environment "$BACKFILL_ENVIRONMENT_ID" \
+  --service 5912f97f-aa1e-4274-8fbf-eed5da0dceb9
+```
+
+The backend Docker image contains source and `tsx`, but does not install a global
+`vp` executable. Run its native runtime command from `/app/packages/backend`:
+
+```sh
+cd /app/packages/backend
+node --import tsx -e 'import("./src/build-release.ts").then(console.log)'
+test -f src/scripts/backfill-inferred-sessions.ts
+```
+
+Match the stamped build release to the deployed commit containing these fixes.
+Use the service's injected `DATABASE_URL`; never paste credentials into commands,
+logs, or the PR. Confirm it targets the primary before running either mode.
+Use one process. Arrange a persistent operator session and retain its output;
+do not assume an SSH disconnect keeps a process alive.
+
+## Read-only preflight
+
+Confirm a recent recoverable database backup and record its timestamp. Record the
+deployed commit, selected canary user, start time, and the following primary-DB
+baseline through the normal database console:
+
+```sql
+BEGIN READ ONLY;
+SELECT count(*) AS ticks,
+       count(*) FILTER (WHERE session_id IS NULL) AS unassigned_ticks,
+       count(DISTINCT user_id) FILTER (WHERE session_id IS NULL) AS eligible_users
+FROM boardsesh_ticks;
+SELECT origin, count(*) FROM board_sessions GROUP BY origin;
+COMMIT;
+```
+
+In the backend shell, set a small process-local pool and a query timeout for the
+direct PostgreSQL connection. `DB_STATEMENT_TIMEOUT_MS` is a startup parameter;
+do not use it with a pooler that rejects startup parameters.
+
+```sh
+export DB_POOL_MAX=2 DB_STATEMENT_TIMEOUT_MS=30000
+node --import tsx src/scripts/backfill-inferred-sessions.ts
+node --import tsx src/scripts/backfill-inferred-sessions.ts --user "$BACKFILL_USER_ID" --simulate --delay-ms 50
+node --import tsx src/scripts/backfill-inferred-sessions.ts --simulate --limit 10 --delay-ms 50
+```
+
+Choose canaries covering imported history, a lone tick far from the day's larger
+run, an explicit session far from loose ticks, and a midnight-crossing run. Inspect
+their plans. Require zero failures and zero proposed removals before applying to
+those users. Simulation is a per-window snapshot; concurrent logging can change
+the later apply plan. A full fleet simulation is useful for identifying blocked
+accounts, but can take hours over a public connection.
+
+## Apply, after explicit production approval
+
+First run one reviewed canary:
+
+```sh
+node --import tsx src/scripts/backfill-inferred-sessions.ts --user "$BACKFILL_USER_ID" --apply --delay-ms 50 --progress-every 1
+```
+
+Inspect that climber's Sessions and logbook: every tick appears, same-day loose
+ticks join the expected session, and existing session edits and comments remain.
+Re-run the same canary command: it should create zero sessions and preserve IDs.
+If both passes succeed, proceed with a bounded batch, then the fleet:
+
+```sh
+node --import tsx src/scripts/backfill-inferred-sessions.ts --apply --limit 10 --delay-ms 50 --progress-every 1
+node --import tsx src/scripts/backfill-inferred-sessions.ts --apply --delay-ms 50 --progress-every 10
+```
+
+Watch database CPU, connection usage, lock waits, backend errors, and per-user
+failures. Stop on sustained load or unexpected grouping; increase the delay before
+resuming. No deployment, merge, or flag change starts these commands automatically.
+
+## Verify and recover
+
+Repeat the baseline queries and inventory. On a quiet database, tick count should
+be unchanged and unassigned ticks should fall to zero except explicitly recorded
+failed users. Live imports can add unassigned ticks while the backfill runs; run a
+fresh inventory without `--resume-from` afterwards to catch earlier IDs.
+
+Check assignment integrity using read-only queries:
+
+```sql
+BEGIN READ ONLY;
+SELECT count(*) AS dangling_assignments
+FROM boardsesh_ticks t LEFT JOIN board_sessions s ON s.id = t.session_id
+WHERE t.session_id IS NOT NULL AND s.id IS NULL;
+SELECT count(*) AS invalid_inferred_sessions
+FROM board_sessions s
+WHERE s.origin = 'inferred'
+  AND (s.status <> 'ended' OR s.anchor_tick_id IS NULL
+       OR NOT EXISTS (SELECT 1 FROM boardsesh_ticks t
+                      WHERE t.id = s.anchor_tick_id AND t.session_id = s.id));
+COMMIT;
+```
+
+Compare these counts with the preflight baseline too; pre-existing anomalies need
+their own investigation. Preserve before/after session IDs for each canary.
+
+Each successful window is already committed. An interruption rolls back only the
+in-flight window. Retry the last `starting user=...` with `--user` first, or use
+the emitted inclusive recovery command after a completed run with failures. It
+points at the first failed user, not the last user visited. Keep the same mode,
+delay, and any user limit. Serialization or anchor conflicts can be retried after
+the concurrent writer completes; removal/explicit-assignment/truncation failures
+need investigation rather than repeated blind retries.
+
+Disabling `INFERRED_SESSIONS_ENABLED` stops ordinary reconciliation but does not
+undo committed backfill assignments. There is no destructive undo command here.
+If grouping is wrong, stop, preserve logs and the backup, and review a targeted
+repair or recovery separately. Never delete inferred sessions as an ad-hoc rollback.

--- a/docs/inferred-sessions-backfill.md
+++ b/docs/inferred-sessions-backfill.md
@@ -229,14 +229,14 @@ that its same-UTC-day assumptions reflected separate visits to the wall.
 
 ### Eight-hour audit before resuming
 
-At `2026-09-07T01:34:31.113Z`, a read-only audit covered the 27 climbers present
+At `2026-09-07T01:37:09.505Z`, a read-only audit covered the 27 climbers present
 in operator logs plus four other owners of recently created inferred sessions:
-31 climbers, 14,435 ticks, and 726 inferred sessions created since the preflight.
-This includes concurrent live inference; the 726 are not all backfill creations.
+31 climbers, 14,438 ticks, and 727 inferred sessions created since the preflight.
+This includes concurrent live inference; the 727 are not all backfill creations.
 
 Four recent inferred sessions contain gaps over eight hours. Replanning complete
-histories proposes four inferred-session merges, zero emptied sessions, and 43
-already-assigned inferred ticks changing destination across three climbers. It
+histories proposes five inferred-session merges, zero emptied sessions, and 44
+already-assigned inferred ticks changing destination across four climbers. It
 also proposes 564 new sessions, including groups from 5,388 still-unassigned ticks;
 those new-session totals are not solely repairs.
 
@@ -249,3 +249,9 @@ written. Merge/removal guards remain enabled pending a reviewed repair.
 Ticks already absorbed into explicit sessions have no assignment provenance, so
 this audit cannot distinguish those from deliberately assigned members. Existing
 explicit assignments remain fixed under the approved policy.
+
+The four splits move eight ticks into four new sessions while retaining each original
+session's anchor. Their largest internal gaps are 8.41, 10.65, 15.10, and 17.22 hours.
+The five proposed merge losers contain 36 ticks in total and have no names, edits,
+comments, or votes. These are concrete repair candidates, not authorized removals;
+the backfill's removal guard remains in place.

--- a/docs/inferred-sessions.md
+++ b/docs/inferred-sessions.md
@@ -73,9 +73,10 @@ algorithm is testable in isolation. Callers load a window, call `reconcileWindow
 apply the result in one transaction.
 
 ```
-expandWindow(ticks, from, to)
-  widen outwards until there is a >4h gap on BOTH sides
-    → the blast radius covers whole runs, never a partial one
+expandReconciliationWindow(ticks, from, to)
+  include whole UTC days, expanding connected runs across midnight
+  stop only at a >4h gap across different UTC days on BOTH sides
+    → all same-day adjustments see their neighbours, without partial runs
 
 reconcileWindow({ ticks, existingInferred, existingExplicit })
   → runs              each run and the session it belongs to
@@ -83,6 +84,11 @@ reconcileWindow({ ticks, existingInferred, existingExplicit })
   → merges            {survivorId, loserId} — re-point social rows, THEN delete
   → emptiedSessionIds sessions an explicit session took every tick from
 ```
+
+A window can hold several sessions. Loading only one gap-bounded run misses lone
+ticks and explicit sessions elsewhere on the same day. The database loader widens
+up to a 192-hour radius; if the result is still clipped, reconciliation fails before
+writing. Database `climbed_at` strings are interpreted as UTC on every host.
 
 The window is the important part. Reconciling always decides about complete runs, so a
 tick inserted anywhere — mid-run, before the first, bridging two — produces a correct
@@ -131,6 +137,14 @@ assignment commit or roll back together:
 Still to wire: the Aurora / Kilter / MoonBoard / JSON importers (batched — one call per
 climber per contiguous window, never per tick, since a single import can carry 300k
 rows) and the offline outbox drain.
+
+## Historical backfill
+
+The manual script, production preflight, canary, and recovery procedure are in
+[inferred-sessions-backfill.md](./inferred-sessions-backfill.md). It defaults to a
+read-only inventory; `--simulate` plans grouping and `--apply` commits one complete
+window at a time. The backfill refuses windows that remove existing sessions, and
+reconciliation rejects moving ticks out of their assigned explicit sessions.
 
 ## What went wrong the first time
 

--- a/docs/inferred-sessions.md
+++ b/docs/inferred-sessions.md
@@ -11,36 +11,21 @@ happened once.
 
 ## The rule
 
-A session is a run of one climber's ticks with **no gap longer than 4 hours**
-(`SESSION_GAP_MS`), plus two adjustments:
+Automatic grouping joins consecutive ticks from the same climber when their gap is
+**eight hours or less** (`SESSION_GAP_MS`). A gap **over eight hours** is a hard
+boundary, including for lone ticks and loose ticks near an explicit session.
+Calendar dates never override this boundary.
 
-1. **An explicit session wins.** A run on the same day as a session someone actually
-   started is folded into it. Someone who logs two climbs, presses Start, then logs
-   nine more has one session of eleven, not a session of nine beside an orphan pair.
-   If a timing run contains multiple explicit sessions, each already-assigned tick
-   keeps its session. Loose ticks choose the nearest eligible explicit session.
-   Midnight absorption is settled within the plan, so a second pass does not create
-   or empty sessions merely because the first pass extended an explicit day.
-2. **A lone tick joins the day's real climbing.** A single-tick run on a day that also
-   holds a larger run is almost always someone remembering later that they forgot to
-   log a climb, so it joins that run. A lone tick on a day of its own stays a
-   one-climb session — hiding it is how climbs go missing (#4975).
+Existing explicit assignments remain authoritative, even if someone deliberately
+keeps a session across a longer gap. Within each connected run, unassigned or inferred
+ticks join the nearest explicitly assigned tick's session; ties go to the earlier
+tick. Separate explicit sessions keep their original members.
 
-### Why 4 hours is not a tuning knob
-
-Across the production tick table, inter-tick gaps are sharply bimodal:
-
-| gap | share |
-| --- | --- |
-| ≤ 15 min | 80 % |
-| 15–60 min | 8 % |
-| 1–2 h | 0.7 % |
-| **2–12 h** | **0.4 %** |
-| > 12 h | 11 % |
-
-Only 243 of 60,385 gaps fall in the 2–12 hour valley, so every threshold in that range
-draws nearly the same boundaries. 4 h is what the original implementation used and the
-data says it was a good choice; it is kept so both eras group history identically.
+Eight hours is a product heuristic for separating overnight breaks, not proof that
+someone slept or returned to the wall. It can still join two visits less than eight
+hours apart. Since grouping uses elapsed time, the same evening-to-morning gap has
+the same result in every timezone. PostgreSQL timestamps are parsed consistently as
+UTC; UTC calendar dates are only used to pad database reads for legacy repair.
 
 ## Where they live
 
@@ -79,8 +64,8 @@ apply the result in one transaction.
 ```
 expandReconciliationWindow(ticks, from, to)
   include whole UTC days, expanding connected runs across midnight
-  stop only at a >4h gap across different UTC days on BOTH sides
-    → all same-day adjustments see their neighbours, without partial runs
+  stop only at a >8h gap across different UTC days on BOTH sides
+    → include legacy same-day session anchors when splitting old assignments
 
 reconcileWindow({ ticks, existingInferred, existingExplicit })
   → runs              each run and the session it belongs to
@@ -89,8 +74,9 @@ reconcileWindow({ ticks, existingInferred, existingExplicit })
   → emptiedSessionIds sessions an explicit session took every tick from
 ```
 
-A window can hold several sessions. Loading only one gap-bounded run misses lone
-ticks and explicit sessions elsewhere on the same day. The database loader widens
+A read window can hold several sessions; it does not group them together. Whole-day
+padding keeps anchors from the former same-day grouping policy visible when old
+sessions split. The database loader widens
 up to a 192-hour radius; if the result is still clipped, live inference leaves
 assignments unchanged so the tick write can commit. The backfill reports a failure
 and leaves that window untouched. Database `climbed_at` strings are interpreted as UTC on every host.

--- a/docs/inferred-sessions.md
+++ b/docs/inferred-sessions.md
@@ -17,6 +17,10 @@ A session is a run of one climber's ticks with **no gap longer than 4 hours**
 1. **An explicit session wins.** A run on the same day as a session someone actually
    started is folded into it. Someone who logs two climbs, presses Start, then logs
    nine more has one session of eleven, not a session of nine beside an orphan pair.
+   If a timing run contains multiple explicit sessions, each already-assigned tick
+   keeps its session. Loose ticks choose the nearest eligible explicit session.
+   Midnight absorption is settled within the plan, so a second pass does not create
+   or empty sessions merely because the first pass extended an explicit day.
 2. **A lone tick joins the day's real climbing.** A single-tick run on a day that also
    holds a larger run is almost always someone remembering later that they forgot to
    log a climb, so it joins that run. A lone tick on a day of its own stays a
@@ -87,8 +91,9 @@ reconcileWindow({ ticks, existingInferred, existingExplicit })
 
 A window can hold several sessions. Loading only one gap-bounded run misses lone
 ticks and explicit sessions elsewhere on the same day. The database loader widens
-up to a 192-hour radius; if the result is still clipped, reconciliation fails before
-writing. Database `climbed_at` strings are interpreted as UTC on every host.
+up to a 192-hour radius; if the result is still clipped, live inference leaves
+assignments unchanged so the tick write can commit. The backfill reports a failure
+and leaves that window untouched. Database `climbed_at` strings are interpreted as UTC on every host.
 
 The window is the important part. Reconciling always decides about complete runs, so a
 tick inserted anywhere — mid-run, before the first, bridging two — produces a correct

--- a/packages/backend/src/__tests__/backfill-inferred-sessions-runs.test.ts
+++ b/packages/backend/src/__tests__/backfill-inferred-sessions-runs.test.ts
@@ -20,7 +20,7 @@ describe('reconciliationStartTimestamps', () => {
     expect(reconciliationStartTimestamps(ticks)).toEqual([BASE]);
   });
 
-  it('keeps separated runs on the same UTC day together', () => {
+  it('loads separated same-day groups in one legacy-safe read window', () => {
     const ticks = [BASE, BASE + 20 * MINUTE, BASE + 10 * HOUR, BASE + 10 * HOUR + 15 * MINUTE];
 
     expect(reconciliationStartTimestamps(ticks)).toEqual([BASE]);

--- a/packages/backend/src/__tests__/backfill-inferred-sessions-runs.test.ts
+++ b/packages/backend/src/__tests__/backfill-inferred-sessions-runs.test.ts
@@ -83,7 +83,7 @@ describe('backfill safety', () => {
   it.each([
     ['--user'],
     ['--user', '--apply'],
-    ['--limt', '1'],
+    ['--limt', '1'], // Deliberate typo: unknown options must fail.
     ['--limit', '1.5'],
     ['--limit', '-1'],
     ['--progress-every', '0'],

--- a/packages/backend/src/__tests__/backfill-inferred-sessions-runs.test.ts
+++ b/packages/backend/src/__tests__/backfill-inferred-sessions-runs.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { SESSION_GAP_MS } from '@boardsesh/session-inference';
+import { runStartTimestamps } from '../scripts/backfill-inferred-sessions';
+
+/**
+ * The backfill reconciles once per run rather than once per tick — 435k calls would be
+ * 435k redundant passes over windows already reconciled, since one call covers the whole
+ * run around the timestamp it is given.
+ *
+ * That makes the run-splitting the one rule this script owns: pick too few timestamps
+ * and whole sessions go unbackfilled; pick too many and it is merely slow. Everything
+ * else it does is the shared package's job.
+ */
+
+const HOUR = 60 * 60 * 1000;
+const MINUTE = 60 * 1000;
+const BASE = Date.UTC(2026, 4, 10, 9, 0, 0);
+
+describe('runStartTimestamps', () => {
+  it('returns nothing for a climber with no ticks', () => {
+    expect(runStartTimestamps([])).toEqual([]);
+  });
+
+  it('returns one timestamp for a single run', () => {
+    const ticks = [BASE, BASE + 10 * MINUTE, BASE + 25 * MINUTE];
+
+    expect(runStartTimestamps(ticks)).toEqual([BASE]);
+  });
+
+  it('picks the first climb of each run', () => {
+    const ticks = [BASE, BASE + 20 * MINUTE, BASE + 10 * HOUR, BASE + 10 * HOUR + 15 * MINUTE];
+
+    expect(runStartTimestamps(ticks)).toEqual([BASE, BASE + 10 * HOUR]);
+  });
+
+  it('does not split exactly at the threshold', () => {
+    const ticks = [BASE, BASE + SESSION_GAP_MS];
+
+    expect(runStartTimestamps(ticks)).toEqual([BASE]);
+  });
+
+  it('splits one millisecond past the threshold', () => {
+    const ticks = [BASE, BASE + SESSION_GAP_MS + 1];
+
+    expect(runStartTimestamps(ticks)).toEqual([BASE, BASE + SESSION_GAP_MS + 1]);
+  });
+
+  // Years of imported logbook history is the normal shape here, not the exception.
+  it('handles a long sparse history without collapsing it', () => {
+    const days = Array.from({ length: 200 }, (_, i) => BASE + i * 24 * HOUR);
+
+    expect(runStartTimestamps(days)).toHaveLength(200);
+  });
+
+  it('keeps a run that crosses midnight as one', () => {
+    const ticks = [Date.UTC(2026, 4, 10, 22, 0), Date.UTC(2026, 4, 10, 23, 30), Date.UTC(2026, 4, 11, 0, 45)];
+
+    expect(runStartTimestamps(ticks)).toEqual([ticks[0]]);
+  });
+
+  // Every tick must fall inside some reconciled window, or the backfill silently skips
+  // climbs. Each start covers ticks up to the next start.
+  it('covers every tick — no climb falls between two runs', () => {
+    const ticks = [
+      BASE,
+      BASE + 30 * MINUTE,
+      BASE + 9 * HOUR,
+      BASE + 9 * HOUR + 5 * MINUTE,
+      BASE + 40 * HOUR,
+      BASE + 40 * HOUR + 90 * MINUTE,
+    ];
+
+    const starts = runStartTimestamps(ticks);
+
+    for (const tick of ticks) {
+      const owning = [...starts].reverse().find((start) => start <= tick);
+      expect(owning).toBeDefined();
+      // and the tick is within one gap of its run's previous tick, by construction
+      expect(tick - owning!).toBeGreaterThanOrEqual(0);
+    }
+    expect(starts).toEqual([BASE, BASE + 9 * HOUR, BASE + 40 * HOUR]);
+  });
+});

--- a/packages/backend/src/__tests__/backfill-inferred-sessions-runs.test.ts
+++ b/packages/backend/src/__tests__/backfill-inferred-sessions-runs.test.ts
@@ -1,61 +1,54 @@
-import { describe, it, expect } from 'vite-plus/test';
-import { SESSION_GAP_MS } from '@boardsesh/session-inference';
-import { runStartTimestamps } from '../scripts/backfill-inferred-sessions';
-
-/**
- * The backfill reconciles once per run rather than once per tick — 435k calls would be
- * 435k redundant passes over windows already reconciled, since one call covers the whole
- * run around the timestamp it is given.
- *
- * That makes the run-splitting the one rule this script owns: pick too few timestamps
- * and whole sessions go unbackfilled; pick too many and it is merely slow. Everything
- * else it does is the shared package's job.
- */
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { SESSION_GAP_MS, expandReconciliationWindow } from '@boardsesh/session-inference';
+import { reconciliationStartTimestamps, parseArgs, runBackfill } from '../scripts/backfill-inferred-sessions';
+import { db } from '../db/client';
+import { logger } from '../utils/logger';
+import { parseClimbedAt } from '../services/inferred-sessions/timestamps';
 
 const HOUR = 60 * 60 * 1000;
 const MINUTE = 60 * 1000;
 const BASE = Date.UTC(2026, 4, 10, 9, 0, 0);
 
-describe('runStartTimestamps', () => {
+describe('reconciliationStartTimestamps', () => {
   it('returns nothing for a climber with no ticks', () => {
-    expect(runStartTimestamps([])).toEqual([]);
+    expect(reconciliationStartTimestamps([])).toEqual([]);
   });
 
   it('returns one timestamp for a single run', () => {
     const ticks = [BASE, BASE + 10 * MINUTE, BASE + 25 * MINUTE];
 
-    expect(runStartTimestamps(ticks)).toEqual([BASE]);
+    expect(reconciliationStartTimestamps(ticks)).toEqual([BASE]);
   });
 
-  it('picks the first climb of each run', () => {
+  it('keeps separated runs on the same UTC day together', () => {
     const ticks = [BASE, BASE + 20 * MINUTE, BASE + 10 * HOUR, BASE + 10 * HOUR + 15 * MINUTE];
 
-    expect(runStartTimestamps(ticks)).toEqual([BASE, BASE + 10 * HOUR]);
+    expect(reconciliationStartTimestamps(ticks)).toEqual([BASE]);
   });
 
   it('does not split exactly at the threshold', () => {
-    const ticks = [BASE, BASE + SESSION_GAP_MS];
+    const ticks = [BASE + 12 * HOUR, BASE + 12 * HOUR + SESSION_GAP_MS];
 
-    expect(runStartTimestamps(ticks)).toEqual([BASE]);
+    expect(reconciliationStartTimestamps(ticks)).toEqual([ticks[0]]);
   });
 
   it('splits one millisecond past the threshold', () => {
-    const ticks = [BASE, BASE + SESSION_GAP_MS + 1];
+    const ticks = [BASE + 12 * HOUR, BASE + 12 * HOUR + SESSION_GAP_MS + 1];
 
-    expect(runStartTimestamps(ticks)).toEqual([BASE, BASE + SESSION_GAP_MS + 1]);
+    expect(reconciliationStartTimestamps(ticks)).toEqual(ticks);
   });
 
   // Years of imported logbook history is the normal shape here, not the exception.
   it('handles a long sparse history without collapsing it', () => {
     const days = Array.from({ length: 200 }, (_, i) => BASE + i * 24 * HOUR);
 
-    expect(runStartTimestamps(days)).toHaveLength(200);
+    expect(reconciliationStartTimestamps(days)).toHaveLength(200);
   });
 
   it('keeps a run that crosses midnight as one', () => {
     const ticks = [Date.UTC(2026, 4, 10, 22, 0), Date.UTC(2026, 4, 10, 23, 30), Date.UTC(2026, 4, 11, 0, 45)];
 
-    expect(runStartTimestamps(ticks)).toEqual([ticks[0]]);
+    expect(reconciliationStartTimestamps(ticks)).toEqual([ticks[0]]);
   });
 
   // Every tick must fall inside some reconciled window, or the backfill silently skips
@@ -70,14 +63,80 @@ describe('runStartTimestamps', () => {
       BASE + 40 * HOUR + 90 * MINUTE,
     ];
 
-    const starts = runStartTimestamps(ticks);
+    const starts = reconciliationStartTimestamps(ticks);
+    const inferenceTicks = ticks.map((climbedAt, index) => ({ id: index, climbedAt, sessionId: null }));
+    const coveredIds = starts.flatMap((start) =>
+      expandReconciliationWindow(inferenceTicks, start, start).map((tick) => tick.id),
+    );
+    expect(coveredIds).toEqual(inferenceTicks.map((tick) => tick.id));
 
-    for (const tick of ticks) {
-      const owning = [...starts].reverse().find((start) => start <= tick);
-      expect(owning).toBeDefined();
-      // and the tick is within one gap of its run's previous tick, by construction
-      expect(tick - owning!).toBeGreaterThanOrEqual(0);
+    expect(starts).toEqual([BASE, BASE + 40 * HOUR]);
+  });
+});
+
+describe('backfill safety', () => {
+  it('rejects invalid or unordered timestamps', () => {
+    expect(() => reconciliationStartTimestamps([BASE + HOUR, BASE])).toThrow('ascending');
+    expect(() => reconciliationStartTimestamps([NaN])).toThrow('finite');
+  });
+
+  it.each([
+    ['--user'],
+    ['--user', '--apply'],
+    ['--limt', '1'],
+    ['--limit', '1.5'],
+    ['--limit', '-1'],
+    ['--progress-every', '0'],
+    ['--delay-ms', '2147483648'],
+    ['--apply', '--simulate'],
+    ['--apply', '--apply'],
+    ['--user', 'u', '--limit', '1'],
+    ['--user', 'u', '--resume-from', 'v'],
+  ])('rejects unsafe arguments %j', (...args: string[]) => {
+    expect(() => parseArgs(args)).toThrow();
+  });
+
+  it('defaults to dry run and accepts bounded execution', () => {
+    expect(parseArgs([]).apply).toBe(false);
+    expect(parseArgs(['--limit', '0']).limit).toBe(0);
+    expect(parseArgs(['--user', 'u', '--simulate', '--delay-ms', '50'])).toMatchObject({
+      userId: 'u',
+      simulate: true,
+      apply: false,
+      delayMs: 50,
+    });
+  });
+
+  it('parses database timestamps as UTC regardless of the host timezone', () => {
+    expect(parseClimbedAt('2026-05-10 09:00:00').getTime()).toBe(BASE);
+    expect(parseClimbedAt('2026-05-10T19:00:00+10:00').getTime()).toBe(BASE);
+    expect(parseClimbedAt('2026-05-10T09:00:00Z').getTime()).toBe(BASE);
+    expect(() => parseClimbedAt('invalid')).toThrow();
+  });
+
+  it('returns failure and resumes at the first failed user after later users succeed', async () => {
+    const selection = vi.spyOn(db, 'selectDistinct').mockReturnValue({
+      from: () => ({ where: () => ({ orderBy: async () => [{ userId: 'a' }, { userId: 'b' }] }) }),
+    } as unknown as ReturnType<typeof db.selectDistinct>);
+    const ticks = vi
+      .spyOn(db, 'select')
+      .mockImplementationOnce(() => {
+        throw new Error('failed first user');
+      })
+      .mockReturnValue({
+        from: () => ({ where: () => ({ orderBy: async () => [] }) }),
+      } as unknown as ReturnType<typeof db.select>);
+    const warning = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+    const error = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+    try {
+      expect(await runBackfill(parseArgs([]))).toBe(1);
+      expect(ticks).toHaveBeenCalledTimes(2);
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('--resume-from a'));
+    } finally {
+      selection.mockRestore();
+      ticks.mockRestore();
+      warning.mockRestore();
+      error.mockRestore();
     }
-    expect(starts).toEqual([BASE, BASE + 9 * HOUR, BASE + 40 * HOUR]);
   });
 });

--- a/packages/backend/src/__tests__/inferred-session-reconcile-integration.test.ts
+++ b/packages/backend/src/__tests__/inferred-session-reconcile-integration.test.ts
@@ -7,6 +7,16 @@ import { reconcileInferredSessions } from '../services/inferred-sessions/reconci
 import { runBackfill, parseArgs } from '../scripts/backfill-inferred-sessions';
 import { logger } from '../utils/logger';
 import { vi } from 'vite-plus/test';
+import { tickMutations } from '../graphql/resolvers/ticks/mutations';
+
+vi.mock('../events', () => ({ publishSocialEvent: vi.fn(async () => undefined) }));
+vi.mock('../graphql/resolvers/ticks/debounced-climb-stats-publisher', () => ({
+  queueClimbStatsRecompute: vi.fn(),
+}));
+vi.mock('../graphql/resolvers/sessions/debounced-stats-publisher', () => ({
+  publishDebouncedSessionStats: vi.fn(),
+}));
+vi.mock('../graphql/resolvers/board-presence/stats', () => ({ queueBoardStatsPublish: vi.fn() }));
 
 /**
  * Real-DB coverage for turning a reconciliation decision into rows.
@@ -118,6 +128,7 @@ describe('reconcileInferredSessions (real DB)', () => {
   // whatever ran next — and the tick-mutation suites would start writing sessions.
   afterEach(() => {
     delete process.env.INFERRED_SESSIONS_ENABLED;
+    vi.unstubAllEnvs();
   });
 
   afterAll(async () => {
@@ -135,6 +146,65 @@ describe('reconcileInferredSessions (real DB)', () => {
 
     expect(await sessionsForUser()).toHaveLength(0);
     expect((await ticksForUser())[0].sessionId).toBeNull();
+  });
+
+  // Force Brisbane time even on UTC CI hosts: parsing the returned zone-less DB
+  // string as local time selects the previous day's run instead of the modified tick.
+  it.each(['save', 'update', 'delete'] as const)('%sTick reconciles the stored UTC day', async (operation) => {
+    vi.stubEnv('TZ', 'Australia/Brisbane');
+    expect(new Date('2026-05-10 01:00:00').toISOString()).toBe('2026-05-09T15:00:00.000Z');
+    const previousDay = Date.UTC(2026, 4, 9, 15);
+    const touchedAt = Date.UTC(2026, 4, 10, 1);
+    const previousTick = await insertTick(previousDay);
+    await insertTick(previousDay + 20 * MINUTE);
+    await reconcileAt(previousDay);
+    const [previousSession] = await sessionsForUser();
+
+    const context = { connectionId: 'utc-reconciliation', isAuthenticated: true, userId: USER_ID };
+    let survivingTickId: number;
+    if (operation === 'save') {
+      await tickMutations.saveTick(
+        null,
+        {
+          input: {
+            boardType: 'kilter',
+            climbUuid: CLIMB_UUID,
+            angle: 40,
+            isMirror: false,
+            status: 'send',
+            attemptCount: 1,
+            isBenchmark: false,
+            comment: '',
+            climbedAt: new Date(touchedAt).toISOString(),
+          },
+        },
+        context,
+      );
+      survivingTickId = Number((await ticksForUser()).at(-1)!.id);
+    } else {
+      const targetId = await insertTick(touchedAt);
+      survivingTickId = await insertTick(touchedAt + 20 * MINUTE);
+      const [target] = await db
+        .select()
+        .from(dbSchema.boardseshTicks)
+        .where(eq(dbSchema.boardseshTicks.id, BigInt(targetId)));
+      if (operation === 'update') {
+        await tickMutations.updateTick(null, { uuid: target.uuid, input: { comment: 'Updated notes' } }, context);
+      } else {
+        await tickMutations.deleteTick(null, { uuid: target.uuid }, context);
+      }
+    }
+
+    const ticks = await ticksForUser();
+    const survivingTick = ticks.find((tick) => Number(tick.id) === survivingTickId)!;
+    expect(survivingTick.sessionId).not.toBeNull();
+    expect(survivingTick.sessionId).not.toBe(previousSession.id);
+    expect(ticks.find((tick) => Number(tick.id) === previousTick)?.sessionId).toBe(previousSession.id);
+    const sessions = await sessionsForUser();
+    expect(sessions).toHaveLength(2);
+    expect(sessions.find((session) => session.id === survivingTick.sessionId)?.startedAt?.getTime()).toBe(
+      operation === 'delete' ? touchedAt + 20 * MINUTE : touchedAt,
+    );
   });
 
   it('creates one session per run and assigns every tick', async () => {

--- a/packages/backend/src/__tests__/inferred-session-reconcile-integration.test.ts
+++ b/packages/backend/src/__tests__/inferred-session-reconcile-integration.test.ts
@@ -3,7 +3,7 @@ import { sql, eq, and, asc } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import { db } from '../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
-import { reconcileInferredSessions, planReconciliation } from '../services/inferred-sessions/reconcile';
+import { reconcileInferredSessions } from '../services/inferred-sessions/reconcile';
 import { runBackfill, parseArgs } from '../scripts/backfill-inferred-sessions';
 import { logger } from '../utils/logger';
 import { vi } from 'vite-plus/test';
@@ -50,8 +50,12 @@ async function seedFixtures() {
 }
 
 /** Insert a tick and return the bigserial id reconciliation anchors on. */
-async function insertTick(climbedAtMs: number, sessionId: string | null = null): Promise<number> {
-  const [row] = await db
+async function insertTick(
+  climbedAtMs: number,
+  sessionId: string | null = null,
+  writer: Pick<typeof db, 'insert'> = db,
+): Promise<number> {
+  const [row] = await writer
     .insert(dbSchema.boardseshTicks)
     .values({
       uuid: uuidv4(),
@@ -369,12 +373,12 @@ describe('reconcileInferredSessions (real DB)', () => {
 
   it('refuses to reconcile a clipped window instead of splitting a long history', async () => {
     for (let hours = -220; hours <= 220; hours += 4) await insertTick(BASE + hours * HOUR);
-    await expect(reconcileAt(BASE)).rejects.toThrow('truncated');
+    expect(await runBackfill(parseArgs(['--user', USER_ID, '--apply']))).toBe(1);
     expect(await sessionsForUser()).toEqual([]);
     expect((await ticksForUser()).every((tick) => tick.sessionId === null)).toBe(true);
   });
 
-  it('refuses to move a tick between two explicit sessions in one run', async () => {
+  it('backfills loose ticks without moving ticks between explicit sessions', async () => {
     for (let index = 0; index < 2; index++) {
       const explicitId = uuidv4();
       await db.insert(dbSchema.boardSessions).values({
@@ -386,9 +390,45 @@ describe('reconcileInferredSessions (real DB)', () => {
       await insertTick(BASE + index * HOUR, explicitId);
     }
     const beforeTicks = await ticksForUser();
-    await expect(db.transaction((tx) => planReconciliation(tx, USER_ID, new Date(BASE)))).rejects.toThrow(
-      'explicit session',
-    );
-    expect(await ticksForUser()).toEqual(beforeTicks);
+    await insertTick(BASE + 50 * MINUTE);
+    expect(await runBackfill(parseArgs(['--user', USER_ID, '--apply']))).toBe(0);
+    const afterTicks = await ticksForUser();
+    for (const beforeTick of beforeTicks) {
+      expect(afterTicks.find((tick) => tick.id === beforeTick.id)?.sessionId).toBe(beforeTick.sessionId);
+    }
+    expect(afterTicks[1].sessionId).toBe(beforeTicks[1].sessionId);
+    expect(await sessionsForUser()).toHaveLength(2);
+  });
+
+  it('settles explicit midnight absorption in one plan and keeps apply idempotent', async () => {
+    const explicitId = uuidv4();
+    await db.insert(dbSchema.boardSessions).values({
+      id: explicitId,
+      boardPath: '/kilter/1/10/1,20/40',
+      createdByUserId: USER_ID,
+      status: 'ended',
+    });
+    await insertTick(BASE);
+    await insertTick(BASE + HOUR);
+    await insertTick(BASE + 14 * HOUR);
+    await insertTick(BASE + 16 * HOUR, explicitId);
+    expect(await runBackfill(parseArgs(['--user', USER_ID, '--apply']))).toBe(0);
+    const ticks = await ticksForUser();
+    expect(ticks.every((tick) => tick.sessionId === explicitId)).toBe(true);
+    expect(await sessionsForUser()).toHaveLength(1);
+    expect(await runBackfill(parseArgs(['--user', USER_ID, '--apply']))).toBe(0);
+    expect(await ticksForUser()).toEqual(ticks);
+    expect(await sessionsForUser()).toHaveLength(1);
+  });
+
+  it('keeps a live tick write when inference cannot load a complete window', async () => {
+    for (let hours = -220; hours <= 220; hours += 4) await insertTick(BASE + hours * HOUR);
+    const addedTickId = await db.transaction(async (tx) => {
+      const tickId = await insertTick(BASE + HOUR, null, tx);
+      expect(await reconcileInferredSessions(tx, USER_ID, new Date(BASE + HOUR))).toBeNull();
+      return tickId;
+    });
+    expect((await ticksForUser()).find((tick) => tick.id === BigInt(addedTickId))?.sessionId).toBeNull();
+    expect(await sessionsForUser()).toHaveLength(0);
   });
 });

--- a/packages/backend/src/__tests__/inferred-session-reconcile-integration.test.ts
+++ b/packages/backend/src/__tests__/inferred-session-reconcile-integration.test.ts
@@ -12,6 +12,7 @@ import { tickMutations } from '../graphql/resolvers/ticks/mutations';
 vi.mock('../events', () => ({ publishSocialEvent: vi.fn(async () => undefined) }));
 vi.mock('../graphql/resolvers/ticks/debounced-climb-stats-publisher', () => ({
   queueClimbStatsRecompute: vi.fn(),
+  recomputeClimbStatsNow: vi.fn(async () => undefined),
 }));
 vi.mock('../graphql/resolvers/sessions/debounced-stats-publisher', () => ({
   publishDebouncedSessionStats: vi.fn(),
@@ -361,18 +362,18 @@ describe('reconcileInferredSessions (real DB)', () => {
     ).rejects.toThrow();
   });
 
-  it('absorbs a lone tick more than four hours from the larger same-day run', async () => {
+  it('keeps a lone tick separate across an eight-hour gap on the same UTC day', async () => {
     await insertTick(BASE);
     await insertTick(BASE + 10 * HOUR);
     await insertTick(BASE + 10 * HOUR + 15 * MINUTE);
     await reconcileAt(BASE);
-    expect(await sessionsForUser()).toHaveLength(1);
+    expect(await sessionsForUser()).toHaveLength(2);
     const ticks = await ticksForUser();
-    expect(new Set(ticks.map((tick) => tick.sessionId)).size).toBe(1);
+    expect(new Set(ticks.map((tick) => tick.sessionId)).size).toBe(2);
     expect(ticks[0].sessionId).not.toBeNull();
   });
 
-  it('discovers an explicit session outside the initial twelve-hour radius', async () => {
+  it('does not absorb loose ticks into a distant same-day explicit session', async () => {
     const explicitId = uuidv4();
     await db.insert(dbSchema.boardSessions).values({
       id: explicitId,
@@ -384,8 +385,10 @@ describe('reconcileInferredSessions (real DB)', () => {
     await insertTick(BASE - 8 * HOUR + 15 * MINUTE);
     await insertTick(BASE + 13 * HOUR, explicitId);
     await reconcileAt(BASE - 8 * HOUR);
-    expect((await ticksForUser()).every((tick) => tick.sessionId === explicitId)).toBe(true);
-    expect(await sessionsForUser()).toHaveLength(1);
+    const assigned = await ticksForUser();
+    expect(assigned[0].sessionId).not.toBe(explicitId);
+    expect(assigned[2].sessionId).toBe(explicitId);
+    expect(await sessionsForUser()).toHaveLength(2);
   });
 
   it('simulates connected days once, writes nothing, and matches apply on rerun', async () => {
@@ -399,12 +402,12 @@ describe('reconcileInferredSessions (real DB)', () => {
       expect(await runBackfill(parseArgs(['--user', USER_ID, '--simulate']))).toBe(0);
       expect(await ticksForUser()).toEqual(beforeTicks);
       expect(await sessionsForUser()).toEqual([]);
-      expect(messages).toHaveBeenCalledWith(expect.stringContaining('would create 1 session(s)'));
+      expect(messages).toHaveBeenCalledWith(expect.stringContaining('would create 3 session(s)'));
       expect(await runBackfill(parseArgs(['--user', USER_ID, '--apply']))).toBe(0);
       const sessions = await sessionsForUser();
-      expect(sessions).toHaveLength(1);
+      expect(sessions).toHaveLength(3);
       const ticks = await ticksForUser();
-      expect(new Set(ticks.map((tick) => tick.sessionId))).toEqual(new Set([sessions[0].id]));
+      expect(new Set(ticks.map((tick) => tick.sessionId))).toEqual(new Set(sessions.map((session) => session.id)));
       expect(await runBackfill(parseArgs(['--user', USER_ID, '--apply']))).toBe(0);
       expect(await sessionsForUser()).toEqual(sessions);
       expect(await ticksForUser()).toEqual(ticks);
@@ -431,7 +434,7 @@ describe('reconcileInferredSessions (real DB)', () => {
       createdByUserId: USER_ID,
       status: 'ended',
     });
-    await insertTick(BASE + 10 * HOUR, explicitId);
+    await insertTick(BASE + 6 * HOUR, explicitId);
     const beforeTicks = await ticksForUser();
     const beforeSessions = await sessionsForUser();
     expect(await runBackfill(parseArgs(['--user', USER_ID, '--apply']))).toBe(1);
@@ -470,7 +473,7 @@ describe('reconcileInferredSessions (real DB)', () => {
     expect(await sessionsForUser()).toHaveLength(2);
   });
 
-  it('settles explicit midnight absorption in one plan and keeps apply idempotent', async () => {
+  it('splits earlier climbing from an explicit midnight run and stays idempotent', async () => {
     const explicitId = uuidv4();
     await db.insert(dbSchema.boardSessions).values({
       id: explicitId,
@@ -484,11 +487,39 @@ describe('reconcileInferredSessions (real DB)', () => {
     await insertTick(BASE + 16 * HOUR, explicitId);
     expect(await runBackfill(parseArgs(['--user', USER_ID, '--apply']))).toBe(0);
     const ticks = await ticksForUser();
-    expect(ticks.every((tick) => tick.sessionId === explicitId)).toBe(true);
-    expect(await sessionsForUser()).toHaveLength(1);
+    expect(ticks.slice(0, 2).every((tick) => tick.sessionId !== explicitId && tick.sessionId !== null)).toBe(true);
+    expect(ticks.slice(2).every((tick) => tick.sessionId === explicitId)).toBe(true);
+    expect(await sessionsForUser()).toHaveLength(2);
     expect(await runBackfill(parseArgs(['--user', USER_ID, '--apply']))).toBe(0);
     expect(await ticksForUser()).toEqual(ticks);
-    expect(await sessionsForUser()).toHaveLength(1);
+    expect(await sessionsForUser()).toHaveLength(2);
+  });
+
+  it('repairs a legacy inferred gap without deleting its session or comments', async () => {
+    await insertTick(BASE);
+    await reconcileAt(BASE);
+    const [original] = await sessionsForUser();
+    await insertTick(BASE + 10 * HOUR, original.id);
+    await db.insert(dbSchema.comments).values({
+      uuid: uuidv4(),
+      userId: USER_ID,
+      entityType: 'session',
+      entityId: original.id,
+      body: 'Keep this history',
+    });
+    expect(await runBackfill(parseArgs(['--user', USER_ID, '--apply']))).toBe(0);
+    const sessions = await sessionsForUser();
+    const ticks = await ticksForUser();
+    expect(sessions).toHaveLength(2);
+    expect(ticks[0].sessionId).toBe(original.id);
+    expect(ticks[1].sessionId).not.toBe(original.id);
+    expect(sessions.find((session) => session.id === original.id)?.anchorTickId).toBe(original.anchorTickId);
+    expect(await db.select().from(dbSchema.comments).where(eq(dbSchema.comments.entityId, original.id))).toHaveLength(
+      1,
+    );
+    expect(await runBackfill(parseArgs(['--user', USER_ID, '--apply']))).toBe(0);
+    expect(await sessionsForUser()).toEqual(sessions);
+    expect(await ticksForUser()).toEqual(ticks);
   });
 
   it('keeps a live tick write when inference cannot load a complete window', async () => {

--- a/packages/backend/src/__tests__/inferred-session-reconcile-integration.test.ts
+++ b/packages/backend/src/__tests__/inferred-session-reconcile-integration.test.ts
@@ -3,7 +3,10 @@ import { sql, eq, and, asc } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import { db } from '../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
-import { reconcileInferredSessions } from '../services/inferred-sessions/reconcile';
+import { reconcileInferredSessions, planReconciliation } from '../services/inferred-sessions/reconcile';
+import { runBackfill, parseArgs } from '../scripts/backfill-inferred-sessions';
+import { logger } from '../utils/logger';
+import { vi } from 'vite-plus/test';
 
 /**
  * Real-DB coverage for turning a reconciliation decision into rows.
@@ -133,10 +136,10 @@ describe('reconcileInferredSessions (real DB)', () => {
   it('creates one session per run and assigns every tick', async () => {
     await insertTick(BASE);
     await insertTick(BASE + 20 * MINUTE);
-    await insertTick(BASE + 10 * HOUR);
+    await insertTick(BASE + 24 * HOUR);
 
     await reconcileAt(BASE);
-    await reconcileAt(BASE + 10 * HOUR);
+    await reconcileAt(BASE + 24 * HOUR);
 
     const sessions = await sessionsForUser();
     expect(sessions).toHaveLength(2);
@@ -144,7 +147,7 @@ describe('reconcileInferredSessions (real DB)', () => {
 
     const ticks = await ticksForUser();
     expect(ticks.every((tick) => tick.sessionId !== null)).toBe(true);
-    // The two morning climbs share a session; the evening one does not.
+    // The two morning climbs share a session; the next-day one does not.
     expect(ticks[0].sessionId).toBe(ticks[1].sessionId);
     expect(ticks[2].sessionId).not.toBe(ticks[0].sessionId);
   });
@@ -282,5 +285,110 @@ describe('reconcileInferredSessions (real DB)', () => {
         anchorTickId: anchor,
       }),
     ).rejects.toThrow();
+  });
+
+  it('absorbs a lone tick more than four hours from the larger same-day run', async () => {
+    await insertTick(BASE);
+    await insertTick(BASE + 10 * HOUR);
+    await insertTick(BASE + 10 * HOUR + 15 * MINUTE);
+    await reconcileAt(BASE);
+    expect(await sessionsForUser()).toHaveLength(1);
+    const ticks = await ticksForUser();
+    expect(new Set(ticks.map((tick) => tick.sessionId)).size).toBe(1);
+    expect(ticks[0].sessionId).not.toBeNull();
+  });
+
+  it('discovers an explicit session outside the initial twelve-hour radius', async () => {
+    const explicitId = uuidv4();
+    await db.insert(dbSchema.boardSessions).values({
+      id: explicitId,
+      boardPath: '/kilter/1/10/1,20/40',
+      createdByUserId: USER_ID,
+      status: 'ended',
+    });
+    await insertTick(BASE - 8 * HOUR);
+    await insertTick(BASE - 8 * HOUR + 15 * MINUTE);
+    await insertTick(BASE + 13 * HOUR, explicitId);
+    await reconcileAt(BASE - 8 * HOUR);
+    expect((await ticksForUser()).every((tick) => tick.sessionId === explicitId)).toBe(true);
+    expect(await sessionsForUser()).toHaveLength(1);
+  });
+
+  it('simulates connected days once, writes nothing, and matches apply on rerun', async () => {
+    await insertTick(BASE);
+    await insertTick(BASE + 14 * HOUR);
+    await insertTick(BASE + 16 * HOUR);
+    await insertTick(BASE + 26 * HOUR);
+    const beforeTicks = await ticksForUser();
+    const messages = vi.spyOn(logger, 'info');
+    try {
+      expect(await runBackfill(parseArgs(['--user', USER_ID, '--simulate']))).toBe(0);
+      expect(await ticksForUser()).toEqual(beforeTicks);
+      expect(await sessionsForUser()).toEqual([]);
+      expect(messages).toHaveBeenCalledWith(expect.stringContaining('would create 1 session(s)'));
+      expect(await runBackfill(parseArgs(['--user', USER_ID, '--apply']))).toBe(0);
+      const sessions = await sessionsForUser();
+      expect(sessions).toHaveLength(1);
+      const ticks = await ticksForUser();
+      expect(new Set(ticks.map((tick) => tick.sessionId))).toEqual(new Set([sessions[0].id]));
+      expect(await runBackfill(parseArgs(['--user', USER_ID, '--apply']))).toBe(0);
+      expect(await sessionsForUser()).toEqual(sessions);
+      expect(await ticksForUser()).toEqual(ticks);
+    } finally {
+      messages.mockRestore();
+    }
+  });
+
+  it('leaves existing sessions and social rows untouched when a backfill would remove them', async () => {
+    await insertTick(BASE);
+    await reconcileAt(BASE);
+    const [original] = await sessionsForUser();
+    await db.insert(dbSchema.comments).values({
+      uuid: uuidv4(),
+      userId: USER_ID,
+      entityType: 'session',
+      entityId: original.id,
+      body: 'Keep my session',
+    });
+    const explicitId = uuidv4();
+    await db.insert(dbSchema.boardSessions).values({
+      id: explicitId,
+      boardPath: '/kilter/1/10/1,20/40',
+      createdByUserId: USER_ID,
+      status: 'ended',
+    });
+    await insertTick(BASE + 10 * HOUR, explicitId);
+    const beforeTicks = await ticksForUser();
+    const beforeSessions = await sessionsForUser();
+    expect(await runBackfill(parseArgs(['--user', USER_ID, '--apply']))).toBe(1);
+    expect(await ticksForUser()).toEqual(beforeTicks);
+    expect(await sessionsForUser()).toEqual(beforeSessions);
+    const comments = await db.select().from(dbSchema.comments).where(eq(dbSchema.comments.entityId, original.id));
+    expect(comments).toHaveLength(1);
+  });
+
+  it('refuses to reconcile a clipped window instead of splitting a long history', async () => {
+    for (let hours = -220; hours <= 220; hours += 4) await insertTick(BASE + hours * HOUR);
+    await expect(reconcileAt(BASE)).rejects.toThrow('truncated');
+    expect(await sessionsForUser()).toEqual([]);
+    expect((await ticksForUser()).every((tick) => tick.sessionId === null)).toBe(true);
+  });
+
+  it('refuses to move a tick between two explicit sessions in one run', async () => {
+    for (let index = 0; index < 2; index++) {
+      const explicitId = uuidv4();
+      await db.insert(dbSchema.boardSessions).values({
+        id: explicitId,
+        boardPath: '/kilter/1/10/1,20/40',
+        createdByUserId: USER_ID,
+        status: 'ended',
+      });
+      await insertTick(BASE + index * HOUR, explicitId);
+    }
+    const beforeTicks = await ticksForUser();
+    await expect(db.transaction((tx) => planReconciliation(tx, USER_ID, new Date(BASE)))).rejects.toThrow(
+      'explicit session',
+    );
+    expect(await ticksForUser()).toEqual(beforeTicks);
   });
 });

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -36,6 +36,7 @@ import { resolveMoonBoardTickAngle } from '@boardsesh/db/queries';
 import { captureBackendEvent } from '../../../services/analytics/posthog';
 import { logger } from '../../../utils/logger';
 import { reconcileInferredSessions } from '../../../services/inferred-sessions/reconcile';
+import { parseClimbedAt } from '../../../services/inferred-sessions/timestamps';
 import {
   acquireUserTickMutationLock,
   isDirectAuroraTwin,
@@ -720,7 +721,7 @@ export const tickMutations = {
       // logical ascent's rows share one climbed_at and would otherwise reconcile the
       // same window repeatedly.
       for (const climbedAt of new Set(affectedTicks.map((tick) => tick.climbedAt))) {
-        await reconcileInferredSessions(tx, userId, new Date(climbedAt));
+        await reconcileInferredSessions(tx, userId, parseClimbedAt(climbedAt));
       }
 
       return { affectedTicks, detachedBetaLinks: detachedBetaLinks.length > 0 };
@@ -1149,7 +1150,7 @@ export const tickMutations = {
         // transaction so the tick and its assignment commit together. Inert unless
         // INFERRED_SESSIONS_ENABLED is set. A tick that already carries an explicit
         // session still goes through, because the run around it may need redrawing.
-        await reconcileInferredSessions(tx, userId, new Date(createdTick.climbedAt));
+        await reconcileInferredSessions(tx, userId, parseClimbedAt(createdTick.climbedAt));
 
         return [createdTick];
       },
@@ -1464,7 +1465,7 @@ export const tickMutations = {
         ...existingTicks.map((tick) => tick.climbedAt),
         ...updatedTicks.map((tick) => tick.climbedAt),
       ])) {
-        await reconcileInferredSessions(tx, userId, new Date(climbedAt));
+        await reconcileInferredSessions(tx, userId, parseClimbedAt(climbedAt));
       }
 
       return { existingTicks, updatedTicks, updatedTarget, movedBetaLinks };

--- a/packages/backend/src/scripts/backfill-inferred-sessions.ts
+++ b/packages/backend/src/scripts/backfill-inferred-sessions.ts
@@ -17,9 +17,20 @@
  *
  * DRY RUN BY DEFAULT. `--apply` is the only thing that writes.
  *
+ * Two dry-run depths, because they cost very different amounts:
+ *   - default: counts the runs it would reconcile. One query per climber, seconds for
+ *     the fleet. Answers "how much work is there".
+ *   - `--simulate`: plans each run for real, reporting the sessions it would create, the
+ *     climbs an explicit session would absorb, merges, and the size/duration spread.
+ *     A query per run — minutes for one climber, hours for the fleet — so pair it with
+ *     `--user` or `--limit`.
+ *
  * Usage:
- *   # what would happen, no writes
+ *   # how much work is there — fast
  *   vp exec tsx packages/backend/src/scripts/backfill-inferred-sessions.ts
+ *
+ *   # what the grouping would actually look like for one climber
+ *   vp exec tsx packages/backend/src/scripts/backfill-inferred-sessions.ts --user <userId> --simulate
  *
  *   # one climber first — the sane way to start
  *   vp exec tsx packages/backend/src/scripts/backfill-inferred-sessions.ts --user <userId> --apply
@@ -33,11 +44,12 @@ import { asc, eq, isNull, sql } from 'drizzle-orm';
 import * as dbSchema from '@boardsesh/db/schema';
 import { SESSION_GAP_MS } from '@boardsesh/session-inference';
 import { db } from '../db/client';
-import { reconcileInferredSessions } from '../services/inferred-sessions/reconcile';
+import { planReconciliation, reconcileInferredSessions } from '../services/inferred-sessions/reconcile';
 import { logger } from '../utils/logger';
 
 type Options = {
   apply: boolean;
+  simulate: boolean;
   userId: string | null;
   limit: number | null;
   resumeFrom: string | null;
@@ -60,6 +72,7 @@ function parseArgs(argv: string[]): Options {
 
   return {
     apply: argv.includes('--apply'),
+    simulate: argv.includes('--simulate'),
     userId: value('--user'),
     limit: number('--limit', null),
     resumeFrom: value('--resume-from'),
@@ -157,6 +170,15 @@ async function main(): Promise<void> {
   let sessionsCreated = 0;
   let failed = 0;
   let lastUserId = '';
+  const plan = {
+    wouldCreate: 0,
+    absorbedRuns: 0,
+    absorbedTicks: 0,
+    merges: 0,
+    emptied: 0,
+    tickCounts: [] as number[],
+    durationsMin: [] as number[],
+  };
 
   for (const userId of userIds) {
     lastUserId = userId;
@@ -173,6 +195,27 @@ async function main(): Promise<void> {
           await db.transaction((tx) => reconcileInferredSessions(tx, userId, start));
         }
         sessionsCreated += (await countInferredSessions(userId)) - before;
+      } else if (options.simulate) {
+        // Exercise the real decisions rather than approximating them. Counting runs
+        // would say nothing about merges, or about how many climbs an explicit session
+        // is going to absorb — which is the part worth seeing before 63k sessions
+        // appear across everyone's history at once.
+        for (const start of starts) {
+          const planned = await db.transaction((tx) => planReconciliation(tx, userId, start, { ignoreFlag: true }));
+          if (!planned) continue;
+          for (const run of planned.result.runs) {
+            if (run.sessionId !== null && planned.explicitSessionIds.has(run.sessionId)) {
+              plan.absorbedRuns++;
+              plan.absorbedTicks += run.tickIds.length;
+            } else if (run.sessionId === null) {
+              plan.wouldCreate++;
+              plan.tickCounts.push(run.tickIds.length);
+              plan.durationsMin.push(Math.round((run.lastTickAt - run.firstTickAt) / 60000));
+            }
+          }
+          plan.merges += planned.result.merges.length;
+          plan.emptied += planned.result.emptiedSessionIds.length;
+        }
       }
     } catch (error) {
       failed++;
@@ -195,8 +238,30 @@ async function main(): Promise<void> {
     `[backfill-inferred-sessions] done — ${processed} climber(s), ${runsSeen} run(s), ` +
       `${sessionsCreated} session(s) created, ${failed} failure(s)`,
   );
+  if (!options.apply && options.simulate) {
+    const percentile = (values: number[], p: number): number => {
+      if (values.length === 0) return 0;
+      const sorted = [...values].sort((a, b) => a - b);
+      return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))];
+    };
+    logger.info(
+      `[backfill-inferred-sessions] would create ${plan.wouldCreate} session(s); ` +
+        `${plan.absorbedRuns} run(s) / ${plan.absorbedTicks} tick(s) absorbed by an explicit session; ` +
+        `${plan.merges} merge(s); ${plan.emptied} emptied`,
+    );
+    logger.info(
+      `[backfill-inferred-sessions] session size ticks p50=${percentile(plan.tickCounts, 0.5)} ` +
+        `p90=${percentile(plan.tickCounts, 0.9)} max=${Math.max(0, ...plan.tickCounts)} · ` +
+        `duration min p50=${percentile(plan.durationsMin, 0.5)} ` +
+        `p90=${percentile(plan.durationsMin, 0.9)} max=${Math.max(0, ...plan.durationsMin)} · ` +
+        `single-climb=${plan.tickCounts.filter((n) => n === 1).length}`,
+    );
+  }
   if (!options.apply) {
     logger.info('[backfill-inferred-sessions] dry run: nothing was written. Re-run with --apply to commit.');
+    if (!options.simulate) {
+      logger.info('[backfill-inferred-sessions] add --simulate to plan the real grouping (slower — a query per run).');
+    }
   }
   if (failed > 0) {
     logger.warn(`[backfill-inferred-sessions] resume the remainder with --resume-from ${lastUserId}`);

--- a/packages/backend/src/scripts/backfill-inferred-sessions.ts
+++ b/packages/backend/src/scripts/backfill-inferred-sessions.ts
@@ -1,53 +1,28 @@
 /**
- * Group every climber's existing ticks into inferred sessions.
+ * Backfill historical ticks with the live session reconciler. Dry-run by default.
  *
- * The write path (`saveTick`/`updateTick`/`deleteTick`) only reconciles climbs logged
- * from now on, so all history stays on the day-bucketed `daily:` cards until this runs.
- * Against production that is roughly 435k ticks resolving to ~63,584 sessions.
+ * Default mode counts non-overlapping reconciliation windows. --simulate reads the
+ * actual grouping in read-only transactions. --apply commits one complete window at
+ * a time and refuses plans that remove existing sessions or their social history.
+ * Windows include whole UTC days and connected midnight-crossing runs; a window may
+ * produce several sessions. See docs/inferred-sessions-backfill.md for rollout.
  *
- * It calls the same `reconcileInferredSessions` the live writers use — deliberately, so
- * there is one implementation of the rules rather than two. The previous generation of
- * this feature kept a separate SQL backfill alongside the TypeScript builder, and they
- * drifted: the SQL path's `ON CONFLICT DO UPDATE` *added* counts while the TS path
- * recomputed them, so a re-run silently double-counted.
- *
- * Idempotent and interruptible. `reconcileWindow` returns the same answer for a window
- * however many times it is applied, each run commits in its own transaction, and
- * `--resume-from` picks up where a stopped run left off.
- *
- * DRY RUN BY DEFAULT. `--apply` is the only thing that writes.
- *
- * Two dry-run depths, because they cost very different amounts:
- *   - default: counts the runs it would reconcile. One query per climber, seconds for
- *     the fleet. Answers "how much work is there".
- *   - `--simulate`: plans each run for real, reporting the sessions it would create, the
- *     climbs an explicit session would absorb, merges, and the size/duration spread.
- *     A query per run — minutes for one climber, hours for the fleet — so pair it with
- *     `--user` or `--limit`.
- *
- * Usage:
- *   # how much work is there — fast
- *   vp exec tsx packages/backend/src/scripts/backfill-inferred-sessions.ts
- *
- *   # what the grouping would actually look like for one climber
- *   vp exec tsx packages/backend/src/scripts/backfill-inferred-sessions.ts --user <userId> --simulate
- *
- *   # one climber first — the sane way to start
- *   vp exec tsx packages/backend/src/scripts/backfill-inferred-sessions.ts --user <userId> --apply
- *
- *   # the fleet, pacing between climbers, resuming after a stop
- *   vp exec tsx packages/backend/src/scripts/backfill-inferred-sessions.ts --apply --delay-ms 50
- *   vp exec tsx packages/backend/src/scripts/backfill-inferred-sessions.ts --apply --resume-from <userId>
+ * vp exec tsx packages/backend/src/scripts/backfill-inferred-sessions.ts --user <id> --simulate
+ * vp exec tsx packages/backend/src/scripts/backfill-inferred-sessions.ts --user <id> --apply
  */
 
-import { asc, eq, isNull, sql } from 'drizzle-orm';
+import { and, asc, eq, gte, isNull } from 'drizzle-orm';
 import * as dbSchema from '@boardsesh/db/schema';
-import { SESSION_GAP_MS } from '@boardsesh/session-inference';
+import { isReconciliationBoundary } from '@boardsesh/session-inference';
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+import { closePool } from '@boardsesh/db/client';
+import { parseClimbedAt } from '../services/inferred-sessions/timestamps';
 import { db } from '../db/client';
 import { planReconciliation, reconcileInferredSessions } from '../services/inferred-sessions/reconcile';
 import { logger } from '../utils/logger';
 
-type Options = {
+export type Options = {
   apply: boolean;
   simulate: boolean;
   userId: string | null;
@@ -57,27 +32,44 @@ type Options = {
   progressEvery: number;
 };
 
-function parseArgs(argv: string[]): Options {
-  const value = (flag: string): string | null => {
-    const index = argv.indexOf(flag);
-    return index === -1 || index === argv.length - 1 ? null : argv[index + 1];
-  };
-  const number = (flag: string, fallback: number | null): number | null => {
-    const raw = value(flag);
-    if (raw === null) return fallback;
-    const parsed = Number(raw);
-    if (!Number.isFinite(parsed) || parsed < 0) throw new Error(`${flag} must be a non-negative number`);
+export function parseArgs(argv: string[]): Options {
+  const flags = new Map<string, string>();
+  const switches = new Set(['--apply', '--simulate']);
+  const parameters = new Set(['--user', '--limit', '--resume-from', '--delay-ms', '--progress-every']);
+  for (let index = 0; index < argv.length; index++) {
+    const flag = argv[index];
+    if (flags.has(flag)) throw new Error(`Duplicate option: ${flag}`);
+    if (switches.has(flag)) {
+      flags.set(flag, 'true');
+    } else if (parameters.has(flag)) {
+      const argument = argv[++index];
+      if (!argument || argument.startsWith('--')) throw new Error(`${flag} requires a value`);
+      flags.set(flag, argument);
+    } else {
+      throw new Error(`Unknown option: ${flag}`);
+    }
+  }
+  if (flags.has('--apply') && flags.has('--simulate')) throw new Error('--apply and --simulate are mutually exclusive');
+  if (flags.has('--user') && flags.has('--resume-from'))
+    throw new Error('--user and --resume-from are mutually exclusive');
+  if (flags.has('--user') && flags.has('--limit')) throw new Error('--user and --limit are mutually exclusive');
+  const integer = (flag: string, fallback: number | null, minimum: number): number | null => {
+    const argument = flags.get(flag);
+    if (argument === undefined) return fallback;
+    const parsed = Number(argument);
+    if (!/^\d+$/.test(argument) || !Number.isSafeInteger(parsed) || parsed < minimum || parsed > 2147483647) {
+      throw new Error(`${flag} must be an integer between ${minimum} and 2147483647`);
+    }
     return parsed;
   };
-
   return {
-    apply: argv.includes('--apply'),
-    simulate: argv.includes('--simulate'),
-    userId: value('--user'),
-    limit: number('--limit', null),
-    resumeFrom: value('--resume-from'),
-    delayMs: number('--delay-ms', 0) ?? 0,
-    progressEvery: number('--progress-every', 100) ?? 100,
+    apply: flags.has('--apply'),
+    simulate: flags.has('--simulate'),
+    userId: flags.get('--user') ?? null,
+    limit: integer('--limit', null, 0),
+    resumeFrom: flags.get('--resume-from') ?? null,
+    delayMs: integer('--delay-ms', 0, 0) ?? 0,
+    progressEvery: integer('--progress-every', 100, 1) ?? 100,
   };
 }
 
@@ -96,63 +88,51 @@ async function usersNeedingBackfill(options: Options): Promise<string[]> {
   const rows = await db
     .selectDistinct({ userId: dbSchema.boardseshTicks.userId })
     .from(dbSchema.boardseshTicks)
-    .where(isNull(dbSchema.boardseshTicks.sessionId))
+    .where(
+      and(
+        isNull(dbSchema.boardseshTicks.sessionId),
+        options.resumeFrom ? gte(dbSchema.boardseshTicks.userId, options.resumeFrom) : undefined,
+      ),
+    )
     .orderBy(asc(dbSchema.boardseshTicks.userId));
 
-  let userIds = rows.map((row) => row.userId);
-  if (options.resumeFrom) {
-    const index = userIds.indexOf(options.resumeFrom);
-    userIds = index === -1 ? userIds.filter((id) => id >= options.resumeFrom!) : userIds.slice(index);
-  }
+  const userIds = rows.map((row) => row.userId);
   return options.limit === null ? userIds : userIds.slice(0, options.limit);
 }
 
 /**
- * One timestamp per run, from a climber's climb times in ascending order.
+ * One timestamp per non-overlapping reconciliation window, from a climber's climb times in ascending order.
  *
- * Reconciliation is window-scoped: a single call covers the whole run around the
- * timestamp it is given. Calling it per tick would mean 435k redundant passes over
- * windows already reconciled, so this picks the first climb of each run and lets each
- * call do the rest.
- *
- * Exported for tests — it is the only rule this script owns that the shared package
- * does not already cover.
+ * Split only at a >4h gap across different UTC days. Same-day runs need to see
+ * each other for lone-tick and explicit-session absorption. Midnight connections
+ * bring the next whole day into the same window, so simulation never counts it twice.
  */
-export function runStartTimestamps(ascendingClimbedAt: readonly number[]): number[] {
+export function reconciliationStartTimestamps(ascendingClimbedAt: readonly number[]): number[] {
   const starts: number[] = [];
   let previous: number | null = null;
   for (const climbedAt of ascendingClimbedAt) {
-    if (previous === null || climbedAt - previous > SESSION_GAP_MS) starts.push(climbedAt);
+    if (!Number.isFinite(climbedAt) || (previous !== null && climbedAt < previous)) {
+      throw new Error('Climb timestamps must be finite and sorted in ascending order');
+    }
+    if (previous === null || isReconciliationBoundary(previous, climbedAt)) starts.push(climbedAt);
     previous = climbedAt;
   }
   return starts;
 }
 
-async function runStartsForUser(userId: string): Promise<Date[]> {
+async function reconciliationStartsForUser(userId: string): Promise<Date[]> {
   const ticks = await db
     .select({ climbedAt: dbSchema.boardseshTicks.climbedAt })
     .from(dbSchema.boardseshTicks)
     .where(eq(dbSchema.boardseshTicks.userId, userId))
     .orderBy(asc(dbSchema.boardseshTicks.climbedAt), asc(dbSchema.boardseshTicks.id));
 
-  return runStartTimestamps(ticks.map((tick) => new Date(tick.climbedAt).getTime())).map(
+  return reconciliationStartTimestamps(ticks.map((tick) => parseClimbedAt(tick.climbedAt).getTime())).map(
     (epochMs) => new Date(epochMs),
   );
 }
 
-async function countInferredSessions(userId: string): Promise<number> {
-  const [row] = await db
-    .select({ total: sql<number>`COUNT(*)::int` })
-    .from(dbSchema.boardSessions)
-    .where(
-      sql`${dbSchema.boardSessions.createdByUserId} = ${userId} AND ${dbSchema.boardSessions.origin} = 'inferred'`,
-    );
-  return row?.total ?? 0;
-}
-
-async function main(): Promise<void> {
-  const options = parseArgs(process.argv.slice(2));
-
+export async function runBackfill(options: Options): Promise<number> {
   // The live gate is an env var read at call time, and the backfill must not depend on
   // whether writes happen to be switched on for normal traffic. `--apply` is this
   // script's own gate; without it nothing below ever reaches a write.
@@ -166,10 +146,10 @@ async function main(): Promise<void> {
   );
 
   let processed = 0;
-  let runsSeen = 0;
+  let windowsSeen = 0;
   let sessionsCreated = 0;
   let failed = 0;
-  let lastUserId = '';
+  let firstFailedUserId: string | null = null;
   const plan = {
     wouldCreate: 0,
     absorbedRuns: 0,
@@ -181,27 +161,33 @@ async function main(): Promise<void> {
   };
 
   for (const userId of userIds) {
-    lastUserId = userId;
+    logger.info(`[backfill-inferred-sessions] starting user=${userId}`);
     try {
-      const starts = await runStartsForUser(userId);
-      runsSeen += starts.length;
+      const starts = await reconciliationStartsForUser(userId);
+      windowsSeen += starts.length;
 
       if (options.apply) {
-        const before = await countInferredSessions(userId);
         for (const start of starts) {
-          // One transaction per run: an interrupted backfill leaves whole sessions
+          // One transaction per window: an interrupted backfill leaves whole sessions
           // behind, never a half-assigned one, and a single bad climber cannot roll
           // back the climbers already done.
-          await db.transaction((tx) => reconcileInferredSessions(tx, userId, start));
+          const applied = await db.transaction(
+            (tx) => reconcileInferredSessions(tx, userId, start, { preserveExistingSessions: true }),
+            { isolationLevel: 'serializable' },
+          );
+          if (applied) sessionsCreated += applied.runs.filter((run) => run.sessionId === null).length;
+          await sleep(options.delayMs);
         }
-        sessionsCreated += (await countInferredSessions(userId)) - before;
       } else if (options.simulate) {
         // Exercise the real decisions rather than approximating them. Counting runs
         // would say nothing about merges, or about how many climbs an explicit session
         // is going to absorb — which is the part worth seeing before 63k sessions
         // appear across everyone's history at once.
         for (const start of starts) {
-          const planned = await db.transaction((tx) => planReconciliation(tx, userId, start, { ignoreFlag: true }));
+          const planned = await db.transaction(
+            (tx) => planReconciliation(tx, userId, start, { ignoreFeatureFlag: true }),
+            { accessMode: 'read only', isolationLevel: 'repeatable read' },
+          );
           if (!planned) continue;
           for (const run of planned.result.runs) {
             if (run.sessionId !== null && planned.explicitSessionIds.has(run.sessionId)) {
@@ -215,28 +201,32 @@ async function main(): Promise<void> {
           }
           plan.merges += planned.result.merges.length;
           plan.emptied += planned.result.emptiedSessionIds.length;
+          await sleep(options.delayMs);
         }
       }
     } catch (error) {
       failed++;
+      firstFailedUserId ??= userId;
       // Keep going. One climber with unusual data should not strand the rest, and the
       // run is resumable from here if the failures turn out to matter.
-      logger.error(`[backfill-inferred-sessions] ${userId} failed: ${error instanceof Error ? error.message : error}`);
+      logger.error(
+        `[backfill-inferred-sessions] ${userId} failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
 
     processed++;
     if (processed % options.progressEvery === 0) {
       logger.info(
-        `[backfill-inferred-sessions] ${processed}/${userIds.length} climbers · ${runsSeen} runs · ` +
+        `[backfill-inferred-sessions] ${processed}/${userIds.length} climbers · ${windowsSeen} windows · ` +
           `${sessionsCreated} sessions created · ${failed} failed · last=${userId}`,
       );
     }
-    await sleep(options.delayMs);
+    if (!options.apply && !options.simulate) await sleep(options.delayMs);
   }
 
   logger.info(
-    `[backfill-inferred-sessions] done — ${processed} climber(s), ${runsSeen} run(s), ` +
-      `${sessionsCreated} session(s) created, ${failed} failure(s)`,
+    `[backfill-inferred-sessions] done — ${processed} climber(s), ${windowsSeen} window(s), ` +
+      `${sessionsCreated} sessions created, ${failed} failure(s)`,
   );
   if (!options.apply && options.simulate) {
     const percentile = (values: number[], p: number): number => {
@@ -249,32 +239,49 @@ async function main(): Promise<void> {
         `${plan.absorbedRuns} run(s) / ${plan.absorbedTicks} tick(s) absorbed by an explicit session; ` +
         `${plan.merges} merge(s); ${plan.emptied} emptied`,
     );
+    if (plan.merges > 0 || plan.emptied > 0) {
+      logger.warn(
+        '[backfill-inferred-sessions] apply will refuse windows that remove existing sessions; inspect these users first',
+      );
+    }
     logger.info(
       `[backfill-inferred-sessions] session size ticks p50=${percentile(plan.tickCounts, 0.5)} ` +
-        `p90=${percentile(plan.tickCounts, 0.9)} max=${Math.max(0, ...plan.tickCounts)} · ` +
+        `p90=${percentile(plan.tickCounts, 0.9)} max=${plan.tickCounts.reduce((largest, count) => Math.max(largest, count), 0)} · ` +
         `duration min p50=${percentile(plan.durationsMin, 0.5)} ` +
-        `p90=${percentile(plan.durationsMin, 0.9)} max=${Math.max(0, ...plan.durationsMin)} · ` +
+        `p90=${percentile(plan.durationsMin, 0.9)} max=${plan.durationsMin.reduce((largest, minutes) => Math.max(largest, minutes), 0)} · ` +
         `single-climb=${plan.tickCounts.filter((n) => n === 1).length}`,
     );
   }
   if (!options.apply) {
     logger.info('[backfill-inferred-sessions] dry run: nothing was written. Re-run with --apply to commit.');
     if (!options.simulate) {
-      logger.info('[backfill-inferred-sessions] add --simulate to plan the real grouping (slower — a query per run).');
+      logger.info(
+        '[backfill-inferred-sessions] add --simulate to plan the real grouping (slower — queries per window).',
+      );
     }
   }
   if (failed > 0) {
-    logger.warn(`[backfill-inferred-sessions] resume the remainder with --resume-from ${lastUserId}`);
+    const recoveryScope = options.userId ? `--user ${options.userId}` : `--resume-from ${firstFailedUserId}`;
+    const recoveryMode = options.apply ? ' --apply' : options.simulate ? ' --simulate' : '';
+    const recoveryLimit = options.limit !== null ? ` --limit ${options.limit}` : '';
+    logger.warn(
+      `[backfill-inferred-sessions] retry with ${recoveryScope}${recoveryMode}${recoveryLimit} --delay-ms ${options.delayMs}`,
+    );
   }
+  return failed > 0 ? 1 : 0;
 }
 
 // Only when executed directly. Importing this module (the run-splitting test does)
 // must not kick off a fleet-wide backfill.
-if (process.argv[1] && process.argv[1].includes('backfill-inferred-sessions')) {
-  main()
-    .then(() => process.exit(0))
-    .catch((error) => {
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  Promise.resolve()
+    .then(() => runBackfill(parseArgs(process.argv.slice(2))))
+    .then((exitCode) => {
+      process.exitCode = exitCode;
+    })
+    .catch((error: unknown) => {
       logger.error('[backfill-inferred-sessions] fatal:', error);
-      process.exit(1);
-    });
+      process.exitCode = 1;
+    })
+    .finally(() => closePool());
 }

--- a/packages/backend/src/scripts/backfill-inferred-sessions.ts
+++ b/packages/backend/src/scripts/backfill-inferred-sessions.ts
@@ -85,7 +85,7 @@ const sleep = (ms: number) => (ms > 0 ? new Promise((resolve) => setTimeout(reso
 async function usersNeedingBackfill(options: Options): Promise<string[]> {
   if (options.userId) return [options.userId];
 
-  const rows = await db
+  const query = db
     .selectDistinct({ userId: dbSchema.boardseshTicks.userId })
     .from(dbSchema.boardseshTicks)
     .where(
@@ -96,8 +96,8 @@ async function usersNeedingBackfill(options: Options): Promise<string[]> {
     )
     .orderBy(asc(dbSchema.boardseshTicks.userId));
 
-  const userIds = rows.map((row) => row.userId);
-  return options.limit === null ? userIds : userIds.slice(0, options.limit);
+  const rows = await (options.limit === null ? query : query.limit(options.limit));
+  return rows.map((row) => row.userId);
 }
 
 /**

--- a/packages/backend/src/scripts/backfill-inferred-sessions.ts
+++ b/packages/backend/src/scripts/backfill-inferred-sessions.ts
@@ -103,9 +103,9 @@ async function usersNeedingBackfill(options: Options): Promise<string[]> {
 /**
  * One timestamp per non-overlapping reconciliation window, from a climber's climb times in ascending order.
  *
- * Split only at a >4h gap across different UTC days. Same-day runs need to see
- * each other for lone-tick and explicit-session absorption. Midnight connections
- * bring the next whole day into the same window, so simulation never counts it twice.
+ * Partition broad reads at >8h gaps across different UTC days, keeping legacy
+ * same-day anchors visible for repair. Actual groups always split at >8h gaps.
+ * Connected read windows are counted once, even when they contain several groups.
  */
 export function reconciliationStartTimestamps(ascendingClimbedAt: readonly number[]): number[] {
   const starts: number[] = [];

--- a/packages/backend/src/scripts/backfill-inferred-sessions.ts
+++ b/packages/backend/src/scripts/backfill-inferred-sessions.ts
@@ -172,7 +172,11 @@ export async function runBackfill(options: Options): Promise<number> {
           // behind, never a half-assigned one, and a single bad climber cannot roll
           // back the climbers already done.
           const applied = await db.transaction(
-            (tx) => reconcileInferredSessions(tx, userId, start, { preserveExistingSessions: true }),
+            (tx) =>
+              reconcileInferredSessions(tx, userId, start, {
+                preserveExistingSessions: true,
+                rejectTruncatedWindow: true,
+              }),
             { isolationLevel: 'serializable' },
           );
           if (applied) sessionsCreated += applied.runs.filter((run) => run.sessionId === null).length;
@@ -185,7 +189,7 @@ export async function runBackfill(options: Options): Promise<number> {
         // appear across everyone's history at once.
         for (const start of starts) {
           const planned = await db.transaction(
-            (tx) => planReconciliation(tx, userId, start, { ignoreFeatureFlag: true }),
+            (tx) => planReconciliation(tx, userId, start, { ignoreFeatureFlag: true, rejectTruncatedWindow: true }),
             { accessMode: 'read only', isolationLevel: 'repeatable read' },
           );
           if (!planned) continue;

--- a/packages/backend/src/scripts/backfill-inferred-sessions.ts
+++ b/packages/backend/src/scripts/backfill-inferred-sessions.ts
@@ -1,0 +1,215 @@
+/**
+ * Group every climber's existing ticks into inferred sessions.
+ *
+ * The write path (`saveTick`/`updateTick`/`deleteTick`) only reconciles climbs logged
+ * from now on, so all history stays on the day-bucketed `daily:` cards until this runs.
+ * Against production that is roughly 435k ticks resolving to ~63,584 sessions.
+ *
+ * It calls the same `reconcileInferredSessions` the live writers use — deliberately, so
+ * there is one implementation of the rules rather than two. The previous generation of
+ * this feature kept a separate SQL backfill alongside the TypeScript builder, and they
+ * drifted: the SQL path's `ON CONFLICT DO UPDATE` *added* counts while the TS path
+ * recomputed them, so a re-run silently double-counted.
+ *
+ * Idempotent and interruptible. `reconcileWindow` returns the same answer for a window
+ * however many times it is applied, each run commits in its own transaction, and
+ * `--resume-from` picks up where a stopped run left off.
+ *
+ * DRY RUN BY DEFAULT. `--apply` is the only thing that writes.
+ *
+ * Usage:
+ *   # what would happen, no writes
+ *   vp exec tsx packages/backend/src/scripts/backfill-inferred-sessions.ts
+ *
+ *   # one climber first — the sane way to start
+ *   vp exec tsx packages/backend/src/scripts/backfill-inferred-sessions.ts --user <userId> --apply
+ *
+ *   # the fleet, pacing between climbers, resuming after a stop
+ *   vp exec tsx packages/backend/src/scripts/backfill-inferred-sessions.ts --apply --delay-ms 50
+ *   vp exec tsx packages/backend/src/scripts/backfill-inferred-sessions.ts --apply --resume-from <userId>
+ */
+
+import { asc, eq, isNull, sql } from 'drizzle-orm';
+import * as dbSchema from '@boardsesh/db/schema';
+import { SESSION_GAP_MS } from '@boardsesh/session-inference';
+import { db } from '../db/client';
+import { reconcileInferredSessions } from '../services/inferred-sessions/reconcile';
+import { logger } from '../utils/logger';
+
+type Options = {
+  apply: boolean;
+  userId: string | null;
+  limit: number | null;
+  resumeFrom: string | null;
+  delayMs: number;
+  progressEvery: number;
+};
+
+function parseArgs(argv: string[]): Options {
+  const value = (flag: string): string | null => {
+    const index = argv.indexOf(flag);
+    return index === -1 || index === argv.length - 1 ? null : argv[index + 1];
+  };
+  const number = (flag: string, fallback: number | null): number | null => {
+    const raw = value(flag);
+    if (raw === null) return fallback;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed < 0) throw new Error(`${flag} must be a non-negative number`);
+    return parsed;
+  };
+
+  return {
+    apply: argv.includes('--apply'),
+    userId: value('--user'),
+    limit: number('--limit', null),
+    resumeFrom: value('--resume-from'),
+    delayMs: number('--delay-ms', 0) ?? 0,
+    progressEvery: number('--progress-every', 100) ?? 100,
+  };
+}
+
+const sleep = (ms: number) => (ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve());
+
+/**
+ * Climbers with at least one tick that belongs to no session, oldest id first.
+ *
+ * Ordering by user id rather than by volume is what makes `--resume-from` meaningful:
+ * the sequence is stable across runs, so a stopped run resumes at a known point instead
+ * of re-walking climbers it already finished.
+ */
+async function usersNeedingBackfill(options: Options): Promise<string[]> {
+  if (options.userId) return [options.userId];
+
+  const rows = await db
+    .selectDistinct({ userId: dbSchema.boardseshTicks.userId })
+    .from(dbSchema.boardseshTicks)
+    .where(isNull(dbSchema.boardseshTicks.sessionId))
+    .orderBy(asc(dbSchema.boardseshTicks.userId));
+
+  let userIds = rows.map((row) => row.userId);
+  if (options.resumeFrom) {
+    const index = userIds.indexOf(options.resumeFrom);
+    userIds = index === -1 ? userIds.filter((id) => id >= options.resumeFrom!) : userIds.slice(index);
+  }
+  return options.limit === null ? userIds : userIds.slice(0, options.limit);
+}
+
+/**
+ * One timestamp per run, from a climber's climb times in ascending order.
+ *
+ * Reconciliation is window-scoped: a single call covers the whole run around the
+ * timestamp it is given. Calling it per tick would mean 435k redundant passes over
+ * windows already reconciled, so this picks the first climb of each run and lets each
+ * call do the rest.
+ *
+ * Exported for tests — it is the only rule this script owns that the shared package
+ * does not already cover.
+ */
+export function runStartTimestamps(ascendingClimbedAt: readonly number[]): number[] {
+  const starts: number[] = [];
+  let previous: number | null = null;
+  for (const climbedAt of ascendingClimbedAt) {
+    if (previous === null || climbedAt - previous > SESSION_GAP_MS) starts.push(climbedAt);
+    previous = climbedAt;
+  }
+  return starts;
+}
+
+async function runStartsForUser(userId: string): Promise<Date[]> {
+  const ticks = await db
+    .select({ climbedAt: dbSchema.boardseshTicks.climbedAt })
+    .from(dbSchema.boardseshTicks)
+    .where(eq(dbSchema.boardseshTicks.userId, userId))
+    .orderBy(asc(dbSchema.boardseshTicks.climbedAt), asc(dbSchema.boardseshTicks.id));
+
+  return runStartTimestamps(ticks.map((tick) => new Date(tick.climbedAt).getTime())).map(
+    (epochMs) => new Date(epochMs),
+  );
+}
+
+async function countInferredSessions(userId: string): Promise<number> {
+  const [row] = await db
+    .select({ total: sql<number>`COUNT(*)::int` })
+    .from(dbSchema.boardSessions)
+    .where(
+      sql`${dbSchema.boardSessions.createdByUserId} = ${userId} AND ${dbSchema.boardSessions.origin} = 'inferred'`,
+    );
+  return row?.total ?? 0;
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+
+  // The live gate is an env var read at call time, and the backfill must not depend on
+  // whether writes happen to be switched on for normal traffic. `--apply` is this
+  // script's own gate; without it nothing below ever reaches a write.
+  if (options.apply) process.env.INFERRED_SESSIONS_ENABLED = 'true';
+
+  const userIds = await usersNeedingBackfill(options);
+  logger.info(
+    `[backfill-inferred-sessions] ${options.apply ? 'APPLYING' : 'DRY RUN'} — ${userIds.length} climber(s)` +
+      (options.resumeFrom ? ` resuming from ${options.resumeFrom}` : '') +
+      (options.limit !== null ? ` (limited to ${options.limit})` : ''),
+  );
+
+  let processed = 0;
+  let runsSeen = 0;
+  let sessionsCreated = 0;
+  let failed = 0;
+  let lastUserId = '';
+
+  for (const userId of userIds) {
+    lastUserId = userId;
+    try {
+      const starts = await runStartsForUser(userId);
+      runsSeen += starts.length;
+
+      if (options.apply) {
+        const before = await countInferredSessions(userId);
+        for (const start of starts) {
+          // One transaction per run: an interrupted backfill leaves whole sessions
+          // behind, never a half-assigned one, and a single bad climber cannot roll
+          // back the climbers already done.
+          await db.transaction((tx) => reconcileInferredSessions(tx, userId, start));
+        }
+        sessionsCreated += (await countInferredSessions(userId)) - before;
+      }
+    } catch (error) {
+      failed++;
+      // Keep going. One climber with unusual data should not strand the rest, and the
+      // run is resumable from here if the failures turn out to matter.
+      logger.error(`[backfill-inferred-sessions] ${userId} failed: ${error instanceof Error ? error.message : error}`);
+    }
+
+    processed++;
+    if (processed % options.progressEvery === 0) {
+      logger.info(
+        `[backfill-inferred-sessions] ${processed}/${userIds.length} climbers · ${runsSeen} runs · ` +
+          `${sessionsCreated} sessions created · ${failed} failed · last=${userId}`,
+      );
+    }
+    await sleep(options.delayMs);
+  }
+
+  logger.info(
+    `[backfill-inferred-sessions] done — ${processed} climber(s), ${runsSeen} run(s), ` +
+      `${sessionsCreated} session(s) created, ${failed} failure(s)`,
+  );
+  if (!options.apply) {
+    logger.info('[backfill-inferred-sessions] dry run: nothing was written. Re-run with --apply to commit.');
+  }
+  if (failed > 0) {
+    logger.warn(`[backfill-inferred-sessions] resume the remainder with --resume-from ${lastUserId}`);
+  }
+}
+
+// Only when executed directly. Importing this module (the run-splitting test does)
+// must not kick off a fleet-wide backfill.
+if (process.argv[1] && process.argv[1].includes('backfill-inferred-sessions')) {
+  main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      logger.error('[backfill-inferred-sessions] fatal:', error);
+      process.exit(1);
+    });
+}

--- a/packages/backend/src/services/inferred-sessions/reconcile.ts
+++ b/packages/backend/src/services/inferred-sessions/reconcile.ts
@@ -8,7 +8,7 @@ import {
   type ReconcileResult,
   type SessionMerge,
 } from '@boardsesh/session-inference';
-import { logger } from '../../utils/logger';
+import { parseClimbedAt } from './timestamps';
 import { loadReconciliationWindow, type ReconciliationTransaction } from './window-loader';
 
 /**
@@ -49,19 +49,6 @@ async function applyMerge(tx: ReconciliationTransaction, merge: SessionMerge): P
 }
 
 /**
- * Reassign the ticks around `touchedAt` to the sessions they belong to.
- *
- * Runs inside the caller's transaction so a tick and its session assignment commit or
- * roll back together. Safe to call from every writer — save, edit, delete, importer,
- * offline drain — because {@link reconcileWindow} returns the same answer for a window
- * however many times it is applied.
- *
- * Concurrency is settled by the unique partial index on `board_sessions.anchor_tick_id`:
- * two writers reconciling the same unassigned run both decide to create a session, and
- * the loser's insert raises a unique violation that rolls its transaction back. The
- * caller retries the tick write, and the second pass finds the anchor and inherits it.
- */
-/**
  * Work out what reconciliation WOULD do to the window around `touchedAt`, reading only.
  *
  * Split out from the write path so a dry run exercises the real decisions rather than
@@ -75,15 +62,13 @@ export async function planReconciliation(
   tx: ReconciliationTransaction,
   userId: string,
   touchedAt: Date,
-  options: { ignoreFlag?: boolean } = {},
+  options: { ignoreFeatureFlag?: boolean } = {},
 ): Promise<PlannedReconciliation | null> {
-  if (!options.ignoreFlag && !inferredSessionsEnabled()) return null;
+  if (!options.ignoreFeatureFlag && !inferredSessionsEnabled()) return null;
 
   const { ticks, truncated } = await loadReconciliationWindow(tx, userId, touchedAt);
   if (truncated) {
-    logger.warn(
-      `[inferredSessions] window for ${userId} around ${touchedAt.toISOString()} hit the widening ceiling; reconciling the clipped range`,
-    );
+    throw new Error(`Reconciliation window for ${userId} around ${touchedAt.toISOString()} is truncated`);
   }
   if (ticks.length === 0) return null;
 
@@ -136,11 +121,21 @@ export async function planReconciliation(
     .filter((row): row is typeof row & { sessionId: string } => row.sessionId !== null)
     .map((row) => ({
       id: row.sessionId,
-      firstTickAt: new Date(row.firstTickAt).getTime(),
-      lastTickAt: new Date(row.lastTickAt).getTime(),
+      firstTickAt: parseClimbedAt(row.firstTickAt).getTime(),
+      lastTickAt: parseClimbedAt(row.lastTickAt).getTime(),
     }));
 
   const result = reconcileWindow({ ticks, existingInferred, existingExplicit });
+  const explicitSessionIds = new Set(explicitIds);
+  const originalAssignments = new Map(ticks.map((tick) => [tick.id, tick.sessionId]));
+  for (const run of result.runs) {
+    for (const tickId of run.tickIds) {
+      const originalSessionId = originalAssignments.get(tickId);
+      if (originalSessionId && explicitSessionIds.has(originalSessionId) && originalSessionId !== run.sessionId) {
+        throw new Error(`Reconciliation would move tick ${tickId} out of its explicit session`);
+      }
+    }
+  }
   return { result, explicitSessionIds: new Set(existingExplicit.map((session) => session.id)) };
 }
 
@@ -161,10 +156,17 @@ export async function reconcileInferredSessions(
   tx: ReconciliationTransaction,
   userId: string,
   touchedAt: Date,
-): Promise<void> {
+  options: { preserveExistingSessions?: boolean } = {},
+): Promise<ReconcileResult | null> {
   const planned = await planReconciliation(tx, userId, touchedAt);
-  if (!planned) return;
+  if (!planned) return null;
   const { result } = planned;
+
+  // Backfills must leave existing sessions and their social history for a separate,
+  // reviewed repair. The normal reconciler below can delete emptied social rows.
+  if (options.preserveExistingSessions && (result.merges.length > 0 || result.emptiedSessionIds.length > 0)) {
+    throw new Error('Reconciliation requires removing existing sessions; inspect this user before retrying');
+  }
 
   for (const merge of result.merges) {
     await applyMerge(tx, merge);
@@ -239,6 +241,7 @@ export async function reconcileInferredSessions(
         ),
       );
   }
+  return result;
 }
 
 /** Convenience for callers holding a `climbed_at` string rather than a Date. */
@@ -247,5 +250,5 @@ export async function reconcileInferredSessionsAt(
   userId: string,
   climbedAt: string | Date,
 ): Promise<void> {
-  await reconcileInferredSessions(tx, userId, climbedAt instanceof Date ? climbedAt : new Date(climbedAt));
+  await reconcileInferredSessions(tx, userId, climbedAt instanceof Date ? climbedAt : parseClimbedAt(climbedAt));
 }

--- a/packages/backend/src/services/inferred-sessions/reconcile.ts
+++ b/packages/backend/src/services/inferred-sessions/reconcile.ts
@@ -9,6 +9,7 @@ import {
   type SessionMerge,
 } from '@boardsesh/session-inference';
 import { parseClimbedAt } from './timestamps';
+import { logger } from '../../utils/logger';
 import { loadReconciliationWindow, type ReconciliationTransaction } from './window-loader';
 
 /**
@@ -62,13 +63,16 @@ export async function planReconciliation(
   tx: ReconciliationTransaction,
   userId: string,
   touchedAt: Date,
-  options: { ignoreFeatureFlag?: boolean } = {},
+  options: { ignoreFeatureFlag?: boolean; rejectTruncatedWindow?: boolean } = {},
 ): Promise<PlannedReconciliation | null> {
   if (!options.ignoreFeatureFlag && !inferredSessionsEnabled()) return null;
 
   const { ticks, truncated } = await loadReconciliationWindow(tx, userId, touchedAt);
   if (truncated) {
-    throw new Error(`Reconciliation window for ${userId} around ${touchedAt.toISOString()} is truncated`);
+    const message = `Reconciliation window for ${userId} around ${touchedAt.toISOString()} is truncated`;
+    if (options.rejectTruncatedWindow) throw new Error(message);
+    logger.warn(`[inferredSessions] ${message}; leaving assignments unchanged`);
+    return null;
   }
   if (ticks.length === 0) return null;
 
@@ -156,9 +160,11 @@ export async function reconcileInferredSessions(
   tx: ReconciliationTransaction,
   userId: string,
   touchedAt: Date,
-  options: { preserveExistingSessions?: boolean } = {},
+  options: { preserveExistingSessions?: boolean; rejectTruncatedWindow?: boolean } = {},
 ): Promise<ReconcileResult | null> {
-  const planned = await planReconciliation(tx, userId, touchedAt);
+  const planned = await planReconciliation(tx, userId, touchedAt, {
+    rejectTruncatedWindow: options.rejectTruncatedWindow,
+  });
   if (!planned) return null;
   const { result } = planned;
 

--- a/packages/backend/src/services/inferred-sessions/reconcile.ts
+++ b/packages/backend/src/services/inferred-sessions/reconcile.ts
@@ -5,6 +5,7 @@ import {
   reconcileWindow,
   type ExistingExplicitSession,
   type ExistingInferredSession,
+  type ReconcileResult,
   type SessionMerge,
 } from '@boardsesh/session-inference';
 import { logger } from '../../utils/logger';
@@ -21,6 +22,13 @@ import { loadReconciliationWindow, type ReconciliationTransaction } from './wind
 export function inferredSessionsEnabled(): boolean {
   return process.env.INFERRED_SESSIONS_ENABLED === 'true';
 }
+
+/** What a reconciliation would do, before anything is written. */
+export type PlannedReconciliation = {
+  result: ReconcileResult;
+  /** Ids in `result.runs` that belong to explicit sessions rather than inferred ones. */
+  explicitSessionIds: Set<string>;
+};
 
 /** Move a merged-away session's social rows onto the survivor, then drop the session. */
 async function applyMerge(tx: ReconciliationTransaction, merge: SessionMerge): Promise<void> {
@@ -53,12 +61,23 @@ async function applyMerge(tx: ReconciliationTransaction, merge: SessionMerge): P
  * the loser's insert raises a unique violation that rolls its transaction back. The
  * caller retries the tick write, and the second pass finds the anchor and inherits it.
  */
-export async function reconcileInferredSessions(
+/**
+ * Work out what reconciliation WOULD do to the window around `touchedAt`, reading only.
+ *
+ * Split out from the write path so a dry run exercises the real decisions rather than
+ * approximating them. The backfill's job is to convince a human that ~63k sessions are
+ * about to be created correctly, and counting runs does not do that — this returns the
+ * merges, the absorptions and the sessions that would be minted.
+ *
+ * Returns null when the flag is off or the window holds no ticks.
+ */
+export async function planReconciliation(
   tx: ReconciliationTransaction,
   userId: string,
   touchedAt: Date,
-): Promise<void> {
-  if (!inferredSessionsEnabled()) return;
+  options: { ignoreFlag?: boolean } = {},
+): Promise<PlannedReconciliation | null> {
+  if (!options.ignoreFlag && !inferredSessionsEnabled()) return null;
 
   const { ticks, truncated } = await loadReconciliationWindow(tx, userId, touchedAt);
   if (truncated) {
@@ -66,7 +85,7 @@ export async function reconcileInferredSessions(
       `[inferredSessions] window for ${userId} around ${touchedAt.toISOString()} hit the widening ceiling; reconciling the clipped range`,
     );
   }
-  if (ticks.length === 0) return;
+  if (ticks.length === 0) return null;
 
   const tickIds = ticks.map((tick) => tick.id);
   const assignedIds = [...new Set(ticks.map((tick) => tick.sessionId).filter((id): id is string => id !== null))];
@@ -122,6 +141,30 @@ export async function reconcileInferredSessions(
     }));
 
   const result = reconcileWindow({ ticks, existingInferred, existingExplicit });
+  return { result, explicitSessionIds: new Set(existingExplicit.map((session) => session.id)) };
+}
+
+/**
+ * Reassign the ticks around `touchedAt` to the sessions they belong to.
+ *
+ * Runs inside the caller's transaction so a tick and its session assignment commit or
+ * roll back together. Safe to call from every writer — save, edit, delete, importer,
+ * offline drain — because {@link reconcileWindow} returns the same answer for a window
+ * however many times it is applied.
+ *
+ * Concurrency is settled by the unique partial index on `board_sessions.anchor_tick_id`:
+ * two writers reconciling the same unassigned run both decide to create a session, and
+ * the loser's insert raises a unique violation that rolls its transaction back. The
+ * caller retries the tick write, and the second pass finds the anchor and inherits it.
+ */
+export async function reconcileInferredSessions(
+  tx: ReconciliationTransaction,
+  userId: string,
+  touchedAt: Date,
+): Promise<void> {
+  const planned = await planReconciliation(tx, userId, touchedAt);
+  if (!planned) return;
+  const { result } = planned;
 
   for (const merge of result.merges) {
     await applyMerge(tx, merge);

--- a/packages/backend/src/services/inferred-sessions/reconcile.ts
+++ b/packages/backend/src/services/inferred-sessions/reconcile.ts
@@ -104,30 +104,11 @@ export async function planReconciliation(
     .filter((row) => row.origin === 'inferred')
     .map((row) => ({ id: row.id, anchorTickId: row.anchorTickId, userEdited: row.userEdited }));
 
-  // Explicit sessions are matched by day, so their own tick spans are what matter —
-  // not the window's bounds, which is why this reads the ticks rather than the session
-  // rows' started_at/ended_at (those are wall-clock, and an inferred day is derived
-  // from climbed_at).
-  const explicitIds = sessionRows.filter((row) => row.origin === 'explicit').map((row) => row.id);
-  const explicitSpans = explicitIds.length
-    ? await tx
-        .select({
-          sessionId: dbSchema.boardseshTicks.sessionId,
-          firstTickAt: sql<string>`MIN(${dbSchema.boardseshTicks.climbedAt})`,
-          lastTickAt: sql<string>`MAX(${dbSchema.boardseshTicks.climbedAt})`,
-        })
-        .from(dbSchema.boardseshTicks)
-        .where(inArray(dbSchema.boardseshTicks.sessionId, explicitIds))
-        .groupBy(dbSchema.boardseshTicks.sessionId)
-    : [];
-
-  const existingExplicit: ExistingExplicitSession[] = explicitSpans
-    .filter((row): row is typeof row & { sessionId: string } => row.sessionId !== null)
-    .map((row) => ({
-      id: row.sessionId,
-      firstTickAt: parseClimbedAt(row.firstTickAt).getTime(),
-      lastTickAt: parseClimbedAt(row.lastTickAt).getTime(),
-    }));
+  // Eligibility comes from this user's assigned ticks within each connected run.
+  const existingExplicit: ExistingExplicitSession[] = sessionRows
+    .filter((row) => row.origin === 'explicit')
+    .map((row) => ({ id: row.id }));
+  const explicitIds = existingExplicit.map((session) => session.id);
 
   const result = reconcileWindow({ ticks, existingInferred, existingExplicit });
   const explicitSessionIds = new Set(explicitIds);

--- a/packages/backend/src/services/inferred-sessions/timestamps.ts
+++ b/packages/backend/src/services/inferred-sessions/timestamps.ts
@@ -1,0 +1,7 @@
+/** climbed_at is a PostgreSQL timestamp without time zone, stored as UTC. */
+export function parseClimbedAt(climbedAt: string): Date {
+  const normalized = climbedAt.replace(' ', 'T');
+  const parsed = new Date(/(?:Z|[+-]\d{2}(?::?\d{2})?)$/i.test(normalized) ? normalized : `${normalized}Z`);
+  if (!Number.isFinite(parsed.getTime())) throw new Error('Invalid climb timestamp');
+  return parsed;
+}

--- a/packages/backend/src/services/inferred-sessions/window-loader.ts
+++ b/packages/backend/src/services/inferred-sessions/window-loader.ts
@@ -1,7 +1,8 @@
 import { and, asc, eq, gte, lte } from 'drizzle-orm';
 import * as dbSchema from '@boardsesh/db/schema';
-import { SESSION_GAP_MS, expandWindow, type InferenceTick } from '@boardsesh/session-inference';
+import { expandReconciliationWindow, isReconciliationBoundary, type InferenceTick } from '@boardsesh/session-inference';
 import { db } from '../../db/client';
+import { parseClimbedAt } from './timestamps';
 
 /**
  * The transaction handle the tick mutations already open. Reconciliation runs inside
@@ -14,22 +15,21 @@ export type ReconciliationTransaction = Parameters<Parameters<typeof db.transact
 /**
  * How wide a slice of the climber's ticks to pull on the first attempt.
  *
- * Runs are short — median 5 ticks, p90 15, and only 1.2% span midnight — so half a day
- * either side covers essentially every one in a single query.
+ * Start with half a day either side, then widen until both the gap and whole-day
+ * rules are bounded. Early/late climbing and midnight connections need wider reads.
  */
 const INITIAL_RADIUS_MS = 12 * 60 * 60 * 1000;
 
 /**
  * Give up widening after this many doublings (12h → 192h).
  *
- * Reaching it would mean an unbroken chain of ticks less than 4h apart stretching over
- * a week, which is not climbing. Bailing out keeps a pathological row from turning one
- * tick write into an unbounded scan.
+ * Repeated midnight connections can join many days into one window. Stop after this
+ * budget and let the caller reject the incomplete window rather than split history.
  */
 const MAX_WIDENINGS = 4;
 
 type LoadedWindow = {
-  /** Ticks in the gap-bounded window, ascending by climbedAt. */
+  /** Ticks in the gap- and UTC-day-bounded window, ascending by climbedAt. */
   ticks: InferenceTick[];
   /** True when widening hit its ceiling and the window may still be clipped. */
   truncated: boolean;
@@ -38,14 +38,14 @@ type LoadedWindow = {
 function toInferenceTick(row: { id: bigint | number; climbedAt: string; sessionId: string | null }): InferenceTick {
   return {
     id: Number(row.id),
-    climbedAt: new Date(row.climbedAt).getTime(),
+    climbedAt: parseClimbedAt(row.climbedAt).getTime(),
     sessionId: row.sessionId,
   };
 }
 
 /**
  * Load every tick belonging to the run(s) around `touchedAt`, bounded on both sides by
- * a real gap.
+ * a >4h gap across different UTC days.
  *
  * Reconciliation is only correct over complete runs: a window that stops mid-run would
  * let it split that run in half. The obvious query — "everything within 12h" — cannot
@@ -53,8 +53,8 @@ function toInferenceTick(row: { id: bigint | number; climbedAt: string; sessionI
  * expands within it, and reloads wider if the expansion reached the block's boundary
  * with no gap to stop at.
  *
- * In practice the first query is enough; the loop exists so that the guarantee holds
- * rather than usually holding.
+ * Expand complete UTC days as well: same-day lone ticks and explicit sessions must
+ * be visible even across a >4h gap.
  */
 export async function loadReconciliationWindow(
   tx: ReconciliationTransaction,
@@ -87,15 +87,17 @@ export async function loadReconciliationWindow(
     const loaded = rows.map(toInferenceTick);
     if (loaded.length === 0) return { ticks: [], truncated: false };
 
-    const windowTicks = expandWindow(loaded, centre, centre);
+    const windowTicks = expandReconciliationWindow(loaded, centre, centre);
     if (windowTicks.length === 0) return { ticks: [], truncated: false };
 
-    // Expansion stops at a >4h gap. If it instead stopped because it ran out of loaded
-    // rows, there may be more of this run just outside the block — widen and retry.
-    const clippedStart = windowTicks[0].id === loaded[0].id && loaded[0].climbedAt - from.getTime() <= SESSION_GAP_MS;
+    // A safe edge needs both a >4h gap and a different UTC day. If either rule
+    // could reach past the loaded block, widen before making any assignments.
+    const clippedStart =
+      windowTicks[0].id === loaded[0].id && !isReconciliationBoundary(from.getTime(), loaded[0].climbedAt);
     const lastLoaded = loaded[loaded.length - 1];
     const clippedEnd =
-      windowTicks[windowTicks.length - 1].id === lastLoaded.id && to.getTime() - lastLoaded.climbedAt <= SESSION_GAP_MS;
+      windowTicks[windowTicks.length - 1].id === lastLoaded.id &&
+      !isReconciliationBoundary(lastLoaded.climbedAt, to.getTime());
 
     if (!clippedStart && !clippedEnd) return { ticks: windowTicks, truncated: false };
 

--- a/packages/backend/src/services/inferred-sessions/window-loader.ts
+++ b/packages/backend/src/services/inferred-sessions/window-loader.ts
@@ -1,6 +1,11 @@
 import { and, asc, eq, gte, lte } from 'drizzle-orm';
 import * as dbSchema from '@boardsesh/db/schema';
-import { expandReconciliationWindow, isReconciliationBoundary, type InferenceTick } from '@boardsesh/session-inference';
+import {
+  SESSION_GAP_MS,
+  expandReconciliationWindow,
+  isReconciliationBoundary,
+  type InferenceTick,
+} from '@boardsesh/session-inference';
 import { db } from '../../db/client';
 import { parseClimbedAt } from './timestamps';
 
@@ -62,11 +67,15 @@ export async function loadReconciliationWindow(
   touchedAt: Date,
 ): Promise<LoadedWindow> {
   const centre = touchedAt.getTime();
+  const dayStart = Date.UTC(touchedAt.getUTCFullYear(), touchedAt.getUTCMonth(), touchedAt.getUTCDate());
+  const dayEnd = dayStart + 24 * 60 * 60 * 1000 - 1;
   let radius = INITIAL_RADIUS_MS;
 
   for (let attempt = 0; attempt <= MAX_WIDENINGS; attempt++) {
-    const from = new Date(centre - radius);
-    const to = new Date(centre + radius);
+    // Load the complete touched day plus a gap on each side immediately, avoiding
+    // an extra query for ordinary morning/evening ticks. Connected days can widen.
+    const from = new Date(Math.min(centre - radius, dayStart - SESSION_GAP_MS - 1));
+    const to = new Date(Math.max(centre + radius, dayEnd + SESSION_GAP_MS + 1));
 
     const rows = await tx
       .select({

--- a/packages/backend/src/services/inferred-sessions/window-loader.ts
+++ b/packages/backend/src/services/inferred-sessions/window-loader.ts
@@ -50,7 +50,7 @@ function toInferenceTick(row: { id: bigint | number; climbedAt: string; sessionI
 
 /**
  * Load every tick belonging to the run(s) around `touchedAt`, bounded on both sides by
- * a >4h gap across different UTC days.
+ * a >8h gap across different UTC days.
  *
  * Reconciliation is only correct over complete runs: a window that stops mid-run would
  * let it split that run in half. The obvious query — "everything within 12h" — cannot
@@ -58,8 +58,8 @@ function toInferenceTick(row: { id: bigint | number; climbedAt: string; sessionI
  * expands within it, and reloads wider if the expansion reached the block's boundary
  * with no gap to stop at.
  *
- * Expand complete UTC days as well: same-day lone ticks and explicit sessions must
- * be visible even across a >4h gap.
+ * Load complete UTC days as well so old same-day inferred assignments include their
+ * anchors when split. This is read padding, not a grouping override.
  */
 export async function loadReconciliationWindow(
   tx: ReconciliationTransaction,
@@ -99,7 +99,7 @@ export async function loadReconciliationWindow(
     const windowTicks = expandReconciliationWindow(loaded, centre, centre);
     if (windowTicks.length === 0) return { ticks: [], truncated: false };
 
-    // A safe edge needs both a >4h gap and a different UTC day. If either rule
+    // A safe edge needs both a >8h gap and a different UTC day. If either rule
     // could reach past the loaded block, widen before making any assignments.
     const clippedStart =
       windowTicks[0].id === loaded[0].id && !isReconciliationBoundary(from.getTime(), loaded[0].climbedAt);

--- a/packages/shared/session-inference/src/__tests__/reconcile.test.ts
+++ b/packages/shared/session-inference/src/__tests__/reconcile.test.ts
@@ -359,3 +359,65 @@ describe('expandReconciliationWindow', () => {
     }
   });
 });
+
+describe('multiple explicit sessions in a timing run', () => {
+  it('preserves explicit assignments and sends only loose ticks to the nearest session', () => {
+    const explicitSessions = [
+      explicit('morning', DAY_ONE, DAY_ONE + HOUR),
+      explicit('later', DAY_ONE + 2 * HOUR, DAY_ONE + 3 * HOUR),
+    ];
+    const ticks = [
+      tick(1, DAY_ONE, 'morning'),
+      tick(2, DAY_ONE + HOUR, 'morning'),
+      tick(3, DAY_ONE + HOUR + 5 * MINUTE),
+      tick(4, DAY_ONE + 2 * HOUR - 5 * MINUTE),
+      tick(5, DAY_ONE + 2 * HOUR, 'later'),
+      tick(6, DAY_ONE + 3 * HOUR, 'later'),
+    ];
+    const result = reconcile(ticks, [], explicitSessions);
+    expect(result.runs.map((run) => ({ sessionId: run.sessionId, tickIds: run.tickIds }))).toEqual([
+      { sessionId: 'morning', tickIds: [1, 2, 3] },
+      { sessionId: 'later', tickIds: [4, 5, 6] },
+    ]);
+    const assigned = ticks.map((tick) => ({
+      ...tick,
+      sessionId: result.runs.find((run) => run.tickIds.includes(tick.id))!.sessionId,
+    }));
+    expect(reconcile(assigned, [], explicitSessions)).toEqual(result);
+  });
+
+  it('preserves a lone explicit tick absorbed into another explicit session’s run', () => {
+    const ticks = [
+      tick(1, DAY_ONE, 'morning'),
+      tick(2, DAY_ONE + 10 * MINUTE, 'morning'),
+      tick(3, DAY_ONE + 10 * HOUR, 'later'),
+    ];
+    const result = reconcile(
+      ticks,
+      [],
+      [
+        explicit('morning', DAY_ONE, DAY_ONE + 10 * MINUTE),
+        explicit('later', DAY_ONE + 10 * HOUR, DAY_ONE + 10 * HOUR),
+      ],
+    );
+    expect(result.runs.map((run) => ({ sessionId: run.sessionId, tickIds: run.tickIds }))).toEqual([
+      { sessionId: 'morning', tickIds: [1, 2] },
+      { sessionId: 'later', tickIds: [3] },
+    ]);
+  });
+});
+
+describe('explicit sessions crossing midnight', () => {
+  it('settles same-day absorption before creating a session that the next pass would empty', () => {
+    const midnight = Date.UTC(2026, 8, 2);
+    const ticks = [
+      tick(1, midnight - 14 * HOUR),
+      tick(2, midnight - 13 * HOUR),
+      tick(3, midnight - HOUR),
+      tick(4, midnight + HOUR, 'party'),
+    ];
+    const result = reconcile(ticks, [], [explicit('party', midnight + HOUR, midnight + HOUR)]);
+    expect(result.runs.every((run) => run.sessionId === 'party')).toBe(true);
+    expect(result.runs.flatMap((run) => run.tickIds).sort((first, second) => first - second)).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/packages/shared/session-inference/src/__tests__/reconcile.test.ts
+++ b/packages/shared/session-inference/src/__tests__/reconcile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { SESSION_GAP_MS, expandWindow, reconcileWindow } from '../index';
+import { SESSION_GAP_MS, expandWindow, expandReconciliationWindow, reconcileWindow } from '../index';
 import type { ExistingExplicitSession, ExistingInferredSession, InferenceTick } from '../types';
 
 const HOUR = 60 * 60 * 1000;
@@ -336,5 +336,26 @@ describe('empty window', () => {
 
     expect(result.runs).toEqual([]);
     expect(result.emptiedSessionIds).toEqual(['sess-a', 'sess-b']);
+  });
+});
+
+describe('expandReconciliationWindow', () => {
+  it('includes same-day runs separated by more than four hours', () => {
+    const ticks = [...run(1, DAY_ONE, 3), ...run(10, DAY_ONE + 10 * HOUR, 3)];
+    expect(expandReconciliationWindow(ticks, DAY_ONE, DAY_ONE)).toEqual(ticks);
+  });
+
+  it('includes both whole days when a run crosses midnight', () => {
+    const midnight = Date.UTC(2026, 4, 11);
+    const ticks = [
+      { id: 1, climbedAt: midnight - 12 * HOUR, sessionId: null },
+      { id: 2, climbedAt: midnight - HOUR, sessionId: null },
+      { id: 3, climbedAt: midnight + HOUR, sessionId: null },
+      { id: 4, climbedAt: midnight + 12 * HOUR, sessionId: null },
+      { id: 5, climbedAt: midnight + 36 * HOUR, sessionId: null },
+    ];
+    for (const tick of ticks.slice(0, 4)) {
+      expect(expandReconciliationWindow(ticks, tick.climbedAt, tick.climbedAt)).toEqual(ticks.slice(0, 4));
+    }
   });
 });

--- a/packages/shared/session-inference/src/__tests__/reconcile.test.ts
+++ b/packages/shared/session-inference/src/__tests__/reconcile.test.ts
@@ -408,6 +408,21 @@ describe('multiple explicit sessions in a timing run', () => {
 });
 
 describe('explicit sessions crossing midnight', () => {
+  it('converges through more than thirty connected UTC days', () => {
+    const firstDay = Date.UTC(2026, 0, 1);
+    const ticks = Array.from({ length: 40 }, (_, day) => [
+      tick(day * 2 + 1, firstDay + day * 24 * HOUR + HOUR, day === 0 ? 'party' : null),
+      tick(day * 2 + 2, firstDay + day * 24 * HOUR + 23 * HOUR),
+    ]).flat();
+    expect(expandReconciliationWindow(ticks, ticks[0].climbedAt, ticks[0].climbedAt)).toEqual(ticks);
+
+    const result = reconcile(ticks, [], [explicit('party', ticks[0].climbedAt, ticks[0].climbedAt)]);
+    expect(result.runs.every((run) => run.sessionId === 'party')).toBe(true);
+    expect(result.runs.flatMap((run) => run.tickIds).sort((first, second) => first - second)).toEqual(
+      ticks.map((tick) => tick.id),
+    );
+  });
+
   it('settles same-day absorption before creating a session that the next pass would empty', () => {
     const midnight = Date.UTC(2026, 8, 2);
     const ticks = [

--- a/packages/shared/session-inference/src/__tests__/reconcile.test.ts
+++ b/packages/shared/session-inference/src/__tests__/reconcile.test.ts
@@ -19,8 +19,8 @@ function inferred(id: string, anchorTickId: number, userEdited = false): Existin
   return { id, anchorTickId, userEdited };
 }
 
-function explicit(id: string, firstTickAt: number, lastTickAt: number): ExistingExplicitSession {
-  return { id, firstTickAt, lastTickAt };
+function explicit(id: string): ExistingExplicitSession {
+  return { id };
 }
 
 function reconcile(
@@ -186,7 +186,7 @@ describe('runs whose ticks already carry an inferred session id', () => {
       ...entry,
       sessionId: 'party-1',
     }));
-    const party = explicit('party-1', DAY_ONE + 90 * MINUTE, DAY_ONE + 2 * HOUR);
+    const party = explicit('party-1');
 
     const result = reconcile([...loose, ...partyTicks], [inferred('sess-a', 1)], [party]);
 
@@ -200,7 +200,7 @@ describe('runs whose ticks already carry an inferred session id', () => {
 
 describe('explicit sessions win', () => {
   const sessionTicks = run(10, DAY_ONE + 8 * HOUR, 4).map((entry) => ({ ...entry, sessionId: 'party-1' }));
-  const party = explicit('party-1', DAY_ONE + 8 * HOUR, DAY_ONE + 8 * HOUR + 30 * MINUTE);
+  const party = explicit('party-1');
 
   it('absorbs loose ticks logged earlier the same day', () => {
     const beforeStart = run(1, DAY_ONE, 2);
@@ -228,24 +228,28 @@ describe('explicit sessions win', () => {
     expect(otherRun?.sessionId).toBeNull();
   });
 
-  it('picks the nearer session when a day holds two', () => {
-    const morningParty = explicit('party-am', DAY_ONE, DAY_ONE + 30 * MINUTE);
-    const eveningParty = explicit('party-pm', DAY_ONE + 12 * HOUR, DAY_ONE + 13 * HOUR);
+  it('picks the nearer assigned tick inside a connected run', () => {
+    const morningParty = explicit('party-am');
+    const eveningParty = explicit('party-pm');
     const strays = [tick(77, DAY_ONE + 11 * HOUR)];
-    const result = reconcile(strays, [], [morningParty, eveningParty]);
+    const result = reconcile(
+      [tick(1, DAY_ONE, 'party-am'), ...strays, tick(2, DAY_ONE + 12 * HOUR, 'party-pm')],
+      [],
+      [morningParty, eveningParty],
+    );
 
-    expect(result.runs[0].sessionId).toBe('party-pm');
+    expect(result.runs.find((run) => run.tickIds.includes(77))?.sessionId).toBe('party-pm');
   });
 });
 
 describe('lone ticks', () => {
-  it('folds into a bigger run on the same day', () => {
+  it('keeps a singleton separate across an eight-hour gap on the same UTC day', () => {
     const main = run(1, DAY_ONE, 5);
     const afterthought = [tick(80, DAY_ONE + 9 * HOUR)];
     const result = reconcile([...main, ...afterthought]);
 
-    expect(result.runs).toHaveLength(1);
-    expect(result.runs[0].tickIds).toContain(80);
+    expect(result.runs).toHaveLength(2);
+    expect(result.runs[1].tickIds).toEqual([80]);
   });
 
   it('stands alone when it is the only climbing that day', () => {
@@ -340,7 +344,7 @@ describe('empty window', () => {
 });
 
 describe('expandReconciliationWindow', () => {
-  it('includes same-day runs separated by more than four hours', () => {
+  it('includes same-day runs separated by more than eight hours', () => {
     const ticks = [...run(1, DAY_ONE, 3), ...run(10, DAY_ONE + 10 * HOUR, 3)];
     expect(expandReconciliationWindow(ticks, DAY_ONE, DAY_ONE)).toEqual(ticks);
   });
@@ -362,10 +366,7 @@ describe('expandReconciliationWindow', () => {
 
 describe('multiple explicit sessions in a timing run', () => {
   it('preserves explicit assignments and sends only loose ticks to the nearest session', () => {
-    const explicitSessions = [
-      explicit('morning', DAY_ONE, DAY_ONE + HOUR),
-      explicit('later', DAY_ONE + 2 * HOUR, DAY_ONE + 3 * HOUR),
-    ];
+    const explicitSessions = [explicit('morning'), explicit('later')];
     const ticks = [
       tick(1, DAY_ONE, 'morning'),
       tick(2, DAY_ONE + HOUR, 'morning'),
@@ -386,20 +387,13 @@ describe('multiple explicit sessions in a timing run', () => {
     expect(reconcile(assigned, [], explicitSessions)).toEqual(result);
   });
 
-  it('preserves a lone explicit tick absorbed into another explicit session’s run', () => {
+  it('preserves a lone explicit tick across a hard gap', () => {
     const ticks = [
       tick(1, DAY_ONE, 'morning'),
       tick(2, DAY_ONE + 10 * MINUTE, 'morning'),
       tick(3, DAY_ONE + 10 * HOUR, 'later'),
     ];
-    const result = reconcile(
-      ticks,
-      [],
-      [
-        explicit('morning', DAY_ONE, DAY_ONE + 10 * MINUTE),
-        explicit('later', DAY_ONE + 10 * HOUR, DAY_ONE + 10 * HOUR),
-      ],
-    );
+    const result = reconcile(ticks, [], [explicit('morning'), explicit('later')]);
     expect(result.runs.map((run) => ({ sessionId: run.sessionId, tickIds: run.tickIds }))).toEqual([
       { sessionId: 'morning', tickIds: [1, 2] },
       { sessionId: 'later', tickIds: [3] },
@@ -408,7 +402,7 @@ describe('multiple explicit sessions in a timing run', () => {
 });
 
 describe('explicit sessions crossing midnight', () => {
-  it('converges through more than thirty connected UTC days', () => {
+  it('loads legacy connected UTC days without merging their separate runs', () => {
     const firstDay = Date.UTC(2026, 0, 1);
     const ticks = Array.from({ length: 40 }, (_, day) => [
       tick(day * 2 + 1, firstDay + day * 24 * HOUR + HOUR, day === 0 ? 'party' : null),
@@ -416,14 +410,15 @@ describe('explicit sessions crossing midnight', () => {
     ]).flat();
     expect(expandReconciliationWindow(ticks, ticks[0].climbedAt, ticks[0].climbedAt)).toEqual(ticks);
 
-    const result = reconcile(ticks, [], [explicit('party', ticks[0].climbedAt, ticks[0].climbedAt)]);
-    expect(result.runs.every((run) => run.sessionId === 'party')).toBe(true);
+    const result = reconcile(ticks, [], [explicit('party')]);
+    expect(result.runs).toHaveLength(41);
+    expect(result.runs.filter((run) => run.sessionId === 'party').map((run) => run.tickIds)).toEqual([[1]]);
     expect(result.runs.flatMap((run) => run.tickIds).sort((first, second) => first - second)).toEqual(
       ticks.map((tick) => tick.id),
     );
   });
 
-  it('settles same-day absorption before creating a session that the next pass would empty', () => {
+  it('keeps earlier climbing separate from a midnight explicit session', () => {
     const midnight = Date.UTC(2026, 8, 2);
     const ticks = [
       tick(1, midnight - 14 * HOUR),
@@ -431,8 +426,42 @@ describe('explicit sessions crossing midnight', () => {
       tick(3, midnight - HOUR),
       tick(4, midnight + HOUR, 'party'),
     ];
-    const result = reconcile(ticks, [], [explicit('party', midnight + HOUR, midnight + HOUR)]);
-    expect(result.runs.every((run) => run.sessionId === 'party')).toBe(true);
+    const result = reconcile(ticks, [], [explicit('party')]);
+    expect(result.runs.map((run) => ({ sessionId: run.sessionId, tickIds: run.tickIds }))).toEqual([
+      { sessionId: null, tickIds: [1, 2] },
+      { sessionId: 'party', tickIds: [3, 4] },
+    ]);
     expect(result.runs.flatMap((run) => run.tickIds).sort((first, second) => first - second)).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe('eight-hour automatic boundary', () => {
+  it.each([0, 10, -7])('is independent of calendar dates at UTC offset %i', (offset) => {
+    const evening = Date.UTC(2026, 4, 10, 19) - offset * HOUR;
+    const result = reconcile([tick(1, evening), tick(2, evening + 30 * MINUTE), tick(3, evening + 14 * HOUR)]);
+    expect(result.runs.map((run) => run.tickIds)).toEqual([[1, 2], [3]]);
+  });
+
+  it.each([8 * HOUR, 8 * HOUR + 1])('splits only when gap %i exceeds eight hours', (gap) => {
+    expect(reconcile([tick(1, DAY_ONE), tick(2, DAY_ONE + gap)]).runs).toHaveLength(gap > 8 * HOUR ? 2 : 1);
+  });
+
+  it('preserves explicit ownership across a long gap without absorbing an unrelated middle run', () => {
+    const result = reconcile(
+      [tick(1, DAY_ONE, 'party'), tick(2, DAY_ONE + 10 * HOUR), tick(3, DAY_ONE + 20 * HOUR, 'party')],
+      [],
+      [explicit('party')],
+    );
+    expect(result.runs.map((run) => run.sessionId)).toEqual(['party', null, 'party']);
+  });
+
+  it('splits a legacy inferred session while preserving its anchor and social identity', () => {
+    const result = reconcile(
+      [tick(1, DAY_ONE, 'old'), tick(2, DAY_ONE + 10 * HOUR, 'old')],
+      [inferred('old', 1, true)],
+    );
+    expect(result.runs.map((run) => run.sessionId)).toEqual(['old', null]);
+    expect(result.merges).toEqual([]);
+    expect(result.emptiedSessionIds).toEqual([]);
   });
 });

--- a/packages/shared/session-inference/src/index.ts
+++ b/packages/shared/session-inference/src/index.ts
@@ -8,4 +8,4 @@ export type {
   ResolvedRun,
   SessionMerge,
 } from './types';
-export { expandWindow, reconcileWindow } from './reconcile';
+export { expandWindow, expandReconciliationWindow, isReconciliationBoundary, reconcileWindow } from './reconcile';

--- a/packages/shared/session-inference/src/reconcile.ts
+++ b/packages/shared/session-inference/src/reconcile.ts
@@ -24,7 +24,9 @@ export function isReconciliationBoundary(previousAt: number, nextAt: number): bo
 export function expandReconciliationWindow(allTicks: InferenceTick[], from: number, to: number): InferenceTick[] {
   let windowFrom = dayStart(from);
   let windowTo = dayStart(to) + 24 * 60 * 60 * 1000 - 1;
-  while (true) {
+  // Each expansion reaches another tick's UTC day; allow one final stable pass.
+  // Bound by the input size, so long histories do not hit an arbitrary day limit.
+  for (let expansion = 0; expansion <= allTicks.length; expansion++) {
     const ticks = expandWindow(allTicks, windowFrom, windowTo);
     if (ticks.length === 0) return ticks;
     const nextFrom = Math.min(windowFrom, dayStart(ticks[0].climbedAt));
@@ -33,6 +35,7 @@ export function expandReconciliationWindow(allTicks: InferenceTick[], from: numb
     windowFrom = nextFrom;
     windowTo = nextTo;
   }
+  throw new Error('Reconciliation window did not converge within its tick count');
 }
 
 /**
@@ -319,7 +322,7 @@ export function reconcileWindow({ ticks, existingInferred, existingExplicit }: R
   // sessions that the next reconciliation would immediately empty. Each iteration
   // must reach a new UTC day from this finite window; assignments already made to
   // explicit sessions stay fixed, just as they would after a committed pass.
-  while (true) {
+  for (let expansion = 0; expansion <= ordered.length; expansion++) {
     const expandedById = new Map(explicitSpans.map((session) => [session.id, { ...session }]));
     for (const run of resolved) {
       const session = run.sessionId === null ? undefined : expandedById.get(run.sessionId);
@@ -335,6 +338,10 @@ export function reconcileWindow({ ticks, existingInferred, existingExplicit }: R
       );
     });
     if (!expanded) break;
+    // Expanding a span must claim at least one previously unclaimed tick. Once
+    // assigned, that tick's explicit ownership is fixed in subsequent passes.
+    if (expansion === ordered.length)
+      throw new Error('Explicit session spans did not converge within their tick count');
 
     const explicitAssignments = new Map<number, string>();
     for (const run of resolved) {

--- a/packages/shared/session-inference/src/reconcile.ts
+++ b/packages/shared/session-inference/src/reconcile.ts
@@ -229,6 +229,35 @@ function resolveIdentity(
 
     const explicitId = explicitSessionForRun(run, explicitSessions);
     if (explicitId !== null) {
+      // A timing run can span several sessions somebody explicitly started. Keep
+      // each assigned tick authoritative instead of handing the whole run to its
+      // first explicit session. Loose ticks choose the nearest same-day session;
+      // a midnight-crossing run can fall back to the session owning the run.
+      const explicitIds = new Set(explicitSessions.map((session) => session.id));
+      const assignedExplicitIds = new Set(
+        run
+          .map((tick) => tick.sessionId)
+          .filter((sessionId): sessionId is string => sessionId !== null && explicitIds.has(sessionId)),
+      );
+      if (assignedExplicitIds.size > 1) {
+        const ticksBySession = new Map<string, InferenceTick[]>();
+        for (const tick of run) {
+          const sessionId = explicitSessionForRun([tick], explicitSessions) ?? explicitId;
+          const assignedTicks = ticksBySession.get(sessionId) ?? [];
+          assignedTicks.push(tick);
+          ticksBySession.set(sessionId, assignedTicks);
+        }
+        for (const [sessionId, assignedTicks] of ticksBySession) {
+          resolved.push({
+            sessionId,
+            tickIds: assignedTicks.map((tick) => tick.id),
+            anchorTickId: Math.min(...assignedTicks.map((tick) => tick.id)),
+            firstTickAt: assignedTicks[0].climbedAt,
+            lastTickAt: assignedTicks[assignedTicks.length - 1].climbedAt,
+          });
+        }
+        continue;
+      }
       // Any inferred sessions anchored in here lose their ticks to the explicit
       // session; the caller drops them via `emptiedSessionIds`.
       resolved.push({ sessionId: explicitId, tickIds, anchorTickId, firstTickAt, lastTickAt });
@@ -281,8 +310,43 @@ export function reconcileWindow({ ticks, existingInferred, existingExplicit }: R
   }
 
   const ordered = [...ticks].sort((a, b) => a.climbedAt - b.climbedAt || a.id - b.id);
-  const runs = absorbLoneRuns(drawRuns(ordered));
-  const { resolved, merges } = resolveIdentity(runs, existingInferred, existingExplicit);
+  let runs = absorbLoneRuns(drawRuns(ordered));
+  let explicitSpans = existingExplicit;
+  let { resolved, merges } = resolveIdentity(runs, existingInferred, explicitSpans);
+
+  // Absorbing a midnight-crossing run can extend an explicit session onto another
+  // day. Settle that day's loose runs in this plan too, rather than minting inferred
+  // sessions that the next reconciliation would immediately empty. Each iteration
+  // must reach a new UTC day from this finite window; assignments already made to
+  // explicit sessions stay fixed, just as they would after a committed pass.
+  while (true) {
+    const expandedById = new Map(explicitSpans.map((session) => [session.id, { ...session }]));
+    for (const run of resolved) {
+      const session = run.sessionId === null ? undefined : expandedById.get(run.sessionId);
+      if (!session) continue;
+      session.firstTickAt = Math.min(session.firstTickAt, run.firstTickAt);
+      session.lastTickAt = Math.max(session.lastTickAt, run.lastTickAt);
+    }
+    const expanded = explicitSpans.some((session) => {
+      const next = expandedById.get(session.id)!;
+      return (
+        dayStart(next.firstTickAt) !== dayStart(session.firstTickAt) ||
+        dayStart(next.lastTickAt) !== dayStart(session.lastTickAt)
+      );
+    });
+    if (!expanded) break;
+
+    const explicitAssignments = new Map<number, string>();
+    for (const run of resolved) {
+      if (run.sessionId === null || !expandedById.has(run.sessionId)) continue;
+      for (const tickId of run.tickIds) explicitAssignments.set(tickId, run.sessionId);
+    }
+    runs = runs.map((run) =>
+      run.map((tick) => ({ ...tick, sessionId: explicitAssignments.get(tick.id) ?? tick.sessionId })),
+    );
+    explicitSpans = [...expandedById.values()];
+    ({ resolved, merges } = resolveIdentity(runs, existingInferred, explicitSpans));
+  }
 
   // Anything that kept no run of its own has been emptied — either absorbed by an
   // explicit session or merged away.

--- a/packages/shared/session-inference/src/reconcile.ts
+++ b/packages/shared/session-inference/src/reconcile.ts
@@ -15,6 +15,26 @@ function dayStart(epochMs: number): number {
   return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
 }
 
+/** Separate windows only where neither the gap nor same-UTC-day rules can cross. */
+export function isReconciliationBoundary(previousAt: number, nextAt: number): boolean {
+  return nextAt - previousAt > SESSION_GAP_MS && dayStart(previousAt) !== dayStart(nextAt);
+}
+
+/** Include whole UTC days and every run connected to them, including across midnight. */
+export function expandReconciliationWindow(allTicks: InferenceTick[], from: number, to: number): InferenceTick[] {
+  let windowFrom = dayStart(from);
+  let windowTo = dayStart(to) + 24 * 60 * 60 * 1000 - 1;
+  while (true) {
+    const ticks = expandWindow(allTicks, windowFrom, windowTo);
+    if (ticks.length === 0) return ticks;
+    const nextFrom = Math.min(windowFrom, dayStart(ticks[0].climbedAt));
+    const nextTo = Math.max(windowTo, dayStart(ticks[ticks.length - 1].climbedAt) + 24 * 60 * 60 * 1000 - 1);
+    if (nextFrom === windowFrom && nextTo === windowTo) return ticks;
+    windowFrom = nextFrom;
+    windowTo = nextTo;
+  }
+}
+
 /**
  * Widen `[from, to]` outwards until there is a gap greater than {@link SESSION_GAP_MS}
  * on both sides, and return the ticks inside.

--- a/packages/shared/session-inference/src/reconcile.ts
+++ b/packages/shared/session-inference/src/reconcile.ts
@@ -15,12 +15,15 @@ function dayStart(epochMs: number): number {
   return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
 }
 
-/** Separate windows only where neither the gap nor same-UTC-day rules can cross. */
+/** Partition broad read windows, including legacy same-day assignments that may need splitting. */
 export function isReconciliationBoundary(previousAt: number, nextAt: number): boolean {
   return nextAt - previousAt > SESSION_GAP_MS && dayStart(previousAt) !== dayStart(nextAt);
 }
 
-/** Include whole UTC days and every run connected to them, including across midnight. */
+/**
+ * Load whole UTC days and connected runs so legacy same-day assignments include their anchors.
+ * This padding controls reads only: automatic grouping always stops at gaps over eight hours.
+ */
 export function expandReconciliationWindow(allTicks: InferenceTick[], from: number, to: number): InferenceTick[] {
   let windowFrom = dayStart(from);
   let windowTo = dayStart(to) + 24 * 60 * 60 * 1000 - 1;
@@ -104,104 +107,6 @@ function drawRuns(ticks: InferenceTick[]): InferenceTick[][] {
 }
 
 /**
- * The explicit session that owns a run, if any.
- *
- * Explicit sessions always win: someone deliberately pressed Start, so their record is
- * authoritative and a run overlapping their day is folded into them rather than
- * standing beside them. This is what stops the "I logged 9 climbs in my session and 2
- * before it, and the 2 vanished" case — those 2 join the session instead of forming a
- * card that the old day-suppression rule then hid entirely.
- *
- * Matching is by calendar day rather than by the session's tick span, because the
- * ticks being absorbed are by definition outside that span. When a day holds more than
- * one explicit session the nearest in time wins, so a morning run does not land in an
- * evening session.
- */
-function explicitSessionForRun(run: InferenceTick[], explicitSessions: ExistingExplicitSession[]): string | null {
-  // Only an id that belongs to an EXPLICIT session settles this. Ticks normally carry
-  // the inferred session they were last assigned to, so accepting any non-null id here
-  // would short-circuit anchor and merge resolution on nearly every reconciliation —
-  // and, where an inferred run sits next to a party session on the same day, would hand
-  // the party session's own ticks to the inferred one.
-  const explicitIds = new Set(explicitSessions.map((session) => session.id));
-  const assignedExplicit = run.find((tick) => tick.sessionId !== null && explicitIds.has(tick.sessionId));
-  if (assignedExplicit) return assignedExplicit.sessionId;
-
-  const runStart = run[0].climbedAt;
-  const runEnd = run[run.length - 1].climbedAt;
-  const runDays = new Set([dayStart(runStart), dayStart(runEnd)]);
-
-  const sameDay = explicitSessions.filter(
-    (session) => runDays.has(dayStart(session.firstTickAt)) || runDays.has(dayStart(session.lastTickAt)),
-  );
-  if (sameDay.length === 0) return null;
-
-  let best = sameDay[0];
-  let bestDistance = Number.POSITIVE_INFINITY;
-  for (const session of sameDay) {
-    // Zero when the run overlaps the session's span, otherwise the nearer edge gap.
-    const distance =
-      runEnd < session.firstTickAt
-        ? session.firstTickAt - runEnd
-        : runStart > session.lastTickAt
-          ? runStart - session.lastTickAt
-          : 0;
-    if (distance < bestDistance) {
-      best = session;
-      bestDistance = distance;
-    }
-  }
-  return best.id;
-}
-
-/**
- * Fold lone ticks into a bigger run on the same day.
- *
- * A single-tick run is usually someone remembering hours later that they forgot to log
- * a climb, not a second trip to the wall — so when the day already has real climbing on
- * it, the stray tick belongs there. When the lone tick is all there is for that day it
- * stays its own session; hiding it would recreate the "where did my climb go" bug that
- * started all this.
- *
- * Fleet-wide this merges 605 runs and leaves 8,694 standing alone, of which only 1,874
- * are natively logged — the rest are bulk logbook imports sitting far back in history.
- */
-function absorbLoneRuns(runs: InferenceTick[][]): InferenceTick[][] {
-  if (runs.length < 2) return runs;
-
-  const result: InferenceTick[][] = runs.map((run) => [...run]);
-  const isLone = (run: InferenceTick[]) => run.length === 1;
-
-  for (let i = 0; i < result.length; i++) {
-    if (!isLone(result[i])) continue;
-    const day = dayStart(result[i][0].climbedAt);
-
-    // Nearest larger run on the same day, in either direction.
-    let target = -1;
-    let bestDistance = Number.POSITIVE_INFINITY;
-    for (let j = 0; j < result.length; j++) {
-      if (j === i || result[j].length === 0 || isLone(result[j])) continue;
-      const otherStart = result[j][0].climbedAt;
-      const otherEnd = result[j][result[j].length - 1].climbedAt;
-      if (dayStart(otherStart) !== day && dayStart(otherEnd) !== day) continue;
-      const tickAt = result[i][0].climbedAt;
-      const distance = tickAt < otherStart ? otherStart - tickAt : tickAt > otherEnd ? tickAt - otherEnd : 0;
-      if (distance < bestDistance) {
-        target = j;
-        bestDistance = distance;
-      }
-    }
-
-    if (target !== -1) {
-      result[target] = [...result[target], ...result[i]].sort((a, b) => a.climbedAt - b.climbedAt);
-      result[i] = [];
-    }
-  }
-
-  return result.filter((run) => run.length > 0);
-}
-
-/**
  * Decide which inferred sessions in the window each run inherits.
  *
  * A run inherits the identity of any existing session whose anchor tick it still
@@ -221,6 +126,7 @@ function resolveIdentity(
     if (session.anchorTickId !== null) byAnchor.set(session.anchorTickId, session);
   }
 
+  const explicitIds = new Set(explicitSessions.map((session) => session.id));
   const resolved: ResolvedRun[] = [];
   const merges: SessionMerge[] = [];
 
@@ -230,40 +136,41 @@ function resolveIdentity(
     const firstTickAt = run[0].climbedAt;
     const lastTickAt = run[run.length - 1].climbedAt;
 
-    const explicitId = explicitSessionForRun(run, explicitSessions);
-    if (explicitId !== null) {
-      // A timing run can span several sessions somebody explicitly started. Keep
-      // each assigned tick authoritative instead of handing the whole run to its
-      // first explicit session. Loose ticks choose the nearest same-day session;
-      // a midnight-crossing run can fall back to the session owning the run.
-      const explicitIds = new Set(explicitSessions.map((session) => session.id));
-      const assignedExplicitIds = new Set(
-        run
-          .map((tick) => tick.sessionId)
-          .filter((sessionId): sessionId is string => sessionId !== null && explicitIds.has(sessionId)),
-      );
-      if (assignedExplicitIds.size > 1) {
-        const ticksBySession = new Map<string, InferenceTick[]>();
-        for (const tick of run) {
-          const sessionId = explicitSessionForRun([tick], explicitSessions) ?? explicitId;
-          const assignedTicks = ticksBySession.get(sessionId) ?? [];
-          assignedTicks.push(tick);
-          ticksBySession.set(sessionId, assignedTicks);
+    const explicitTicks = run.filter((tick) => tick.sessionId !== null && explicitIds.has(tick.sessionId));
+    if (explicitTicks.length > 0) {
+      // Preserve assigned explicit ticks. Loose ticks choose the nearest explicit
+      // tick inside this connected run, never a session on an unrelated UTC day.
+      const ticksBySession = new Map<string, InferenceTick[]>();
+      let nextExplicitIndex = 0;
+      for (const tick of run) {
+        while (
+          nextExplicitIndex < explicitTicks.length &&
+          explicitTicks[nextExplicitIndex].climbedAt < tick.climbedAt
+        ) {
+          nextExplicitIndex++;
         }
-        for (const [sessionId, assignedTicks] of ticksBySession) {
-          resolved.push({
-            sessionId,
-            tickIds: assignedTicks.map((tick) => tick.id),
-            anchorTickId: Math.min(...assignedTicks.map((tick) => tick.id)),
-            firstTickAt: assignedTicks[0].climbedAt,
-            lastTickAt: assignedTicks[assignedTicks.length - 1].climbedAt,
-          });
-        }
-        continue;
+        const previous = explicitTicks[nextExplicitIndex - 1];
+        const next = explicitTicks[nextExplicitIndex];
+        const nearest = !previous
+          ? next
+          : !next || tick.climbedAt - previous.climbedAt <= next.climbedAt - tick.climbedAt
+            ? previous
+            : next;
+        const sessionId =
+          tick.sessionId !== null && explicitIds.has(tick.sessionId) ? tick.sessionId : nearest.sessionId!;
+        const assignedTicks = ticksBySession.get(sessionId) ?? [];
+        assignedTicks.push(tick);
+        ticksBySession.set(sessionId, assignedTicks);
       }
-      // Any inferred sessions anchored in here lose their ticks to the explicit
-      // session; the caller drops them via `emptiedSessionIds`.
-      resolved.push({ sessionId: explicitId, tickIds, anchorTickId, firstTickAt, lastTickAt });
+      for (const [sessionId, assignedTicks] of ticksBySession) {
+        resolved.push({
+          sessionId,
+          tickIds: assignedTicks.map((tick) => tick.id),
+          anchorTickId: Math.min(...assignedTicks.map((tick) => tick.id)),
+          firstTickAt: assignedTicks[0].climbedAt,
+          lastTickAt: assignedTicks[assignedTicks.length - 1].climbedAt,
+        });
+      }
       continue;
     }
 
@@ -313,47 +220,7 @@ export function reconcileWindow({ ticks, existingInferred, existingExplicit }: R
   }
 
   const ordered = [...ticks].sort((a, b) => a.climbedAt - b.climbedAt || a.id - b.id);
-  let runs = absorbLoneRuns(drawRuns(ordered));
-  let explicitSpans = existingExplicit;
-  let { resolved, merges } = resolveIdentity(runs, existingInferred, explicitSpans);
-
-  // Absorbing a midnight-crossing run can extend an explicit session onto another
-  // day. Settle that day's loose runs in this plan too, rather than minting inferred
-  // sessions that the next reconciliation would immediately empty. Each iteration
-  // must reach a new UTC day from this finite window; assignments already made to
-  // explicit sessions stay fixed, just as they would after a committed pass.
-  for (let expansion = 0; expansion <= ordered.length; expansion++) {
-    const expandedById = new Map(explicitSpans.map((session) => [session.id, { ...session }]));
-    for (const run of resolved) {
-      const session = run.sessionId === null ? undefined : expandedById.get(run.sessionId);
-      if (!session) continue;
-      session.firstTickAt = Math.min(session.firstTickAt, run.firstTickAt);
-      session.lastTickAt = Math.max(session.lastTickAt, run.lastTickAt);
-    }
-    const expanded = explicitSpans.some((session) => {
-      const next = expandedById.get(session.id)!;
-      return (
-        dayStart(next.firstTickAt) !== dayStart(session.firstTickAt) ||
-        dayStart(next.lastTickAt) !== dayStart(session.lastTickAt)
-      );
-    });
-    if (!expanded) break;
-    // Expanding a span must claim at least one previously unclaimed tick. Once
-    // assigned, that tick's explicit ownership is fixed in subsequent passes.
-    if (expansion === ordered.length)
-      throw new Error('Explicit session spans did not converge within their tick count');
-
-    const explicitAssignments = new Map<number, string>();
-    for (const run of resolved) {
-      if (run.sessionId === null || !expandedById.has(run.sessionId)) continue;
-      for (const tickId of run.tickIds) explicitAssignments.set(tickId, run.sessionId);
-    }
-    runs = runs.map((run) =>
-      run.map((tick) => ({ ...tick, sessionId: explicitAssignments.get(tick.id) ?? tick.sessionId })),
-    );
-    explicitSpans = [...expandedById.values()];
-    ({ resolved, merges } = resolveIdentity(runs, existingInferred, explicitSpans));
-  }
+  const { resolved, merges } = resolveIdentity(drawRuns(ordered), existingInferred, existingExplicit);
 
   // Anything that kept no run of its own has been emptied — either absorbed by an
   // explicit session or merged away.

--- a/packages/shared/session-inference/src/types.ts
+++ b/packages/shared/session-inference/src/types.ts
@@ -1,16 +1,5 @@
-/**
- * The gap that separates two sessions.
- *
- * Measured across the whole production tick table, inter-tick gaps are sharply
- * bimodal: 80% land under 15 minutes and 11% are over 12 hours, with only 0.4%
- * (243 of 60,385) anywhere in the 2–12 hour valley between. Any threshold in that
- * valley draws essentially the same boundaries, so this number is robust rather
- * than tuned — moving it to 2h or 12h changes well under 1% of session edges.
- *
- * 4h is what the pre-#2663 implementation used, and the data says it was a fine
- * choice. Kept identical so the two eras group history the same way.
- */
-export const SESSION_GAP_MS = 4 * 60 * 60 * 1000;
+/** Automatic grouping stops at gaps over eight hours; exactly eight hours stays connected. */
+export const SESSION_GAP_MS = 8 * 60 * 60 * 1000;
 
 /** The subset of a tick this module needs. Keeps the algorithm free of DB types. */
 export type InferenceTick = {
@@ -34,10 +23,6 @@ export type ExistingInferredSession = {
 /** An explicit (someone-pressed-Start) session overlapping the window. */
 export type ExistingExplicitSession = {
   id: string;
-  /** Epoch ms of the session's first tick. */
-  firstTickAt: number;
-  /** Epoch ms of the session's last tick. */
-  lastTickAt: number;
 };
 
 /**


### PR DESCRIPTION
## Summary

Reconstruct historical climbing sessions from tick timing using the live reconciler. Inventory is the default; `--simulate` is read-only and `--apply` commits one complete window at a time, refusing clipped windows and removal of existing sessions.

Automatic grouping now stops at gaps over eight hours, including within the same UTC date. Exactly eight hours remains connected. Removed same-day singleton absorption and explicit-session day matching, which could join an evening session with the following local morning. Existing explicit assignments stay fixed; loose ticks choose the nearest explicitly assigned tick within their connected run. Broad UTC-day read windows remain to include legacy session anchors when splitting old assignments.

Live save, update, and delete parse stored climb timestamps as UTC on every host. Backfill limits apply in SQL, recovery resumes at the first failed user, and bounded read expansion rejects incomplete histories. Updated the integration mock for the upstream inline climb-statistics recompute that caused CI failures.

Validation: 95 affected backend/shared tests passed, including timezone-independent grouping, exact eight-hour boundaries, live mutations under Australia/Brisbane, and an idempotent legacy-session split preserving its original ID and comments. Full workspace typechecking and `vp check` passed.

The approved production repair is complete: four session splits, five allowlisted inferred-session merges, and 44 corrected tick assignments across nine windows (133 ticks), with no climbs deleted. The final window used the explicitly approved refreshed snapshot after a concurrent tick appeared. Every repaired window stabilized before commit.

The initial detached worker in the backend container was stopped at `2026-09-07T02:20:23.113Z` at the operator's request. Its committed work remains; the temporary SSH key was revoked and its report/logs were retained.

The backfill now runs as a dedicated [temporary Railway service](https://railway.com/project/afceee45-0af1-46b3-abbe-8b9094c23bc6/service/dbd68eb2-b151-4814-b409-7bd5b3126269), deployment `5ed41309-d3c7-4ce1-8894-94006d8ba61e`. It started at `2026-09-07T02:29:39.745Z` with 400,293 unassigned ticks across 2,289 climbers. The service has one replica, 1 vCPU, 1 GB RAM, two database connections, no HTTP healthcheck, and restart policy Never. Its Docker image uses a pinned Boardsesh runtime and the exact reviewed backfill artifact from `9b24ee0f0`; production credentials are supplied through a Railway variable reference, not included in the image. It is independent of backend deployments and uses native Railway logs and monitoring.

The main dedicated-service run completed at `2026-09-07T04:16:08.514Z`: 2,289 climbers, 56,736 windows, 55,238 new sessions, zero failures. A catch-up pass processed the remaining 61 ticks across two climbers (44 were created during the main run), creating seven sessions across 339 windows with zero failures. It finished at `2026-09-07T04:18:51.696Z`.

Final verification: all 462,218 ticks assigned; zero eligible users, dangling assignments, ownership errors, invalid nonempty anchors, nonempty timestamp mismatches, lifecycle errors, or inferred gaps over eight hours. The dedicated service created 55,245 sessions across both passes. Two known empty inferred sessions from live activity remain untouched; the additional previously identified merge candidate is outside this completed assignment backfill. The temporary service is retained with its logs and automatic restarts disabled.

## Release Notes

Your climbing history groups climbs into sessions, with breaks over eight hours starting a new one.

## Test plan

1. Sign in → You → Sessions shows your climbing history.
2. Open a backfilled session → its logged climbs appear.
3. Open an existing session → its name and comments remain.

## Risk

Risk: 5/5 — historical tick assignments and shared live grouping change; production execution is manual and guarded.
