### PR TITLE
feat(mobile): route mode behind a menu, and a pace the setter actually sets

### DIFF
--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -288,7 +288,11 @@ export const SaveClimbInputSchema = z
     isDraft: z.boolean(),
     frames: z.string().min(1).max(10000),
     framesCount: z.number().int().min(1).optional(),
-    framesPace: z.number().int().min(0).optional(),
+    // Upper bound so a client bug can't publish a route that sits on one frame
+    // for hours. 30s is well past the 10s ceiling the authoring control offers,
+    // so it rejects nonsense without second-guessing a deliberate slow route or
+    // a pace synced in from Aurora. 0 stays legal: it means "use the default".
+    framesPace: z.number().int().min(0).max(30_000).optional(),
     angle: z.number().int().min(-5).max(90),
     characteristics: ToggleableCharacteristicsSchema,
     noMatch: RuleFlagSchema,
@@ -310,7 +314,11 @@ export const UpdateClimbInputSchema = z
     angle: z.number().int().min(-5).max(90).optional(),
     isDraft: z.boolean().optional(),
     framesCount: z.number().int().min(1).optional(),
-    framesPace: z.number().int().min(0).optional(),
+    // Upper bound so a client bug can't publish a route that sits on one frame
+    // for hours. 30s is well past the 10s ceiling the authoring control offers,
+    // so it rejects nonsense without second-guessing a deliberate slow route or
+    // a pace synced in from Aurora. 0 stays legal: it means "use the default".
+    framesPace: z.number().int().min(0).max(30_000).optional(),
     characteristics: ToggleableCharacteristicsSchema,
     noMatch: RuleFlagSchema,
     anyFeet: RuleFlagSchema,

--- a/packages/mobile/src/components/AppMenu.android.tsx
+++ b/packages/mobile/src/components/AppMenu.android.tsx
@@ -2,9 +2,10 @@
 // @expo/ui/jetpack-compose. Replaces the react-native-paper `Menu` (a JS M3
 // re-creation) with the real Compose dropdown — M3 ripple, elevation, open/close
 // motion for free. The anchor is a flat `Text` + caret trigger (the M3 app-bar
-// title-menu); the active row shows a leading ✓ (no SF Symbols on Android) and
-// destructive rows take the `m3.error` text colour. Controlled `expanded` state,
-// closed on each select.
+// title-menu) or a bare glyph trigger in icon mode; the active row shows a leading ✓
+// (no SF Symbols on Android), destructive rows take the `m3.error` text colour and
+// disabled rows are `enabled={false}`. Controlled `expanded` state, closed on each
+// select.
 
 import { useMemo, useState } from 'react';
 import { Host } from '@expo/ui';
@@ -13,23 +14,16 @@ import { clickable, padding } from '@expo/ui/jetpack-compose/modifiers';
 import { useTheme } from '../providers/theme-provider';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
 import { spacing } from '../theme/tokens';
-import { resolveMenuActions } from './AppMenu.logic';
+import { anchorGlyphForIcon, isMenuActionSelectable, resolveMenuActions } from './AppMenu.logic';
 import type { AppMenuProps } from './AppMenu.types';
 
 // Down-caret glyph: the Compose `Icon` needs a vector-drawable source and @expo/ui
 // bundles none for a chevron, so a muted glyph stands in (mirrors MoreForm's `›`).
+// The icon anchor's glyph comes from `anchorGlyphForIcon` for the same reason.
 const CARET = '▾';
 
-export function AppMenu({
-  label,
-  actions,
-  onSelectIndex,
-  showCaret = true,
-  maxWidth,
-  accessibilityLabel,
-  accessibilityHint,
-  style,
-}: AppMenuProps) {
+export function AppMenu(props: AppMenuProps) {
+  const { actions, onSelectIndex, maxWidth, accessibilityLabel, accessibilityHint, style } = props;
   const { brandColors, m3, systemColors, colorScheme } = useTheme();
   const [expanded, setExpanded] = useState(false);
   const resolved = useMemo(() => resolveMenuActions(actions), [actions]);
@@ -41,6 +35,11 @@ export function AppMenu({
   // scheme (the bug this fixes). Sourced from `useTheme()`, which is scheme-aware.
   const labelColor = systemColors.label as string;
   const caretColor = systemColors.secondaryLabel as string;
+  // Same reason a disabled row needs its own colour here: `disabledTextColor` only
+  // reaches the item's default content, not the `Text` we hand to its slot.
+  const disabledColor = systemColors.tertiaryLabel as string;
+
+  const showCaret = props.iconName == null && props.showCaret !== false;
 
   return (
     // `matchContents` (content width AND height): the title-menu hugs its label so it
@@ -63,7 +62,7 @@ export function AppMenu({
       matchContents
       colorScheme={colorScheme}
       accessibilityRole="button"
-      accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityLabel={accessibilityLabel ?? props.label}
       accessibilityHint={accessibilityHint}
       style={[maxWidth != null ? { maxWidth } : null, style]}
     >
@@ -73,9 +72,15 @@ export function AppMenu({
             modifiers={[clickable(() => setExpanded(true)), padding(spacing[2], spacing[1], spacing[2], spacing[1])]}
             verticalAlignment="center"
           >
-            <Text style={{ typography: 'titleMedium' }} color={labelColor} maxLines={1} overflow="ellipsis">
-              {label}
-            </Text>
+            {props.iconName != null ? (
+              <Text style={{ typography: 'titleLarge' }} color={labelColor}>
+                {anchorGlyphForIcon(props.iconName)}
+              </Text>
+            ) : (
+              <Text style={{ typography: 'titleMedium' }} color={labelColor} maxLines={1} overflow="ellipsis">
+                {props.label}
+              </Text>
+            )}
             {showCaret ? (
               <Text style={{ typography: 'titleMedium' }} color={caretColor}>
                 {` ${CARET}`}
@@ -85,14 +90,20 @@ export function AppMenu({
         </DropdownMenu.Trigger>
         <DropdownMenu.Items>
           {resolved.map((action, index) => {
-            const itemColor = action.isDestructive ? (m3.error as string) : labelColor;
+            const itemColor = action.isDisabled
+              ? disabledColor
+              : action.isDestructive
+                ? (m3.error as string)
+                : labelColor;
             return (
               <DropdownMenuItem
                 // Composite key: scope entries can share a display name (two gyms named
                 // the same), so the label alone isn't unique — pair it with the position.
                 key={`${index}-${action.label}`}
-                elementColors={{ textColor: itemColor }}
+                enabled={!action.isDisabled}
+                elementColors={{ textColor: itemColor, disabledTextColor: disabledColor }}
                 onClick={() => {
+                  if (!isMenuActionSelectable(resolved, index)) return;
                   setExpanded(false);
                   onSelectIndex(index);
                 }}

--- a/packages/mobile/src/components/AppMenu.ios.tsx
+++ b/packages/mobile/src/components/AppMenu.ios.tsx
@@ -1,11 +1,12 @@
 // AppMenu — iOS implementation, a real native UIMenu via @expo/ui/swift-ui `Menu`.
 //
-// The anchor is a neutral Liquid Glass capsule (`buttonStyle('glass')`) whose label
-// is the active scope text + a trailing chevron — matching the hand-built `clear`
-// glass pill it replaces (neutral, NOT brand-tinted). Each action is a `Button`; the
-// selected row shows a `checkmark` (the native active marker, replacing its scope
-// glyph in the single SF Symbol slot), destructive rows take the system destructive
-// role. SF Symbols come straight from `action.systemIcon`.
+// The text anchor is a neutral Liquid Glass capsule (`buttonStyle('glass')`) whose
+// label is the active scope text + a trailing chevron — matching the hand-built
+// `clear` glass pill it replaces (neutral, NOT brand-tinted). The icon anchor is a
+// bare glyph instead (see `menuModifiers`). Each action is a `Button`; the selected
+// row shows a `checkmark` (the native active marker, replacing its scope glyph in the
+// single SF Symbol slot), destructive rows take the system destructive role, disabled
+// rows take SwiftUI's `.disabled`. SF Symbols come straight from `action.systemIcon`.
 //
 // The menu popup is always a native UIMenu, so this file is OS-split (iOS), not
 // variant-routed — a user who forces the Material variant on iOS still gets it.
@@ -14,7 +15,10 @@ import { Host } from '@expo/ui';
 import { Menu, Button, HStack, Text, Image } from '@expo/ui/swift-ui';
 import {
   buttonStyle,
+  clipShape,
   controlSize,
+  backgroundOverlay,
+  disabled as disabledModifier,
   frame,
   font,
   lineLimit,
@@ -26,8 +30,9 @@ import { useMemo, type ComponentProps } from 'react';
 import { StyleSheet } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
 import { spacing } from '../theme/tokens';
-import { resolveMenuActions } from './AppMenu.logic';
+import { isMenuActionSelectable, resolveMenuActions } from './AppMenu.logic';
 import type { AppMenuProps } from './AppMenu.types';
+import { iconMap } from './icon-map';
 
 // Floor the Host height in RN's layout: the native iOS Host under-reports the glass
 // capsule's intrinsic height to React Native, so without a floor the anchor renders
@@ -35,32 +40,47 @@ import type { AppMenuProps } from './AppMenu.types';
 // SwitchRow caveat; ~44pt ≈ the old pill's `glassSize.capsule`.
 const ANCHOR_MIN_HEIGHT = 44;
 
-export function AppMenu({
-  label,
-  actions,
-  onSelectIndex,
-  showCaret = true,
-  maxWidth,
-  accessibilityLabel,
-  accessibilityHint,
-  style,
-}: AppMenuProps) {
+// The glyph inside the 44pt circle, matching the 20–24pt SF Symbols the sibling
+// header buttons draw at that diameter.
+const ICON_ANCHOR_GLYPH_SIZE = 20;
+
+export function AppMenu(props: AppMenuProps) {
+  const { actions, onSelectIndex, maxWidth, accessibilityLabel, accessibilityHint, style } = props;
   const { systemColors } = useTheme();
+  const fillColor = systemColors.fill;
   const resolved = useMemo(() => resolveMenuActions(actions), [actions]);
+  const iconName = props.iconName;
 
   // Memoised so a re-render with stable inputs doesn't hand the native Menu a fresh
   // modifier array (avoids redundant SwiftUI diffs).
   const menuModifiers = useMemo(
-    () => [
-      // Neutral translucent glass capsule (no brand tint) — matches the old `clear`
-      // GlassSurface pill. iOS 26 Liquid Glass, degrades gracefully on older iOS.
-      buttonStyle('glass'),
-      controlSize('large'),
-      ...(maxWidth != null ? [frame({ maxWidth })] : []),
-      ...(accessibilityLabel ? [a11yLabel(accessibilityLabel)] : []),
-      ...(accessibilityHint ? [a11yHint(accessibilityHint)] : []),
-    ],
-    [maxWidth, accessibilityLabel, accessibilityHint],
+    () =>
+      iconName != null
+        ? [
+            // A glyph anchor deliberately skips `buttonStyle('glass')`: the glass
+            // style grows a capsule around its label, which around three dots reads
+            // as a stretched pill next to round siblings. Instead it copies the
+            // creator header's own buttons — a 44pt `systemFill` circle — so the
+            // overflow trigger sits in the same row as the close chevron and the BLE
+            // lightbulb without looking like a different control.
+            frame({ width: ANCHOR_MIN_HEIGHT, height: ANCHOR_MIN_HEIGHT }),
+            backgroundOverlay({ color: fillColor }),
+            clipShape('circle'),
+            buttonStyle('plain'),
+            ...(accessibilityLabel ? [a11yLabel(accessibilityLabel)] : []),
+            ...(accessibilityHint ? [a11yHint(accessibilityHint)] : []),
+          ]
+        : [
+            // Neutral translucent glass capsule (no brand tint) — matches the old
+            // `clear` GlassSurface pill. iOS 26 Liquid Glass, degrades gracefully on
+            // older iOS.
+            buttonStyle('glass'),
+            controlSize('large'),
+            ...(maxWidth != null ? [frame({ maxWidth })] : []),
+            ...(accessibilityLabel ? [a11yLabel(accessibilityLabel)] : []),
+            ...(accessibilityHint ? [a11yHint(accessibilityHint)] : []),
+          ],
+    [iconName, fillColor, maxWidth, accessibilityLabel, accessibilityHint],
   );
 
   return (
@@ -68,12 +88,20 @@ export function AppMenu({
       <Menu
         modifiers={menuModifiers}
         label={
-          <HStack spacing={spacing[1]} alignment="center">
-            {/* Headline weight + label colour by default — reads like the old pill's
-                bold title; truncates a long scope name within the capped frame. */}
-            <Text modifiers={[font({ textStyle: 'headline' }), lineLimit(1), truncationMode('tail')]}>{label}</Text>
-            {showCaret ? <Image systemName="chevron.down" size={13} color={systemColors.secondaryLabel} /> : null}
-          </HStack>
+          props.iconName != null ? (
+            <Image systemName={iconMap[props.iconName].ios} size={ICON_ANCHOR_GLYPH_SIZE} color={systemColors.label} />
+          ) : (
+            <HStack spacing={spacing[1]} alignment="center">
+              {/* Headline weight + label colour by default — reads like the old pill's
+                  bold title; truncates a long scope name within the capped frame. */}
+              <Text modifiers={[font({ textStyle: 'headline' }), lineLimit(1), truncationMode('tail')]}>
+                {props.label}
+              </Text>
+              {props.showCaret !== false ? (
+                <Image systemName="chevron.down" size={13} color={systemColors.secondaryLabel} />
+              ) : null}
+            </HStack>
+          )
         }
       >
         {resolved.map((action, index) => (
@@ -88,7 +116,11 @@ export function AppMenu({
             // isn't directly resolvable here).
             systemImage={action.iosSystemImage as ComponentProps<typeof Button>['systemImage']}
             role={action.isDestructive ? 'destructive' : undefined}
-            onPress={() => onSelectIndex(index)}
+            modifiers={action.isDisabled ? [disabledModifier(true)] : undefined}
+            onPress={() => {
+              if (!isMenuActionSelectable(resolved, index)) return;
+              onSelectIndex(index);
+            }}
           />
         ))}
       </Menu>

--- a/packages/mobile/src/components/AppMenu.logic.ts
+++ b/packages/mobile/src/components/AppMenu.logic.ts
@@ -1,4 +1,5 @@
 import type { AppMenuAction } from './AppMenu.types';
+import type { IconName } from './icon-map';
 
 /** A menu action resolved to the per-platform pieces each native impl renders. */
 export type ResolvedMenuAction = {
@@ -12,6 +13,8 @@ export type ResolvedMenuAction = {
   /** Android renders a leading ✓ on the active row (no SF Symbols there). */
   showCheck: boolean;
   isDestructive: boolean;
+  /** Row is shown but unselectable — SwiftUI `.disabled`, Compose `enabled={false}`, Paper `disabled`. */
+  isDisabled: boolean;
 };
 
 export function resolveMenuAction(action: AppMenuAction): ResolvedMenuAction {
@@ -20,7 +23,31 @@ export function resolveMenuAction(action: AppMenuAction): ResolvedMenuAction {
     iosSystemImage: action.selected ? 'checkmark' : action.systemIcon,
     showCheck: action.selected === true,
     isDestructive: action.destructive === true,
+    isDisabled: action.disabled === true,
   };
 }
 
 export const resolveMenuActions = (actions: AppMenuAction[]): ResolvedMenuAction[] => actions.map(resolveMenuAction);
+
+/**
+ * Whether a press on row `index` may reach `onSelectIndex`. Every native menu already
+ * swallows a disabled row's press (SwiftUI `.disabled`, Compose `enabled={false}`,
+ * Paper `disabled`), so this is the JS-side backstop each impl runs first — and the
+ * only version of the rule a test can reach, since none of those menus mount under
+ * Vitest.
+ */
+export const isMenuActionSelectable = (resolvedActions: ResolvedMenuAction[], index: number): boolean =>
+  resolvedActions[index]?.isDisabled === false;
+
+// Plain-text stand-ins for an icon anchor's glyph on Android and web. The Compose
+// `Icon` needs a vector-drawable source and @expo/ui bundles none, so the glyph is a
+// text character there — the same trade-off the `▾` caret already makes. Only the
+// overflow family has a faithful stand-in; every other icon falls back to the
+// horizontal ellipsis, which is what a glyph-anchored menu reads as anyway.
+const ANCHOR_GLYPHS: Partial<Record<IconName, string>> = {
+  more: '⋯',
+  'more.actions': '⋯',
+  'more.vertical': '⋮',
+};
+
+export const anchorGlyphForIcon = (iconName: IconName): string => ANCHOR_GLYPHS[iconName] ?? '⋯';

--- a/packages/mobile/src/components/AppMenu.types.ts
+++ b/packages/mobile/src/components/AppMenu.types.ts
@@ -1,4 +1,5 @@
 import type { StyleProp, ViewStyle } from 'react-native';
+import type { IconName } from './icon-map';
 
 /** A single menu row, neutral across the native iOS `Menu` / Android `DropdownMenu` impls. */
 export type AppMenuAction = {
@@ -8,24 +9,50 @@ export type AppMenuAction = {
   /** Tints the row as destructive — the system destructive role on iOS, `m3.error` text on Android. */
   destructive?: boolean;
   /**
+   * Greys the row out and blocks selection. A disabled row still occupies its slot:
+   * it stays visible (so the menu explains what's unavailable rather than hiding it)
+   * and, critically, keeps its position — `onSelectIndex` is an index into `actions`,
+   * so dropping a row would silently shift every action after it.
+   */
+  disabled?: boolean;
+  /**
    * SF Symbol name shown on the native iOS dropdown row (e.g. `person.2.fill`).
    * iOS-only: the Android Compose menu has no SF Symbols, so it's ignored there.
    */
   systemIcon?: string;
 };
 
-export type AppMenuProps = {
-  /** The anchor button's text (the active scope). The native trigger renders this — there's no RN `children` anchor anymore. */
-  label: string;
+type AppMenuSharedProps = {
   actions: AppMenuAction[];
-  /** Called with the index of the tapped action, matching `actions` order. */
+  /** Called with the index of the tapped action, matching `actions` order. Never fires for a disabled row. */
   onSelectIndex: (index: number) => void;
-  /** Trailing down-caret on the anchor. Default `true`. */
-  showCaret?: boolean;
   /** Caps the anchor's width (iOS: SwiftUI `frame`; Android: best-effort RN clip). */
   maxWidth?: number;
-  accessibilityLabel?: string;
   accessibilityHint?: string;
   /** Positions the menu's `Host` in its parent; not the menu popup. */
   style?: StyleProp<ViewStyle>;
 };
+
+/** Text anchor: the active scope's name, with an optional trailing caret. */
+type AppMenuTextAnchorProps = AppMenuSharedProps & {
+  /** The anchor button's text (the active scope). The native trigger renders this — there's no RN `children` anchor anymore. */
+  label: string;
+  iconName?: never;
+  /** Falls back to `label` — the anchor already reads its scope aloud. */
+  accessibilityLabel?: string;
+  /** Trailing down-caret on the anchor. Default `true`. */
+  showCaret?: boolean;
+};
+
+/** Icon anchor: a bare glyph trigger (the "⋯" overflow button), with no visible text. */
+type AppMenuIconAnchorProps = AppMenuSharedProps & {
+  label?: never;
+  iconName: IconName;
+  /** Required here: a glyph-only anchor has no visible text for a screen reader to fall back on. */
+  accessibilityLabel: string;
+  /** A glyph anchor never carries a caret — the glyph itself is the affordance. */
+  showCaret?: never;
+};
+
+/** Exactly one of `label` / `iconName`: a text anchor or a glyph anchor, never both. */
+export type AppMenuProps = AppMenuTextAnchorProps | AppMenuIconAnchorProps;

--- a/packages/mobile/src/components/AppMenu.web.tsx
+++ b/packages/mobile/src/components/AppMenu.web.tsx
@@ -1,9 +1,10 @@
 // AppMenu — web implementation (react-native-web + react-native-paper). A Paper
-// `Menu` anchored to a flat text + caret trigger — the Material counterpart to the
-// Compose `DropdownMenu` in AppMenu.android.tsx. The active row shows a leading ✓
-// (Paper's `check` glyph, no SF Symbols on web) and destructive rows take the
-// `m3.error` text colour. Controlled `visible` state, closed on each select. The
-// per-platform action resolution (which glyph, when to check) lives in
+// `Menu` anchored to a flat text + caret trigger (or a bare glyph trigger in icon
+// mode) — the Material counterpart to the Compose `DropdownMenu` in
+// AppMenu.android.tsx. The active row shows a leading ✓ (Paper's `check` glyph, no
+// SF Symbols on web), destructive rows take the `m3.error` text colour and disabled
+// rows use Paper's own `disabled`. Controlled `visible` state, closed on each select.
+// The per-platform action resolution (which glyph, when to check) lives in
 // AppMenu.logic.ts, shared with the iOS file.
 //
 // `systemIcon` (an iOS SF Symbol name) is ignored here — it isn't a Material glyph
@@ -14,42 +15,53 @@ import { Pressable, StyleSheet, Text } from 'react-native';
 import { Menu } from 'react-native-paper';
 import { useTheme } from '../providers/theme-provider';
 import { spacing } from '../theme/tokens';
-import { resolveMenuActions } from './AppMenu.logic';
+import { anchorGlyphForIcon, isMenuActionSelectable, resolveMenuActions } from './AppMenu.logic';
 import type { AppMenuProps } from './AppMenu.types';
 
 // Down-caret glyph — Paper's Menu anchor is arbitrary content, so a muted glyph
-// stands in (mirrors the Compose `▾` in AppMenu.android.tsx).
+// stands in (mirrors the Compose `▾` in AppMenu.android.tsx). The icon anchor's
+// glyph comes from `anchorGlyphForIcon`, which Android shares.
 const CARET = '▾';
 
-export function AppMenu({
-  label,
-  actions,
-  onSelectIndex,
-  showCaret = true,
-  maxWidth,
-  accessibilityLabel,
-  accessibilityHint,
-  style,
-}: AppMenuProps) {
+// Matches the 44pt circle the iOS glyph anchor draws, so the overflow trigger keeps
+// its touch target and its round silhouette in the browser build.
+const ICON_ANCHOR_SIZE = 44;
+
+export function AppMenu(props: AppMenuProps) {
+  const { actions, onSelectIndex, maxWidth, accessibilityLabel, accessibilityHint, style } = props;
   const { m3, systemColors } = useTheme();
   const [visible, setVisible] = useState(false);
   const resolved = useMemo(() => resolveMenuActions(actions), [actions]);
 
   const labelColor = systemColors.label as string;
   const caretColor = systemColors.secondaryLabel as string;
+  // Paper greys a disabled row itself, but `titleStyle` would override that colour,
+  // so the disabled tint is picked here rather than left to the theme.
+  const disabledColor = systemColors.tertiaryLabel as string;
 
   const anchor = (
     <Pressable
       onPress={() => setVisible(true)}
       accessibilityRole="button"
-      accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityLabel={accessibilityLabel ?? props.label}
       accessibilityHint={accessibilityHint}
-      style={[styles.anchor, maxWidth != null ? { maxWidth } : null, style]}
+      style={[
+        styles.anchor,
+        props.iconName != null ? [styles.iconAnchor, { backgroundColor: systemColors.fill as string }] : null,
+        maxWidth != null ? { maxWidth } : null,
+        style,
+      ]}
     >
-      <Text numberOfLines={1} style={[styles.anchorLabel, { color: labelColor }]}>
-        {label}
-      </Text>
-      {showCaret ? <Text style={[styles.caret, { color: caretColor }]}>{` ${CARET}`}</Text> : null}
+      {props.iconName != null ? (
+        <Text style={[styles.anchorLabel, { color: labelColor }]}>{anchorGlyphForIcon(props.iconName)}</Text>
+      ) : (
+        <Text numberOfLines={1} style={[styles.anchorLabel, { color: labelColor }]}>
+          {props.label}
+        </Text>
+      )}
+      {props.iconName == null && props.showCaret !== false ? (
+        <Text style={[styles.caret, { color: caretColor }]}>{` ${CARET}`}</Text>
+      ) : null}
     </Pressable>
   );
 
@@ -62,8 +74,12 @@ export function AppMenu({
           key={`${index}-${action.label}`}
           title={action.label}
           leadingIcon={action.showCheck ? 'check' : undefined}
-          titleStyle={{ color: action.isDestructive ? (m3.error as string) : labelColor }}
+          disabled={action.isDisabled}
+          titleStyle={{
+            color: action.isDisabled ? disabledColor : action.isDestructive ? (m3.error as string) : labelColor,
+          }}
           onPress={() => {
+            if (!isMenuActionSelectable(resolved, index)) return;
             setVisible(false);
             onSelectIndex(index);
           }}
@@ -79,6 +95,14 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: spacing[1],
     paddingVertical: spacing[2],
+  },
+  iconAnchor: {
+    width: ICON_ANCHOR_SIZE,
+    height: ICON_ANCHOR_SIZE,
+    borderRadius: ICON_ANCHOR_SIZE / 2,
+    justifyContent: 'center',
+    paddingHorizontal: 0,
+    paddingVertical: 0,
   },
   anchorLabel: {
     fontSize: 17,

--- a/packages/mobile/src/components/__tests__/app-menu.test.tsx
+++ b/packages/mobile/src/components/__tests__/app-menu.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
-import { resolveMenuAction, resolveMenuActions } from '../AppMenu.logic';
+import { anchorGlyphForIcon, isMenuActionSelectable, resolveMenuAction, resolveMenuActions } from '../AppMenu.logic';
 import type { AppMenuAction } from '../AppMenu.types';
 
 // AppMenu's per-platform rendering is native (@expo/ui SwiftUI `Menu` / Compose
@@ -37,6 +37,19 @@ describe('AppMenu.logic — resolveMenuAction', () => {
     expect(resolveMenuAction({ label: 'Delete', destructive: true }).isDestructive).toBe(true);
     expect(resolveMenuAction({ label: 'Keep' }).isDestructive).toBe(false);
   });
+
+  it('flags disabled rows and leaves the rest selectable', () => {
+    expect(resolveMenuAction({ label: 'Save', disabled: true }).isDisabled).toBe(true);
+    expect(resolveMenuAction({ label: 'Save', disabled: false }).isDisabled).toBe(false);
+    expect(resolveMenuAction({ label: 'Save' }).isDisabled).toBe(false);
+  });
+
+  it('keeps a disabled row otherwise intact — it still shows its label, check and icon', () => {
+    const resolved = resolveMenuAction({ label: 'Save', disabled: true, selected: true, systemIcon: 'tray' });
+    expect(resolved.label).toBe('Save');
+    expect(resolved.showCheck).toBe(true);
+    expect(resolved.iosSystemImage).toBe('checkmark');
+  });
 });
 
 describe('AppMenu.logic — resolveMenuActions', () => {
@@ -50,6 +63,54 @@ describe('AppMenu.logic — resolveMenuActions', () => {
     expect(resolved.map((action) => action.label)).toEqual(['My crew', 'Everyone', 'Find a gym']);
     expect(resolved.map((action) => action.showCheck)).toEqual([true, false, false]);
     expect(resolved[2].iosSystemImage).toBe('mappin.and.ellipse');
+  });
+
+  it('keeps a disabled row in its slot so the indices after it do not shift', () => {
+    const actions: AppMenuAction[] = [
+      { label: 'Undo' },
+      { label: 'Save', disabled: true },
+      { label: 'Delete', destructive: true },
+    ];
+    const resolved = resolveMenuActions(actions);
+    expect(resolved.map((action) => action.label)).toEqual(['Undo', 'Save', 'Delete']);
+    expect(resolved.map((action) => action.isDisabled)).toEqual([false, true, false]);
+    // The row after the disabled one still answers to its own index.
+    expect(resolved[2].isDestructive).toBe(true);
+  });
+});
+
+describe('AppMenu.logic — isMenuActionSelectable', () => {
+  const RESOLVED = resolveMenuActions([{ label: 'Undo' }, { label: 'Save', disabled: true }]);
+
+  it('blocks a disabled row and allows the rest', () => {
+    expect(isMenuActionSelectable(RESOLVED, 0)).toBe(true);
+    expect(isMenuActionSelectable(RESOLVED, 1)).toBe(false);
+  });
+
+  it('blocks an index past the end rather than throwing', () => {
+    expect(isMenuActionSelectable(RESOLVED, 2)).toBe(false);
+  });
+
+  it('is the guard each impl runs before calling onSelectIndex', () => {
+    const onSelectIndex = vi.fn();
+    // What every platform's row handler does: guard, then report the tapped index.
+    [0, 1].forEach((index) => {
+      if (!isMenuActionSelectable(RESOLVED, index)) return;
+      onSelectIndex(index);
+    });
+    expect(onSelectIndex).toHaveBeenCalledTimes(1);
+    expect(onSelectIndex).toHaveBeenCalledWith(0);
+  });
+});
+
+describe('AppMenu.logic — anchorGlyphForIcon', () => {
+  it('maps the overflow family to its matching text glyph', () => {
+    expect(anchorGlyphForIcon('more')).toBe('⋯');
+    expect(anchorGlyphForIcon('more.vertical')).toBe('⋮');
+  });
+
+  it('falls back to the horizontal ellipsis for an icon with no text stand-in', () => {
+    expect(anchorGlyphForIcon('settings')).toBe('⋯');
   });
 });
 
@@ -109,5 +170,21 @@ describe('AppMenu stub — interaction contract', () => {
     expect(onSelectIndex).toHaveBeenCalledWith(1);
     fireEvent.click(getByText('Find a gym'));
     expect(onSelectIndex).toHaveBeenCalledWith(2);
+  });
+
+  it('takes an icon anchor with no label, naming it by its required accessibilityLabel', () => {
+    const { container, getByLabelText } = render(
+      createElement(AppMenu, {
+        iconName: 'more',
+        actions: ACTIONS,
+        onSelectIndex: () => {},
+        accessibilityLabel: 'More actions',
+      }),
+    );
+    const anchor = getByLabelText('More actions');
+    // A glyph anchor has no visible text, so the a11y label is its only name.
+    expect(anchor.textContent).toBe('');
+    // The rows are unaffected by which anchor the menu wears.
+    expect(container.querySelectorAll('button[data-role="button"]').length).toBe(ACTIONS.length + 1);
   });
 });

--- a/packages/mobile/src/components/create-climb/CreateDrawer.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawer.tsx
@@ -198,9 +198,6 @@ export function CreateDrawer({
         case 'makeBoulder':
           controller.leaveRouteMode();
           return;
-        case 'deleteFrame':
-          controller.deleteFrame();
-          return;
         case 'newClimb':
           controller.handleNewClimb();
       }
@@ -387,6 +384,7 @@ export function CreateDrawer({
               playback={controller.playback}
               wallStateLabel={controller.handedOff ? tSession('playView.wallState.onWall') : null}
               onAddFrame={controller.duplicateFrame}
+              onDeleteFrame={controller.deleteFrame}
               onPaceChange={controller.setFramesPace}
             />
 

--- a/packages/mobile/src/components/create-climb/CreateDrawer.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawer.tsx
@@ -184,9 +184,12 @@ export function CreateDrawer({
       supportsMultiFrame: controller.supportsMultiFrame,
       routeMode: controller.routeMode,
       frameCount: controller.frameCount,
-      frameIndex: controller.currentFrameIndex,
     }),
-    [controller.supportsMultiFrame, controller.routeMode, controller.frameCount, controller.currentFrameIndex],
+    // Deliberately NOT currentFrameIndex: the menu stopped reading it when the
+    // frame commands moved to the transport card, and CreateDrawerHeader is
+    // memo'd — keeping it here handed the header a new object on every playback
+    // tick, as often as twice a second.
+    [controller.supportsMultiFrame, controller.routeMode, controller.frameCount],
   );
 
   const handleOverflowAction = useCallback(
@@ -398,6 +401,7 @@ export function CreateDrawer({
               onRedo={controller.redo}
               onClearHolds={controller.handleClearHolds}
               frameCount={controller.frameCount}
+              frameDeletions={controller.frameDeletions}
               currentFrameIndex={controller.currentFrameIndex}
               canSetActive={controller.canSetActive}
               onSetActive={controller.handleSetActive}

--- a/packages/mobile/src/components/create-climb/CreateDrawer.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawer.tsx
@@ -40,6 +40,8 @@ import { CreateDrawerHeader } from './CreateDrawerHeader';
 import { CreateDrawerActionBar } from './CreateDrawerActionBar';
 import { CreateDrawerForm } from './CreateDrawerForm';
 import { CreateRoutePlaybackSlot } from './CreateRoutePlaybackSlot';
+import type { CreateOverflowAction } from './create-overflow-menu';
+import { computeBoardMaxHeight } from './create-drawer-layout';
 import { OpenDraftsSection } from './OpenDraftsSection';
 import { DuplicateBanner } from './DuplicateBanner';
 import { InlineConfirmBanner } from './InlineConfirmBanner';
@@ -68,31 +70,6 @@ type CreateDrawerProps = {
   /** Open the climb that a publish collided with (the duplicate banner link). */
   onViewDuplicate: (uuid: string) => void;
 };
-
-// Space the header + action bar + draft-status line + handle + safe areas need,
-// so the board is sized to leave them on-screen at the peek (a rough reserve —
-// the peek snap itself is measured from the real above-fold height, so erring
-// high only costs a few dp of board).
-//
-// Raised from 300 by exactly what the status line costs the action bar: +32 for
-// its line box and padding, −8 from the action row's bottom padding, so +24. The
-// board shrinks by the same 24, which makes the peek height IDENTICAL to what it
-// was before the line existed — the status line is free at the peek, in every
-// state (the row reserves its height even when empty, so this doesn't drift as
-// you paint). Deliberately not rounded: a round number here would silently make
-// the peek taller and eat into an already-tight budget on a tall board.
-const ABOVE_FOLD_CHROME = 324;
-
-// PlaybackControls' resting height (paddingVertical 12 x 2 + the 52dp play
-// button + marginTop 8 = 84) plus the frame-actions row under it (a 44dp button
-// row + its 8dp margin = 52). Claimed once a climb actually has frames to play.
-const PLAYBACK_TRANSPORT_RESERVE = 136;
-
-// The single-frame route strip: a 44dp control row plus its 8dp marginTop. It
-// costs the board 52dp on a fresh climb, which is the price of the transport
-// being discoverable at all — the feature was invisible until you found a bare
-// `copy` glyph fourth inside the action bar's scroller (#4761 QA).
-const ROUTE_STRIP_RESERVE = 52;
 
 // The peek must never grow into the '100%' snap — at that point the two snap
 // points collapse into one, the sheet has no travel and the "drag up for the
@@ -202,16 +179,45 @@ export function CreateDrawer({
     [resetBoardZoom, onLoadDraft],
   );
 
-  // Woods pays neither reserve: the slot renders nothing there.
-  const routeSlotReserve = controller.supportsMultiFrame
-    ? controller.frameCount > 1
-      ? PLAYBACK_TRANSPORT_RESERVE
-      : ROUTE_STRIP_RESERVE
-    : 0;
-  const boardMaxHeight = Math.max(
-    200,
-    windowHeight - insets.top - windowInsetBottom - ABOVE_FOLD_CHROME - routeSlotReserve,
+  const overflowState = useMemo(
+    () => ({
+      supportsMultiFrame: controller.supportsMultiFrame,
+      routeMode: controller.routeMode,
+      frameCount: controller.frameCount,
+      frameIndex: controller.currentFrameIndex,
+    }),
+    [controller.supportsMultiFrame, controller.routeMode, controller.frameCount, controller.currentFrameIndex],
   );
+
+  const handleOverflowAction = useCallback(
+    (action: CreateOverflowAction) => {
+      switch (action) {
+        case 'makeRoute':
+          controller.enterRouteMode();
+          return;
+        case 'makeBoulder':
+          controller.leaveRouteMode();
+          return;
+        case 'deleteFrame':
+          controller.deleteFrame();
+          return;
+        case 'newClimb':
+          controller.handleNewClimb();
+      }
+    },
+    [controller],
+  );
+
+  // A boulder pays nothing for route chrome now that route mode is opt-in from
+  // the header's overflow menu — #4761 charged every climb 52dp for a strip
+  // pitching a feature most setters never use. Woods, which can only ever hold
+  // one frame, likewise.
+  const boardMaxHeight = computeBoardMaxHeight({
+    windowHeight,
+    insetTop: insets.top,
+    insetBottom: windowInsetBottom,
+    showRouteTransport: controller.showRouteTransport,
+  });
 
   // Compute the on-screen board size up front (window width minus the board
   // section margins, capped by the height budget) so the board paints on the
@@ -308,6 +314,8 @@ export function CreateDrawer({
               bleConnected={controller.bleConnected}
               bleConnecting={controller.bleConnecting}
               onToggleBle={controller.handleToggleBle}
+              overflow={overflowState}
+              onSelectOverflowAction={handleOverflowAction}
             />
           </View>
 
@@ -373,13 +381,13 @@ export function CreateDrawer({
             </View>
 
             <CreateRoutePlaybackSlot
-              supportsMultiFrame={controller.supportsMultiFrame}
+              showRouteTransport={controller.showRouteTransport}
               frameCount={controller.frameCount}
               frameIndex={controller.currentFrameIndex}
               playback={controller.playback}
               wallStateLabel={controller.handedOff ? tSession('playView.wallState.onWall') : null}
               onAddFrame={controller.duplicateFrame}
-              onDeleteFrame={controller.deleteFrame}
+              onPaceChange={controller.setFramesPace}
             />
 
             <CreateDrawerActionBar
@@ -391,7 +399,6 @@ export function CreateDrawer({
               onUndo={controller.undo}
               onRedo={controller.redo}
               onClearHolds={controller.handleClearHolds}
-              onNewClimb={controller.handleNewClimb}
               frameCount={controller.frameCount}
               currentFrameIndex={controller.currentFrameIndex}
               canSetActive={controller.canSetActive}

--- a/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
@@ -37,10 +37,9 @@ type CreateDrawerActionBarProps = {
   onRedo: () => void;
   /** Empty this frame's holds. Undoable; leaves name/description/storage alone. */
   onClearHolds: () => void;
-  /** Park this climb and start a blank one (confirms when nothing is saved yet). */
-  onNewClimb: () => void;
   /** Frame count and index are read only to announce a new frame — the buttons
-   *  that CHANGE them live in the route slot under the board. */
+   *  that CHANGE them live in the transport card under the board, and the
+   *  destructive ones in the header's overflow menu. */
   frameCount: number;
   currentFrameIndex: number;
   canSetActive: boolean;
@@ -77,7 +76,6 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
   onUndo,
   onRedo,
   onClearHolds,
-  onNewClimb,
   frameCount,
   currentFrameIndex,
   canSetActive,
@@ -209,15 +207,6 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
             iconName="delete"
             onPress={onClearHolds}
             accessibilityLabel={t('mobile.create.actions.clear')}
-          />
-          {/* Last in the scroller: the least-used control in the row, and the one
-              it's fine to scroll for. `plus`, not `refresh` — that's already the
-              playback-restart glyph. */}
-          <ActionButton
-            size="sm"
-            iconName="plus"
-            onPress={onNewClimb}
-            accessibilityLabel={t('mobile.create.actions.newClimb')}
           />
         </ScrollView>
 

--- a/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
@@ -93,20 +93,30 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
   // announcement can't talk over each other.
   const announce = useRateLimitedAnnouncer();
 
-  // Adding a frame is undoable, so it needs feedback rather than a confirm: the
-  // only other sign a frame appeared is the transport's "2 / 2". Add frame now
-  // lives in the route slot, so this keys on the COUNT GOING UP rather than on a
-  // press here. Frame navigation moves the index, not the count, so it stays
-  // silent, and a delete is a decrease and stays silent too. Announcing from
-  // this component (rather than from the slot that owns the button) keeps ONE
-  // voice on the surface, so a frame announcement and a draft-status transition
-  // still can't talk over each other.
+  // Adding and removing a frame are both undoable, so they need feedback rather
+  // than a confirm: the only other sign the strip changed is a chip appearing or
+  // vanishing, which a screen reader never sees. Both controls live in the route
+  // slot, so this keys on the COUNT MOVING rather than on a press here. Frame
+  // navigation moves the index, not the count, so it stays silent. Announcing
+  // from this component (rather than from the slot that owns the buttons) keeps
+  // ONE voice on the surface, so a frame announcement and a draft-status
+  // transition still can't talk over each other.
+  //
+  // A delete gets its own line rather than the plain counter: after it, focus is
+  // gone and the strip has reshuffled under the reader, so "3 of 4" alone would
+  // not say that anything was removed. It carries no ordinal — the index this
+  // component sees has already been clamped past the frame that went, so naming
+  // one here would name the wrong frame.
   const previousFrameCountRef = useRef(frameCount);
   useEffect(() => {
-    const gainedAFrame = frameCount > previousFrameCountRef.current;
+    const previousFrameCount = previousFrameCountRef.current;
     previousFrameCountRef.current = frameCount;
-    if (!gainedAFrame) return;
-    announce(t('mobile.create.frames.counter', { index: currentFrameIndex + 1, total: frameCount }));
+    if (frameCount === previousFrameCount) return;
+    if (frameCount > previousFrameCount) {
+      announce(t('mobile.create.frames.counter', { index: currentFrameIndex + 1, total: frameCount }));
+      return;
+    }
+    announce(t('mobile.create.playback.frameDeleted', { total: frameCount }));
   }, [frameCount, currentFrameIndex, announce, t]);
 
   const paintRoles = useMemo(() => getPaintRoles(boardName), [boardName]);

--- a/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
@@ -41,6 +41,9 @@ type CreateDrawerActionBarProps = {
    *  that CHANGE them live in the transport card under the board, and the
    *  destructive ones in the header's overflow menu. */
   frameCount: number;
+  /** Monotonic count of frame deletions, so a delete can be announced without
+   *  inferring it from the frame count falling — which a reset also does. */
+  frameDeletions: number;
   currentFrameIndex: number;
   canSetActive: boolean;
   onSetActive: () => void;
@@ -77,6 +80,7 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
   onRedo,
   onClearHolds,
   frameCount,
+  frameDeletions,
   currentFrameIndex,
   canSetActive,
   onSetActive,
@@ -96,28 +100,34 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
   // Adding and removing a frame are both undoable, so they need feedback rather
   // than a confirm: the only other sign the strip changed is a chip appearing or
   // vanishing, which a screen reader never sees. Both controls live in the route
-  // slot, so this keys on the COUNT MOVING rather than on a press here. Frame
+  // slot, so add keys on the COUNT GOING UP rather than on a press here. Frame
   // navigation moves the index, not the count, so it stays silent. Announcing
   // from this component (rather than from the slot that owns the buttons) keeps
   // ONE voice on the surface, so a frame announcement and a draft-status
   // transition still can't talk over each other.
-  //
-  // A delete gets its own line rather than the plain counter: after it, focus is
-  // gone and the strip has reshuffled under the reader, so "3 of 4" alone would
-  // not say that anything was removed. It carries no ordinal — the index this
-  // component sees has already been clamped past the frame that went, so naming
-  // one here would name the wrong frame.
   const previousFrameCountRef = useRef(frameCount);
   useEffect(() => {
-    const previousFrameCount = previousFrameCountRef.current;
+    const gainedAFrame = frameCount > previousFrameCountRef.current;
     previousFrameCountRef.current = frameCount;
-    if (frameCount === previousFrameCount) return;
-    if (frameCount > previousFrameCount) {
-      announce(t('mobile.create.frames.counter', { index: currentFrameIndex + 1, total: frameCount }));
-      return;
-    }
-    announce(t('mobile.create.playback.frameDeleted', { total: frameCount }));
+    if (!gainedAFrame) return;
+    announce(t('mobile.create.frames.counter', { index: currentFrameIndex + 1, total: frameCount }));
   }, [frameCount, currentFrameIndex, announce, t]);
+
+  // A delete gets its own line rather than the plain counter: after it, focus is
+  // gone and the strip has reshuffled under the reader, so "3 of 4" alone would
+  // not say anything was removed. It carries no ordinal — the index this
+  // component sees has already been clamped past the frame that went, so naming
+  // one here would name the wrong frame.
+  //
+  // Keyed on a counter the delete path bumps, NOT on the count falling: "Start a
+  // new climb" and "Clear holds" both RESET to one empty frame, and undoing an
+  // add walks the count back. All three would have announced a delete.
+  const previousFrameDeletionsRef = useRef(frameDeletions);
+  useEffect(() => {
+    if (frameDeletions === previousFrameDeletionsRef.current) return;
+    previousFrameDeletionsRef.current = frameDeletions;
+    announce(t('mobile.create.playback.frameDeleted', { total: frameCount }));
+  }, [frameDeletions, frameCount, announce, t]);
 
   const paintRoles = useMemo(() => getPaintRoles(boardName), [boardName]);
   const roleChips = useMemo(

--- a/packages/mobile/src/components/create-climb/CreateDrawerHeader.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerHeader.tsx
@@ -1,10 +1,16 @@
-import { memo, useEffect, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { View, StyleSheet, Pressable, type TextInput } from 'react-native';
 import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { BleLightbulbButton } from '../ble/BleLightbulbButton';
+import { AppMenu } from '../AppMenu';
+import {
+  buildCreateOverflowMenu,
+  type CreateOverflowAction,
+  type CreateOverflowMenuState,
+} from './create-overflow-menu';
 import { useTheme } from '../../providers/theme-provider';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
@@ -22,6 +28,9 @@ type CreateDrawerHeaderProps = {
   bleConnected: boolean;
   bleConnecting: boolean;
   onToggleBle: () => void;
+  /** Editor state the overflow (⋯) menu builds its rows from. */
+  overflow: CreateOverflowMenuState;
+  onSelectOverflowAction: (action: CreateOverflowAction) => void;
 };
 
 /**
@@ -39,6 +48,8 @@ export const CreateDrawerHeader = memo(function CreateDrawerHeader({
   bleConnected,
   bleConnecting,
   onToggleBle,
+  overflow,
+  onSelectOverflowAction,
 }: CreateDrawerHeaderProps) {
   const { t } = useTranslation('climbs');
   const { t: tSettings } = useTranslation('settings');
@@ -53,6 +64,18 @@ export const CreateDrawerHeader = memo(function CreateDrawerHeader({
   const counts = `${t('mobile.create.counts.start', { count: startingCount })} · ${t('mobile.create.counts.finish', {
     count: finishCount,
   })}`;
+
+  const overflowRows = useMemo(() => buildCreateOverflowMenu(overflow, t), [overflow, t]);
+  // The menu reports a position; the rows carry what that position means, so a
+  // state that drops a row (Woods, or a boulder with no frame to delete) can
+  // never shift a tap onto the wrong action.
+  const handleSelectOverflowIndex = useCallback(
+    (index: number) => {
+      const row = overflowRows[index];
+      if (row) onSelectOverflowAction(row.action);
+    },
+    [overflowRows, onSelectOverflowAction],
+  );
 
   return (
     <View style={styles.row}>
@@ -90,6 +113,20 @@ export const CreateDrawerHeader = memo(function CreateDrawerHeader({
         </Text>
       </View>
 
+      {/* Document-level commands (what kind of climb this is, start over) live in
+          the nav-bar overflow, not the action bar: that bar is a tool bar you use
+          with a brush in hand, and its middle is a horizontal scroller, so a
+          command placed there can scroll off-screen. That is exactly how the bare
+          `copy` glyph went unfound twice. Left of the lightbulb, which is a
+          stateful toggle whose position climbers track across sessions. */}
+      <AppMenu
+        iconName="more"
+        actions={overflowRows}
+        onSelectIndex={handleSelectOverflowIndex}
+        accessibilityLabel={t('mobile.create.routeMenu.open')}
+        style={styles.overflow}
+      />
+
       <BleLightbulbButton
         isConnected={bleConnected}
         isScanning={bleConnecting}
@@ -117,6 +154,12 @@ const styles = StyleSheet.create({
   // A 44pt circle echoing the Play Drawer's close button. The fill is applied
   // inline from the theme (systemColors.fill) so it adapts to dark mode and
   // matches the drawer's action buttons.
+  overflow: {
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   iconButton: {
     width: 44,
     height: 44,

--- a/packages/mobile/src/components/create-climb/CreateDrawerHeader.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerHeader.tsx
@@ -69,10 +69,15 @@ export const CreateDrawerHeader = memo(function CreateDrawerHeader({
   // The menu reports a position; the rows carry what that position means, so a
   // state that drops a row (Woods, or a boulder with no frame to delete) can
   // never shift a tap onto the wrong action.
+  //
+  // Disabled rows are refused here as well as by all three platform menus. Every
+  // action behind one guards itself too, so this is depth rather than a fix —
+  // but the row set is data, and the next action added to it may not.
   const handleSelectOverflowIndex = useCallback(
     (index: number) => {
       const row = overflowRows[index];
-      if (row) onSelectOverflowAction(row.action);
+      if (!row || row.disabled) return;
+      onSelectOverflowAction(row.action);
     },
     [overflowRows, onSelectOverflowAction],
   );

--- a/packages/mobile/src/components/create-climb/CreateRoutePlaybackSlot.tsx
+++ b/packages/mobile/src/components/create-climb/CreateRoutePlaybackSlot.tsx
@@ -1,15 +1,7 @@
 import { memo } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { useTranslation } from 'react-i18next';
-import { Text } from '../Text';
-import { Icon } from '../Icon';
-import { Button } from '../Button';
-import { ButtonSurfaceProvider } from '../Button.surface';
 import { PlaybackControls } from '../playback/PlaybackControls';
-import { useTheme } from '../../providers/theme-provider';
-import { glassSize } from '../../theme/layout';
-import { spacing, borderRadius } from '../../theme/tokens';
 
 type PlaybackSlotControls = {
   isPlaying: boolean;
@@ -22,8 +14,12 @@ type PlaybackSlotControls = {
 };
 
 type CreateRoutePlaybackSlotProps = {
-  /** False on a board whose climbs can only ever hold one frame (Woods). */
-  supportsMultiFrame: boolean;
+  /**
+   * Whether the creator is authoring a route. False for a boulder and on a board
+   * whose climbs can only ever hold one frame (Woods) — in both cases the slot
+   * renders nothing and the board keeps the space.
+   */
+  showRouteTransport: boolean;
   frameCount: number;
   frameIndex: number;
   playback: PlaybackSlotControls;
@@ -32,158 +28,68 @@ type CreateRoutePlaybackSlotProps = {
   wallStateLabel: string | null;
   /** Adds a frame. Wired to the controller's GUARDED duplicate. */
   onAddFrame: () => void;
-  /** Removes the frame the transport is sitting on. Only reachable on a route. */
-  onDeleteFrame: () => void;
+  /** The setter's authored per-frame pace, in ms. Published as `frames_pace`. */
+  onPaceChange: (paceMs: number) => void;
 };
 
 /**
- * The route slot under the board: one component that is never empty on a
- * multi-frame board.
+ * The route transport under the board.
  *
- * The transport used to mount only at two frames, and the only way to reach two
- * frames was a bare `copy` glyph fourth inside the action bar's horizontal
- * scroller. A fresh create sheet therefore showed no play control at all and no
- * hint that routes existed — the reason #4761 came back QA-declined. So the slot
- * always occupies the same place: an inert strip that names the feature and
- * offers the one action that unlocks it, replaced by the real transport the
- * moment there is something to play.
+ * This used to be a permanent strip on every climb, because route-ness was
+ * inferred from `frames.length > 1` and there was no way to say "this is a
+ * route" before the second frame existed — so the only way to make the feature
+ * discoverable was to charge every boulder 52dp for an advert. Route mode is now
+ * an explicit state the header's overflow menu owns, which means a boulder can
+ * render nothing here and a route can show its transport from frame one.
  *
- * The strip deliberately borrows PlaybackControls' card chrome (same radius,
- * hairline, margins) so the swap reads as the same surface waking up rather than
- * as two unrelated controls trading places.
+ * Frame editing lives inside the transport card (a frame strip, with add pinned
+ * to it) rather than in a detached row of pills underneath, and deleting a frame
+ * moved to the same overflow menu that turned route mode on. One card, one
+ * control set.
  */
 export const CreateRoutePlaybackSlot = memo(function CreateRoutePlaybackSlot({
-  supportsMultiFrame,
+  showRouteTransport,
   frameCount,
   frameIndex,
   playback,
   wallStateLabel,
   onAddFrame,
-  onDeleteFrame,
+  onPaceChange,
 }: CreateRoutePlaybackSlotProps) {
-  const { t } = useTranslation('climbs');
-  const { systemColors } = useTheme();
+  if (!showRouteTransport) return null;
 
-  // A board that lights one static frame has no route to play, and the frames
-  // string it would build carries a comma its packet builder rejects outright.
-  if (!supportsMultiFrame) return null;
-
-  if (frameCount > 1) {
-    // The nested root is load-bearing on Android, not decoration: the speed
-    // slider is a GestureDetector, and this sheet's content lives inside a
-    // Jetpack Compose ModalBottomSheet that the app's single root
-    // GestureHandlerRootView does not cover (#4320). The explicit style matters
-    // too — RNGH defaults to flex: 1, and a flex child inside the drawer's
-    // measured View would corrupt peekHeight.
-    return (
-      <>
-        <GestureHandlerRootView style={styles.playbackRoot}>
-          <PlaybackControls
-            frameIndex={frameIndex}
-            frameCount={frameCount}
-            isPlaying={playback.isPlaying}
-            speed={playback.speed}
-            paceMs={playback.paceMs}
-            wallStateLabel={wallStateLabel}
-            onPlay={playback.play}
-            onPause={playback.pause}
-            onSeek={playback.seek}
-            onSpeedChange={playback.setSpeed}
-          />
-        </GestureHandlerRootView>
-
-        {/* Frame editing lives here and nowhere else. The strip's own pill only
-            gets you to two frames; without this row the third frame was back
-            behind the action bar's bare `copy` glyph, which is the same
-            discoverability hole one frame later (Marco, iOS). Deliberately
-            OUTSIDE PlaybackControls — the play drawer mounts that component too
-            and has no frames to edit, so it stays prop-identical.
-
-            Delete leads, Add trails: the primary action belongs nearest the
-            thumb on a right-aligned row, and the destructive one belongs
-            furthest from it. */}
-        <View style={styles.frameActions}>
-          <ButtonSurfaceProvider surface="content">
-            <Button
-              title={t('mobile.create.frames.delete')}
-              variant="tonal"
-              size="small"
-              minHeight={glassSize.inline}
-              onPress={onDeleteFrame}
-            />
-            <Button
-              title={t('mobile.create.playback.addFrame')}
-              variant="filled"
-              size="small"
-              minHeight={glassSize.inline}
-              onPress={onAddFrame}
-            />
-          </ButtonSurfaceProvider>
-        </View>
-      </>
-    );
-  }
-
+  // The nested root is load-bearing on Android, not decoration: the pace slider
+  // is a GestureDetector, and this sheet's content lives inside a Jetpack Compose
+  // ModalBottomSheet that the app's single root GestureHandlerRootView does not
+  // cover (#4320). The explicit style matters too — RNGH defaults to flex: 1, and
+  // a flex child inside the drawer's measured View would corrupt peekHeight.
   return (
-    <View
-      style={[styles.emptyStrip, { borderColor: systemColors.separator }]}
-      testID="create-route-playback-empty"
-      accessibilityLabel={t('mobile.create.playback.emptyA11y')}
-    >
-      {/* Decorative, and deliberately NOT an accessible node: it is a play glyph
-          that does not play. The row is not `accessible` either — collapsing it
-          into one node would swallow the Add frame button, the only thing here
-          worth reaching. */}
-      <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
-        <Icon name="play.circle" size={22} color={systemColors.tertiaryLabel} />
-      </View>
-      <Text variant="caption1" style={styles.emptyHint} numberOfLines={1}>
-        {t('mobile.create.playback.emptyHint')}
-      </Text>
-      <ButtonSurfaceProvider surface="content">
-        <Button
-          title={t('mobile.create.playback.addFrame')}
-          variant="filled"
-          size="small"
-          // Compose sizes a small filled button at 40; this one sits in a row
-          // whose other affordance is a 44dp-tall icon. Floor it, the same way
-          // the action bar's Save pill is floored.
-          minHeight={glassSize.inline}
-          onPress={onAddFrame}
-        />
-      </ButtonSurfaceProvider>
-    </View>
+    <GestureHandlerRootView style={styles.playbackRoot}>
+      <PlaybackControls
+        frameIndex={frameIndex}
+        frameCount={frameCount}
+        isPlaying={playback.isPlaying}
+        speed={playback.speed}
+        paceMs={playback.paceMs}
+        wallStateLabel={wallStateLabel}
+        onPlay={playback.play}
+        onPause={playback.pause}
+        onSeek={playback.seek}
+        onSpeedChange={playback.setSpeed}
+        // Seconds, not a multiplier: in the creator this control authors the
+        // climb's own `frames_pace`, so it shows the unit the setter is choosing.
+        // The play drawer mounts the same component without these two props and
+        // keeps the ×multiplier, which is a reader's lens over the setter's pace.
+        paceUnit="seconds"
+        onPaceChange={onPaceChange}
+        frameEditing={{ onAddFrame }}
+      />
+    </GestureHandlerRootView>
   );
 });
 
 const styles = StyleSheet.create({
   playbackRoot: {
     alignSelf: 'stretch',
-  },
-  // A 44dp row plus its 8dp margin — the 52dp CreateDrawer takes out of the
-  // board budget on top of the transport's own 84.
-  frameActions: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-    gap: spacing[2],
-    marginHorizontal: spacing[4],
-    marginTop: spacing[2],
-  },
-  // Deliberately the same card chrome as PlaybackControls' container, minus its
-  // vertical padding: this strip is one 44dp row, not a transport.
-  emptyStrip: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[2],
-    marginHorizontal: spacing[4],
-    marginTop: spacing[2],
-    paddingHorizontal: spacing[4],
-    paddingVertical: spacing[2],
-    borderRadius: borderRadius.lg,
-    borderWidth: StyleSheet.hairlineWidth,
-  },
-  emptyHint: {
-    flex: 1,
   },
 });

--- a/packages/mobile/src/components/create-climb/CreateRoutePlaybackSlot.tsx
+++ b/packages/mobile/src/components/create-climb/CreateRoutePlaybackSlot.tsx
@@ -28,6 +28,8 @@ type CreateRoutePlaybackSlotProps = {
   wallStateLabel: string | null;
   /** Adds a frame. Wired to the controller's GUARDED duplicate. */
   onAddFrame: () => void;
+  /** Removes the frame the transport is sitting on. Guarded the same way. */
+  onDeleteFrame: () => void;
   /** The setter's authored per-frame pace, in ms. Published as `frames_pace`. */
   onPaceChange: (paceMs: number) => void;
 };
@@ -42,10 +44,11 @@ type CreateRoutePlaybackSlotProps = {
  * an explicit state the header's overflow menu owns, which means a boulder can
  * render nothing here and a route can show its transport from frame one.
  *
- * Frame editing lives inside the transport card (a frame strip, with add pinned
- * to it) rather than in a detached row of pills underneath, and deleting a frame
- * moved to the same overflow menu that turned route mode on. One card, one
- * control set.
+ * Frame editing lives inside the transport card rather than in a detached row of
+ * pills underneath: a chip strip on top, and add/remove as one icon capsule in
+ * the transport row beside prev/play/next. One card, one control set — and both
+ * frame commands sit where the frames are, rather than one of them hiding in the
+ * header's overflow menu a board's height away.
  */
 export const CreateRoutePlaybackSlot = memo(function CreateRoutePlaybackSlot({
   showRouteTransport,
@@ -54,6 +57,7 @@ export const CreateRoutePlaybackSlot = memo(function CreateRoutePlaybackSlot({
   playback,
   wallStateLabel,
   onAddFrame,
+  onDeleteFrame,
   onPaceChange,
 }: CreateRoutePlaybackSlotProps) {
   if (!showRouteTransport) return null;
@@ -82,7 +86,7 @@ export const CreateRoutePlaybackSlot = memo(function CreateRoutePlaybackSlot({
         // keeps the ×multiplier, which is a reader's lens over the setter's pace.
         paceUnit="seconds"
         onPaceChange={onPaceChange}
-        frameEditing={{ onAddFrame }}
+        frameEditing={{ onAddFrame, onDeleteFrame }}
       />
     </GestureHandlerRootView>
   );

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-action-bar.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-action-bar.test.tsx
@@ -72,7 +72,6 @@ const baseProps = {
   onUndo: vi.fn(),
   onRedo: vi.fn(),
   onClearHolds: vi.fn(),
-  onNewClimb: vi.fn(),
   frameCount: 1,
   currentFrameIndex: 0,
   canSetActive: true,
@@ -139,21 +138,22 @@ describe('CreateDrawerActionBar', () => {
     expect(scroller.querySelector('[data-action="redo"]')).toBeTruthy();
   });
 
-  it('keeps the trash glyph for Clear holds and adds a separate Start-a-new-climb', () => {
-    // Two buttons, two jobs. `eraser` is not available for Clear holds — it is
-    // already the Erase BRUSH chip in the row above, and one glyph can't mean both
-    // a mode you enter and a destructive command you fire.
-    const { container, scroller } = renderBar(1);
+  it('keeps the trash glyph for Clear holds, and no longer carries a plus', () => {
+    // `eraser` is not available for Clear holds — it is already the Erase BRUSH
+    // chip in the row above, and one glyph can't mean both a mode you enter and a
+    // destructive command you fire.
+    //
+    // The `plus` is gone: "Start a new climb" moved to the header's overflow
+    // menu, because on a route screen a `+` that DISCARDS the climb sat a thumb's
+    // width from the `+` that adds a frame to it. Two plusses, opposite
+    // consequences, one row apart.
+    const { container } = renderBar(1);
 
     const clear = container.querySelector('[data-action="delete"]') as HTMLElement;
-    const newClimb = container.querySelector('[data-action="plus"]') as HTMLElement;
     expect(clear).toBeTruthy();
     expect(clear.getAttribute('data-label')).toBe('mobile.create.actions.clear');
-    expect(newClimb).toBeTruthy();
-    expect(newClimb.getAttribute('data-label')).toBe('mobile.create.actions.newClimb');
     expect(container.querySelector('[data-action="eraser"]')).toBeNull();
-    // "Start a new climb" is the least-used control, so it's the one that scrolls.
-    expect(scroller.contains(newClimb)).toBe(true);
+    expect(container.querySelector('[data-action="plus"]')).toBeNull();
   });
 
   it('floors the Save pill at the 44dp touch target', () => {

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-action-bar.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-action-bar.test.tsx
@@ -61,6 +61,7 @@ vi.mock('../../../theme/colors', () => ({ brandColors: { primary: '#6D28D9', suc
 vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 3: 12, 4: 16 }, borderRadius: { md: 8 } }));
 
 import { CreateDrawerActionBar } from '../CreateDrawerActionBar';
+import { ANNOUNCE_MIN_INTERVAL_MS } from '../use-rate-limited-announcer';
 import type { DraftStatusView } from '../draft-status-view';
 
 const baseProps = {
@@ -73,6 +74,7 @@ const baseProps = {
   onRedo: vi.fn(),
   onClearHolds: vi.fn(),
   frameCount: 1,
+  frameDeletions: 0,
   currentFrameIndex: 0,
   canSetActive: true,
   onSetActive: vi.fn(),
@@ -209,7 +211,7 @@ describe('CreateDrawerActionBar', () => {
     expect(scroller.contains(save)).toBe(false);
   });
 
-  it('speaks the new count when a frame is ADDED, and stays silent on navigation or delete', () => {
+  it('speaks the new count when a frame is ADDED, and stays silent on navigation', () => {
     // Adding a frame is undoable, so it gets feedback rather than a confirm —
     // the only other sign it worked is the transport's "2 / 2". The button that
     // does it now lives in the route slot, so this keys on the count going UP
@@ -229,10 +231,42 @@ describe('CreateDrawerActionBar', () => {
     // Stepping between frames moves the INDEX, not the count.
     rerender(bar(2, 0));
     expect(announceSpy).toHaveBeenCalledTimes(1);
+  });
 
-    // A delete moves the count DOWN; the status line speaks for that, not this.
-    rerender(bar(1, 0));
-    expect(announceSpy).toHaveBeenCalledTimes(1);
+  it('speaks a delete off the delete COUNTER, never off the count falling', () => {
+    // Three things lower the frame count without a frame being deleted: "Start a
+    // new climb" and "Clear holds" both RESET to one empty frame, and undoing an
+    // add walks it back. Keying on the count would announce "Frame deleted" for
+    // all three, so the controller counts real deletes and this reads that.
+    //
+    // Fake timers because the announcer is rate-limited to one utterance per
+    // ANNOUNCE_MIN_INTERVAL_MS across the whole surface: without advancing them,
+    // a second announcement is parked on a timeout and never reaches the spy —
+    // which is how the previous version of this test passed while asserting the
+    // opposite of what the component did.
+    vi.useFakeTimers();
+    try {
+      const bar = (frameCount: number, frameDeletions: number) =>
+        createElement(CreateDrawerActionBar, { ...baseProps, frameCount, frameDeletions, currentFrameIndex: 0 });
+
+      // A reset: four frames collapse to one, and no delete was counted. The
+      // timer advance is what makes this assertion mean anything — a parked
+      // announcement would otherwise look identical to no announcement.
+      const reset = render(bar(4, 0));
+      reset.rerender(bar(1, 0));
+      vi.advanceTimersByTime(ANNOUNCE_MIN_INTERVAL_MS);
+      expect(announceSpy).not.toHaveBeenCalled();
+      reset.unmount();
+
+      // A real delete: the count falls AND the counter moves.
+      const deleted = render(bar(4, 0));
+      deleted.rerender(bar(3, 1));
+      vi.advanceTimersByTime(ANNOUNCE_MIN_INTERVAL_MS);
+      expect(announceSpy).toHaveBeenCalledTimes(1);
+      expect(announceSpy).toHaveBeenLastCalledWith('mobile.create.playback.frameDeleted');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('labels Set Active with a queue glyph, not a play glyph', () => {

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-auto-reset-zoom.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-auto-reset-zoom.test.tsx
@@ -46,10 +46,14 @@ vi.mock('../InteractiveCreateBoard', () => ({
     return createElement('div', { 'data-node': 'board' });
   },
 }));
-vi.mock('../CreateDrawerHeader', () => ({ CreateDrawerHeader: () => createElement('div') }));
+// "Start a new climb" moved off the action bar into the header's overflow menu,
+// so the button that stands in for it lives on the header mock now.
+vi.mock('../CreateDrawerHeader', () => ({
+  CreateDrawerHeader: ({ onSelectOverflowAction }: { onSelectOverflowAction?: (action: string) => void }) =>
+    createElement('button', { 'data-new-climb': 'true', onClick: () => onSelectOverflowAction?.('newClimb') }),
+}));
 vi.mock('../CreateDrawerActionBar', () => ({
-  CreateDrawerActionBar: ({ onNewClimb }: { onNewClimb?: () => void }) =>
-    createElement('button', { 'data-new-climb': 'true', onClick: onNewClimb }),
+  CreateDrawerActionBar: () => createElement('div', { 'data-node': 'action-bar' }),
 }));
 vi.mock('../CreateDrawerForm', () => ({ CreateDrawerForm: () => createElement('div') }));
 vi.mock('../OpenDraftsSection', () => ({

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-header-overflow.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-header-overflow.test.tsx
@@ -112,6 +112,19 @@ describe('CreateDrawerHeader overflow menu', () => {
     expect(onSelectOverflowAction).toHaveBeenLastCalledWith('newClimb');
   });
 
+  it('resolves the FIRST row on a board that renders fewer of them', () => {
+    // With the frame commands gone, Woods is the only state whose menu is a
+    // different LENGTH — one row where every other state has two. Index 0 there
+    // is newClimb, not the makeRoute that sits at 0 everywhere else, so this is
+    // what guards the header's index-to-action mapping against a stale row set.
+    const { onSelectOverflowAction, container } = renderHeader({ supportsMultiFrame: false });
+    const rows = Array.from(container.querySelectorAll('[data-row]')) as HTMLButtonElement[];
+
+    expect(rows).toHaveLength(1);
+    rows[0]?.click();
+    expect(onSelectOverflowAction).toHaveBeenLastCalledWith('newClimb');
+  });
+
   it('marks the blocked route-to-boulder row disabled rather than dropping it', () => {
     const { row } = renderHeader({ routeMode: true, frameCount: 4 });
     expect(row('mobile.create.routeMenu.makeBoulderBlocked')?.getAttribute('data-disabled')).toBe('true');

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-header-overflow.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-header-overflow.test.tsx
@@ -75,11 +75,11 @@ function renderHeader(overflow: Partial<Parameters<typeof CreateDrawerHeader>[0]
       bleConnected: false,
       bleConnecting: false,
       onToggleBle: vi.fn(),
-      overflow: { supportsMultiFrame: true, routeMode: false, frameCount: 1, frameIndex: 0, ...overflow },
+      overflow: { supportsMultiFrame: true, routeMode: false, frameCount: 1, ...overflow },
       onSelectOverflowAction,
     }),
   );
-  // Looked up by scanning rather than a CSS selector: the Delete label carries
+  // Looked up by scanning rather than a CSS selector: a label may carry
   // interpolated JSON, whose quotes and braces are not selector-safe.
   const row = (label: string) =>
     (Array.from(container.querySelectorAll('[data-row]')).find((node) => node.getAttribute('data-row') === label) ??
@@ -102,13 +102,11 @@ describe('CreateDrawerHeader overflow menu', () => {
   });
 
   it('resolves a tap through the rows the CURRENT state rendered', () => {
-    // A route at four frames grows a Delete row ahead of the others. Resolving
-    // by position against a stale row set would fire delete for a tap on the
-    // row after it.
-    const { onSelectOverflowAction, row } = renderHeader({ routeMode: true, frameCount: 4, frameIndex: 2 });
+    // A boulder's first row is Make it a route; a route's is Make it a boulder.
+    // Resolving by position against a stale row set would fire the wrong one.
+    const { onSelectOverflowAction, row } = renderHeader({ routeMode: true, frameCount: 4 });
 
-    row('mobile.create.routeMenu.deleteFrame:{"index":3}')?.click();
-    expect(onSelectOverflowAction).toHaveBeenLastCalledWith('deleteFrame');
+    expect(row('mobile.create.routeMenu.makeRoute')).toBeNull();
 
     row('mobile.create.actions.newClimb')?.click();
     expect(onSelectOverflowAction).toHaveBeenLastCalledWith('newClimb');

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-header-overflow.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-header-overflow.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// The header owns the ⋯ menu, and the menu reports a POSITION. The row set
+// changes with editor state — Woods drops the route rows, a one-frame route has
+// no frame to delete — so a stale index-to-action assumption would quietly fire
+// the wrong command. These pin that the header resolves a tap through the rows
+// it actually rendered.
+
+type ViewMockProps = { children?: ReactNode; testID?: string };
+vi.mock('react-native', () => ({
+  View: ({ children, testID }: ViewMockProps) => createElement('div', { 'data-testid': testID }, children),
+  Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
+    createElement('button', { onClick: onPress }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+vi.mock('@expo/ui/community/bottom-sheet', () => ({ BottomSheetTextInput: () => createElement('input') }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, number | string>) => (params ? `${key}:${JSON.stringify(params)}` : key),
+  }),
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: ({ name }: { name?: string }) => createElement('span', { 'data-icon': name }) }));
+vi.mock('../../ble/BleLightbulbButton', () => ({
+  BleLightbulbButton: () => createElement('span', { 'data-ble': 'true' }),
+}));
+// One button per row, in the order the header handed them over — enough to fire
+// a specific POSITION, which is the thing under test.
+vi.mock('../../AppMenu', () => ({
+  AppMenu: ({
+    actions,
+    onSelectIndex,
+    accessibilityLabel,
+  }: {
+    actions: { label: string; disabled?: boolean }[];
+    onSelectIndex: (index: number) => void;
+    accessibilityLabel?: string;
+  }) =>
+    createElement(
+      'div',
+      { 'data-node': 'overflow', 'data-label': accessibilityLabel },
+      actions.map((action, index) =>
+        createElement('button', {
+          key: action.label,
+          'data-row': action.label,
+          'data-disabled': action.disabled ? 'true' : 'false',
+          onClick: () => onSelectIndex(index),
+        }),
+      ),
+    ),
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { label: '#000', secondaryLabel: '#666', fill: '#EEE' } }),
+}));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#8E8E93' } }));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 3: 12, 4: 16 } }));
+
+import { CreateDrawerHeader } from '../CreateDrawerHeader';
+
+function renderHeader(overflow: Partial<Parameters<typeof CreateDrawerHeader>[0]['overflow']> = {}) {
+  const onSelectOverflowAction = vi.fn();
+  const { container } = render(
+    createElement(CreateDrawerHeader, {
+      name: 'Test climb',
+      onChangeName: vi.fn(),
+      startingCount: 0,
+      finishCount: 0,
+      focusSignal: 0,
+      onClose: vi.fn(),
+      bleConnected: false,
+      bleConnecting: false,
+      onToggleBle: vi.fn(),
+      overflow: { supportsMultiFrame: true, routeMode: false, frameCount: 1, frameIndex: 0, ...overflow },
+      onSelectOverflowAction,
+    }),
+  );
+  // Looked up by scanning rather than a CSS selector: the Delete label carries
+  // interpolated JSON, whose quotes and braces are not selector-safe.
+  const row = (label: string) =>
+    (Array.from(container.querySelectorAll('[data-row]')).find((node) => node.getAttribute('data-row') === label) ??
+      null) as HTMLButtonElement | null;
+  return { container, onSelectOverflowAction, row };
+}
+
+describe('CreateDrawerHeader overflow menu', () => {
+  it('labels the anchor, which is the only text a glyph trigger has', () => {
+    const { container } = renderHeader();
+    expect(container.querySelector('[data-node="overflow"]')?.getAttribute('data-label')).toBe(
+      'mobile.create.routeMenu.open',
+    );
+  });
+
+  it('fires Make it a route from a boulder', () => {
+    const { onSelectOverflowAction, row } = renderHeader();
+    row('mobile.create.routeMenu.makeRoute')?.click();
+    expect(onSelectOverflowAction).toHaveBeenCalledWith('makeRoute');
+  });
+
+  it('resolves a tap through the rows the CURRENT state rendered', () => {
+    // A route at four frames grows a Delete row ahead of the others. Resolving
+    // by position against a stale row set would fire delete for a tap on the
+    // row after it.
+    const { onSelectOverflowAction, row } = renderHeader({ routeMode: true, frameCount: 4, frameIndex: 2 });
+
+    row('mobile.create.routeMenu.deleteFrame:{"index":3}')?.click();
+    expect(onSelectOverflowAction).toHaveBeenLastCalledWith('deleteFrame');
+
+    row('mobile.create.actions.newClimb')?.click();
+    expect(onSelectOverflowAction).toHaveBeenLastCalledWith('newClimb');
+  });
+
+  it('marks the blocked route-to-boulder row disabled rather than dropping it', () => {
+    const { row } = renderHeader({ routeMode: true, frameCount: 4 });
+    expect(row('mobile.create.routeMenu.makeBoulderBlocked')?.getAttribute('data-disabled')).toBe('true');
+  });
+
+  it('offers no route rows on a board that can only hold one frame', () => {
+    const { row } = renderHeader({ supportsMultiFrame: false });
+    expect(row('mobile.create.routeMenu.makeRoute')).toBeNull();
+    expect(row('mobile.create.actions.newClimb')).not.toBeNull();
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-layout.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-layout.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ABOVE_FOLD_CHROME,
+  MIN_BOARD_HEIGHT,
+  PLAYBACK_TRANSPORT_RESERVE,
+  computeBoardMaxHeight,
+} from '../create-drawer-layout';
+
+// The board is the surface: every dp reserved by the drawer's chrome is a dp of
+// climb the setter cannot see. Both constants were wrong before #5189 and the
+// code gave no sign of it — the strip reserved 52dp while rendering 69, and the
+// chrome constant over-reserved by 46. Neither is visible without doing the
+// arithmetic, so the arithmetic is pinned here.
+
+/** iPhone SE 3 — the smallest phone we support, and the one that binds. */
+const SE = { windowHeight: 667, insetTop: 20, insetBottom: 0 };
+
+/** The board budget as it stood before #4761 added a permanent route strip. */
+const BOULDER_BUDGET_BEFORE_ROUTE_STRIP = 323;
+
+describe('create drawer board budget', () => {
+  it('gives a boulder more board than it had before the route strip landed', () => {
+    // The issue's own acceptance gate. #4761 charged every boulder 52dp for a
+    // strip advertising routes, taking the SE from 323 to 271 — a sixth of the
+    // board, permanently, for a feature most setters never use.
+    const boulder = computeBoardMaxHeight({ ...SE, showRouteTransport: false });
+
+    expect(boulder).toBe(357);
+    expect(boulder).toBeGreaterThanOrEqual(BOULDER_BUDGET_BEFORE_ROUTE_STRIP);
+  });
+
+  it('charges a route exactly one transport card and nothing else', () => {
+    const boulder = computeBoardMaxHeight({ ...SE, showRouteTransport: false });
+    const route = computeBoardMaxHeight({ ...SE, showRouteTransport: true });
+
+    expect(boulder - route).toBe(PLAYBACK_TRANSPORT_RESERVE);
+  });
+
+  it('keeps the smallest phone off the board-height floor in both states', () => {
+    // Reaching the floor means the reserves are lying about what fits: the sheet
+    // then wants a taller peek than MAX_PEEK_FRACTION allows and clamps, which
+    // drops the draft-status line and part of the Save row below the fold. A
+    // route on an SE did exactly that before this change (it computed 187).
+    for (const showRouteTransport of [false, true]) {
+      expect(computeBoardMaxHeight({ ...SE, showRouteTransport })).toBeGreaterThan(MIN_BOARD_HEIGHT);
+    }
+  });
+
+  it('still floors the board on a window small enough to run out of room', () => {
+    expect(computeBoardMaxHeight({ windowHeight: 300, insetTop: 44, insetBottom: 34, showRouteTransport: true })).toBe(
+      MIN_BOARD_HEIGHT,
+    );
+  });
+
+  it('subtracts both safe-area insets', () => {
+    const withInsets = computeBoardMaxHeight({
+      windowHeight: 874,
+      insetTop: 59,
+      insetBottom: 34,
+      showRouteTransport: false,
+    });
+    expect(withInsets).toBe(874 - 59 - 34 - ABOVE_FOLD_CHROME);
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-layout.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-layout.test.ts
@@ -34,6 +34,11 @@ describe('create drawer board budget', () => {
     const route = computeBoardMaxHeight({ ...SE, showRouteTransport: true });
 
     expect(boulder - route).toBe(PLAYBACK_TRANSPORT_RESERVE);
+    // Pinned as a number too, not only as the difference: the difference is
+    // computed FROM the reserve, so on its own it stays green no matter what the
+    // reserve becomes. This is the assertion that notices the card changing
+    // height. 667 - 20 - 290 - 116.
+    expect(route).toBe(241);
   });
 
   it('keeps the smallest phone off the board-height floor in both states', () => {

--- a/packages/mobile/src/components/create-climb/__tests__/create-overflow-menu.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/create-overflow-menu.test.ts
@@ -59,7 +59,16 @@ describe('buildCreateOverflowMenu', () => {
   it('treats a multi-frame climb as a route even without the flag', () => {
     // An edit or a fork opens on frames that already exist; the controller seeds
     // the flag from them, but the menu must not depend on that having happened.
-    expect(actionsOf(state({ routeMode: false, frameCount: 3 }))).toEqual(['deleteFrame', 'makeBoulder', 'newClimb']);
+    const rows = buildCreateOverflowMenu(state({ routeMode: false, frameCount: 3 }), translate);
+    expect(rows.map((row) => row.action)).toEqual(['deleteFrame', 'makeBoulder', 'newClimb']);
+
+    // And the way out is blocked here for the same reason it is with the flag
+    // set: the block keys off the FRAMES, not the mode. Asserting only the row
+    // set would leave it open to reading as an enabled row that silently no-ops
+    // against `leaveRouteMode`'s own guard.
+    const makeBoulder = rows.find((row) => row.action === 'makeBoulder');
+    expect(makeBoulder?.disabled).toBe(true);
+    expect(makeBoulder?.label).toBe('mobile.create.routeMenu.makeBoulderBlocked');
   });
 
   it('offers no route rows at all on a single-frame board', () => {

--- a/packages/mobile/src/components/create-climb/__tests__/create-overflow-menu.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/create-overflow-menu.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { buildCreateOverflowMenu, type CreateOverflowMenuState } from '../create-overflow-menu';
 
 // The overflow menu is the ONLY way into and out of route mode, so "which rows
-// exist in which state" is behaviour rather than presentation. It is also the
-// only place a frame can be deleted now, and the rows are addressed by index —
-// a state that drops a row must not shift a tap onto a neighbouring action.
+// exist in which state" is behaviour rather than presentation. Rows are
+// addressed by index — a state that drops a row must not shift a tap onto a
+// neighbouring action.
 
 const translate = (key: string, params?: Record<string, number | string>) =>
   params ? `${key}:${JSON.stringify(params)}` : key;
@@ -13,7 +13,6 @@ const state = (overrides: Partial<CreateOverflowMenuState> = {}): CreateOverflow
   supportsMultiFrame: true,
   routeMode: false,
   frameCount: 1,
-  frameIndex: 0,
   ...overrides,
 });
 
@@ -44,23 +43,21 @@ describe('buildCreateOverflowMenu', () => {
     expect(makeBoulder?.label).toBe('mobile.create.routeMenu.makeBoulderBlocked');
   });
 
-  it('names the frame that Delete would remove', () => {
-    // "Delete frame" beside a strip of four makes you guess which one it means.
-    const rows = buildCreateOverflowMenu(state({ routeMode: true, frameCount: 4, frameIndex: 2 }), translate);
-    const deleteFrame = rows.find((row) => row.action === 'deleteFrame');
-    expect(deleteFrame?.label).toBe('mobile.create.routeMenu.deleteFrame:{"index":3}');
-    expect(deleteFrame?.destructive).toBe(true);
-  });
-
-  it('offers no frame to delete while a route is still one frame', () => {
-    expect(actionsOf(state({ routeMode: true }))).not.toContain('deleteFrame');
+  it('keeps frame commands out of the menu at every frame count', () => {
+    // Add and remove live on the transport card, beside the strip they act on.
+    // A second door in the header would put a destructive action a board's
+    // height from the frames it deletes, and leave two controls to keep in step.
+    for (const frameCount of [1, 2, 4, 12]) {
+      const rows = buildCreateOverflowMenu(state({ routeMode: true, frameCount }), translate);
+      expect(rows.map((row) => row.action)).not.toContain('deleteFrame');
+    }
   });
 
   it('treats a multi-frame climb as a route even without the flag', () => {
     // An edit or a fork opens on frames that already exist; the controller seeds
     // the flag from them, but the menu must not depend on that having happened.
     const rows = buildCreateOverflowMenu(state({ routeMode: false, frameCount: 3 }), translate);
-    expect(rows.map((row) => row.action)).toEqual(['deleteFrame', 'makeBoulder', 'newClimb']);
+    expect(rows.map((row) => row.action)).toEqual(['makeBoulder', 'newClimb']);
 
     // And the way out is blocked here for the same reason it is with the flag
     // set: the block keys off the FRAMES, not the mode. Asserting only the row
@@ -82,7 +79,7 @@ describe('buildCreateOverflowMenu', () => {
     const everyState: CreateOverflowMenuState[] = [
       state(),
       state({ routeMode: true }),
-      state({ routeMode: true, frameCount: 4, frameIndex: 3 }),
+      state({ routeMode: true, frameCount: 4 }),
       state({ supportsMultiFrame: false }),
     ];
     for (const input of everyState) {

--- a/packages/mobile/src/components/create-climb/__tests__/create-overflow-menu.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/create-overflow-menu.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { buildCreateOverflowMenu, type CreateOverflowMenuState } from '../create-overflow-menu';
+
+// The overflow menu is the ONLY way into and out of route mode, so "which rows
+// exist in which state" is behaviour rather than presentation. It is also the
+// only place a frame can be deleted now, and the rows are addressed by index —
+// a state that drops a row must not shift a tap onto a neighbouring action.
+
+const translate = (key: string, params?: Record<string, number | string>) =>
+  params ? `${key}:${JSON.stringify(params)}` : key;
+
+const state = (overrides: Partial<CreateOverflowMenuState> = {}): CreateOverflowMenuState => ({
+  supportsMultiFrame: true,
+  routeMode: false,
+  frameCount: 1,
+  frameIndex: 0,
+  ...overrides,
+});
+
+const actionsOf = (input: CreateOverflowMenuState) =>
+  buildCreateOverflowMenu(input, translate).map((row) => row.action);
+
+describe('buildCreateOverflowMenu', () => {
+  it('offers route mode on a boulder', () => {
+    expect(actionsOf(state())).toEqual(['makeRoute', 'newClimb']);
+  });
+
+  it('offers the way back out while a route is still one frame', () => {
+    const rows = buildCreateOverflowMenu(state({ routeMode: true }), translate);
+    expect(rows.map((row) => row.action)).toEqual(['makeBoulder', 'newClimb']);
+    expect(rows[0].disabled).toBeFalsy();
+    expect(rows[0].label).toBe('mobile.create.routeMenu.makeBoulder');
+  });
+
+  it('blocks the way out above one frame rather than hiding it', () => {
+    // Frames are absolute snapshots: keeping frame 1 would discard every hold
+    // painted after the start position, and flattening would rewrite the climb
+    // silently. Deleting frames is the explicit, undoable path — so the row
+    // stays visible and says so, because a missing row reads as a missing
+    // feature and leaves the setter stuck in route mode with no explanation.
+    const rows = buildCreateOverflowMenu(state({ routeMode: true, frameCount: 4 }), translate);
+    const makeBoulder = rows.find((row) => row.action === 'makeBoulder');
+    expect(makeBoulder?.disabled).toBe(true);
+    expect(makeBoulder?.label).toBe('mobile.create.routeMenu.makeBoulderBlocked');
+  });
+
+  it('names the frame that Delete would remove', () => {
+    // "Delete frame" beside a strip of four makes you guess which one it means.
+    const rows = buildCreateOverflowMenu(state({ routeMode: true, frameCount: 4, frameIndex: 2 }), translate);
+    const deleteFrame = rows.find((row) => row.action === 'deleteFrame');
+    expect(deleteFrame?.label).toBe('mobile.create.routeMenu.deleteFrame:{"index":3}');
+    expect(deleteFrame?.destructive).toBe(true);
+  });
+
+  it('offers no frame to delete while a route is still one frame', () => {
+    expect(actionsOf(state({ routeMode: true }))).not.toContain('deleteFrame');
+  });
+
+  it('treats a multi-frame climb as a route even without the flag', () => {
+    // An edit or a fork opens on frames that already exist; the controller seeds
+    // the flag from them, but the menu must not depend on that having happened.
+    expect(actionsOf(state({ routeMode: false, frameCount: 3 }))).toEqual(['deleteFrame', 'makeBoulder', 'newClimb']);
+  });
+
+  it('offers no route rows at all on a single-frame board', () => {
+    // Woods: its packet builder rejects the comma a second frame introduces, so
+    // offering the mode would offer a climb that cannot reach the wall.
+    expect(actionsOf(state({ supportsMultiFrame: false }))).toEqual(['newClimb']);
+    expect(actionsOf(state({ supportsMultiFrame: false, routeMode: true, frameCount: 3 }))).toEqual(['newClimb']);
+  });
+
+  it('keeps every row addressable by its own index in every state', () => {
+    const everyState: CreateOverflowMenuState[] = [
+      state(),
+      state({ routeMode: true }),
+      state({ routeMode: true, frameCount: 4, frameIndex: 3 }),
+      state({ supportsMultiFrame: false }),
+    ];
+    for (const input of everyState) {
+      const rows = buildCreateOverflowMenu(input, translate);
+      expect(rows.length).toBeGreaterThan(0);
+      // Uniqueness is what makes index-to-action mapping safe in the header.
+      expect(new Set(rows.map((row) => row.action)).size).toBe(rows.length);
+      expect(rows.every((row) => row.label.length > 0)).toBe(true);
+    }
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/create-route-playback-slot.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-route-playback-slot.test.tsx
@@ -62,6 +62,7 @@ const playback = {
 
 function renderSlot(overrides: Partial<Parameters<typeof CreateRoutePlaybackSlot>[0]> = {}) {
   const onAddFrame = vi.fn();
+  const onDeleteFrame = vi.fn();
   const onPaceChange = vi.fn();
   const { container } = render(
     createElement(CreateRoutePlaybackSlot, {
@@ -71,6 +72,7 @@ function renderSlot(overrides: Partial<Parameters<typeof CreateRoutePlaybackSlot
       playback,
       wallStateLabel: null,
       onAddFrame,
+      onDeleteFrame,
       onPaceChange,
       ...overrides,
     }),
@@ -78,6 +80,7 @@ function renderSlot(overrides: Partial<Parameters<typeof CreateRoutePlaybackSlot
   return {
     container,
     onAddFrame,
+    onDeleteFrame,
     onPaceChange,
     transport: container.querySelector('[data-node="transport"]'),
     gestureRoot: container.querySelector('[data-node="gesture-root"]'),

--- a/packages/mobile/src/components/create-climb/__tests__/create-route-playback-slot.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-route-playback-slot.test.tsx
@@ -3,13 +3,14 @@ import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
-// The slot is the only route affordance a fresh create sheet has. #4761 came
-// back QA-declined because the transport mounted only at two frames and the one
-// control that made a second frame was a bare `copy` glyph fourth inside the
-// action bar's horizontal scroller — so a climber saw no play control and no
-// sign routes existed. These cases pin the three states that fixes: nothing on a
-// board that can't hold a route, a self-explaining strip on a fresh climb, and
-// the real transport once there is something to play.
+// The slot decides ONE thing: whether the route transport is on screen at all.
+//
+// #4761 made it unconditional on a multi-frame board, because route-ness could
+// only be inferred from `frames.length > 1` and the feature was otherwise
+// invisible — which charged every boulder 52dp of board for an advert. Route
+// mode is now explicit state the header's overflow menu owns, so these cases pin
+// the contract that replaces it: nothing at all unless the setter is authoring a
+// route, and the transport in creator configuration when they are.
 
 type ViewMockProps = { children?: ReactNode; testID?: string; accessibilityLabel?: string };
 vi.mock('react-native', () => ({
@@ -21,45 +22,30 @@ vi.mock('react-native-gesture-handler', () => ({
   GestureHandlerRootView: ({ children }: { children?: ReactNode }) =>
     createElement('div', { 'data-node': 'gesture-root' }, children),
 }));
-vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
-vi.mock('../../Text', () => ({
-  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
-}));
-vi.mock('../../Icon', () => ({ Icon: ({ name }: { name?: string }) => createElement('span', { 'data-icon': name }) }));
-vi.mock('../../Button', () => ({
-  Button: ({
-    title,
-    onPress,
-    minHeight,
-    variant,
-  }: {
-    title?: string;
-    onPress?: () => void;
-    minHeight?: number;
-    variant?: string;
-  }) =>
-    createElement(
-      'button',
-      { 'data-title': title, 'data-min-height': minHeight, 'data-variant': variant, onClick: onPress },
-      title,
-    ),
-}));
-vi.mock('../../Button.surface', () => ({
-  ButtonSurfaceProvider: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-}));
 // The real transport pulls Reanimated and a GestureDetector into jsdom; the slot
 // only owes it the right props and the right mounting condition.
 vi.mock('../../playback/PlaybackControls', () => ({
-  PlaybackControls: ({ frameCount, frameIndex }: { frameCount?: number; frameIndex?: number }) =>
-    createElement('div', { 'data-node': 'transport', 'data-frames': frameCount, 'data-index': frameIndex }),
-}));
-vi.mock('../../../providers/theme-provider', () => ({
-  useTheme: () => ({ systemColors: { separator: '#C6C6C8', tertiaryLabel: '#3C3C4399' } }),
-}));
-vi.mock('../../../theme/layout', () => ({ glassSize: { inline: 44 } }));
-vi.mock('../../../theme/tokens', () => ({
-  spacing: { 2: 8, 4: 16 },
-  borderRadius: { lg: 12 },
+  PlaybackControls: ({
+    frameCount,
+    frameIndex,
+    paceUnit,
+    frameEditing,
+    onPaceChange,
+  }: {
+    frameCount?: number;
+    frameIndex?: number;
+    paceUnit?: string;
+    frameEditing?: { onAddFrame: () => void };
+    onPaceChange?: (paceMs: number) => void;
+  }) =>
+    createElement('div', {
+      'data-node': 'transport',
+      'data-frames': frameCount,
+      'data-index': frameIndex,
+      'data-pace-unit': paceUnit,
+      'data-frame-editing': frameEditing ? 'yes' : 'no',
+      'data-pace-change': onPaceChange ? 'yes' : 'no',
+    }),
 }));
 
 import { CreateRoutePlaybackSlot } from '../CreateRoutePlaybackSlot';
@@ -76,123 +62,74 @@ const playback = {
 
 function renderSlot(overrides: Partial<Parameters<typeof CreateRoutePlaybackSlot>[0]> = {}) {
   const onAddFrame = vi.fn();
-  const onDeleteFrame = vi.fn();
+  const onPaceChange = vi.fn();
   const { container } = render(
     createElement(CreateRoutePlaybackSlot, {
-      supportsMultiFrame: true,
+      showRouteTransport: true,
       frameCount: 1,
       frameIndex: 0,
       playback,
       wallStateLabel: null,
       onAddFrame,
-      onDeleteFrame,
+      onPaceChange,
       ...overrides,
     }),
   );
-  const button = (title: string) => container.querySelector(`[data-title="${title}"]`) as HTMLButtonElement | null;
   return {
     container,
     onAddFrame,
-    onDeleteFrame,
-    button,
-    strip: container.querySelector('[data-testid="create-route-playback-empty"]') as HTMLElement | null,
-    transport: container.querySelector('[data-node="transport"]') as HTMLElement | null,
-    addFrame: button('mobile.create.playback.addFrame'),
-    deleteFrame: button('mobile.create.frames.delete'),
+    onPaceChange,
+    transport: container.querySelector('[data-node="transport"]'),
+    gestureRoot: container.querySelector('[data-node="gesture-root"]'),
   };
 }
 
 describe('CreateRoutePlaybackSlot', () => {
-  it('renders nothing on a board that cannot hold a second frame', () => {
-    // Woods lights one static frame, and a two-frame string carries a comma its
-    // packet builder rejects outright. Offering the strip there would advertise
-    // a climb the wall then refuses to light.
-    const { container } = renderSlot({ supportsMultiFrame: false });
+  it('renders nothing for a boulder, however many frames it somehow has', () => {
+    // The frame count is deliberately >1: a route that was never switched into
+    // route mode cannot exist, and if one ever did, the flag still decides.
+    const { container } = renderSlot({ showRouteTransport: false, frameCount: 3 });
     expect(container.innerHTML).toBe('');
-
-    const asRoute = renderSlot({ supportsMultiFrame: false, frameCount: 3, frameIndex: 1 });
-    expect(asRoute.container.innerHTML).toBe('');
   });
 
-  it('offers a named way in on a single-frame climb', () => {
-    const { strip, transport, addFrame, container } = renderSlot({ frameCount: 1 });
-
-    expect(strip).toBeTruthy();
-    expect(transport).toBeNull();
-    // The strip says what it is, so the feature is not a glyph hunt.
-    expect(container.textContent).toContain('mobile.create.playback.emptyHint');
-    expect(addFrame).toBeTruthy();
-    expect(addFrame?.textContent).toContain('mobile.create.playback.addFrame');
-    expect(strip?.getAttribute('data-label')).toBe('mobile.create.playback.emptyA11y');
-    // Nothing to delete yet — one frame IS the climb.
-    expect(container.querySelector('[data-title="mobile.create.frames.delete"]')).toBeNull();
-    // The play glyph is inert here — a control that played nothing would be half
-    // of "the play button doesn't work".
-    expect(container.querySelector('[data-icon="play.circle"]')).toBeTruthy();
+  it('mounts the transport from the FIRST frame of a route', () => {
+    // The whole point of an explicit route mode: the transport no longer has to
+    // wait for a second frame to exist, so the control that creates one is on
+    // screen when you need it.
+    const { transport } = renderSlot({ frameCount: 1, frameIndex: 0 });
+    expect(transport).not.toBeNull();
+    expect(transport?.getAttribute('data-frames')).toBe('1');
   });
 
-  it('floors the Add frame pill at the 44dp touch target', () => {
-    // Compose sizes a small filled button at 40, and this one shares a row with
-    // a 44dp-tall glyph.
-    const { addFrame } = renderSlot({ frameCount: 1 });
-    expect(addFrame?.getAttribute('data-min-height')).toBe('44');
+  it('passes the frame position through to the transport', () => {
+    const { transport } = renderSlot({ frameCount: 4, frameIndex: 2 });
+    expect(transport?.getAttribute('data-frames')).toBe('4');
+    expect(transport?.getAttribute('data-index')).toBe('2');
   });
 
-  it('adds the frame when the pill is pressed', () => {
-    const { addFrame, onAddFrame } = renderSlot({ frameCount: 1 });
-
-    addFrame?.click();
-    expect(onAddFrame).toHaveBeenCalledTimes(1);
-  });
-
-  it('swaps the strip for the real transport once there is a route to play', () => {
-    const { strip, transport } = renderSlot({ frameCount: 2, frameIndex: 1 });
-
-    expect(strip).toBeNull();
-    expect(transport).toBeTruthy();
-    expect(transport?.getAttribute('data-frames')).toBe('2');
-    expect(transport?.getAttribute('data-index')).toBe('1');
-  });
-
-  it('keeps adding and deleting frames reachable on a route', () => {
-    // Marco, iOS: the strip got you to two frames and then vanished, putting the
-    // THIRD frame back behind the action bar's bare `copy` glyph. Both frame
-    // actions live under the transport now, in words.
-    const { addFrame, deleteFrame, onAddFrame, onDeleteFrame } = renderSlot({ frameCount: 2, frameIndex: 1 });
-
-    expect(addFrame).toBeTruthy();
-    expect(deleteFrame).toBeTruthy();
-
-    addFrame?.click();
-    expect(onAddFrame).toHaveBeenCalledTimes(1);
-    deleteFrame?.click();
-    expect(onDeleteFrame).toHaveBeenCalledTimes(1);
-  });
-
-  it('floors both frame buttons at the touch target and leads with the plainer one', () => {
-    // Add frame is the primary and sits nearest the thumb on a right-aligned
-    // row; the destructive one is plainer and further away.
-    const { addFrame, deleteFrame, container } = renderSlot({ frameCount: 3, frameIndex: 0 });
-
-    expect(addFrame?.getAttribute('data-min-height')).toBe('44');
-    expect(deleteFrame?.getAttribute('data-min-height')).toBe('44');
-    expect(addFrame?.getAttribute('data-variant')).toBe('filled');
-    expect(deleteFrame?.getAttribute('data-variant')).toBe('tonal');
-
-    const titles = Array.from(container.querySelectorAll('[data-title]')).map((node) =>
-      node.getAttribute('data-title'),
-    );
-    expect(titles).toEqual(['mobile.create.frames.delete', 'mobile.create.playback.addFrame']);
+  it('puts the transport in creator configuration: frame editing and seconds', () => {
+    // Both are creator-only. The play drawer mounts the same component without
+    // them and keeps the counter and the x-multiplier, so a regression here is a
+    // regression there too.
+    const { transport } = renderSlot({ frameCount: 2 });
+    expect(transport?.getAttribute('data-frame-editing')).toBe('yes');
+    expect(transport?.getAttribute('data-pace-unit')).toBe('seconds');
+    expect(transport?.getAttribute('data-pace-change')).toBe('yes');
   });
 
   it('keeps the transport under its own gesture root', () => {
-    // Load-bearing on Android: the speed slider is a GestureDetector, and this
-    // sheet's content lives inside a Compose ModalBottomSheet the app's single
-    // root GestureHandlerRootView does not cover (#4320).
-    const { container, transport } = renderSlot({ frameCount: 2 });
-    const gestureRoot = container.querySelector('[data-node="gesture-root"]');
-
-    expect(gestureRoot).toBeTruthy();
+    // Load-bearing on Android: the pace slider is a GestureDetector and this
+    // sheet is a Compose ModalBottomSheet the app's root GHRV does not cover.
+    const { gestureRoot, transport } = renderSlot({ frameCount: 2 });
+    expect(gestureRoot).not.toBeNull();
     expect(gestureRoot?.contains(transport)).toBe(true);
+  });
+
+  it('no longer renders a detached frame-actions row', () => {
+    // Delete moved into the header's overflow menu and add became a chip inside
+    // the transport card. Two rows collapsing into one card is the issue's
+    // "integrate them cleanly" requirement; a button row here would undo it.
+    const { container } = renderSlot({ frameCount: 3 });
+    expect(container.querySelector('button')).toBeNull();
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-playback.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-playback.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import type { LitUpHoldsMap } from '@boardsesh/shared-schema';
+import { DEFAULT_PACE_MS } from '@boardsesh/playback-react';
 import { useCreateClimbPlayback } from '../use-create-climb-playback';
 
 const START = { state: 'STARTING' as const, color: '#00FF00', displayColor: '#00FF00' };
@@ -11,7 +12,13 @@ const frameOne: LitUpHoldsMap = { 100: START, 200: HAND };
 const frameTwo: LitUpHoldsMap = { 100: START, 200: HAND, 300: HAND };
 const frameThree: LitUpHoldsMap = { 100: START, 200: HAND, 300: HAND, 400: HAND };
 
-type Props = { frames: LitUpHoldsMap[]; currentFrameIndex: number; goToFrame: (index: number) => void };
+type Props = {
+  frames: LitUpHoldsMap[];
+  currentFrameIndex: number;
+  goToFrame: (index: number) => void;
+  /** The setter's authored pace. Defaults to what a fresh climb starts at. */
+  paceMs?: number;
+};
 
 function renderPlayback(initialProps: Props) {
   return renderHook(
@@ -21,6 +28,7 @@ function renderPlayback(initialProps: Props) {
         boardName: 'kilter',
         currentFrameIndex: props.currentFrameIndex,
         goToFrame: props.goToFrame,
+        paceMs: props.paceMs ?? DEFAULT_PACE_MS,
       }),
     { initialProps },
   );

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
@@ -469,6 +469,38 @@ describe('useCreateClimbScreen autosave flush', () => {
     expect(boardActions.saveClimb).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a synced climb's pace when it is slower than the slider allows", async () => {
+    // The authoring slider tops out at 10s, but that bounds what this control
+    // can PRODUCE, not what a climb may hold: Aurora climbs arrive with whatever
+    // pace their setter chose and the server accepts up to 30s so they survive a
+    // round trip. Clamping on load would halve a 20s route the next time its
+    // owner opened it and saved an unrelated edit — with nothing on screen to
+    // say anything had changed.
+    graphql.climb = {
+      uuid: 'climb-slow',
+      name: 'Slow Aurora Route',
+      description: '',
+      frames: 'p1r12,"p2r13',
+      is_draft: true,
+      created_at: null,
+      published_at: null,
+      framesPace: 20_000,
+    };
+
+    createClimb.frameCount = 2;
+
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD, editClimbUuid: 'climb-slow' }));
+    await waitFor(() => expect(result.current.name).toBe('Slow Aurora Route'));
+
+    // 20s, not the slider's 10s ceiling.
+    expect(result.current.framesPaceMs).toBe(20_000);
+
+    // Deliberately not asserting draftStatus here: this suite's editor mock holds
+    // a fixed single-frame `frames` array and a no-op `loadFrames`, so `framesJson`
+    // can never match a two-frame server row whatever the pace does. That would
+    // pin the mock, not the product.
+  });
+
   it('autosaves an edit session into its own identity-keyed slot', async () => {
     graphql.climb = {
       uuid: 'climb-9',

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
@@ -469,6 +469,36 @@ describe('useCreateClimbScreen autosave flush', () => {
     expect(boardActions.saveClimb).toHaveBeenCalledTimes(1);
   });
 
+  it('restores route mode on a draft that never got its second frame', async () => {
+    // The single case the persisted `routeMode` flag exists for. Route-ness is
+    // inferred from `frames.length > 1` everywhere else, which cannot express the
+    // state a setter is in between choosing "Make it a route" and adding frame
+    // two — so without the flag, backgrounding the app there would drop them
+    // silently back to a boulder and take the transport away.
+    draftStore.loadDraft.mockImplementation((key: string) =>
+      Promise.resolve(
+        key === 'draft-key'
+          ? {
+              holdsJson: '{}',
+              framesJson: '[{}]',
+              name: 'One frame so far',
+              description: '',
+              isDraft: true,
+              routeMode: true,
+              framesPaceMs: 2_000,
+            }
+          : null,
+      ),
+    );
+
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    await waitFor(() => expect(result.current.name).toBe('One frame so far'));
+
+    expect(result.current.routeMode).toBe(true);
+    expect(result.current.showRouteTransport).toBe(true);
+    expect(result.current.framesPaceMs).toBe(2_000);
+  });
+
   it("keeps a synced climb's pace when it is slower than the slider allows", async () => {
     // The authoring slider tops out at 10s, but that bounds what this control
     // can PRODUCE, not what a climb may hold: Aurora climbs arrive with whatever

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
@@ -125,6 +125,7 @@ vi.mock('../brush-roles', () => ({
 }));
 
 import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
+import { DEFAULT_PACE_MS } from '@boardsesh/playback-react';
 import { climbToQueueItem, toClimbInput } from '../../../lib/climb-to-queue-item';
 import { useCreateClimbScreen } from '../use-create-climb-screen';
 
@@ -399,6 +400,26 @@ describe('route mode', () => {
     act(() => result.current.enterRouteMode());
     expect(result.current.routeMode).toBe(false);
     expect(result.current.showRouteTransport).toBe(false);
+  });
+
+  it('hands back a boulder when you start a new climb from a route', async () => {
+    // Every other authoring field resets here; these two have to as well, or the
+    // next climb opens wearing route chrome nobody asked for — the exact thing
+    // this issue exists to stop, one climb later.
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.enterRouteMode());
+    act(() => result.current.setFramesPace(2000));
+    expect(result.current.showRouteTransport).toBe(true);
+
+    act(() => result.current.handleNewClimb());
+    await act(async () => {
+      await result.current.confirmNewClimb();
+    });
+
+    expect(result.current.routeMode).toBe(false);
+    expect(result.current.showRouteTransport).toBe(false);
+    expect(result.current.framesPaceMs).toBe(DEFAULT_PACE_MS);
   });
 
   it('treats an already-multi-frame climb as a route without being told', () => {

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
@@ -322,6 +322,20 @@ describe('authored pace reaches the queue and the server', () => {
     expect(board.saveClimb.mock.calls[0][0]).toMatchObject({ frames_count: 1, frames_pace: 0 });
   });
 
+  it('does not let a boulder look edited over a pace it will never publish', () => {
+    // The pace signs into the payload signature, which is what decides whether
+    // the draft reads "unsynced edits". A boulder writes `frames_pace: 0`
+    // whatever the control last held, so signing the raw control value would
+    // make two byte-identical boulders look like different payloads.
+    createClimb.frameCount = 1;
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    const before = result.current.draftStatus;
+    act(() => result.current.setFramesPace(2000));
+    expect(result.current.framesPaceMs).toBe(2000);
+    expect(result.current.draftStatus).toEqual(before);
+  });
+
   it('plays the preview at the authored pace, so the transport is honest', () => {
     createClimb.frameCount = 2;
     const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
@@ -145,6 +145,7 @@ beforeEach(() => {
   board.isDuplicateClimbError.mockReturnValue(false);
   board.saveClimb.mockReset();
   board.updateClimb.mockReset();
+  createClimb.frameCount = 1;
 });
 
 describe('create-climb queue hand-off carries board identity', () => {
@@ -272,6 +273,125 @@ describe('create-climb queue hand-off carries board identity', () => {
     const { climb } = lastQueuedItem();
     expect(climb.framesCount).toBe(1);
     expect(climb.framesPace).toBeNull();
+  });
+});
+
+// The creator wrote `frames_pace: 0` on every save, so a published route always
+// played at the 750ms default however the setter set the transport — the speed
+// control authored nothing. These pin the value actually reaching the wire.
+describe('authored pace reaches the queue and the server', () => {
+  it('publishes the pace the setter dialled on a route', async () => {
+    createClimb.frameCount = 3;
+    board.saveClimb.mockResolvedValue({ uuid: 'route-1', createdAt: null, publishedAt: null, isDraft: true });
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.setName('Paced Route'));
+    act(() => result.current.setFramesPace(2000));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(board.saveClimb).toHaveBeenCalledTimes(1);
+    expect(board.saveClimb.mock.calls[0][0]).toMatchObject({ frames_count: 3, frames_pace: 2000 });
+  });
+
+  it('clamps an out-of-range pace rather than publishing it', () => {
+    createClimb.frameCount = 2;
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.setFramesPace(50_000));
+    expect(result.current.framesPaceMs).toBe(10_000);
+
+    act(() => result.current.setFramesPace(10));
+    expect(result.current.framesPaceMs).toBe(300);
+  });
+
+  it('publishes no pace on a boulder, whatever the control last held', async () => {
+    // Load-bearing rather than tidiness: `assertWoodsSingleFrame` rejects a
+    // non-zero pace outright, so a single-frame climb carrying one fails the
+    // mutation on Woods. A boulder has no gap between frames to pace anyway.
+    board.saveClimb.mockResolvedValue({ uuid: 'boulder-1', createdAt: null, publishedAt: null, isDraft: true });
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.setName('Just A Boulder'));
+    act(() => result.current.setFramesPace(2000));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(board.saveClimb.mock.calls[0][0]).toMatchObject({ frames_count: 1, frames_pace: 0 });
+  });
+
+  it('plays the preview at the authored pace, so the transport is honest', () => {
+    createClimb.frameCount = 2;
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.setFramesPace(1500));
+    expect(result.current.playback.paceMs).toBe(1500);
+  });
+});
+
+// Route mode is an explicit state now, not something inferred from frame count.
+// It decides whether the board pays for route chrome at all, which is the whole
+// reason #5189 exists.
+describe('route mode', () => {
+  it('starts a fresh climb as a boulder showing no route chrome', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    expect(result.current.routeMode).toBe(false);
+    expect(result.current.showRouteTransport).toBe(false);
+  });
+
+  it('shows the transport from the first frame once route mode is on', () => {
+    // The point of an explicit mode: the control that makes frame 2 has to be on
+    // screen BEFORE frame 2 exists, or the feature is only discoverable to
+    // someone who already knows it is there.
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.enterRouteMode());
+    expect(result.current.showRouteTransport).toBe(true);
+    expect(result.current.frameCount).toBe(1);
+  });
+
+  it('lets a one-frame route go back to being a boulder', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.enterRouteMode());
+    expect(result.current.canLeaveRouteMode).toBe(true);
+    act(() => result.current.leaveRouteMode());
+    expect(result.current.showRouteTransport).toBe(false);
+  });
+
+  it('refuses to leave route mode while frames would be destroyed', () => {
+    // Frames are absolute snapshots, so there is no lossless answer here: keeping
+    // frame 1 discards every hold painted after the start position. The setter
+    // deletes frames down to one instead, which is undoable.
+    createClimb.frameCount = 4;
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.enterRouteMode());
+    expect(result.current.canLeaveRouteMode).toBe(false);
+    act(() => result.current.leaveRouteMode());
+    expect(result.current.showRouteTransport).toBe(true);
+  });
+
+  it('never enters route mode on a board that can only hold one frame', () => {
+    // Woods: a second frame puts a comma in the frames string, which its packet
+    // builder rejects outright.
+    const { result } = renderHook(() =>
+      useCreateClimbScreen({ board: { ...kilterBoard, boardName: 'woods' as const } }),
+    );
+
+    act(() => result.current.enterRouteMode());
+    expect(result.current.routeMode).toBe(false);
+    expect(result.current.showRouteTransport).toBe(false);
+  });
+
+  it('treats an already-multi-frame climb as a route without being told', () => {
+    createClimb.frameCount = 3;
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    expect(result.current.showRouteTransport).toBe(true);
   });
 });
 

--- a/packages/mobile/src/components/create-climb/create-drawer-layout.ts
+++ b/packages/mobile/src/components/create-climb/create-drawer-layout.ts
@@ -31,23 +31,23 @@ export const ABOVE_FOLD_CHROME = 290;
 
 /**
  * The route transport card, which carries the whole route control set: marginTop
- * 8 + paddingVertical 12 x 2 + the 44dp frame-strip row + an 8dp row gap + the
+ * 8 + paddingVertical 12 x 2 + the 32dp frame-strip row + an 8dp row gap + the
  * 44dp transport row.
  *
  * A contract with `PlaybackControls`' strip mode — if the rendered card and this
  * number disagree, the peek drifts against the real content height.
  *
- * The strip row is 44 rather than the 32 its chips occupy so the "+ Add frame"
- * button in it clears the touch floor: `Button` sizes itself from `minHeight`
- * and exposes no `hitSlop`, so unlike the frame chips it cannot borrow the extra
- * 12dp. Paying 12dp of board for the strip's primary action to be tappable is
- * the right trade on a screen this issue exists to fix the touch targets of.
+ * The strip row is exactly one chip tall. It was 44 while a labelled "+ Add
+ * frame" `Button` sat in it: `Button` sizes itself from `minHeight` and exposes
+ * no `hitSlop`, so unlike the frame chips it could not borrow the missing 12dp.
+ * Add and remove are now one icon capsule in the transport row's left slot — the
+ * empty space beside prev/play/next — which meets the touch floor there and
+ * hands the 12dp back to the board.
  *
- * It still replaces more than it costs: an 84dp card plus a detached 52dp button
- * row (136 total). Delete moved into the header's overflow menu and add became a
- * chip pinned inside the strip, so one card now does the work of two rows.
+ * It replaces far more than it costs: an 84dp card plus a detached 52dp button
+ * row (136 total) before #5189, and 128 in that PR's first cut.
  */
-export const PLAYBACK_TRANSPORT_RESERVE = 128;
+export const PLAYBACK_TRANSPORT_RESERVE = 116;
 
 /**
  * Floor on the board's height. A board this small is already unusable, so

--- a/packages/mobile/src/components/create-climb/create-drawer-layout.ts
+++ b/packages/mobile/src/components/create-climb/create-drawer-layout.ts
@@ -10,10 +10,17 @@
  * Space the header, action bar, draft-status line, sheet handle and safe areas
  * need, so the board is sized to leave them on screen at the peek.
  *
- * Derived from the peek formula rather than guessed: handle reserve (24) +
- * ScrollView top padding (8) + header row (68) + action bar (70 brush row + 56
- * action row + 32 status line = 158) + the peek's own 12dp reveal = 278. The
- * remaining 12 absorbs a taller locale or one Dynamic Type step.
+ * Derived from the peek formula rather than guessed. Every term, with where it
+ * comes from, so the sum can be re-checked without a device:
+ *
+ * - 24 — the native sheet's drag-grabber reserve (`NATIVE_HANDLE_RESERVE`)
+ * - 8  — the ScrollView's `contentContainerStyle` paddingTop
+ * - 68 — the header row (12 padding x 2 + a 44dp control, `minHeight: 56` floor)
+ * - 8  — `boardSection`'s marginTop, above the board itself
+ * - 158 — the action bar: 70 brush row + 56 action row + 32 status line
+ * - 12 — the peek's own reveal, so a hint of the below-fold form shows
+ *
+ * = 278. The remaining 12 absorbs a taller locale or one Dynamic Type step.
  *
  * This was 324 — 46dp of unclaimed slack taken straight off the board on every
  * screen, in every state. Erring high is cheap but it is not free.

--- a/packages/mobile/src/components/create-climb/create-drawer-layout.ts
+++ b/packages/mobile/src/components/create-climb/create-drawer-layout.ts
@@ -19,8 +19,10 @@
  * - 8  — `boardSection`'s marginTop, above the board itself
  * - 158 — the action bar: 70 brush row + 56 action row + 32 status line
  * - 12 — the peek's own reveal, so a hint of the below-fold form shows
+ * - 12 — deliberate slack, absorbing a taller locale or one Dynamic Type step
  *
- * = 278. The remaining 12 absorbs a taller locale or one Dynamic Type step.
+ * = 290. Six measured terms and one buffer; the buffer is listed so the column
+ * adds up to the constant rather than to 278 and reading as an error.
  *
  * This was 324 — 46dp of unclaimed slack taken straight off the board on every
  * screen, in every state. Erring high is cheap but it is not free.

--- a/packages/mobile/src/components/create-climb/create-drawer-layout.ts
+++ b/packages/mobile/src/components/create-climb/create-drawer-layout.ts
@@ -1,0 +1,69 @@
+// The create drawer's vertical budget, extracted so the arithmetic can be
+// asserted rather than eyeballed on a device.
+//
+// It is worth pinning: the board is the surface, and every dp reserved here is
+// a dp of climb the setter cannot see. Both constants below were wrong before
+// #5189 — one under-counted what it reserved, the other over-counted by a sixth
+// of the board on a small phone — and neither error was visible from the code.
+
+/**
+ * Space the header, action bar, draft-status line, sheet handle and safe areas
+ * need, so the board is sized to leave them on screen at the peek.
+ *
+ * Derived from the peek formula rather than guessed: handle reserve (24) +
+ * ScrollView top padding (8) + header row (68) + action bar (70 brush row + 56
+ * action row + 32 status line = 158) + the peek's own 12dp reveal = 278. The
+ * remaining 12 absorbs a taller locale or one Dynamic Type step.
+ *
+ * This was 324 — 46dp of unclaimed slack taken straight off the board on every
+ * screen, in every state. Erring high is cheap but it is not free.
+ */
+export const ABOVE_FOLD_CHROME = 290;
+
+/**
+ * The route transport card, which carries the whole route control set: marginTop
+ * 8 + paddingVertical 12 x 2 + the 44dp frame-strip row + an 8dp row gap + the
+ * 44dp transport row.
+ *
+ * A contract with `PlaybackControls`' strip mode — if the rendered card and this
+ * number disagree, the peek drifts against the real content height.
+ *
+ * The strip row is 44 rather than the 32 its chips occupy so the "+ Add frame"
+ * button in it clears the touch floor: `Button` sizes itself from `minHeight`
+ * and exposes no `hitSlop`, so unlike the frame chips it cannot borrow the extra
+ * 12dp. Paying 12dp of board for the strip's primary action to be tappable is
+ * the right trade on a screen this issue exists to fix the touch targets of.
+ *
+ * It still replaces more than it costs: an 84dp card plus a detached 52dp button
+ * row (136 total). Delete moved into the header's overflow menu and add became a
+ * chip pinned inside the strip, so one card now does the work of two rows.
+ */
+export const PLAYBACK_TRANSPORT_RESERVE = 128;
+
+/**
+ * Floor on the board's height. A board this small is already unusable, so
+ * reaching it means the reserves above are lying about what fits — the sheet
+ * then wants a taller peek than `MAX_PEEK_FRACTION` allows and clamps, dropping
+ * real controls below the fold. Pinned by a test at the smallest phone we
+ * support so it stays unreachable.
+ */
+export const MIN_BOARD_HEIGHT = 200;
+
+export type BoardBudget = {
+  windowHeight: number;
+  /** Top safe-area inset. */
+  insetTop: number;
+  /** Bottom safe-area inset, as the sheet sees it. */
+  insetBottom: number;
+  /** Whether the route transport is on screen — a boulder pays nothing for it. */
+  showRouteTransport: boolean;
+};
+
+/** Height budget left for the board once the drawer's fixed chrome is reserved. */
+export function computeBoardMaxHeight(budget: BoardBudget): number {
+  const routeSlotReserve = budget.showRouteTransport ? PLAYBACK_TRANSPORT_RESERVE : 0;
+  return Math.max(
+    MIN_BOARD_HEIGHT,
+    budget.windowHeight - budget.insetTop - budget.insetBottom - ABOVE_FOLD_CHROME - routeSlotReserve,
+  );
+}

--- a/packages/mobile/src/components/create-climb/create-overflow-menu.ts
+++ b/packages/mobile/src/components/create-climb/create-overflow-menu.ts
@@ -1,7 +1,7 @@
 import type { AppMenuAction } from '../AppMenu.types';
 
 /** What the climber picked. The header maps a tapped index back to one of these. */
-export type CreateOverflowAction = 'makeRoute' | 'makeBoulder' | 'deleteFrame' | 'newClimb';
+export type CreateOverflowAction = 'makeRoute' | 'makeBoulder' | 'newClimb';
 
 export type CreateOverflowRow = AppMenuAction & { action: CreateOverflowAction };
 
@@ -11,8 +11,6 @@ export type CreateOverflowMenuState = {
   /** Whether the setter has switched this climb into route mode. */
   routeMode: boolean;
   frameCount: number;
-  /** The frame the transport is sitting on, zero-based. */
-  frameIndex: number;
 };
 
 /** Translate hook shaped like `react-i18next`'s `t`, so the builder stays pure. */
@@ -24,6 +22,12 @@ type Translate = (key: string, params?: Record<string, number | string>) => stri
  * Pure and total so the row set can be unit-tested per state — the menu is the
  * only way to reach route mode, so "which rows exist when" is behaviour, not
  * presentation.
+ *
+ * Frame commands are deliberately NOT here. Delete lived in this menu for one
+ * revision, next to the mode switch that created the frames — a board's height
+ * from the strip it acts on, and a second door to an action the transport card
+ * now shows inline as a `−` beside its `+`. The menu owns what a climb IS; the
+ * card owns what its frames are.
  *
  * Two rules the row order encodes:
  *
@@ -47,17 +51,6 @@ export function buildCreateOverflowMenu(state: CreateOverflowMenuState, t: Trans
         systemIcon: 'film.stack',
       });
     } else {
-      if (state.frameCount > 1) {
-        rows.push({
-          action: 'deleteFrame',
-          // Named by ordinal: "Delete frame" beside a strip of four makes you
-          // guess which one it means, and the answer (the one you are on) is not
-          // visible in the menu.
-          label: t('mobile.create.routeMenu.deleteFrame', { index: state.frameIndex + 1 }),
-          systemIcon: 'trash',
-          destructive: true,
-        });
-      }
       const canLeave = state.frameCount === 1;
       rows.push({
         action: 'makeBoulder',

--- a/packages/mobile/src/components/create-climb/create-overflow-menu.ts
+++ b/packages/mobile/src/components/create-climb/create-overflow-menu.ts
@@ -1,0 +1,81 @@
+import type { AppMenuAction } from '../AppMenu.types';
+
+/** What the climber picked. The header maps a tapped index back to one of these. */
+export type CreateOverflowAction = 'makeRoute' | 'makeBoulder' | 'deleteFrame' | 'newClimb';
+
+export type CreateOverflowRow = AppMenuAction & { action: CreateOverflowAction };
+
+export type CreateOverflowMenuState = {
+  /** False on a board whose climbs can only ever hold one frame (Woods). */
+  supportsMultiFrame: boolean;
+  /** Whether the setter has switched this climb into route mode. */
+  routeMode: boolean;
+  frameCount: number;
+  /** The frame the transport is sitting on, zero-based. */
+  frameIndex: number;
+};
+
+/** Translate hook shaped like `react-i18next`'s `t`, so the builder stays pure. */
+type Translate = (key: string, params?: Record<string, number | string>) => string;
+
+/**
+ * The rows the creator's overflow (⋯) menu shows, for one editor state.
+ *
+ * Pure and total so the row set can be unit-tested per state — the menu is the
+ * only way to reach route mode, so "which rows exist when" is behaviour, not
+ * presentation.
+ *
+ * Two rules the row order encodes:
+ *
+ * - **Woods gets no route rows at all.** Its packet builder rejects the comma a
+ *   second frame introduces, so offering the mode would be offering a climb that
+ *   cannot be sent to the wall.
+ * - **Leaving route mode is blocked, not hidden, above one frame.** Frames are
+ *   absolute snapshots: "keep frame 1" would discard every hold painted after the
+ *   start position, and flattening would silently rewrite the climb. Neither is
+ *   an honest answer to a menu tap, so the row stays visible, disabled, and says
+ *   what to do instead — a hidden row would just read as a missing feature.
+ */
+export function buildCreateOverflowMenu(state: CreateOverflowMenuState, t: Translate): CreateOverflowRow[] {
+  const rows: CreateOverflowRow[] = [];
+
+  if (state.supportsMultiFrame) {
+    if (!state.routeMode && state.frameCount === 1) {
+      rows.push({
+        action: 'makeRoute',
+        label: t('mobile.create.routeMenu.makeRoute'),
+        systemIcon: 'film.stack',
+      });
+    } else {
+      if (state.frameCount > 1) {
+        rows.push({
+          action: 'deleteFrame',
+          // Named by ordinal: "Delete frame" beside a strip of four makes you
+          // guess which one it means, and the answer (the one you are on) is not
+          // visible in the menu.
+          label: t('mobile.create.routeMenu.deleteFrame', { index: state.frameIndex + 1 }),
+          systemIcon: 'trash',
+          destructive: true,
+        });
+      }
+      const canLeave = state.frameCount === 1;
+      rows.push({
+        action: 'makeBoulder',
+        label: canLeave ? t('mobile.create.routeMenu.makeBoulder') : t('mobile.create.routeMenu.makeBoulderBlocked'),
+        systemIcon: 'square.stack',
+        disabled: !canLeave,
+      });
+    }
+  }
+
+  rows.push({
+    action: 'newClimb',
+    // Moved out of the action bar, where a `+` that discards the whole climb sat
+    // a thumb's width from the `+` that adds a frame to it.
+    label: t('mobile.create.actions.newClimb'),
+    systemIcon: 'plus',
+    destructive: true,
+  });
+
+  return rows;
+}

--- a/packages/mobile/src/components/create-climb/use-create-climb-playback.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-playback.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useId, useMemo } from 'react';
 import type { BoardName, LitUpHoldsMap } from '@boardsesh/shared-schema';
 import { accumulatedMapsToFrameStrings } from '@boardsesh/board-constants/hold-states';
-import { DEFAULT_PACE_MS, usePlaybackEngine } from '@boardsesh/playback-react';
+import { usePlaybackEngine } from '@boardsesh/playback-react';
 
 type UseCreateClimbPlaybackInput = {
   /** The editor's live frame list — absolute lit-state snapshots, one per frame. */
@@ -10,6 +10,8 @@ type UseCreateClimbPlaybackInput = {
   /** The editor's cursor. Painting targets this frame. */
   currentFrameIndex: number;
   goToFrame: (index: number) => void;
+  /** The setter's authored per-frame pace, in ms — what the climb will publish with. */
+  paceMs: number;
 };
 
 export type CreateClimbPlayback = {
@@ -37,16 +39,16 @@ export type CreateClimbPlayback = {
  * must never be broadcast to the crew (hence no `externalState` and no
  * `onLocalStateChange` here).
  *
- * Pace is `DEFAULT_PACE_MS`, which is what the published climb will actually
- * play at: `handleSave` writes `frames_pace: 0` and `useClimbFrames` falls back
- * to the default for 0. So "1×" in the creator is honestly the shipped speed —
- * the speed control is a preview aid, it does not author the pace.
+ * Pace is the setter's own authored value, which is what `handleSave` now writes
+ * as the climb's `frames_pace`. So "0.8s" in the creator is honestly the shipped
+ * speed: the control authors the pace, it is not just a preview aid.
  */
 export function useCreateClimbPlayback({
   frames,
   boardName,
   currentFrameIndex,
   goToFrame,
+  paceMs,
 }: UseCreateClimbPlaybackInput): CreateClimbPlayback {
   const frameStrings = useMemo(() => accumulatedMapsToFrameStrings(frames, boardName), [frames, boardName]);
   const playbackClientId = useId();
@@ -54,7 +56,7 @@ export function useCreateClimbPlayback({
   const engine = usePlaybackEngine({
     frames,
     frameStrings,
-    paceMs: DEFAULT_PACE_MS,
+    paceMs,
     clientId: playbackClientId,
   });
 
@@ -99,7 +101,7 @@ export function useCreateClimbPlayback({
       isAnimatable: engine.isAnimatable,
       isPlaying: engine.isPlaying,
       speed: engine.speed,
-      paceMs: DEFAULT_PACE_MS,
+      paceMs,
       currentFrameString: engine.currentFrameString,
       play: engine.play,
       pause: engine.pause,
@@ -111,6 +113,7 @@ export function useCreateClimbPlayback({
       engine.isPlaying,
       engine.speed,
       engine.currentFrameString,
+      paceMs,
       engine.play,
       engine.pause,
       engine.setSpeed,

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -1015,10 +1015,25 @@ export function useCreateClimbScreen({
     duplicateFrame();
   }, [duplicateFrame, reclaimWall]);
 
+  // Counts deletes rather than letting the announcer infer one from the frame
+  // count falling. Three other things lower that count — "Start a new climb" and
+  // "Clear holds" both RESET to a single empty frame, and undoing an add walks it
+  // back — and every one of them would have announced "Frame deleted".
+  const [frameDeletions, setFrameDeletions] = useState(0);
   const handleDeleteFrame = useCallback(() => {
+    // Mirrors the reducer's own `length <= 1` refusal. The button is disabled
+    // there, but a counter that ticks for a delete that did not happen would
+    // announce a phantom one.
+    if (frameCount <= 1) return;
+    // Stop the clock first. Delete used to be two taps deep in a menu; it is one
+    // tap beside the strip now, and while playback runs the active index moves
+    // on its own — so the frame that went would be whichever the clock had
+    // reached, not the one the button named when the setter read it.
+    playback.pause();
     reclaimWall();
     deleteFrame();
-  }, [deleteFrame, reclaimWall]);
+    setFrameDeletions((count) => count + 1);
+  }, [deleteFrame, reclaimWall, frameCount, playback]);
 
   // Undo/redo change what the wall should show as surely as a paint stroke does,
   // so they take the wall back too. Without this, undoing a hold after Set Active
@@ -1605,6 +1620,7 @@ export function useCreateClimbScreen({
     currentFrameIndex,
     duplicateFrame: guardedDuplicateFrame,
     deleteFrame: handleDeleteFrame,
+    frameDeletions,
     // route playback (transport)
     playback: playbackControls,
     handedOff,

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -805,6 +805,15 @@ export function useCreateClimbScreen({
   // stale save-failure the moment the payload moves, and `handleSave` compares it
   // before and after the round trip so a publish never clears work typed while
   // the mutation was in flight.
+  // The `frames_pace` every write path publishes.
+  //
+  // Null on anything that is not a multi-frame route, and that guard is
+  // load-bearing rather than tidiness: `assertWoodsSingleFrame` rejects a
+  // non-zero pace outright, so a Woods climb carrying one fails the mutation.
+  // A boulder has no gap between frames to pace either, and 0/null both read as
+  // "use the default" downstream in `useClimbFrames`.
+  const publishedFramesPace = frameCount > 1 ? clampAuthoredPaceMs(framesPaceMs) : null;
+
   const payloadSignature = createPayloadSignature({
     holdsJson,
     framesJson,
@@ -815,7 +824,10 @@ export function useCreateClimbScreen({
     campus,
     anyFeet,
     isDraft,
-    framesPaceMs,
+    // The PUBLISHED pace, not the control's raw value: a boulder writes no pace
+    // at all, so a leftover one from a spell in route mode must not make two
+    // identical boulders look like different payloads.
+    framesPaceMs: publishedFramesPace ?? DEFAULT_PACE_MS,
   });
   const payloadSignatureRef = useRef(payloadSignature);
   payloadSignatureRef.current = payloadSignature;
@@ -1143,15 +1155,6 @@ export function useCreateClimbScreen({
   // you just made lands in the queue as if it belonged to nobody, so the play
   // drawer's owner-only Edit action never appears on your own fresh draft —
   // `computeCanUpdate` reads exactly userId + is_draft + published_at.
-  // The `frames_pace` every write path publishes.
-  //
-  // Null on anything that is not a multi-frame route, and that guard is
-  // load-bearing rather than tidiness: `assertWoodsSingleFrame` rejects a
-  // non-zero pace outright, so a Woods climb carrying one fails the mutation.
-  // A boulder has no gap between frames to pace either, and 0/null both read as
-  // "use the default" downstream in `useClimbFrames`.
-  const publishedFramesPace = frameCount > 1 ? clampAuthoredPaceMs(framesPaceMs) : null;
-
   const buildProvisionalClimb = useCallback(
     (uuid: string, frames: string): Climb => ({
       uuid,

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -1090,6 +1090,11 @@ export function useCreateClimbScreen({
       // A blank climb is nobody's remix and nobody's edit, so it inherits no
       // MoonBoard method either — the Any-feet row comes back with it.
       setSeededMethod(null);
+      // And it is a boulder, like every fresh climb. Without this the transport
+      // stays on a blank single-frame climb the setter never asked to be a
+      // route — the boulder-pays-nothing invariant, broken one climb later.
+      setRouteMode(false);
+      setFramesPaceMs(DEFAULT_PACE_MS);
       setIsDraft(true);
       setSavedClimb(null);
       setPublishDuplicateError(null);

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -25,7 +25,7 @@ import {
   type SavedClimbSnapshot,
 } from '@boardsesh/create-climb-react';
 import { useBoardActions, isDuplicateClimbError } from '@boardsesh/board-react';
-import { DEFAULT_PACE_MS, clampAuthoredPaceMs } from '@boardsesh/playback-react';
+import { DEFAULT_PACE_MS, clampAuthoredPaceMs, resolveStoredPaceMs } from '@boardsesh/playback-react';
 import { GraphQLOperationError } from '@boardsesh/graphql-client';
 import { getLayoutName } from '@boardsesh/board-constants/product-sizes';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -567,7 +567,7 @@ export function useCreateClimbScreen({
       // Explicit flag first, then infer from the restored frames: a slot written
       // before route mode existed carries no flag but may well carry a route.
       setRouteMode(draft.routeMode ?? restoredFrameCount > 1);
-      setFramesPaceMs(clampAuthoredPaceMs(draft.framesPaceMs ?? DEFAULT_PACE_MS));
+      setFramesPaceMs(resolveStoredPaceMs(draft.framesPaceMs));
     },
     [loadFrames, usesNoMatchDescription],
   );
@@ -644,11 +644,8 @@ export function useCreateClimbScreen({
     const serverAnyFeet = !serverCampus && isAnyFeet(editClimb.characteristics);
     const serverIsDraft = editClimb.is_draft ?? false;
     // 0/null mean "never authored" and play at the default, so that is what the
-    // control should open on — not a clamped 0.
-    const serverPaceMs =
-      editClimb.framesPace != null && editClimb.framesPace > 0
-        ? clampAuthoredPaceMs(editClimb.framesPace)
-        : DEFAULT_PACE_MS;
+    // control opens on. Preserved as stored otherwise — see `resolveStoredPaceMs`.
+    const serverPaceMs = resolveStoredPaceMs(editClimb.framesPace);
     const serverSignature = createPayloadSignature({
       holdsJson: JSON.stringify(serverFrames[0] ?? {}),
       framesJson: JSON.stringify(serverFrames),
@@ -659,7 +656,11 @@ export function useCreateClimbScreen({
       campus: serverCampus,
       anyFeet: serverAnyFeet,
       isDraft: serverIsDraft,
-      framesPaceMs: serverPaceMs,
+      // Signed by the same rule the live signature uses — the pace this payload
+      // would PUBLISH. A single-frame row carrying a stray pace publishes none,
+      // so counting it here would make the two sides disagree forever and the
+      // climb read as permanently edited.
+      framesPaceMs: serverFrames.length > 1 ? serverPaceMs : DEFAULT_PACE_MS,
     });
     const serverSnapshot: SavedClimbSnapshot = {
       uuid: editClimb.uuid,
@@ -812,7 +813,14 @@ export function useCreateClimbScreen({
   // non-zero pace outright, so a Woods climb carrying one fails the mutation.
   // A boulder has no gap between frames to pace either, and 0/null both read as
   // "use the default" downstream in `useClimbFrames`.
-  const publishedFramesPace = frameCount > 1 ? clampAuthoredPaceMs(framesPaceMs) : null;
+  //
+  // Passed through rather than re-clamped: the authoring slider's 10s ceiling
+  // bounds what this control can PRODUCE, not what a climb may hold. An Aurora
+  // climb synced with a slower pace keeps it here, so opening one and saving an
+  // unrelated edit republishes the pace its setter chose instead of quietly
+  // halving it. The two writers are already bounded — `setFramesPace` clamps the
+  // control, and the server bounds what it accepts.
+  const publishedFramesPace = frameCount > 1 ? Math.round(framesPaceMs) : null;
 
   const payloadSignature = createPayloadSignature({
     holdsJson,

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -25,6 +25,7 @@ import {
   type SavedClimbSnapshot,
 } from '@boardsesh/create-climb-react';
 import { useBoardActions, isDuplicateClimbError } from '@boardsesh/board-react';
+import { DEFAULT_PACE_MS, clampAuthoredPaceMs } from '@boardsesh/playback-react';
 import { GraphQLOperationError } from '@boardsesh/graphql-client';
 import { getLayoutName } from '@boardsesh/board-constants/product-sizes';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -100,10 +101,11 @@ type PayloadSignatureFields = {
   campus: boolean;
   anyFeet: boolean;
   isDraft: boolean;
+  framesPaceMs: number;
 };
 
 function createPayloadSignature(fields: PayloadSignatureFields): string {
-  return [
+  const parts = [
     fields.holdsJson,
     fields.framesJson,
     fields.name,
@@ -113,7 +115,19 @@ function createPayloadSignature(fields: PayloadSignatureFields): string {
     fields.campus ? '1' : '0',
     fields.anyFeet ? '1' : '0',
     fields.isDraft ? '1' : '0',
-  ].join(SIGNATURE_SEPARATOR);
+  ];
+  // Appended only when the setter moved it off the default, which keeps every
+  // signature written before the pace was authorable byte-identical. Signatures
+  // are opaque equality checks compared against a value PERSISTED in the draft
+  // slot, so widening the format unconditionally would make every stored draft
+  // on every phone announce "unsynced edits" once after the update — a lie, for
+  // a field the climber never touched.
+  //
+  // Only the pace is signed, not `routeMode`: the pace changes what Save writes,
+  // whereas toggling route mode at one frame changes no field of the payload at
+  // all (a single-frame climb always publishes `frames_pace: 0`).
+  if (fields.framesPaceMs !== DEFAULT_PACE_MS) parts.push(`pace:${fields.framesPaceMs}`);
+  return parts.join(SIGNATURE_SEPARATOR);
 }
 
 /**
@@ -333,6 +347,27 @@ export function useCreateClimbScreen({
   const [isDraft, setIsDraft] = useState(true);
   const [showAllHolds, setShowAllHolds] = useState(false);
 
+  // ---- Route mode. ----
+  // Whether this climb is being authored as a route. Route-ness is inferred from
+  // `frames.length > 1` everywhere else in the product (search filters read
+  // `frames_count`), but the creator needs a state the data cannot express: the
+  // moment after "Make it a route" and before the second frame exists. Without
+  // it the transport could only appear once a route already existed, which is
+  // the discoverability hole #4761 was opened to fix — and every boulder would
+  // keep paying for route chrome it never uses.
+  //
+  // Deliberately NOT in the shared editor reducer: it is not an edit, so it must
+  // not land in the undo stack. Seeded true when the editor opens on something
+  // that already has frames (a fork, an edit, or a restored multi-frame draft).
+  const [routeMode, setRouteMode] = useState(() => initialFrames != null && initialFrames.length > 1);
+
+  // Authored per-frame pace, in milliseconds. This is the value the published
+  // climb carries as `frames_pace`, and what the creator's own preview plays at,
+  // so "0.8s" in the transport is honestly the shipped speed. Aurora, Kilter and
+  // our own schema all store exactly ONE pace per climb — there is no per-frame
+  // duration anywhere in the format — so this is a single scalar by design.
+  const [framesPaceMs, setFramesPaceMs] = useState<number>(DEFAULT_PACE_MS);
+
   // The MoonBoard "method" of the climb this session is attached to, if any. The
   // editor cannot set or clear a method token (that is creation-time-only, via
   // SaveMoonBoardClimbInput), so a footless problem's own row keeps saying "no
@@ -506,11 +541,13 @@ export function useCreateClimbScreen({
   // Apply a stored working copy over whatever the editor currently holds.
   const applyStoredDraft = useCallback(
     (draft: CreateClimbDraft) => {
+      let restoredFrameCount = 0;
       try {
         const restoredFrames = draft.framesJson
           ? (JSON.parse(draft.framesJson) as Parameters<typeof loadFrames>[0])
           : [JSON.parse(draft.holdsJson) as Parameters<typeof loadFrames>[0][number]];
         loadFrames(restoredFrames);
+        restoredFrameCount = restoredFrames.length;
       } catch {
         // Corrupt holds payload — keep whatever is already loaded.
       }
@@ -527,6 +564,10 @@ export function useCreateClimbScreen({
       setCampusState(draft.campus ?? false);
       setAnyFeetState(!draft.campus && (draft.anyFeet ?? false));
       setIsDraft(draft.isDraft);
+      // Explicit flag first, then infer from the restored frames: a slot written
+      // before route mode existed carries no flag but may well carry a route.
+      setRouteMode(draft.routeMode ?? restoredFrameCount > 1);
+      setFramesPaceMs(clampAuthoredPaceMs(draft.framesPaceMs ?? DEFAULT_PACE_MS));
     },
     [loadFrames, usesNoMatchDescription],
   );
@@ -602,6 +643,12 @@ export function useCreateClimbScreen({
     const serverCampus = isCampus(editClimb.characteristics);
     const serverAnyFeet = !serverCampus && isAnyFeet(editClimb.characteristics);
     const serverIsDraft = editClimb.is_draft ?? false;
+    // 0/null mean "never authored" and play at the default, so that is what the
+    // control should open on — not a clamped 0.
+    const serverPaceMs =
+      editClimb.framesPace != null && editClimb.framesPace > 0
+        ? clampAuthoredPaceMs(editClimb.framesPace)
+        : DEFAULT_PACE_MS;
     const serverSignature = createPayloadSignature({
       holdsJson: JSON.stringify(serverFrames[0] ?? {}),
       framesJson: JSON.stringify(serverFrames),
@@ -612,6 +659,7 @@ export function useCreateClimbScreen({
       campus: serverCampus,
       anyFeet: serverAnyFeet,
       isDraft: serverIsDraft,
+      framesPaceMs: serverPaceMs,
     });
     const serverSnapshot: SavedClimbSnapshot = {
       uuid: editClimb.uuid,
@@ -621,6 +669,8 @@ export function useCreateClimbScreen({
       isDraft: serverIsDraft,
     };
     setSavedClimb(serverSnapshot);
+    setFramesPaceMs(serverPaceMs);
+    setRouteMode(serverFrames.length > 1);
     setSavedSignature(serverSignature);
     setSavedSignatureUnknown(false);
     // Outside the reseed guard below: the row's MoonBoard method belongs to the
@@ -765,6 +815,7 @@ export function useCreateClimbScreen({
     campus,
     anyFeet,
     isDraft,
+    framesPaceMs,
   });
   const payloadSignatureRef = useRef(payloadSignature);
   payloadSignatureRef.current = payloadSignature;
@@ -788,6 +839,8 @@ export function useCreateClimbScreen({
       noKickboard,
       campus,
       anyFeet,
+      routeMode,
+      framesPaceMs,
       savedClimbJson,
       savedPayloadSignature: savedSignature ?? undefined,
       origin: isEditing ? 'edit' : isForking ? 'fork' : 'new',
@@ -802,6 +855,8 @@ export function useCreateClimbScreen({
       noKickboard,
       campus,
       anyFeet,
+      routeMode,
+      framesPaceMs,
       isDraft,
       savedClimbJson,
       savedSignature,
@@ -829,6 +884,7 @@ export function useCreateClimbScreen({
     boardName: board.boardName,
     currentFrameIndex,
     goToFrame,
+    paceMs: framesPaceMs,
   });
 
   // True once Set-Active handed the route to the queue. The auto-sender then
@@ -1087,6 +1143,15 @@ export function useCreateClimbScreen({
   // you just made lands in the queue as if it belonged to nobody, so the play
   // drawer's owner-only Edit action never appears on your own fresh draft —
   // `computeCanUpdate` reads exactly userId + is_draft + published_at.
+  // The `frames_pace` every write path publishes.
+  //
+  // Null on anything that is not a multi-frame route, and that guard is
+  // load-bearing rather than tidiness: `assertWoodsSingleFrame` rejects a
+  // non-zero pace outright, so a Woods climb carrying one fails the mutation.
+  // A boulder has no gap between frames to pace either, and 0/null both read as
+  // "use the default" downstream in `useClimbFrames`.
+  const publishedFramesPace = frameCount > 1 ? clampAuthoredPaceMs(framesPaceMs) : null;
+
   const buildProvisionalClimb = useCallback(
     (uuid: string, frames: string): Climb => ({
       uuid,
@@ -1118,9 +1183,11 @@ export function useCreateClimbScreen({
       userAscents: 0,
       userAttempts: 0,
       framesCount: frameCount,
-      // 0/null both mean "use the default pace" — useClimbFrames falls back to
-      // DEFAULT_PACE_MS whenever framesPace isn't a positive number.
-      framesPace: null,
+      // Mirrors what Save writes, so the queue plays a WIP route at the pace the
+      // setter dialled rather than at the default. Null on a boulder: 0/null both
+      // mean "use the default pace" to `useClimbFrames`, and a one-frame climb has
+      // no pace to honour anyway.
+      framesPace: publishedFramesPace,
     }),
     [
       name,
@@ -1138,6 +1205,7 @@ export function useCreateClimbScreen({
       board.sizeId,
       t,
       frameCount,
+      publishedFramesPace,
     ],
   );
 
@@ -1283,7 +1351,7 @@ export function useCreateClimbScreen({
           // against the wrong wall.
           sizeId: board.sizeId,
           framesCount: frameCount,
-          framesPace: 0,
+          framesPace: publishedFramesPace ?? 0,
           isDraft,
           characteristics,
           // Explicit booleans, never null: an omitted flag PRESERVES whatever the
@@ -1318,7 +1386,7 @@ export function useCreateClimbScreen({
           is_draft: isDraft,
           frames,
           frames_count: frameCount,
-          frames_pace: 0,
+          frames_pace: publishedFramesPace ?? 0,
           angle: board.angle,
           characteristics,
           no_match: noMatch,
@@ -1412,6 +1480,7 @@ export function useCreateClimbScreen({
     litUpHoldsMap,
     generateFramesString,
     frameCount,
+    publishedFramesPace,
     updateClimb,
     saveClimb,
     board,
@@ -1446,6 +1515,36 @@ export function useCreateClimbScreen({
     if (!supportsMultiFrame) return;
     handleDuplicateFrame();
   }, [supportsMultiFrame, handleDuplicateFrame]);
+
+  // ---- Route mode, entered and left from the header's overflow menu. ----
+  // Entering changes no data: the transport simply appears, sitting on frame 1
+  // with an add-frame chip. Deliberately NOT auto-creating frame 2 — a mode
+  // switch that silently mutates the climb is a surprise, and the tool it
+  // reveals is one tap away.
+  const enterRouteMode = useCallback(() => {
+    if (!supportsMultiFrame) return;
+    setRouteMode(true);
+  }, [supportsMultiFrame]);
+
+  // Leaving is only offered while the climb is still one frame. Above that there
+  // is no honest answer: frames are absolute snapshots, so "keep frame 1" throws
+  // away every hold painted after the start position, and flattening silently
+  // rewrites the climb. Deleting frames down to one is the explicit, undoable
+  // path, so the menu row stays visible and disabled rather than doing either.
+  const canLeaveRouteMode = frameCount === 1;
+  const leaveRouteMode = useCallback(() => {
+    if (frameCount > 1) return;
+    setRouteMode(false);
+  }, [frameCount]);
+
+  // A route that lost its frames is a boulder again in every other reader's eyes
+  // (search filters key off `frames_count`), but the setter is still in route
+  // mode and may be about to re-add one. Only the flag's own control clears it.
+  const showRouteTransport = supportsMultiFrame && (routeMode || frameCount > 1);
+
+  const setFramesPace = useCallback((paceMs: number) => {
+    setFramesPaceMs(clampAuthoredPaceMs(paceMs));
+  }, []);
 
   const canSetActive = isValid;
 
@@ -1493,6 +1592,15 @@ export function useCreateClimbScreen({
     // route playback (transport)
     playback: playbackControls,
     handedOff,
+    // route mode (the header's overflow menu owns entering and leaving)
+    routeMode,
+    showRouteTransport,
+    enterRouteMode,
+    leaveRouteMode,
+    canLeaveRouteMode,
+    /** Authored per-frame pace in ms — published as the climb's `frames_pace`. */
+    framesPaceMs,
+    setFramesPace,
     // undo/redo (current editing session only)
     undo: handleUndo,
     redo: handleRedo,

--- a/packages/mobile/src/components/playback/PlaybackControls.tsx
+++ b/packages/mobile/src/components/playback/PlaybackControls.tsx
@@ -26,7 +26,7 @@ import { hapticLight, hapticSelection, hapticSuccess } from '../../lib/haptics';
 import { brandColors as staticBrandColors, withAlpha } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { glassSize } from '../../theme/layout';
-import { spacing, borderRadius, opacity } from '../../theme/tokens';
+import { spacing, borderRadius } from '../../theme/tokens';
 import { springs, timing } from '../../theme/animations';
 import {
   clampPaceSeconds,
@@ -336,6 +336,11 @@ function FrameStrip({
           variant="caption1"
           color={systemColors.secondaryLabel}
           numberOfLines={1}
+          // Capped below the 1.5 default: this row is a fixed 32dp inside a card
+          // that clips, and caption1's 16dp line box at 1.5 plus 8dp of padding
+          // is exactly 32 with nothing spare. The reader's copy of this chip, in
+          // the transport row, keeps the full range.
+          maxFontSizeMultiplier={1.2}
           style={[styles.wallStateChip, { backgroundColor: systemColors.fill }]}
         >
           {wallStateLabel}
@@ -429,7 +434,10 @@ function FrameEditPair({
         }
         accessibilityHint={canDelete ? tClimbs('mobile.create.playback.deleteFrameHint') : undefined}
         accessibilityState={{ disabled: !canDelete }}
-        style={[styles.framePairButton, !canDelete && styles.framePairButtonDisabled]}
+        // Dimmed by the glyph colour alone, the way the prev/next chevrons 40dp
+        // away are. Stacking an opacity on `tertiaryLabel` (already ~30% alpha on
+        // iOS) puts the mark near 15% and under the 3:1 non-text floor.
+        style={styles.framePairButton}
         testID="playback-delete-frame"
       >
         <Icon name="minus" size={20} color={canDelete ? systemColors.secondaryLabel : systemColors.tertiaryLabel} />
@@ -1052,9 +1060,6 @@ const styles = StyleSheet.create({
     height: glassSize.inline,
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  framePairButtonDisabled: {
-    opacity: opacity.disabled,
   },
   framePairDivider: {
     width: StyleSheet.hairlineWidth,

--- a/packages/mobile/src/components/playback/PlaybackControls.tsx
+++ b/packages/mobile/src/components/playback/PlaybackControls.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { View, Pressable, StyleSheet, type ColorValue, type LayoutChangeEvent } from 'react-native';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { View, Pressable, ScrollView, StyleSheet, type ColorValue, type LayoutChangeEvent } from 'react-native';
 import Animated, {
   FadeIn,
   FadeOut,
@@ -9,11 +9,14 @@ import Animated, {
   withTiming,
   withSequence,
   runOnJS,
+  type SharedValue,
 } from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { useTranslation } from 'react-i18next';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
+import { Button } from '../Button';
+import { GlassCluster } from '../GlassCluster';
 import type { IconName } from '../icon-map';
 import { useTheme } from '../../providers/theme-provider';
 import { hapticLight, hapticSelection, hapticSuccess } from '../../lib/haptics';
@@ -21,11 +24,20 @@ import { hapticLight, hapticSelection, hapticSuccess } from '../../lib/haptics';
 // (slider/progress fills). `staticBrandColors` is intentionally the static set,
 // used only for the active speed pill — a FILL with white text that must stay
 // legible in both schemes (the lifted dark tint would fail white-on-fill).
-import { brandColors as staticBrandColors } from '../../theme/colors';
+import { brandColors as staticBrandColors, withAlpha } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
+import { glassSize } from '../../theme/layout';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { springs, timing } from '../../theme/animations';
-import { roundedReportSpeed, shouldReportSpeed } from './playback-speed-report';
+import {
+  clampPaceSeconds,
+  roundedReportPaceSeconds,
+  roundedReportSpeed,
+  shouldReportPaceSeconds,
+  shouldReportSpeed,
+  MAX_PACE_SECONDS,
+  MIN_PACE_SECONDS,
+} from './playback-speed-report';
 
 // Continuous range; mirrors web's effective span. 1× is the natural default and
 // gets a gentle release-magnet (see commit()).
@@ -38,15 +50,44 @@ const TRACK_HEIGHT = 6;
 // slider for anything in between. Mirrors Apple Podcasts' tap-to-cycle control.
 const SPEED_STEPS = [0.5, 1, 1.5, 2, 3] as const;
 
+// Seconds-per-frame the pill cycles through when the creator is authoring the
+// climb's own pace rather than reading it through a multiplier.
+const PACE_STEPS = [0.5, 0.8, 1.5, 3, 5] as const;
+
+/** The pace the release-magnet pulls to — `DEFAULT_PACE_MS` (750ms) in seconds. */
+const MAGNET_PACE_SECONDS = 0.75;
+
+// Frame-strip geometry. Chips read as chips at 32dp and reach the 44dp touch
+// floor through hitSlop, but the row itself is 44 so the labelled add-frame
+// Button in it clears the floor on its own — a native Button has no hitSlop to
+// borrow. That fixes the card's resting height in strip mode at 128dp (8 margin
+// + 12 padding + 44 strip + 8 gap + 44 transport + 12 padding); CreateDrawer
+// reserves that number, so changing any of these changes a layout contract.
+const CHIP_SIZE = 32;
+const CHIP_GAP = spacing[2];
+const CHIP_STEP = CHIP_SIZE + CHIP_GAP;
+const UNDERLINE_HEIGHT = 2;
+
 /** Next preset strictly above `current`, wrapping to the slowest past the top. */
 function nextSpeedStep(current: number): number {
   return SPEED_STEPS.find((step) => step > current + 0.001) ?? SPEED_STEPS[0];
+}
+
+/** Next pace preset strictly above `current` seconds, wrapping past the top. */
+function nextPaceStep(current: number): number {
+  return PACE_STEPS.find((step) => step > current + 0.001) ?? PACE_STEPS[0];
 }
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 // Hoisted so the adjustable node isn't handed a fresh array every render.
 const ADJUSTABLE_ACTIONS = [{ name: 'increment' }, { name: 'decrement' }] as const;
+
+/**
+ * How the pill reads and writes the cadence. 'multiplier' is the reader's lens
+ * over whatever pace the setter authored; 'seconds' authors that pace directly.
+ */
+type PaceUnit = 'multiplier' | 'seconds';
 
 type PlaybackControlsProps = {
   frameIndex: number;
@@ -67,6 +108,22 @@ type PlaybackControlsProps = {
    * reading "2 / 3" over it would be a lie. Omit it and the counter renders.
    */
   wallStateLabel?: string | null;
+  /**
+   * Creator-only. Present ⇒ the card grows a frame strip and an add-frame chip.
+   * Absent (the play drawer) ⇒ the card renders the plain counter exactly as it
+   * always has, so this transport stays one component across both callers.
+   */
+  frameEditing?: {
+    /** Inserts a copy of the active frame after it. */
+    onAddFrame: () => void;
+  };
+  /**
+   * 'multiplier' (default) shows "1×" and drives onSpeedChange; 'seconds' shows
+   * "0.8s" and drives onPaceChange.
+   */
+  paceUnit?: PaceUnit;
+  /** Required when paceUnit === 'seconds'. Reports the authored per-frame pace in ms. */
+  onPaceChange?: (paceMs: number) => void;
   onPlay: () => void;
   onPause: () => void;
   onSeek: (index: number) => void;
@@ -77,6 +134,12 @@ type PlaybackControlsProps = {
 function formatSpeed(speed: number): string {
   const rounded = Math.round(speed * 10) / 10;
   return Number.isInteger(rounded) ? `${rounded}×` : `${rounded.toFixed(1)}×`;
+}
+
+/** The seconds-per-frame label, trimmed the way `formatSpeed` trims (3.0 → "3s"). */
+function formatPace(seconds: number): string {
+  const rounded = Math.round(seconds * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}s` : `${rounded.toFixed(1)}s`;
 }
 
 function clamp01(value: number): number {
@@ -115,12 +178,162 @@ function StepButton({
       accessibilityState={{ disabled }}
       style={[styles.stepButton, animatedStyle]}
     >
-      <Icon name={direction === 'prev' ? 'chevron.left' : 'chevron.right'} size={28} color={color} />
+      <Icon name={direction === 'prev' ? 'chevron.left' : 'chevron.right'} size={20} color={color} />
     </AnimatedPressable>
   );
 }
 
-/** Speed pill: tap cycles through the presets, long-press reveals the fine slider. */
+/**
+ * One frame in the strip. Selected reads as a tonal brand chip rather than a
+ * fill, so the strip never competes with the Save CTA for loudest thing on the
+ * sheet.
+ */
+const FrameChip = memo(function FrameChip({
+  index,
+  selected,
+  label,
+  onSeek,
+}: {
+  index: number;
+  selected: boolean;
+  label: string;
+  onSeek: (index: number) => void;
+}) {
+  const { systemColors, brandColors, radii } = useTheme();
+  const handlePress = useCallback(() => {
+    hapticSelection();
+    onSeek(index);
+  }, [index, onSeek]);
+  return (
+    <Pressable
+      onPress={handlePress}
+      // 32dp chip + 6dp of slop on each edge = the 44dp touch floor, without
+      // widening the 32dp strip row the card's height budget is built on.
+      hitSlop={6}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ selected }}
+      style={[
+        styles.frameChip,
+        {
+          borderRadius: radii.button,
+          backgroundColor: selected ? withAlpha(brandColors.primary, 0.18) : systemColors.fill,
+        },
+      ]}
+    >
+      <Text
+        variant="footnote"
+        color={selected ? brandColors.primary : systemColors.secondaryLabel}
+        style={[styles.frameChipDigit, selected && styles.frameChipDigitSelected]}
+      >
+        {index + 1}
+      </Text>
+    </Pressable>
+  );
+});
+
+/**
+ * The creator's frame strip: one tappable chip per frame plus a labelled add
+ * chip, in place of the reader's `1 / 4` counter.
+ *
+ * The add chip is pinned OUTSIDE the scroller (the CreateDrawerActionBar idiom)
+ * because it is the one control that must never scroll out of reach — two
+ * earlier attempts at this feature came back QA-declined for exactly that, and
+ * for reducing it to a bare glyph. It stays a word.
+ *
+ * The 2dp underline is driven by the SAME shared value the reader's top progress
+ * bar uses, so it glides at `paceMs / speed` during playback: one position cue on
+ * the card rather than two saying the same thing.
+ */
+function FrameStrip({
+  frameCount,
+  frameIndex,
+  progress,
+  onSeek,
+  onAddFrame,
+}: {
+  frameCount: number;
+  frameIndex: number;
+  progress: SharedValue<number>;
+  onSeek: (index: number) => void;
+  onAddFrame: () => void;
+}) {
+  const { brandColors } = useTheme();
+  const { t } = useTranslation('session');
+  // A SEPARATE hook, not `useTranslation(['session', 'climbs'])`: with an array,
+  // `t('a.b.c')` resolves against the FIRST namespace only, so the add-frame key
+  // — which lives in climbs.json — would fall through and the chip would render
+  // its raw key. CreateDrawer hit exactly this and only the emulator caught it.
+  const { t: tClimbs } = useTranslation('climbs');
+  const scrollRef = useRef<ScrollView>(null);
+  const [viewportWidth, setViewportWidth] = useState(0);
+
+  const handleViewportLayout = useCallback((event: LayoutChangeEvent) => {
+    setViewportWidth(event.nativeEvent.layout.width);
+  }, []);
+
+  // Past ~9 frames the strip is wider than the row, so keep the frame you are
+  // sitting on centred rather than letting playback walk it off the edge.
+  useEffect(() => {
+    if (viewportWidth <= 0) return;
+    const chipCentre = frameIndex * CHIP_STEP + CHIP_SIZE / 2;
+    scrollRef.current?.scrollTo({ x: Math.max(0, chipCentre - viewportWidth / 2), y: 0, animated: true });
+  }, [frameIndex, viewportWidth]);
+
+  const chips = useMemo(
+    () =>
+      Array.from({ length: frameCount }, (_, index) => ({
+        index,
+        label: t('playView.frameCounterA11y', { index: index + 1, total: frameCount }),
+      })),
+    [frameCount, t],
+  );
+
+  const travel = Math.max(0, frameCount - 1) * CHIP_STEP;
+  const underlineStyle = useAnimatedStyle(() => ({ transform: [{ translateX: progress.value * travel }] }));
+
+  return (
+    <View style={styles.stripRow} testID="playback-frame-strip">
+      <View style={styles.stripScroller} onLayout={handleViewportLayout}>
+        <ScrollView
+          ref={scrollRef}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={styles.stripContent}
+        >
+          {chips.map((chip) => (
+            <FrameChip
+              key={chip.index}
+              index={chip.index}
+              label={chip.label}
+              selected={chip.index === frameIndex}
+              onSeek={onSeek}
+            />
+          ))}
+          <Animated.View
+            style={[styles.frameUnderline, { backgroundColor: brandColors.primary }, underlineStyle]}
+            pointerEvents="none"
+          />
+        </ScrollView>
+      </View>
+
+      <Button
+        title={tClimbs('mobile.create.playback.addFrame')}
+        variant="tonal"
+        size="small"
+        // Floored at 44 rather than sized to the 32dp chip rung. It is the action
+        // the whole feature depends on being tappable, and unlike the chips it
+        // cannot reach the floor through hitSlop — @expo/ui renders a native
+        // button, so the row is 44 and the card's reserve is 128.
+        minHeight={glassSize.inline}
+        onPress={onAddFrame}
+      />
+    </View>
+  );
+}
+
+/** Cadence pill: tap cycles through the presets, long-press reveals the fine slider. */
 function SpeedPill({
   label,
   active,
@@ -169,40 +382,49 @@ function SpeedPill({
 }
 
 /**
- * Hand-rolled speed slider on reanimated + gesture-handler — no native slider
+ * Hand-rolled cadence slider on reanimated + gesture-handler — no native slider
  * dependency (which would force a fresh build and break OTA updates). The thumb
- * tracks a shared value on the UI thread and grows on grab; speed is committed
+ * tracks a shared value on the UI thread and grows on grab; the value is committed
  * once on release (one engine update / one party-sync broadcast), with a haptic
- * tick every 0.5× and a magnet to 1×. The live value is reported up to the pill
- * via `onLiveChange`.
+ * tick every 0.5 units and a magnet to the natural default. The live value is
+ * reported up to the pill via `onLiveChange`.
+ *
+ * Both units share one slider: `unit` swaps the range (0.1–10× vs 0.3–10s), the
+ * magnet target and the label, so the reader's multiplier and the setter's
+ * seconds-per-frame can never drift into two different controls.
  */
 function SpeedSlider({
   value,
+  unit,
   onChange,
   onLiveChange,
 }: {
   value: number;
-  onChange: (speed: number) => void;
-  onLiveChange: (speed: number) => void;
+  unit: PaceUnit;
+  onChange: (value: number) => void;
+  onLiveChange: (value: number) => void;
 }) {
   const theme = useTheme();
   const { systemColors } = theme;
   const { t } = useTranslation('session');
   const [trackWidth, setTrackWidth] = useState(0);
   const usable = Math.max(0, trackWidth - THUMB_SIZE);
+  const inSeconds = unit === 'seconds';
+  const minValue = inSeconds ? MIN_PACE_SECONDS : MIN_SPEED;
+  const maxValue = inSeconds ? MAX_PACE_SECONDS : MAX_SPEED;
   const position = useSharedValue(0);
   const startPosition = useSharedValue(0);
   const dragging = useSharedValue(false);
   const thumbScale = useSharedValue(1);
   const lastNotch = useSharedValue(-1);
-  // The last 0.1×-rounded speed pushed via `reportLive`, so the per-frame
+  // The last 0.1-rounded value pushed via `reportLive`, so the per-frame
   // worklet skips the cross-thread `runOnJS` hop (and the PlaybackControls
   // re-render it triggers) when the displayed value hasn't actually changed.
   const lastReported = useSharedValue(-1);
 
-  const ratioToSpeed = useCallback(
-    (ratio: number) => Math.round((MIN_SPEED + clamp01(ratio) * (MAX_SPEED - MIN_SPEED)) * 10) / 10,
-    [],
+  const ratioToValue = useCallback(
+    (ratio: number) => Math.round((minValue + clamp01(ratio) * (maxValue - minValue)) * 10) / 10,
+    [minValue, maxValue],
   );
 
   // Keep the thumb synced to the external value while not dragging (peer sync,
@@ -211,22 +433,24 @@ function SpeedSlider({
   // the SharedValue with `.get()` (Reanimated JS-thread accessor), not `.value`.
   useEffect(() => {
     if (usable <= 0 || dragging.get()) return;
-    position.value = clamp01((value - MIN_SPEED) / (MAX_SPEED - MIN_SPEED)) * usable;
-  }, [value, usable, position, dragging]);
+    position.value = clamp01((value - minValue) / (maxValue - minValue)) * usable;
+  }, [value, usable, minValue, maxValue, position, dragging]);
 
   const reportLive = useCallback(
-    (px: number) => onLiveChange(ratioToSpeed(usable > 0 ? px / usable : 0)),
-    [onLiveChange, ratioToSpeed, usable],
+    (px: number) => onLiveChange(ratioToValue(usable > 0 ? px / usable : 0)),
+    [onLiveChange, ratioToValue, usable],
   );
   const commit = useCallback(
     (px: number) => {
-      const raw = ratioToSpeed(usable > 0 ? px / usable : 0);
-      // Gentle magnet to 1× — the natural default is easy to land on exactly.
-      const snapped = Math.abs(raw - 1) <= 0.1 ? 1 : raw;
+      const raw = ratioToValue(usable > 0 ? px / usable : 0);
+      // Gentle magnet to the natural default — 1× for a reader, and 0.75s (the
+      // engine's DEFAULT_PACE_MS) for a setter — so it is easy to land on exactly.
+      const magnet = inSeconds ? MAGNET_PACE_SECONDS : 1;
+      const snapped = Math.abs(raw - magnet) <= 0.1 ? magnet : raw;
       onLiveChange(snapped);
       onChange(snapped);
     },
-    [onChange, onLiveChange, ratioToSpeed, usable],
+    [inSeconds, onChange, onLiveChange, ratioToValue, usable],
   );
 
   const pan = useMemo(
@@ -241,24 +465,28 @@ function SpeedSlider({
           startPosition.value = position.value;
           thumbScale.value = withSpring(1.25, springs.snappy);
           lastNotch.value =
-            Math.round((MIN_SPEED + (usable > 0 ? position.value / usable : 0) * (MAX_SPEED - MIN_SPEED)) * 2) / 2;
-          lastReported.value = roundedReportSpeed(position.value, usable);
+            Math.round((minValue + (usable > 0 ? position.value / usable : 0) * (maxValue - minValue)) * 2) / 2;
+          lastReported.value = inSeconds
+            ? roundedReportPaceSeconds(position.value, usable)
+            : roundedReportSpeed(position.value, usable);
           runOnJS(hapticSelection)();
         })
         .onUpdate((event) => {
           const next = Math.max(0, Math.min(usable, startPosition.value + event.translationX));
           position.value = next;
-          // Tick once per 0.5× crossed, so the continuous slider feels notched.
-          const speedAtNext = MIN_SPEED + (usable > 0 ? next / usable : 0) * (MAX_SPEED - MIN_SPEED);
-          const notch = Math.round(speedAtNext * 2) / 2;
+          // Tick once per 0.5 crossed, so the continuous slider feels notched.
+          const valueAtNext = minValue + (usable > 0 ? next / usable : 0) * (maxValue - minValue);
+          const notch = Math.round(valueAtNext * 2) / 2;
           if (notch !== lastNotch.value) {
             lastNotch.value = notch;
             runOnJS(hapticSelection)();
           }
-          // Gate the cross-thread report on the 0.1×-rounded display value
+          // Gate the cross-thread report on the 0.1-rounded display value
           // changing — without this it fires a runOnJS hop + a React setState
           // (and a PlaybackControls re-render) on every drag frame.
-          const report = shouldReportSpeed(next, usable, lastReported.value);
+          const report = inSeconds
+            ? shouldReportPaceSeconds(next, usable, lastReported.value)
+            : shouldReportSpeed(next, usable, lastReported.value);
           if (report.changed) {
             lastReported.value = report.rounded;
             runOnJS(reportLive)(next);
@@ -271,7 +499,20 @@ function SpeedSlider({
           dragging.value = false;
           thumbScale.value = withSpring(1, springs.snappy);
         }),
-    [usable, position, startPosition, dragging, thumbScale, lastNotch, lastReported, reportLive, commit],
+    [
+      usable,
+      inSeconds,
+      minValue,
+      maxValue,
+      position,
+      startPosition,
+      dragging,
+      thumbScale,
+      lastNotch,
+      lastReported,
+      reportLive,
+      commit,
+    ],
   );
 
   // Tap-to-seek on the track.
@@ -299,14 +540,14 @@ function SpeedSlider({
   }, []);
 
   // A pan gesture is invisible to VoiceOver/TalkBack, so the whole track is
-  // published as one `adjustable` node with 0.5× increment/decrement actions.
+  // published as one `adjustable` node with 0.5-step increment/decrement actions.
   const adjustBy = useCallback(
     (step: number) => {
-      const next = Math.min(MAX_SPEED, Math.max(MIN_SPEED, Math.round((value + step) * 10) / 10));
+      const next = Math.min(maxValue, Math.max(minValue, Math.round((value + step) * 10) / 10));
       onLiveChange(next);
       onChange(next);
     },
-    [value, onChange, onLiveChange],
+    [value, minValue, maxValue, onChange, onLiveChange],
   );
 
   return (
@@ -317,7 +558,12 @@ function SpeedSlider({
         accessible
         accessibilityRole="adjustable"
         accessibilityLabel={t('playView.speed')}
-        accessibilityValue={{ text: formatSpeed(value), min: MIN_SPEED, max: MAX_SPEED, now: value }}
+        accessibilityValue={{
+          text: inSeconds ? formatPace(value) : formatSpeed(value),
+          min: minValue,
+          max: maxValue,
+          now: value,
+        }}
         accessibilityActions={ADJUSTABLE_ACTIONS}
         onAccessibilityAction={({ nativeEvent }) => adjustBy(nativeEvent.actionName === 'increment' ? 0.5 : -0.5)}
       >
@@ -343,13 +589,21 @@ function SpeedSlider({
 }
 
 /**
- * Transport + speed controls for multi-frame route playback. Rendered only when
+ * Transport + cadence controls for multi-frame route playback. Rendered only when
  * the active climb is a route (`isAnimatable`); boulders never mount it. Sits in
  * its own surface tied to the board, so it reads as one player distinct from the
- * climb-level action bar below. Play is a ghost glyph (not a filled circle) so the
- * green Tick stays the only hero button; the speed pill on the right cycles the
- * presets on tap and reveals the fine slider on long-press (Apple Podcasts style),
- * keeping the resting state uncluttered.
+ * climb-level action bar below.
+ *
+ * Prev/play/next are one 44dp cluster (iOS 26 fuses them into a single lozenge,
+ * Material groups them into a surfaceContainer) rather than a 52pt hero play
+ * glyph: this card is never the defining action on its sheet — Tick is, and in
+ * the creator Save is — and the old glyph was the loudest thing on both.
+ *
+ * The cadence pill on the right cycles presets on tap and reveals the fine slider
+ * on long-press (Apple Podcasts style), keeping the resting state uncluttered.
+ * Pass `frameEditing` and `paceUnit="seconds"` to turn the reader's transport into
+ * the setter's: a frame strip in place of the counter, and seconds-per-frame in
+ * place of the multiplier.
  */
 export function PlaybackControls({
   frameIndex,
@@ -359,6 +613,9 @@ export function PlaybackControls({
   paceMs,
   peerFrameMismatch = false,
   wallStateLabel = null,
+  frameEditing,
+  paceUnit = 'multiplier',
+  onPaceChange,
   onPlay,
   onPause,
   onSeek,
@@ -372,18 +629,31 @@ export function PlaybackControls({
   // Pause while playing; replay (restart from 0) at the end; otherwise play.
   const mainIcon: IconName = isPlaying ? 'pause' : atLastFrame ? 'refresh' : 'play.fill';
 
+  const inSeconds = paceUnit === 'seconds';
+  // The pill's committed value in the unit it displays: the reader sees the
+  // multiplier over the author's pace, the setter sees the pace itself.
+  const committedValue = inSeconds ? paceMs / 1000 : speed;
+
   const [showSpeed, setShowSpeed] = useState(false);
-  // Pill shows the live value while dragging, the committed speed otherwise.
-  const [liveSpeed, setLiveSpeed] = useState(speed);
+  // Pill shows the live value while dragging, the committed one otherwise.
+  const [liveValue, setLiveValue] = useState(committedValue);
   useEffect(() => {
-    setLiveSpeed(speed);
-  }, [speed]);
-  // Tap the pill to step through the speed presets (the common case); long-press
+    setLiveValue(committedValue);
+  }, [committedValue]);
+
+  const commitValue = useCallback(
+    (next: number) => {
+      if (inSeconds) onPaceChange?.(Math.round(clampPaceSeconds(next) * 1000));
+      else onSpeedChange(next);
+    },
+    [inSeconds, onPaceChange, onSpeedChange],
+  );
+  // Tap the pill to step through the presets (the common case); long-press
   // reveals the fine slider for anything in between.
-  const cycleSpeed = useCallback(() => {
+  const cycleValue = useCallback(() => {
     hapticSelection();
-    onSpeedChange(nextSpeedStep(speed));
-  }, [onSpeedChange, speed]);
+    commitValue(inSeconds ? nextPaceStep(committedValue) : nextSpeedStep(committedValue));
+  }, [commitValue, inSeconds, committedValue]);
   const toggleSpeed = useCallback(() => {
     hapticLight();
     setShowSpeed((open) => !open);
@@ -407,8 +677,10 @@ export function PlaybackControls({
   }, [isPlaying, atLastFrame, playPulse]);
   const playStyle = useAnimatedStyle(() => ({ transform: [{ scale: playPress.value * playPulse.value }] }));
 
-  // Frame-progress hairline, glided at the playback cadence so it feels alive
-  // rather than stepping. Snaps quickly when paused / seeking.
+  // Frame-progress cue, glided at the playback cadence so it feels alive rather
+  // than stepping. Snaps quickly when paused / seeking. One shared value drives
+  // BOTH presentations — the reader's top hairline and the creator's chip
+  // underline — so the two can never disagree about where playback is.
   const progress = useSharedValue(frameCount > 1 ? frameIndex / (frameCount - 1) : 0);
   useEffect(() => {
     const target = frameCount > 1 ? frameIndex / (frameCount - 1) : 0;
@@ -437,12 +709,28 @@ export function PlaybackControls({
     onSeek(frameIndex + 1);
   }, [onSeek, frameIndex]);
 
+  const pillLabel = inSeconds ? formatPace(liveValue) : formatSpeed(liveValue);
+
   return (
     <View style={[styles.container, { backgroundColor: systemColors.tertiaryBackground }]}>
-      <Animated.View
-        style={[styles.progressBar, { backgroundColor: theme.brandColors.primary }, progressStyle]}
-        pointerEvents="none"
-      />
+      {/* The strip carries its own underline off the same shared value, so the
+          top hairline would be a second cue for one position. */}
+      {!frameEditing && (
+        <Animated.View
+          style={[styles.progressBar, { backgroundColor: theme.brandColors.primary }, progressStyle]}
+          pointerEvents="none"
+        />
+      )}
+
+      {frameEditing && (
+        <FrameStrip
+          frameCount={frameCount}
+          frameIndex={frameIndex}
+          progress={progress}
+          onSeek={onSeek}
+          onAddFrame={frameEditing.onAddFrame}
+        />
+      )}
 
       <View style={styles.transportRow}>
         <View style={styles.sideLeft}>
@@ -455,7 +743,7 @@ export function PlaybackControls({
             >
               {wallStateLabel}
             </Text>
-          ) : (
+          ) : frameEditing ? null : (
             <Text
               variant="footnote"
               style={styles.counter}
@@ -470,13 +758,16 @@ export function PlaybackControls({
           )}
         </View>
 
-        <View style={styles.centerGroup}>
+        {/* One cluster, one height: iOS 26 merges the three into a single glass
+            lozenge and Material into one surfaceContainer, which is only true
+            while every member is 44dp (see GlassCluster's guardrail). */}
+        <GlassCluster spacing={CHIP_GAP} style={styles.centerGroup}>
           <StepButton
             direction="prev"
             disabled={atFirstFrame}
             onPress={handlePrev}
             label={t('playView.previousFrame')}
-            color={atFirstFrame ? systemColors.tertiaryLabel : iosSystemColors.systemGray}
+            color={atFirstFrame ? systemColors.tertiaryLabel : systemColors.secondaryLabel}
           />
           <AnimatedPressable
             onPress={handleMain}
@@ -494,24 +785,24 @@ export function PlaybackControls({
             accessibilityState={{ selected: isPlaying }}
             style={[styles.playButton, playStyle]}
           >
-            <Icon name={mainIcon} size={42} color={systemColors.label} />
+            <Icon name={mainIcon} size={24} color={systemColors.label} />
           </AnimatedPressable>
           <StepButton
             direction="next"
             disabled={atLastFrame}
             onPress={handleNext}
             label={t('playView.nextFrame')}
-            color={atLastFrame ? systemColors.tertiaryLabel : iosSystemColors.systemGray}
+            color={atLastFrame ? systemColors.tertiaryLabel : systemColors.secondaryLabel}
           />
-        </View>
+        </GlassCluster>
 
         <View style={styles.sideRight}>
           <SpeedPill
-            label={formatSpeed(liveSpeed)}
+            label={pillLabel}
             active={showSpeed}
-            onCycle={cycleSpeed}
+            onCycle={cycleValue}
             onToggleSlider={toggleSpeed}
-            accessibilityLabel={`${t('playView.speed')}, ${formatSpeed(liveSpeed)}`}
+            accessibilityLabel={`${t('playView.speed')}, ${pillLabel}`}
             accessibilityHint={t('playView.speedHint')}
           />
         </View>
@@ -525,7 +816,7 @@ export function PlaybackControls({
 
       {showSpeed && (
         <Animated.View entering={FadeIn.duration(timing.fast)} exiting={FadeOut.duration(timing.instant)}>
-          <SpeedSlider value={speed} onChange={onSpeedChange} onLiveChange={setLiveSpeed} />
+          <SpeedSlider value={committedValue} unit={paceUnit} onChange={commitValue} onLiveChange={setLiveValue} />
         </Animated.View>
       )}
     </View>
@@ -551,6 +842,48 @@ const styles = StyleSheet.create({
     right: 0,
     height: 3,
   },
+  // 44 rather than one chip tall, so the labelled add chip in it meets the touch
+  // floor without a hitSlop it can't have. The card's 128dp strip-mode reserve is
+  // 8 margin + 12 padding + 44 here + 8 gap + 44 transport + 12 padding.
+  stripRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    height: glassSize.inline,
+  },
+  stripScroller: {
+    // Claims the row's leftover width so the add chip is pinned to the trailing
+    // edge; anything that doesn't fit scrolls in here, never off the card. Held
+    // at chip height inside the taller row so the underline still lands on the
+    // chip's own bottom edge rather than 6dp below it.
+    flex: 1,
+    height: CHIP_SIZE,
+  },
+  stripContent: {
+    alignItems: 'center',
+    gap: CHIP_GAP,
+  },
+  frameChip: {
+    width: CHIP_SIZE,
+    height: CHIP_SIZE,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  frameChipDigit: {
+    fontVariant: ['tabular-nums'],
+  },
+  frameChipDigitSelected: {
+    fontWeight: '600',
+  },
+  // Out of flow, so it neither takes a slot in the gapped row nor grows it.
+  frameUnderline: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    width: CHIP_SIZE,
+    height: UNDERLINE_HEIGHT,
+    borderRadius: UNDERLINE_HEIGHT / 2,
+  },
   transportRow: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -566,7 +899,9 @@ const styles = StyleSheet.create({
   centerGroup: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: spacing[6],
+    // Matches the GlassCluster `spacing`, so on iOS 26 the three shapes fuse
+    // exactly as they meet instead of leaving a seam.
+    gap: spacing[2],
   },
   stepButton: {
     width: 44,
@@ -575,8 +910,8 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   playButton: {
-    width: 52,
-    height: 52,
+    width: 44,
+    height: 44,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -591,9 +926,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     minWidth: 52,
-    // 28 + hitSlop 8 top and bottom = the 44dp touch floor in both type scales
-    // (footnote is 18dp on HIG, 16dp on Material, so padding alone fell short).
-    minHeight: 28,
+    // Meets the 44dp touch floor on its own now that the card has the room —
+    // it used to reach it only via hitSlop, which left the pill visually
+    // shorter than every control it shares the row with.
+    minHeight: 44,
     paddingHorizontal: spacing[3],
     paddingVertical: spacing[1],
     borderRadius: borderRadius.full,
@@ -636,8 +972,8 @@ const styles = StyleSheet.create({
     borderWidth: 2,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.2,
     shadowRadius: 3,
+    shadowOpacity: 0.2,
     elevation: 2,
   },
 });

--- a/packages/mobile/src/components/playback/PlaybackControls.tsx
+++ b/packages/mobile/src/components/playback/PlaybackControls.tsx
@@ -35,6 +35,7 @@ import {
   roundedReportSpeed,
   shouldReportPaceSeconds,
   shouldReportSpeed,
+  valueToTrackPosition,
   MAX_PACE_SECONDS,
   MIN_PACE_SECONDS,
 } from './playback-speed-report';
@@ -421,6 +422,10 @@ function SpeedSlider({
   // worklet skips the cross-thread `runOnJS` hop (and the PlaybackControls
   // re-render it triggers) when the displayed value hasn't actually changed.
   const lastReported = useSharedValue(-1);
+  // The committed value, mirrored for the worklet. Listing `value` in the pan
+  // gesture's deps instead would rebuild the whole gesture every time the pace
+  // changes — including on every commit the slider itself makes.
+  const committedPosition = useSharedValue(value);
 
   const ratioToValue = useCallback(
     (ratio: number) => Math.round((minValue + clamp01(ratio) * (maxValue - minValue)) * 10) / 10,
@@ -432,9 +437,10 @@ function SpeedSlider({
   // `usable` is 0 and the thumb snaps to the left before jumping into place. Read
   // the SharedValue with `.get()` (Reanimated JS-thread accessor), not `.value`.
   useEffect(() => {
+    committedPosition.value = value;
     if (usable <= 0 || dragging.get()) return;
-    position.value = clamp01((value - minValue) / (maxValue - minValue)) * usable;
-  }, [value, usable, minValue, maxValue, position, dragging]);
+    position.value = valueToTrackPosition(value, minValue, maxValue, usable);
+  }, [value, usable, minValue, maxValue, position, dragging, committedPosition]);
 
   const reportLive = useCallback(
     (px: number) => onLiveChange(ratioToValue(usable > 0 ? px / usable : 0)),
@@ -495,9 +501,18 @@ function SpeedSlider({
         .onEnd(() => {
           runOnJS(commit)(position.value);
         })
-        .onFinalize(() => {
+        .onFinalize((_event, success) => {
           dragging.value = false;
           thumbScale.value = withSpring(1, springs.snappy);
+          // A cancelled drag never reaches `onEnd`, so nothing commits — but the
+          // pill has been showing live values the whole way down and the prop it
+          // mirrors never moved, so the effect that syncs them won't re-fire.
+          // Without this the pill keeps reading a pace the climb does not have.
+          if (!success) {
+            const committed = committedPosition.value;
+            position.value = valueToTrackPosition(committed, minValue, maxValue, usable);
+            runOnJS(onLiveChange)(committed);
+          }
         }),
     [
       usable,
@@ -510,6 +525,8 @@ function SpeedSlider({
       thumbScale,
       lastNotch,
       lastReported,
+      committedPosition,
+      onLiveChange,
       reportLive,
       commit,
     ],

--- a/packages/mobile/src/components/playback/PlaybackControls.tsx
+++ b/packages/mobile/src/components/playback/PlaybackControls.tsx
@@ -90,7 +90,7 @@ const ADJUSTABLE_ACTIONS = [{ name: 'increment' }, { name: 'decrement' }] as con
  */
 type PaceUnit = 'multiplier' | 'seconds';
 
-type PlaybackControlsProps = {
+type PlaybackControlsBaseProps = {
   frameIndex: number;
   frameCount: number;
   isPlaying: boolean;
@@ -118,18 +118,28 @@ type PlaybackControlsProps = {
     /** Inserts a copy of the active frame after it. */
     onAddFrame: () => void;
   };
-  /**
-   * 'multiplier' (default) shows "1×" and drives onSpeedChange; 'seconds' shows
-   * "0.8s" and drives onPaceChange.
-   */
-  paceUnit?: PaceUnit;
-  /** Required when paceUnit === 'seconds'. Reports the authored per-frame pace in ms. */
-  onPaceChange?: (paceMs: number) => void;
   onPlay: () => void;
   onPause: () => void;
   onSeek: (index: number) => void;
   onSpeedChange: (speed: number) => void;
 };
+
+/**
+ * Which unit the pill reads and writes, paired with the callback that unit needs.
+ *
+ * A union rather than two independent optional props: in seconds mode the pill
+ * authors the climb's own `frames_pace`, so a caller that asks for seconds and
+ * forgets `onPaceChange` would render a control that silently discards every
+ * change. That is exactly the bug this component's seconds mode exists to fix,
+ * so the type refuses to express it.
+ */
+type PaceControlProps =
+  /** The reader's lens over whatever pace the setter authored. Shows "1×". */
+  | { paceUnit?: 'multiplier'; onPaceChange?: never }
+  /** The setter authoring that pace directly. Shows "0.8s". */
+  | { paceUnit: 'seconds'; onPaceChange: (paceMs: number) => void };
+
+type PlaybackControlsProps = PlaybackControlsBaseProps & PaceControlProps;
 
 // Trim a trailing `.0` like web (7.0 → "7", 6.3 → "6.3").
 function formatSpeed(speed: number): string {

--- a/packages/mobile/src/components/playback/PlaybackControls.tsx
+++ b/packages/mobile/src/components/playback/PlaybackControls.tsx
@@ -15,7 +15,6 @@ import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { useTranslation } from 'react-i18next';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
-import { Button } from '../Button';
 import { GlassCluster } from '../GlassCluster';
 import type { IconName } from '../icon-map';
 import { useTheme } from '../../providers/theme-provider';
@@ -27,7 +26,7 @@ import { hapticLight, hapticSelection, hapticSuccess } from '../../lib/haptics';
 import { brandColors as staticBrandColors, withAlpha } from '../../theme/colors';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { glassSize } from '../../theme/layout';
-import { spacing, borderRadius } from '../../theme/tokens';
+import { spacing, borderRadius, opacity } from '../../theme/tokens';
 import { springs, timing } from '../../theme/animations';
 import {
   clampPaceSeconds,
@@ -59,11 +58,12 @@ const PACE_STEPS = [0.5, 0.8, 1.5, 3, 5] as const;
 const MAGNET_PACE_SECONDS = 0.75;
 
 // Frame-strip geometry. Chips read as chips at 32dp and reach the 44dp touch
-// floor through hitSlop, but the row itself is 44 so the labelled add-frame
-// Button in it clears the floor on its own — a native Button has no hitSlop to
-// borrow. That fixes the card's resting height in strip mode at 128dp (8 margin
-// + 12 padding + 44 strip + 8 gap + 44 transport + 12 padding); CreateDrawer
-// reserves that number, so changing any of these changes a layout contract.
+// floor through hitSlop, and the row is now exactly one chip tall: the 44 it used
+// to be bought the touch floor for a native add Button that has since moved into
+// the transport row as an icon. That fixes the card's resting height in strip
+// mode at 116dp (8 margin + 12 padding + 32 strip + 8 gap + 44 transport + 12
+// padding); CreateDrawer reserves that number, so changing any of these changes
+// a layout contract.
 const CHIP_SIZE = 32;
 const CHIP_GAP = spacing[2];
 const CHIP_STEP = CHIP_SIZE + CHIP_GAP;
@@ -110,13 +110,16 @@ type PlaybackControlsBaseProps = {
    */
   wallStateLabel?: string | null;
   /**
-   * Creator-only. Present ⇒ the card grows a frame strip and an add-frame chip.
-   * Absent (the play drawer) ⇒ the card renders the plain counter exactly as it
-   * always has, so this transport stays one component across both callers.
+   * Creator-only. Present ⇒ the card grows a frame strip, and the transport
+   * row's left slot carries add/remove instead of the counter. Absent (the play
+   * drawer) ⇒ the card renders the plain counter exactly as it always has, so
+   * this transport stays one component across both callers.
    */
   frameEditing?: {
     /** Inserts a copy of the active frame after it. */
     onAddFrame: () => void;
+    /** Removes the active frame. No-ops at one frame; the button is disabled there. */
+    onDeleteFrame: () => void;
   };
   onPlay: () => void;
   onPause: () => void;
@@ -228,7 +231,7 @@ const FrameChip = memo(function FrameChip({
         styles.frameChip,
         {
           borderRadius: radii.button,
-          backgroundColor: selected ? withAlpha(brandColors.primary, 0.18) : systemColors.fill,
+          backgroundColor: selected ? withAlpha(brandColors.primary, 0.32) : systemColors.fill,
         },
       ]}
     >
@@ -244,13 +247,14 @@ const FrameChip = memo(function FrameChip({
 });
 
 /**
- * The creator's frame strip: one tappable chip per frame plus a labelled add
- * chip, in place of the reader's `1 / 4` counter.
+ * The creator's frame strip: one tappable chip per frame, in place of the
+ * reader's `1 / 4` counter.
  *
- * The add chip is pinned OUTSIDE the scroller (the CreateDrawerActionBar idiom)
- * because it is the one control that must never scroll out of reach — two
- * earlier attempts at this feature came back QA-declined for exactly that, and
- * for reducing it to a bare glyph. It stays a word.
+ * Add and remove used to live here — add as a labelled button pinned outside the
+ * scroller, remove in the header's overflow menu. Both moved into the transport
+ * row below as one icon pair (`FrameEditPair`), which is what the strip's empty
+ * left slot was for. The scroller now owns the full row width, so the chips no
+ * longer share it with a control that must never scroll away.
  *
  * The 2dp underline is driven by the SAME shared value the reader's top progress
  * bar uses, so it glides at `paceMs / speed` during playback: one position cue on
@@ -261,21 +265,19 @@ function FrameStrip({
   frameIndex,
   progress,
   onSeek,
-  onAddFrame,
+  wallStateLabel,
 }: {
   frameCount: number;
   frameIndex: number;
   progress: SharedValue<number>;
   onSeek: (index: number) => void;
-  onAddFrame: () => void;
+  /** Rendered at the strip's trailing edge, in the space the add button left.
+   *  The reader shows this in the transport row's left slot, but in edit mode
+   *  that slot is permanently the add/remove pair. */
+  wallStateLabel: string | null;
 }) {
-  const { brandColors } = useTheme();
+  const { brandColors, systemColors } = useTheme();
   const { t } = useTranslation('session');
-  // A SEPARATE hook, not `useTranslation(['session', 'climbs'])`: with an array,
-  // `t('a.b.c')` resolves against the FIRST namespace only, so the add-frame key
-  // — which lives in climbs.json — would fall through and the chip would render
-  // its raw key. CreateDrawer hit exactly this and only the emulator caught it.
-  const { t: tClimbs } = useTranslation('climbs');
   const scrollRef = useRef<ScrollView>(null);
   const [viewportWidth, setViewportWidth] = useState(0);
 
@@ -329,17 +331,109 @@ function FrameStrip({
         </ScrollView>
       </View>
 
-      <Button
-        title={tClimbs('mobile.create.playback.addFrame')}
-        variant="tonal"
-        size="small"
-        // Floored at 44 rather than sized to the 32dp chip rung. It is the action
-        // the whole feature depends on being tappable, and unlike the chips it
-        // cannot reach the floor through hitSlop — @expo/ui renders a native
-        // button, so the row is 44 and the card's reserve is 128.
-        minHeight={glassSize.inline}
-        onPress={onAddFrame}
-      />
+      {wallStateLabel ? (
+        <Text
+          variant="caption1"
+          color={systemColors.secondaryLabel}
+          numberOfLines={1}
+          style={[styles.wallStateChip, { backgroundColor: systemColors.fill }]}
+        >
+          {wallStateLabel}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+/**
+ * Add and remove frame, as one capsule in the transport row's left slot.
+ *
+ * Contained rather than two bare glyphs, because the row would otherwise read as
+ * five interchangeable marks: the pair is a filled capsule on `systemColors.fill`
+ * and prev/play/next are bare, so the card gets one grammar — fill is a frame
+ * command, bare is transport. The ink stays `secondaryLabel` so the only white
+ * glyph in the row is still play.
+ *
+ * `minus` rather than a trash can, even though this deletes: the action bar 60dp
+ * below already spends a trash on "clear every hold", and two trash cans a thumb
+ * apart meaning different things is a worse confusion than the one stroke
+ * between + and −. Delete is a decrement of the strip directly above it.
+ *
+ * Neither half is red. `DELETE_FRAME` pushes onto the undo stack (see
+ * `use-create-climb.ts`), so Undo three rows down restores the frame AND the
+ * index — colour is for loss you cannot walk back, and a standing red glyph here
+ * would outshout Save.
+ */
+function FrameEditPair({
+  frameIndex,
+  frameCount,
+  onAddFrame,
+  onDeleteFrame,
+}: {
+  frameIndex: number;
+  frameCount: number;
+  onAddFrame: () => void;
+  onDeleteFrame: () => void;
+}) {
+  // A SEPARATE hook, not `useTranslation(['session', 'climbs'])`: with an array,
+  // `t('a.b.c')` resolves against the FIRST namespace only, so these keys — which
+  // live in climbs.json — would fall through and the buttons would announce their
+  // raw key. CreateDrawer hit exactly this and only the emulator caught it.
+  const { t: tClimbs } = useTranslation('climbs');
+  const { systemColors } = useTheme();
+  // A route always keeps one frame, so the last one cannot be removed. Disabled
+  // rather than hidden: hiding it would reflow the capsule from 88 to 44 the
+  // moment a second frame appears, walking the whole transport row sideways.
+  const canDelete = frameCount > 1;
+
+  const handleAdd = useCallback(() => {
+    hapticSelection();
+    onAddFrame();
+  }, [onAddFrame]);
+  const handleDelete = useCallback(() => {
+    hapticLight();
+    onDeleteFrame();
+  }, [onDeleteFrame]);
+
+  return (
+    <View style={[styles.framePair, { backgroundColor: systemColors.fill }]} testID="playback-frame-edit-pair">
+      <Pressable
+        onPress={handleAdd}
+        // Asymmetric on purpose. Nothing reaches UP: the frame chips sit 8dp
+        // above with 6dp of their own slop, and a chip tap that slid into a
+        // frame command would be the one mis-tap this layout could cause.
+        hitSlop={{ top: 0, bottom: 6, left: 4, right: 0 }}
+        accessibilityRole="button"
+        accessibilityLabel={tClimbs('mobile.create.playback.addFrame')}
+        accessibilityHint={tClimbs('mobile.create.playback.addFrameHint', { index: frameIndex + 1 })}
+        style={styles.framePairButton}
+        testID="playback-add-frame"
+      >
+        <Icon name="plus" size={20} color={systemColors.secondaryLabel} />
+      </Pressable>
+
+      <View style={[styles.framePairDivider, { backgroundColor: systemColors.separator }]} />
+
+      <Pressable
+        onPress={handleDelete}
+        disabled={!canDelete}
+        hitSlop={{ top: 0, bottom: 6, left: 0, right: 4 }}
+        accessibilityRole="button"
+        // The ordinal AND the total live in the label, not the hint: the label is
+        // the only text this control has now, and "delete frame 1" without "of 1"
+        // does not tell a blind setter the route is about to lose its last frame.
+        accessibilityLabel={
+          canDelete
+            ? tClimbs('mobile.create.playback.deleteFrameA11y', { index: frameIndex + 1, total: frameCount })
+            : tClimbs('mobile.create.playback.deleteFrameBlocked')
+        }
+        accessibilityHint={canDelete ? tClimbs('mobile.create.playback.deleteFrameHint') : undefined}
+        accessibilityState={{ disabled: !canDelete }}
+        style={[styles.framePairButton, !canDelete && styles.framePairButtonDisabled]}
+        testID="playback-delete-frame"
+      >
+        <Icon name="minus" size={20} color={canDelete ? systemColors.secondaryLabel : systemColors.tertiaryLabel} />
+      </Pressable>
     </View>
   );
 }
@@ -739,7 +833,15 @@ export function PlaybackControls({
   const pillLabel = inSeconds ? formatPace(liveValue) : formatSpeed(liveValue);
 
   return (
-    <View style={[styles.container, { backgroundColor: systemColors.tertiaryBackground }]}>
+    <View
+      style={[
+        styles.container,
+        // Scheme-resolved, not the static light `iosSystemColors.separator` this
+        // used to hardcode — that value is a dark translucent grey and vanished
+        // against the card's own dark fill, so the card had no edge at night.
+        { backgroundColor: systemColors.tertiaryBackground, borderColor: systemColors.separator },
+      ]}
+    >
       {/* The strip carries its own underline off the same shared value, so the
           top hairline would be a second cue for one position. */}
       {!frameEditing && (
@@ -755,13 +857,23 @@ export function PlaybackControls({
           frameIndex={frameIndex}
           progress={progress}
           onSeek={onSeek}
-          onAddFrame={frameEditing.onAddFrame}
+          wallStateLabel={wallStateLabel}
         />
       )}
 
       <View style={styles.transportRow}>
-        <View style={styles.sideLeft}>
-          {wallStateLabel ? (
+        {/* Sized to its content in edit mode, not `flex: 1`. Two 44dp halves need
+            88 and an even third of an SE's 311dp card is 81.5 — the capsule would
+            have overflowed a container that clips. */}
+        <View style={[styles.sideLeft, frameEditing && styles.sideLeftEditing]}>
+          {frameEditing ? (
+            <FrameEditPair
+              frameIndex={frameIndex}
+              frameCount={frameCount}
+              onAddFrame={frameEditing.onAddFrame}
+              onDeleteFrame={frameEditing.onDeleteFrame}
+            />
+          ) : wallStateLabel ? (
             <Text
               variant="caption1"
               color={systemColors.secondaryLabel}
@@ -770,7 +882,7 @@ export function PlaybackControls({
             >
               {wallStateLabel}
             </Text>
-          ) : frameEditing ? null : (
+          ) : (
             <Text
               variant="footnote"
               style={styles.counter}
@@ -856,7 +968,6 @@ const styles = StyleSheet.create({
     marginTop: spacing[2],
     borderRadius: borderRadius.lg,
     borderWidth: StyleSheet.hairlineWidth,
-    borderColor: iosSystemColors.separator,
     paddingHorizontal: spacing[4],
     paddingVertical: spacing[3],
     gap: spacing[2],
@@ -869,20 +980,19 @@ const styles = StyleSheet.create({
     right: 0,
     height: 3,
   },
-  // 44 rather than one chip tall, so the labelled add chip in it meets the touch
-  // floor without a hitSlop it can't have. The card's 128dp strip-mode reserve is
-  // 8 margin + 12 padding + 44 here + 8 gap + 44 transport + 12 padding.
+  // One chip tall. It was 44 only so the native add Button in it could reach the
+  // touch floor — that button is now the icon pair in the transport row, and the
+  // chips reach 44 through hitSlop. The card's 116dp strip-mode reserve is
+  // 8 margin + 12 padding + 32 here + 8 gap + 44 transport + 12 padding.
   stripRow: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing[2],
-    height: glassSize.inline,
+    height: CHIP_SIZE,
   },
   stripScroller: {
-    // Claims the row's leftover width so the add chip is pinned to the trailing
-    // edge; anything that doesn't fit scrolls in here, never off the card. Held
-    // at chip height inside the taller row so the underline still lands on the
-    // chip's own bottom edge rather than 6dp below it.
+    // Claims the row's whole width now that nothing is pinned beside it, except
+    // when the wall-state chip takes the trailing edge.
     flex: 1,
     height: CHIP_SIZE,
   },
@@ -903,11 +1013,13 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   // Out of flow, so it neither takes a slot in the gapped row nor grows it.
+  // Inset from the chip's edges rather than spanning it: a full-width 2dp bar
+  // flush against a rounded chip reads as a rendering seam, not a cue.
   frameUnderline: {
     position: 'absolute',
     bottom: 0,
-    left: 0,
-    width: CHIP_SIZE,
+    left: spacing[1],
+    width: CHIP_SIZE - spacing[2],
     height: UNDERLINE_HEIGHT,
     borderRadius: UNDERLINE_HEIGHT / 2,
   },
@@ -918,6 +1030,35 @@ const styles = StyleSheet.create({
   sideLeft: {
     flex: 1,
     alignItems: 'flex-start',
+  },
+  // Content-sized, so the 88dp capsule is never squeezed by an even three-way
+  // split of a narrow card. Costs the centre cluster ~6dp of optical centring on
+  // the smallest phone, which is the cheaper of the two.
+  sideLeftEditing: {
+    flex: 0,
+    flexShrink: 0,
+  },
+  // One capsule holding + and −, the Stepper idiom. `overflow: hidden` clips the
+  // Android ripple to the capsule.
+  framePair: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: borderRadius.full,
+    overflow: 'hidden',
+    height: glassSize.inline,
+  },
+  framePairButton: {
+    width: glassSize.inline,
+    height: glassSize.inline,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  framePairButtonDisabled: {
+    opacity: opacity.disabled,
+  },
+  framePairDivider: {
+    width: StyleSheet.hairlineWidth,
+    height: 20,
   },
   sideRight: {
     flex: 1,
@@ -952,7 +1093,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    minWidth: 52,
+    // Wide enough for the longest label the pill cycles to ("0.8s"), so stepping
+    // through the presets doesn't resize it and walk the transport row sideways.
+    minWidth: 64,
     // Meets the 44dp touch floor on its own now that the card has the room —
     // it used to reach it only via hitSlop, which left the pill visually
     // shorter than every control it shares the row with.

--- a/packages/mobile/src/components/playback/__tests__/playback-controls.test.tsx
+++ b/packages/mobile/src/components/playback/__tests__/playback-controls.test.tsx
@@ -1,0 +1,342 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, forwardRef, useImperativeHandle, type ReactNode } from 'react';
+
+// PlaybackControls is mounted by TWO callers — the play drawer and the create
+// drawer — and only the second one passes the creator props. The first case here
+// is the regression guard for that: with `frameEditing` absent the card must keep
+// rendering the reader's `1 / 4` counter and grow no strip, or the play drawer
+// silently inherits an editor.
+
+const hapticSelection = vi.hoisted(() => vi.fn());
+const scrollTo = vi.hoisted(() => vi.fn());
+
+type PressProps = {
+  children?: ReactNode;
+  onPress?: () => void;
+  accessibilityLabel?: string;
+  accessibilityState?: { selected?: boolean; disabled?: boolean };
+  disabled?: boolean;
+  hitSlop?: number;
+};
+type ViewProps = { children?: ReactNode; testID?: string; accessibilityLabel?: string };
+
+vi.mock('react-native', () => {
+  const View = ({ children, testID, accessibilityLabel }: ViewProps) =>
+    createElement('div', { 'data-testid': testID, 'data-label': accessibilityLabel }, children);
+  const Pressable = ({ children, onPress, accessibilityLabel, accessibilityState, disabled, hitSlop }: PressProps) =>
+    createElement(
+      'button',
+      {
+        'data-label': accessibilityLabel,
+        'data-selected': accessibilityState?.selected == null ? undefined : String(accessibilityState.selected),
+        'data-hit-slop': hitSlop,
+        disabled,
+        onClick: onPress,
+      },
+      children,
+    );
+  const ScrollView = forwardRef<{ scrollTo: typeof scrollTo }, { children?: ReactNode }>(function ScrollView(
+    { children },
+    ref,
+  ) {
+    useImperativeHandle(ref, () => ({ scrollTo }), []);
+    return createElement('div', { 'data-node': 'scroller' }, children);
+  });
+  return {
+    View,
+    Pressable,
+    ScrollView,
+    StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  };
+});
+
+vi.mock('react-native-reanimated', () => {
+  const AnimatedView = ({ children }: { children?: ReactNode }) => createElement('div', null, children);
+  const fade = { duration: () => ({}) };
+  return {
+    default: {
+      View: AnimatedView,
+      // The animated wrappers here only need to render; the press-scale springs
+      // they drive are UI-thread decoration.
+      createAnimatedComponent: <P,>(Component: (props: P) => ReactNode) => Component,
+    },
+    FadeIn: fade,
+    FadeOut: fade,
+    useAnimatedStyle: () => ({}),
+    useSharedValue: (initial: number) => ({ value: initial, get: () => initial, set: () => {} }),
+    withSpring: (value: number) => value,
+    withTiming: (value: number) => value,
+    withSequence: (value: number) => value,
+    runOnJS: <A extends unknown[]>(fn: (...args: A) => void) => fn,
+  };
+});
+
+vi.mock('react-native-gesture-handler', () => {
+  const chainable: Record<string, () => unknown> = {};
+  const gesture = new Proxy(chainable, { get: () => () => gesture });
+  return {
+    Gesture: { Pan: () => gesture, Tap: () => gesture, Race: () => gesture },
+    GestureDetector: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    // Interpolating (rather than the usual identity `t`) so the per-frame chip
+    // labels are distinguishable — they all share one key.
+    t: (key: string, options?: { index?: number; total?: number }) =>
+      options ? `${key}:${options.index}/${options.total}` : key,
+  }),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name, size }: { name?: string; size?: number }) =>
+    createElement('span', { 'data-icon': name, 'data-size': size }),
+}));
+vi.mock('../../Button', () => ({
+  Button: ({
+    title,
+    onPress,
+    variant,
+    minHeight,
+  }: {
+    title?: string;
+    onPress?: () => void;
+    variant?: string;
+    minHeight?: number;
+  }) =>
+    createElement(
+      'button',
+      { 'data-title': title, 'data-variant': variant, 'data-min-height': minHeight, onClick: onPress },
+      title,
+    ),
+}));
+vi.mock('../../GlassCluster', () => ({
+  GlassCluster: ({ children, spacing }: { children?: ReactNode; spacing?: number }) =>
+    createElement('div', { 'data-node': 'cluster', 'data-spacing': spacing }, children),
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: {
+      tertiaryBackground: '#F2F2F7',
+      label: '#000000',
+      secondaryLabel: '#3C3C4399',
+      tertiaryLabel: '#3C3C434D',
+      fill: '#78788033',
+    },
+    brandColors: { primary: '#6D28D9' },
+    radii: { button: 10 },
+  }),
+}));
+vi.mock('../../../lib/haptics', () => ({
+  hapticSelection,
+  hapticLight: vi.fn(),
+  hapticSuccess: vi.fn(),
+}));
+vi.mock('../../../theme/colors', () => ({
+  brandColors: { primary: '#6D28D9' },
+  withAlpha: (color: string, alpha: number) => `${color}/${alpha}`,
+}));
+vi.mock('../../../theme/layout', () => ({ glassSize: { inline: 44, mini: 32 } }));
+vi.mock('../../../theme/ios-colors', () => ({
+  iosSystemColors: { separator: '#C6C6C8', white: '#FFFFFF' },
+}));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24 },
+  borderRadius: { lg: 12, full: 9999 },
+}));
+vi.mock('../../../theme/animations', () => ({
+  springs: { snappy: {}, bouncy: {} },
+  timing: { instant: 100, fast: 200 },
+}));
+
+import { PlaybackControls } from '../PlaybackControls';
+
+type ControlsProps = Parameters<typeof PlaybackControls>[0];
+
+function renderControls(overrides: Partial<ControlsProps> = {}) {
+  const onSeek = vi.fn();
+  const onSpeedChange = vi.fn();
+  const onPaceChange = vi.fn();
+  const onAddFrame = vi.fn();
+  const { container } = render(
+    createElement(PlaybackControls, {
+      frameIndex: 0,
+      frameCount: 4,
+      isPlaying: false,
+      speed: 1,
+      paceMs: 750,
+      onPlay: vi.fn(),
+      onPause: vi.fn(),
+      onSeek,
+      onSpeedChange,
+      onPaceChange,
+      ...overrides,
+    } as ControlsProps),
+  );
+  const strip = container.querySelector('[data-testid="playback-frame-strip"]') as HTMLElement | null;
+  const chips = Array.from(container.querySelectorAll('[data-label^="playView.frameCounterA11y:"]')).filter(
+    (node) => node.tagName === 'BUTTON',
+  ) as HTMLButtonElement[];
+  return {
+    container,
+    onSeek,
+    onSpeedChange,
+    onPaceChange,
+    onAddFrame,
+    strip,
+    chips,
+    scroller: container.querySelector('[data-node="scroller"]') as HTMLElement | null,
+    addFrame: container.querySelector('[data-title="mobile.create.playback.addFrame"]') as HTMLButtonElement | null,
+    pill: container.querySelector('[data-label^="playView.speed,"]') as HTMLButtonElement | null,
+  };
+}
+
+beforeEach(() => {
+  hapticSelection.mockClear();
+  scrollTo.mockClear();
+});
+
+describe('PlaybackControls — play drawer (no creator props)', () => {
+  it('keeps the reader counter and grows no frame strip', () => {
+    const { container, strip, chips, addFrame } = renderControls({ frameIndex: 0, frameCount: 4 });
+
+    expect(strip).toBeNull();
+    expect(chips).toHaveLength(0);
+    expect(addFrame).toBeNull();
+    expect(container.textContent).toContain('1 / 4');
+  });
+
+  it('shows the multiplier, not seconds, and drives onSpeedChange', () => {
+    const { pill, onSpeedChange, onPaceChange } = renderControls({ speed: 1, paceMs: 750 });
+
+    expect(pill?.getAttribute('data-label')).toBe('playView.speed, 1×');
+    pill?.click();
+    // 1× → the next preset above it.
+    expect(onSpeedChange).toHaveBeenCalledWith(1.5);
+    expect(onPaceChange).not.toHaveBeenCalled();
+  });
+
+  it('hands prev/play/next to one cluster at a single height', () => {
+    // GlassCluster only fuses members that share a height, so the demotion from
+    // a 42pt hero glyph to a 24pt one inside a 44dp box is load-bearing.
+    const { container } = renderControls();
+    const cluster = container.querySelector('[data-node="cluster"]');
+
+    expect(cluster?.getAttribute('data-spacing')).toBe('8');
+    const glyphSizes = Array.from(cluster?.querySelectorAll('[data-icon]') ?? []).map((node) =>
+      node.getAttribute('data-size'),
+    );
+    expect(glyphSizes).toEqual(['20', '24', '20']);
+  });
+});
+
+describe('PlaybackControls — creator frame strip', () => {
+  const frameEditing = { onAddFrame: vi.fn() };
+
+  it('replaces the counter with one chip per frame', () => {
+    const { container, strip, chips } = renderControls({ frameCount: 4, frameIndex: 1, frameEditing });
+
+    expect(strip).toBeTruthy();
+    expect(chips).toHaveLength(4);
+    expect(chips.map((chip) => chip.textContent)).toEqual(['1', '2', '3', '4']);
+    // The counter is gone — the strip IS the position readout now.
+    expect(container.textContent).not.toContain('1 / 4');
+    expect(chips[1]?.getAttribute('data-selected')).toBe('true');
+    expect(chips[0]?.getAttribute('data-selected')).toBe('false');
+  });
+
+  it('pins Add frame outside the scroller as a labelled chip', () => {
+    // Twice QA-declined: once as a bare glyph, once for scrolling out of view.
+    const { addFrame, scroller } = renderControls({ frameCount: 12, frameEditing });
+
+    expect(addFrame).toBeTruthy();
+    expect(addFrame?.textContent).toBe('mobile.create.playback.addFrame');
+    expect(scroller).toBeTruthy();
+    expect(scroller?.contains(addFrame)).toBe(false);
+    // Floored at 44 on its own: a native Button has no hitSlop to reach the
+    // touch target with, unlike the 32dp chips beside it. That is what makes the
+    // strip row 44 and the card's reserve 128dp.
+    expect(addFrame?.getAttribute('data-min-height')).toBe('44');
+    expect(addFrame?.getAttribute('data-variant')).toBe('tonal');
+  });
+
+  it('adds a frame from the pinned chip', () => {
+    const onAddFrame = vi.fn();
+    const { addFrame } = renderControls({ frameEditing: { onAddFrame } });
+
+    addFrame?.click();
+    expect(onAddFrame).toHaveBeenCalledTimes(1);
+  });
+
+  it('seeks to the tapped frame', () => {
+    const { chips, onSeek } = renderControls({ frameCount: 4, frameIndex: 0, frameEditing });
+
+    chips[2]?.click();
+    expect(onSeek).toHaveBeenCalledWith(2);
+    chips[0]?.click();
+    expect(onSeek).toHaveBeenLastCalledWith(0);
+  });
+
+  it('keeps every chip at the 44dp touch floor via slop', () => {
+    // 32dp chip + 6dp each edge. The row cannot grow — the card height is a
+    // contract CreateDrawer reserves against.
+    const { chips } = renderControls({ frameCount: 3, frameEditing });
+    expect(chips.every((chip) => chip.getAttribute('data-hit-slop') === '6')).toBe(true);
+  });
+
+  it('still shows the wall-state chip in place of the counter slot', () => {
+    const { container, chips } = renderControls({ frameCount: 3, frameEditing, wallStateLabel: 'On the wall' });
+
+    expect(container.textContent).toContain('On the wall');
+    expect(chips).toHaveLength(3);
+  });
+});
+
+describe('PlaybackControls — seconds-per-frame pill', () => {
+  it('renders the authored pace, trimming a trailing zero', () => {
+    expect(renderControls({ paceMs: 800, paceUnit: 'seconds' }).pill?.getAttribute('data-label')).toBe(
+      'playView.speed, 0.8s',
+    );
+    expect(renderControls({ paceMs: 3000, paceUnit: 'seconds' }).pill?.getAttribute('data-label')).toBe(
+      'playView.speed, 3s',
+    );
+    expect(renderControls({ paceMs: 1500, paceUnit: 'seconds' }).pill?.getAttribute('data-label')).toBe(
+      'playView.speed, 1.5s',
+    );
+  });
+
+  it('cycles the pace presets on tap and reports milliseconds', () => {
+    const fromDefault = renderControls({ paceMs: 800, paceUnit: 'seconds' });
+    fromDefault.pill?.click();
+    expect(fromDefault.onPaceChange).toHaveBeenCalledWith(1500);
+
+    const fromTop = renderControls({ paceMs: 5000, paceUnit: 'seconds' });
+    fromTop.pill?.click();
+    // Past the slowest preset it wraps to the fastest rather than sticking.
+    expect(fromTop.onPaceChange).toHaveBeenCalledWith(500);
+  });
+
+  it('cycles back into the legal range from a pace outside it', () => {
+    // A climb saved with a nonsense pace (or one authored before the range
+    // existed) must not strand the pill: the next tap lands on a real preset.
+    const tooFast = renderControls({ paceMs: 50, paceUnit: 'seconds' });
+    tooFast.pill?.click();
+    expect(tooFast.onPaceChange).toHaveBeenCalledWith(500);
+
+    const tooSlow = renderControls({ paceMs: 60_000, paceUnit: 'seconds' });
+    tooSlow.pill?.click();
+    expect(tooSlow.onPaceChange).toHaveBeenCalledWith(500);
+  });
+
+  it('leaves onSpeedChange alone in seconds mode', () => {
+    const { pill, onSpeedChange } = renderControls({ paceMs: 800, paceUnit: 'seconds' });
+    pill?.click();
+    expect(onSpeedChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/playback/__tests__/playback-controls.test.tsx
+++ b/packages/mobile/src/components/playback/__tests__/playback-controls.test.tsx
@@ -111,24 +111,6 @@ vi.mock('../../Icon', () => ({
   Icon: ({ name, size }: { name?: string; size?: number }) =>
     createElement('span', { 'data-icon': name, 'data-size': size }),
 }));
-vi.mock('../../Button', () => ({
-  Button: ({
-    title,
-    onPress,
-    variant,
-    minHeight,
-  }: {
-    title?: string;
-    onPress?: () => void;
-    variant?: string;
-    minHeight?: number;
-  }) =>
-    createElement(
-      'button',
-      { 'data-title': title, 'data-variant': variant, 'data-min-height': minHeight, onClick: onPress },
-      title,
-    ),
-}));
 vi.mock('../../GlassCluster', () => ({
   GlassCluster: ({ children, spacing }: { children?: ReactNode; spacing?: number }) =>
     createElement('div', { 'data-node': 'cluster', 'data-spacing': spacing }, children),

--- a/packages/mobile/src/components/playback/__tests__/playback-controls.test.tsx
+++ b/packages/mobile/src/components/playback/__tests__/playback-controls.test.tsx
@@ -12,26 +12,39 @@ import { createElement, forwardRef, useImperativeHandle, type ReactNode } from '
 const hapticSelection = vi.hoisted(() => vi.fn());
 const scrollTo = vi.hoisted(() => vi.fn());
 
+type HitSlop = number | { top?: number; bottom?: number; left?: number; right?: number };
 type PressProps = {
   children?: ReactNode;
   onPress?: () => void;
   accessibilityLabel?: string;
   accessibilityState?: { selected?: boolean; disabled?: boolean };
   disabled?: boolean;
-  hitSlop?: number;
+  // An object here is the point, not an incidental: the frame-edit pair's slop is
+  // asymmetric so it can never reach up into the chip row above it.
+  hitSlop?: HitSlop;
+  testID?: string;
 };
 type ViewProps = { children?: ReactNode; testID?: string; accessibilityLabel?: string };
 
 vi.mock('react-native', () => {
   const View = ({ children, testID, accessibilityLabel }: ViewProps) =>
     createElement('div', { 'data-testid': testID, 'data-label': accessibilityLabel }, children);
-  const Pressable = ({ children, onPress, accessibilityLabel, accessibilityState, disabled, hitSlop }: PressProps) =>
+  const Pressable = ({
+    children,
+    onPress,
+    accessibilityLabel,
+    accessibilityState,
+    disabled,
+    hitSlop,
+    testID,
+  }: PressProps) =>
     createElement(
       'button',
       {
+        'data-testid': testID,
         'data-label': accessibilityLabel,
         'data-selected': accessibilityState?.selected == null ? undefined : String(accessibilityState.selected),
-        'data-hit-slop': hitSlop,
+        'data-hit-slop': typeof hitSlop === 'object' ? JSON.stringify(hitSlop) : hitSlop,
         disabled,
         onClick: onPress,
       },
@@ -149,6 +162,7 @@ vi.mock('../../../theme/ios-colors', () => ({
 vi.mock('../../../theme/tokens', () => ({
   spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24 },
   borderRadius: { lg: 12, full: 9999 },
+  opacity: { subtle: 0.7, peek: 0.62, disabled: 0.5 },
 }));
 vi.mock('../../../theme/animations', () => ({
   springs: { snappy: {}, bouncy: {} },
@@ -192,7 +206,9 @@ function renderControls(overrides: Partial<ControlsProps> = {}) {
     strip,
     chips,
     scroller: container.querySelector('[data-node="scroller"]') as HTMLElement | null,
-    addFrame: container.querySelector('[data-title="mobile.create.playback.addFrame"]') as HTMLButtonElement | null,
+    editPair: container.querySelector('[data-testid="playback-frame-edit-pair"]') as HTMLElement | null,
+    addFrame: container.querySelector('[data-testid="playback-add-frame"]') as HTMLButtonElement | null,
+    deleteFrame: container.querySelector('[data-testid="playback-delete-frame"]') as HTMLButtonElement | null,
     pill: container.querySelector('[data-label^="playView.speed,"]') as HTMLButtonElement | null,
   };
 }
@@ -237,7 +253,7 @@ describe('PlaybackControls — play drawer (no creator props)', () => {
 });
 
 describe('PlaybackControls — creator frame strip', () => {
-  const frameEditing = { onAddFrame: vi.fn() };
+  const frameEditing = { onAddFrame: vi.fn(), onDeleteFrame: vi.fn() };
 
   it('replaces the counter with one chip per frame', () => {
     const { container, strip, chips } = renderControls({ frameCount: 4, frameIndex: 1, frameEditing });
@@ -251,27 +267,65 @@ describe('PlaybackControls — creator frame strip', () => {
     expect(chips[0]?.getAttribute('data-selected')).toBe('false');
   });
 
-  it('pins Add frame outside the scroller as a labelled chip', () => {
-    // Twice QA-declined: once as a bare glyph, once for scrolling out of view.
-    const { addFrame, scroller } = renderControls({ frameCount: 12, frameEditing });
+  it('keeps add and remove out of the scroller, at any frame count', () => {
+    // Twice QA-declined before this: once for a control that scrolled out of
+    // view, once for one that was a bare unlabelled glyph. The pair is a glyph
+    // now by design, so the label has to survive in the accessible name — and
+    // the pair must never enter the scroller, whatever the frame count.
+    const { addFrame, deleteFrame, scroller, editPair } = renderControls({ frameCount: 12, frameEditing });
 
-    expect(addFrame).toBeTruthy();
-    expect(addFrame?.textContent).toBe('mobile.create.playback.addFrame');
+    expect(editPair).toBeTruthy();
     expect(scroller).toBeTruthy();
     expect(scroller?.contains(addFrame)).toBe(false);
-    // Floored at 44 on its own: a native Button has no hitSlop to reach the
-    // touch target with, unlike the 32dp chips beside it. That is what makes the
-    // strip row 44 and the card's reserve 128dp.
-    expect(addFrame?.getAttribute('data-min-height')).toBe('44');
-    expect(addFrame?.getAttribute('data-variant')).toBe('tonal');
+    expect(scroller?.contains(deleteFrame)).toBe(false);
+    expect(addFrame?.getAttribute('data-label')).toBe('mobile.create.playback.addFrame');
+    expect(deleteFrame?.getAttribute('data-label')).toBe('mobile.create.playback.deleteFrameA11y:1/12');
   });
 
-  it('adds a frame from the pinned chip', () => {
+  it('adds a frame from the pair', () => {
     const onAddFrame = vi.fn();
-    const { addFrame } = renderControls({ frameEditing: { onAddFrame } });
+    const { addFrame } = renderControls({ frameEditing: { onAddFrame, onDeleteFrame: vi.fn() } });
 
     addFrame?.click();
     expect(onAddFrame).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the frame the transport is sitting on', () => {
+    const onDeleteFrame = vi.fn();
+    const { deleteFrame } = renderControls({
+      frameCount: 4,
+      frameIndex: 2,
+      frameEditing: { onAddFrame: vi.fn(), onDeleteFrame },
+    });
+
+    // The ordinal AND the total are in the label: this is the only text the
+    // control has, and "delete frame 3" without "of 4" does not tell a blind
+    // setter whether the route is about to lose its last frame.
+    expect(deleteFrame?.getAttribute('data-label')).toBe('mobile.create.playback.deleteFrameA11y:3/4');
+    deleteFrame?.click();
+    expect(onDeleteFrame).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables remove at one frame rather than hiding it', () => {
+    // Hiding it would reflow the capsule from 88 to 44 the moment a second frame
+    // appears, walking the whole transport row sideways under the thumb.
+    const { deleteFrame, addFrame } = renderControls({ frameCount: 1, frameEditing });
+
+    expect(deleteFrame).toBeTruthy();
+    expect(deleteFrame?.disabled).toBe(true);
+    expect(deleteFrame?.getAttribute('data-label')).toBe('mobile.create.playback.deleteFrameBlocked');
+    expect(addFrame?.disabled).toBeFalsy();
+  });
+
+  it('never lets either half of the pair reach up into the chip row', () => {
+    // The chips sit 8dp above with 6dp of their own slop. A chip tap that slid
+    // down into a frame command is the one mis-tap this layout could cause, so
+    // the pair's slop is asymmetric: down and outwards, never up, and never into
+    // each other.
+    const { addFrame, deleteFrame } = renderControls({ frameCount: 4, frameEditing });
+
+    expect(addFrame?.getAttribute('data-hit-slop')).toBe('{"top":0,"bottom":6,"left":4,"right":0}');
+    expect(deleteFrame?.getAttribute('data-hit-slop')).toBe('{"top":0,"bottom":6,"left":0,"right":4}');
   });
 
   it('seeks to the tapped frame', () => {
@@ -290,11 +344,20 @@ describe('PlaybackControls — creator frame strip', () => {
     expect(chips.every((chip) => chip.getAttribute('data-hit-slop') === '6')).toBe(true);
   });
 
-  it('still shows the wall-state chip in place of the counter slot', () => {
-    const { container, chips } = renderControls({ frameCount: 3, frameEditing, wallStateLabel: 'On the wall' });
+  it('moves the wall-state chip to the strip, keeping the pair in its slot', () => {
+    // The reader shows "On the wall" in the transport row's left slot. In edit
+    // mode that slot is permanently the add/remove pair, so the chip takes the
+    // trailing edge of the strip — the space the old Add frame button vacated.
+    const { container, chips, editPair, strip } = renderControls({
+      frameCount: 3,
+      frameEditing,
+      wallStateLabel: 'On the wall',
+    });
 
     expect(container.textContent).toContain('On the wall');
     expect(chips).toHaveLength(3);
+    expect(editPair).toBeTruthy();
+    expect(strip?.textContent).toContain('On the wall');
   });
 });
 

--- a/packages/mobile/src/components/playback/__tests__/playback-speed-report.test.ts
+++ b/packages/mobile/src/components/playback/__tests__/playback-speed-report.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { roundedReportSpeed, shouldReportSpeed } from '../playback-speed-report';
+import {
+  clampPaceSeconds,
+  roundedReportPaceSeconds,
+  roundedReportSpeed,
+  shouldReportPaceSeconds,
+  shouldReportSpeed,
+  MAX_PACE_SECONDS,
+  MIN_PACE_SECONDS,
+} from '../playback-speed-report';
 
 // The pan `onUpdate` worklet runs ~60 frames/s. `shouldReportSpeed` is the gate
 // that keeps `runOnJS(reportLive)` (→ setLiveSpeed React state) from firing on
@@ -67,5 +75,86 @@ describe('shouldReportSpeed gate', () => {
     const reported = reportsForDrag(distinctPixels);
     expect(new Set(reported).size).toBe(reported.length);
     expect(reported.length).toBe(distinctPixels.length);
+  });
+});
+
+// The creator authors the climb's own cadence in seconds per frame, over a
+// different range (0.3–10s) than the reader's multiplier. Same gate, its own
+// pair — using the speed pair for a pace drag would report values the pill never
+// shows, because the two ranges don't line up.
+
+/** Replay a pace drag through its gate, the way `reportsForDrag` does for speed. */
+function paceReportsForDrag(pixels: number[]): number[] {
+  let lastReported = -1;
+  const reported: number[] = [];
+  for (const px of pixels) {
+    const { rounded, changed } = shouldReportPaceSeconds(px, USABLE, lastReported);
+    if (changed) {
+      lastReported = rounded;
+      reported.push(rounded);
+    }
+  }
+  return reported;
+}
+
+describe('shouldReportPaceSeconds gate', () => {
+  it('spans the authored pace range, endpoints exact', () => {
+    expect(roundedReportPaceSeconds(0, USABLE)).toBe(MIN_PACE_SECONDS);
+    expect(roundedReportPaceSeconds(USABLE, USABLE)).toBe(MAX_PACE_SECONDS);
+    // A thumb dragged past either end clamps rather than running off the range.
+    expect(roundedReportPaceSeconds(-40, USABLE)).toBe(MIN_PACE_SECONDS);
+    expect(roundedReportPaceSeconds(USABLE + 40, USABLE)).toBe(MAX_PACE_SECONDS);
+    // Never below 0.3s: MIN_PACE_MS (200ms) is the BLE throughput floor and an
+    // authored pace has to keep headroom above it.
+    expect(MIN_PACE_SECONDS).toBeGreaterThan(0.2);
+  });
+
+  it('reports far fewer times than the frame count over a slow drag', () => {
+    // 0.3–10s over 300px = 0.032s/px, so ~3px per 0.1s bucket: a 60-frame,
+    // 1px-per-frame drag must cost ~20 hops, not 60.
+    const pixels = Array.from({ length: 60 }, (_, index) => index + 1);
+    const reported = paceReportsForDrag(pixels);
+
+    expect(reported.length).toBeGreaterThan(0);
+    expect(reported.length).toBeLessThan(pixels.length);
+    for (let index = 1; index < reported.length; index += 1) {
+      expect(reported[index]).not.toBe(reported[index - 1]);
+    }
+  });
+
+  it('does not report while several frames stay inside one 0.1s bucket', () => {
+    let lastReported = roundedReportPaceSeconds(100, USABLE);
+    const decisions = [100, 100, 100, 100].map((px) => {
+      const result = shouldReportPaceSeconds(px, USABLE, lastReported);
+      if (result.changed) lastReported = result.rounded;
+      return result.changed;
+    });
+    expect(decisions.filter(Boolean)).toHaveLength(0);
+  });
+
+  it('still reports every distinct 0.1s step', () => {
+    // ~0.032s/px, so 6px apart is always a fresh bucket.
+    const distinctPixels = [0, 6, 12, 18, 24];
+    const reported = paceReportsForDrag(distinctPixels);
+    expect(new Set(reported).size).toBe(reported.length);
+    expect(reported.length).toBe(distinctPixels.length);
+  });
+});
+
+describe('clampPaceSeconds', () => {
+  it('holds an authored pace inside 0.3-10s', () => {
+    expect(clampPaceSeconds(0.05)).toBe(MIN_PACE_SECONDS);
+    expect(clampPaceSeconds(60)).toBe(MAX_PACE_SECONDS);
+    expect(clampPaceSeconds(1.5)).toBe(1.5);
+  });
+
+  it('passes the 0.75s default through untouched', () => {
+    // The slider's release-magnet lands on DEFAULT_PACE_MS exactly; a clamp that
+    // also rounded to a tenth would turn the app default into 800ms.
+    expect(clampPaceSeconds(0.75)).toBe(0.75);
+  });
+
+  it('falls back to the floor for a value that is not a number', () => {
+    expect(clampPaceSeconds(Number.NaN)).toBe(MIN_PACE_SECONDS);
   });
 });

--- a/packages/mobile/src/components/playback/__tests__/playback-speed-report.test.ts
+++ b/packages/mobile/src/components/playback/__tests__/playback-speed-report.test.ts
@@ -5,6 +5,7 @@ import {
   roundedReportSpeed,
   shouldReportPaceSeconds,
   shouldReportSpeed,
+  valueToTrackPosition,
   MAX_PACE_SECONDS,
   MIN_PACE_SECONDS,
 } from '../playback-speed-report';
@@ -156,5 +157,51 @@ describe('clampPaceSeconds', () => {
 
   it('falls back to the floor for a value that is not a number', () => {
     expect(clampPaceSeconds(Number.NaN)).toBe(MIN_PACE_SECONDS);
+  });
+});
+
+// The inverse mapping. It exists because a CANCELLED drag never reaches
+// `onEnd`: nothing commits, the mirrored value never moves, and the effect that
+// would resync the pill therefore never re-fires — so the gesture has to put
+// both the thumb and the pill back itself.
+describe('valueToTrackPosition', () => {
+  const USABLE = 200;
+
+  it('puts the ends of the range at the ends of the track', () => {
+    expect(valueToTrackPosition(MIN_PACE_SECONDS, MIN_PACE_SECONDS, MAX_PACE_SECONDS, USABLE)).toBe(0);
+    expect(valueToTrackPosition(MAX_PACE_SECONDS, MIN_PACE_SECONDS, MAX_PACE_SECONDS, USABLE)).toBe(USABLE);
+  });
+
+  it('round-trips against the position-to-value mapping the drag reports', () => {
+    // The two directions live in one module precisely so they cannot drift.
+    // Values on the 0.1 display grid: the reporter rounds to a tenth, which is
+    // exactly why `clampPaceSeconds` does not (see its note on the 0.75s magnet).
+    for (const seconds of [0.3, 0.8, 1.5, 4, 10]) {
+      const px = valueToTrackPosition(seconds, MIN_PACE_SECONDS, MAX_PACE_SECONDS, USABLE);
+      expect(roundedReportPaceSeconds(px, USABLE)).toBe(seconds);
+    }
+  });
+
+  it('puts the magnet default back on the track, rounding only for display', () => {
+    // 0.75s is DEFAULT_PACE_MS and the release magnet, so a cancelled drag has
+    // to restore that exact position — the pill may render it as 0.8s.
+    const px = valueToTrackPosition(0.75, MIN_PACE_SECONDS, MAX_PACE_SECONDS, USABLE);
+    expect(px).toBeCloseTo((0.45 / (MAX_PACE_SECONDS - MIN_PACE_SECONDS)) * USABLE, 5);
+    expect(roundedReportPaceSeconds(px, USABLE)).toBe(0.8);
+  });
+
+  it('holds a value from outside the range on the track', () => {
+    expect(valueToTrackPosition(-5, MIN_PACE_SECONDS, MAX_PACE_SECONDS, USABLE)).toBe(0);
+    expect(valueToTrackPosition(999, MIN_PACE_SECONDS, MAX_PACE_SECONDS, USABLE)).toBe(USABLE);
+  });
+
+  it('collapses to zero before layout has given the track a width', () => {
+    // `usable` is 0 until onLayout lands; without this the thumb would jump.
+    expect(valueToTrackPosition(5, MIN_PACE_SECONDS, MAX_PACE_SECONDS, 0)).toBe(0);
+    expect(valueToTrackPosition(5, MIN_PACE_SECONDS, MAX_PACE_SECONDS, -10)).toBe(0);
+  });
+
+  it('does not divide by a zero span', () => {
+    expect(valueToTrackPosition(3, 2, 2, USABLE)).toBe(0);
   });
 });

--- a/packages/mobile/src/components/playback/playback-speed-report.ts
+++ b/packages/mobile/src/components/playback/playback-speed-report.ts
@@ -1,16 +1,42 @@
-// Pure gating logic for the speed-slider's live-value reporting. Extracted so
+// Pure gating logic for the playback slider's live-value reporting. Extracted so
 // the per-frame `runOnJS(reportLive)` decision (which otherwise lives only
 // inside a reanimated worklet) is unit-testable, and so the gate and the
 // reported value can never drift apart.
 //
 // The slider's `onUpdate` worklet runs ~60×/s during a drag. Reporting the live
-// value up to React (`onLiveChange` → `setLiveSpeed`) on every frame floods the
+// value up to React (`onLiveChange` → `setLiveValue`) on every frame floods the
 // JS thread with a cross-thread hop + a PlaybackControls re-render per frame —
-// the rule-5 anti-pattern. The displayed label only shows 0.1× precision, so we
-// gate the hop on the 0.1-rounded speed actually changing, not on the raw frame.
+// the rule-5 anti-pattern. The displayed label only shows one decimal of
+// precision, so we gate the hop on the 0.1-rounded value actually changing, not
+// on the raw frame.
+//
+// Two units share the slider: the reader's ×multiplier (play drawer) and the
+// setter's seconds-per-frame (create drawer). Each gets its own named pair so a
+// call site can't accidentally gate a pace drag against the speed range — the
+// two ranges differ, so the wrong pair would report a value the pill never shows.
+
+import { MAX_PACE_MS, MIN_AUTHORED_PACE_MS } from '@boardsesh/playback-react';
 
 const MIN_SPEED = 0.1;
 const MAX_SPEED = 10;
+
+/**
+ * Seconds-per-frame range the creator's pace slider offers, in the unit the
+ * slider works in. Derived from the engine's authoring bounds rather than
+ * restated, so the control can't drift off the range the wall accepts — the
+ * floor is deliberately above the transport's own `MIN_PACE_MS` (200ms), which
+ * is the BLE throughput limit an authored pace must keep headroom above.
+ */
+export const MIN_PACE_SECONDS = MIN_AUTHORED_PACE_MS / 1000;
+export const MAX_PACE_SECONDS = MAX_PACE_MS / 1000;
+
+/** The 0.1-rounded value a thumb position maps to within an arbitrary range. */
+function roundedForRange(px: number, usable: number, min: number, max: number): number {
+  'worklet';
+  const ratio = usable > 0 ? px / usable : 0;
+  const clamped = ratio < 0 ? 0 : ratio > 1 ? 1 : ratio;
+  return Math.round((min + clamped * (max - min)) * 10) / 10;
+}
 
 /**
  * The displayed (0.1×-rounded) speed for a thumb position, matching the value
@@ -19,9 +45,7 @@ const MAX_SPEED = 10;
  */
 export function roundedReportSpeed(px: number, usable: number): number {
   'worklet';
-  const ratio = usable > 0 ? px / usable : 0;
-  const clamped = ratio < 0 ? 0 : ratio > 1 ? 1 : ratio;
-  return Math.round((MIN_SPEED + clamped * (MAX_SPEED - MIN_SPEED)) * 10) / 10;
+  return roundedForRange(px, usable, MIN_SPEED, MAX_SPEED);
 }
 
 /**
@@ -39,4 +63,43 @@ export function shouldReportSpeed(
   'worklet';
   const rounded = roundedReportSpeed(px, usable);
   return { rounded, changed: rounded !== lastReported };
+}
+
+/**
+ * The displayed (0.1s-rounded) seconds-per-frame for a thumb position — the pace
+ * counterpart of {@link roundedReportSpeed}, over the 0.3–10s authoring range.
+ */
+export function roundedReportPaceSeconds(px: number, usable: number): number {
+  'worklet';
+  return roundedForRange(px, usable, MIN_PACE_SECONDS, MAX_PACE_SECONDS);
+}
+
+/**
+ * The pace counterpart of {@link shouldReportSpeed}: gates the live report on the
+ * 0.1s-rounded seconds changing, so a pace drag costs the JS thread one hop per
+ * tenth of a second authored rather than one per rendered frame.
+ */
+export function shouldReportPaceSeconds(
+  px: number,
+  usable: number,
+  lastReported: number,
+): { rounded: number; changed: boolean } {
+  'worklet';
+  const rounded = roundedReportPaceSeconds(px, usable);
+  return { rounded, changed: rounded !== lastReported };
+}
+
+/**
+ * Hold a seconds-per-frame value inside the range the slider offers. Used on
+ * every committed pace (drag release, track tap, preset cycle, VoiceOver
+ * adjust), so no path can author a pace the wall can't keep up with.
+ *
+ * Deliberately clamps WITHOUT rounding: the display rounds to a tenth, but the
+ * release-magnet commits 0.75s (the engine's `DEFAULT_PACE_MS`) exactly, and a
+ * tenth-rounding clamp would quietly turn that default into 800ms.
+ */
+export function clampPaceSeconds(seconds: number): number {
+  'worklet';
+  if (!Number.isFinite(seconds)) return MIN_PACE_SECONDS;
+  return Math.min(MAX_PACE_SECONDS, Math.max(MIN_PACE_SECONDS, seconds));
 }

--- a/packages/mobile/src/components/playback/playback-speed-report.ts
+++ b/packages/mobile/src/components/playback/playback-speed-report.ts
@@ -103,3 +103,23 @@ export function clampPaceSeconds(seconds: number): number {
   if (!Number.isFinite(seconds)) return MIN_PACE_SECONDS;
   return Math.min(MAX_PACE_SECONDS, Math.max(MIN_PACE_SECONDS, seconds));
 }
+
+/**
+ * Thumb offset (px) for a slider value — the inverse of `roundedReportSpeed` /
+ * `roundedReportPaceSeconds`.
+ *
+ * Shared by the effect that tracks the committed value on the JS thread and the
+ * gesture's `onFinalize` worklet, which has to put the thumb back when a drag is
+ * CANCELLED. A cancelled gesture never reaches `onEnd`, so nothing commits and
+ * the value the pill mirrors never moves — meaning the effect that would
+ * normally resync it does not re-fire, and the pill is left reading a pace the
+ * climb does not have. Living in one place keeps the two directions from
+ * drifting, and lets both be tested without a gesture.
+ */
+export function valueToTrackPosition(value: number, minValue: number, maxValue: number, usable: number): number {
+  'worklet';
+  const span = maxValue - minValue;
+  const ratio = span > 0 ? (value - minValue) / span : 0;
+  const clamped = ratio < 0 ? 0 : ratio > 1 ? 1 : ratio;
+  return clamped * Math.max(0, usable);
+}

--- a/packages/mobile/src/lib/create-climb-draft-store.ts
+++ b/packages/mobile/src/lib/create-climb-draft-store.ts
@@ -44,6 +44,23 @@ export type CreateClimbDraft = {
    *  board's default (feet on the marked holds). */
   anyFeet?: boolean;
   /**
+   * Whether the setter has switched this climb into route mode. Route-ness is
+   * otherwise inferred from `frames.length > 1`, which cannot express the state
+   * a setter is in right after choosing "Make it a route" and before adding the
+   * second frame — restoring such a draft without this would silently drop them
+   * back to a boulder. Optional for back-compat; a slot written before route
+   * mode existed restores as a boulder, then infers `true` from a multi-frame
+   * `framesJson`.
+   */
+  routeMode?: boolean;
+  /**
+   * Authored per-frame pace in milliseconds — what the published climb's
+   * `frames_pace` will be. Optional: a slot written before the pace was
+   * authorable restores at `DEFAULT_PACE_MS`, which is what those climbs
+   * already play at.
+   */
+  framesPaceMs?: number;
+  /**
    * JSON.stringify of the `SavedClimbSnapshot` this working copy is attached to,
    * once it has been saved to the server at least once. Restoring it re-links a
    * cold-started session to its row, so the next Save UPDATES that climb instead

--- a/packages/mobile/src/lib/create-climb-draft-store.web.ts
+++ b/packages/mobile/src/lib/create-climb-draft-store.web.ts
@@ -23,6 +23,10 @@ export type CreateClimbDraft = {
   campus?: boolean;
   /** "Any feet" toggle. Optional for drafts created before this field. */
   anyFeet?: boolean;
+  /** Route mode. See the native fork for why inferring it from frame count isn't enough. */
+  routeMode?: boolean;
+  /** Authored per-frame pace in ms — the published climb's `frames_pace`. See the native fork. */
+  framesPaceMs?: number;
   /** JSON.stringify of the attached `SavedClimbSnapshot`. See the native fork. */
   savedClimbJson?: string;
   /** Payload signature at the last successful server save. See the native fork. */

--- a/packages/mobile/test/app-menu-stub.tsx
+++ b/packages/mobile/test/app-menu-stub.tsx
@@ -16,22 +16,33 @@ import { Pressable, Text, View } from 'react-native';
 // stub — keeps the stub's contract from drifting from the real component.
 import type { AppMenuProps } from '../src/components/AppMenu.types';
 
-export function AppMenu({ label, actions, onSelectIndex, accessibilityLabel, accessibilityHint }: AppMenuProps) {
+export function AppMenu(props: AppMenuProps) {
+  const { actions, onSelectIndex, accessibilityLabel, accessibilityHint } = props;
   return (
     <View>
       <Pressable
         accessibilityRole="button"
-        accessibilityLabel={accessibilityLabel ?? label}
+        accessibilityLabel={accessibilityLabel ?? props.label}
         accessibilityHint={accessibilityHint}
       >
-        <Text>{label}</Text>
+        {/* An icon anchor renders a glyph, so it has no visible text to mirror —
+            its `accessibilityLabel` is the only name it has, and it is required
+            for exactly that reason. Deliberately NOT echoed as text here: doing
+            so would let a screen test find by text an anchor that shows none. */}
+        <Text>{props.label}</Text>
       </Pressable>
       {actions.map((action, index) => (
         <Pressable
           key={`${index}-${action.label}`}
           accessibilityRole="button"
-          accessibilityState={{ selected: action.selected }}
-          onPress={() => onSelectIndex(index)}
+          accessibilityState={{ selected: action.selected, disabled: action.disabled }}
+          // Mirrors the real component's shared guard: a disabled row keeps its
+          // position (indices address actions) but never reports a selection.
+          disabled={action.disabled}
+          onPress={() => {
+            if (action.disabled) return;
+            onSelectIndex(index);
+          }}
         >
           <Text>{action.label}</Text>
         </Pressable>

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -538,11 +538,11 @@
       },
       "playback": {
         "addFrame": "Bild hinzufügen",
-        "addFrameHint": "Kopiert Frame {{index}} und setzt die Kopie dahinter",
-        "deleteFrameA11y": "Frame {{index}} von {{total}} löschen",
-        "deleteFrameBlocked": "Frame löschen — eine Route behält mindestens einen",
+        "addFrameHint": "Kopiert Bild {{index}} und setzt die Kopie dahinter",
+        "deleteFrameA11y": "Bild {{index}} von {{total}} löschen",
+        "deleteFrameBlocked": "Bild löschen — eine Route behält mindestens eins",
         "deleteFrameHint": "Rückgängig findest du in der Leiste darunter",
-        "frameDeleted": "Frame gelöscht. Noch {{total}} übrig."
+        "frameDeleted": "Bild gelöscht. Noch {{total}} übrig."
       },
       "holdRole": {
         "title": "Griff-Rolle festlegen",

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -537,7 +537,12 @@
         "counter": "{{index}}/{{total}}"
       },
       "playback": {
-        "addFrame": "Bild hinzufügen"
+        "addFrame": "Bild hinzufügen",
+        "addFrameHint": "Kopiert Frame {{index}} und setzt die Kopie dahinter",
+        "deleteFrameA11y": "Frame {{index}} von {{total}} löschen",
+        "deleteFrameBlocked": "Frame löschen — eine Route behält mindestens einen",
+        "deleteFrameHint": "Rückgängig findest du in der Leiste darunter",
+        "frameDeleted": "Frame gelöscht. Noch {{total}} übrig."
       },
       "holdRole": {
         "title": "Griff-Rolle festlegen",
@@ -606,8 +611,7 @@
         "open": "Mehr Aktionen",
         "makeRoute": "Zur Route machen",
         "makeBoulder": "Zum Boulder machen",
-        "makeBoulderBlocked": "Zum Boulder machen — erst Bilder löschen",
-        "deleteFrame": "Bild {{index}} löschen"
+        "makeBoulderBlocked": "Zum Boulder machen — erst Bilder löschen"
       }
     },
     "holdFilter": {

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -534,13 +534,10 @@
         "closeHint": "Dein Entwurf bleibt auf diesem Handy."
       },
       "frames": {
-        "delete": "Bild löschen",
         "counter": "{{index}}/{{total}}"
       },
       "playback": {
-        "emptyHint": "Füg ein Bild hinzu, um sie als Route abzuspielen",
-        "addFrame": "Bild hinzufügen",
-        "emptyA11y": "Routen-Wiedergabe. Füg ein zweites Bild hinzu, um sie zu aktivieren"
+        "addFrame": "Bild hinzufügen"
       },
       "holdRole": {
         "title": "Griff-Rolle festlegen",
@@ -604,7 +601,14 @@
       "publish": {
         "blocked": "Füge einen Startgriff und einen Topgriff hinzu, um zu veröffentlichen"
       },
-      "wallSizeMismatch": "Wähle diese Woods-Größe als aktives Board, um es zu beleuchten."
+      "wallSizeMismatch": "Wähle diese Woods-Größe als aktives Board, um es zu beleuchten.",
+      "routeMenu": {
+        "open": "Mehr Aktionen",
+        "makeRoute": "Zur Route machen",
+        "makeBoulder": "Zum Boulder machen",
+        "makeBoulderBlocked": "Zum Boulder machen — erst Bilder löschen",
+        "deleteFrame": "Bild {{index}} löschen"
+      }
     },
     "holdFilter": {
       "title": "Grifftypen",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -537,7 +537,12 @@
         "counter": "{{index}}/{{total}}"
       },
       "playback": {
-        "addFrame": "Add frame"
+        "addFrame": "Add frame",
+        "addFrameHint": "Copies frame {{index}} and puts the copy after it",
+        "deleteFrameA11y": "Delete frame {{index}} of {{total}}",
+        "deleteFrameBlocked": "Delete frame — a route keeps at least one",
+        "deleteFrameHint": "Undo is in the toolbar below",
+        "frameDeleted": "Frame deleted. {{total}} left."
       },
       "holdRole": {
         "title": "Set hold role",
@@ -606,8 +611,7 @@
         "open": "More climb actions",
         "makeRoute": "Make it a route",
         "makeBoulder": "Make it a boulder",
-        "makeBoulderBlocked": "Make it a boulder — delete frames first",
-        "deleteFrame": "Delete frame {{index}}"
+        "makeBoulderBlocked": "Make it a boulder — delete frames first"
       }
     },
     "holdFilter": {

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -534,13 +534,10 @@
         "closeHint": "Your draft stays on this phone."
       },
       "frames": {
-        "delete": "Delete frame",
         "counter": "{{index}}/{{total}}"
       },
       "playback": {
-        "emptyHint": "Add a frame to play it as a route",
-        "addFrame": "Add frame",
-        "emptyA11y": "Route playback. Add a second frame to enable it"
+        "addFrame": "Add frame"
       },
       "holdRole": {
         "title": "Set hold role",
@@ -604,7 +601,14 @@
       "publish": {
         "blocked": "Add a start and a finish hold to publish"
       },
-      "wallSizeMismatch": "Switch your active board to this Woods size to light it."
+      "wallSizeMismatch": "Switch your active board to this Woods size to light it.",
+      "routeMenu": {
+        "open": "More climb actions",
+        "makeRoute": "Make it a route",
+        "makeBoulder": "Make it a boulder",
+        "makeBoulderBlocked": "Make it a boulder — delete frames first",
+        "deleteFrame": "Delete frame {{index}}"
+      }
     },
     "holdFilter": {
       "title": "Hold types",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -534,13 +534,10 @@
         "closeHint": "Tu borrador se queda en este teléfono."
       },
       "frames": {
-        "delete": "Eliminar fotograma",
         "counter": "{{index}}/{{total}}"
       },
       "playback": {
-        "emptyHint": "Añade un fotograma para reproducirla como vía",
-        "addFrame": "Añadir fotograma",
-        "emptyA11y": "Reproducción de la vía. Añade un segundo fotograma para activarla"
+        "addFrame": "Añadir fotograma"
       },
       "holdRole": {
         "title": "Asignar rol de presa",
@@ -604,7 +601,14 @@
       "publish": {
         "blocked": "Añade una presa de salida y una de final para publicar"
       },
-      "wallSizeMismatch": "Cambia tu plafón activo a este tamaño de Woods para iluminarlo."
+      "wallSizeMismatch": "Cambia tu plafón activo a este tamaño de Woods para iluminarlo.",
+      "routeMenu": {
+        "open": "Más acciones",
+        "makeRoute": "Convertir en vía",
+        "makeBoulder": "Convertir en bloque",
+        "makeBoulderBlocked": "Convertir en bloque — elimina primero los fotogramas",
+        "deleteFrame": "Eliminar fotograma {{index}}"
+      }
     },
     "holdFilter": {
       "title": "Tipos de presa",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -540,7 +540,7 @@
         "addFrame": "Añadir fotograma",
         "addFrameHint": "Copia el fotograma {{index}} y coloca la copia después",
         "deleteFrameA11y": "Eliminar el fotograma {{index}} de {{total}}",
-        "deleteFrameBlocked": "Eliminar fotograma: una ruta conserva al menos uno",
+        "deleteFrameBlocked": "Eliminar fotograma: una vía conserva al menos uno",
         "deleteFrameHint": "Deshacer está en la barra de abajo",
         "frameDeleted": "Fotograma eliminado. Quedan {{total}}."
       },

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -537,7 +537,12 @@
         "counter": "{{index}}/{{total}}"
       },
       "playback": {
-        "addFrame": "Añadir fotograma"
+        "addFrame": "Añadir fotograma",
+        "addFrameHint": "Copia el fotograma {{index}} y coloca la copia después",
+        "deleteFrameA11y": "Eliminar el fotograma {{index}} de {{total}}",
+        "deleteFrameBlocked": "Eliminar fotograma: una ruta conserva al menos uno",
+        "deleteFrameHint": "Deshacer está en la barra de abajo",
+        "frameDeleted": "Fotograma eliminado. Quedan {{total}}."
       },
       "holdRole": {
         "title": "Asignar rol de presa",
@@ -606,8 +611,7 @@
         "open": "Más acciones",
         "makeRoute": "Convertir en vía",
         "makeBoulder": "Convertir en bloque",
-        "makeBoulderBlocked": "Convertir en bloque — elimina primero los fotogramas",
-        "deleteFrame": "Eliminar fotograma {{index}}"
+        "makeBoulderBlocked": "Convertir en bloque — elimina primero los fotogramas"
       }
     },
     "holdFilter": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -534,13 +534,10 @@
         "closeHint": "Votre brouillon reste sur ce téléphone."
       },
       "frames": {
-        "delete": "Supprimer l'image",
         "counter": "{{index}}/{{total}}"
       },
       "playback": {
-        "emptyHint": "Ajoute une image pour la jouer comme une voie",
-        "addFrame": "Ajouter une image",
-        "emptyA11y": "Lecture de la voie. Ajoute une deuxième image pour l'activer"
+        "addFrame": "Ajouter une image"
       },
       "holdRole": {
         "title": "Définir le rôle de la prise",
@@ -604,7 +601,14 @@
       "publish": {
         "blocked": "Ajoutez une prise de départ et une prise d'arrivée pour publier"
       },
-      "wallSizeMismatch": "Sélectionne ce format de Woods comme pan actif pour l’allumer."
+      "wallSizeMismatch": "Sélectionne ce format de Woods comme pan actif pour l’allumer.",
+      "routeMenu": {
+        "open": "Plus d'actions",
+        "makeRoute": "Convertir en voie",
+        "makeBoulder": "Convertir en bloc",
+        "makeBoulderBlocked": "Convertir en bloc — supprime d'abord les images",
+        "deleteFrame": "Supprimer l'image {{index}}"
+      }
     },
     "holdFilter": {
       "title": "Types de prise",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -537,7 +537,12 @@
         "counter": "{{index}}/{{total}}"
       },
       "playback": {
-        "addFrame": "Ajouter une image"
+        "addFrame": "Ajouter une image",
+        "addFrameHint": "Copie l’image {{index}} et place la copie juste après",
+        "deleteFrameA11y": "Supprimer l’image {{index}} sur {{total}}",
+        "deleteFrameBlocked": "Supprimer l’image : une voie en garde au moins une",
+        "deleteFrameHint": "Annuler se trouve dans la barre en dessous",
+        "frameDeleted": "Image supprimée. Il en reste {{total}}."
       },
       "holdRole": {
         "title": "Définir le rôle de la prise",
@@ -606,8 +611,7 @@
         "open": "Plus d'actions",
         "makeRoute": "Convertir en voie",
         "makeBoulder": "Convertir en bloc",
-        "makeBoulderBlocked": "Convertir en bloc — supprime d'abord les images",
-        "deleteFrame": "Supprimer l'image {{index}}"
+        "makeBoulderBlocked": "Convertir en bloc — supprime d'abord les images"
       }
     },
     "holdFilter": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -538,9 +538,9 @@
       },
       "playback": {
         "addFrame": "Ajouter une image",
-        "addFrameHint": "Copie l’image {{index}} et place la copie juste après",
-        "deleteFrameA11y": "Supprimer l’image {{index}} sur {{total}}",
-        "deleteFrameBlocked": "Supprimer l’image : une voie en garde au moins une",
+        "addFrameHint": "Copie l'image {{index}} et place la copie juste après",
+        "deleteFrameA11y": "Supprimer l'image {{index}} sur {{total}}",
+        "deleteFrameBlocked": "Supprimer l'image : une voie en garde au moins une",
         "deleteFrameHint": "Annuler se trouve dans la barre en dessous",
         "frameDeleted": "Image supprimée. Il en reste {{total}}."
       },

--- a/packages/shared/playback-react/src/__tests__/pace.test.ts
+++ b/packages/shared/playback-react/src/__tests__/pace.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_PACE_MS,
+  MAX_PACE_MS,
+  MIN_AUTHORED_PACE_MS,
+  MIN_PACE_MS,
+  clampAuthoredPaceMs,
+  resolveStoredPaceMs,
+} from '../pace';
+
+// Two readers of the same field that must NOT behave alike. `clampAuthoredPaceMs`
+// bounds what the authoring slider can produce; `resolveStoredPaceMs` reads a
+// pace that already exists. Collapsing them silently rewrites climbs on edit,
+// which is the failure these cases exist to prevent.
+
+describe('clampAuthoredPaceMs', () => {
+  it('holds a new pace inside what the control offers', () => {
+    expect(clampAuthoredPaceMs(50)).toBe(MIN_AUTHORED_PACE_MS);
+    expect(clampAuthoredPaceMs(50_000)).toBe(MAX_PACE_MS);
+    expect(clampAuthoredPaceMs(2_000)).toBe(2_000);
+  });
+
+  it('keeps the authored floor clear of the transport floor', () => {
+    // MIN_PACE_MS is where the BLE writer physically cannot keep up. Authoring
+    // exactly onto a hardware limit leaves a slow GATT link no headroom.
+    expect(MIN_AUTHORED_PACE_MS).toBeGreaterThan(MIN_PACE_MS);
+  });
+
+  it('falls back to the default rather than propagating a non-number', () => {
+    expect(clampAuthoredPaceMs(Number.NaN)).toBe(DEFAULT_PACE_MS);
+    expect(clampAuthoredPaceMs(Number.POSITIVE_INFINITY)).toBe(DEFAULT_PACE_MS);
+  });
+});
+
+describe('resolveStoredPaceMs', () => {
+  it('keeps a stored pace the authoring control could not have produced', () => {
+    // The whole point. Aurora climbs carry whatever pace their setter chose and
+    // the server accepts up to 30s, so clamping on the way in would halve a 20s
+    // route the next time its owner opened and re-saved it — with nothing on
+    // screen to show that anything changed.
+    expect(resolveStoredPaceMs(20_000)).toBe(20_000);
+    expect(resolveStoredPaceMs(30_000)).toBe(30_000);
+    expect(resolveStoredPaceMs(MAX_PACE_MS + 1)).toBe(MAX_PACE_MS + 1);
+  });
+
+  it('reads "never authored" as the default', () => {
+    // 0 and null both mean unset in the Aurora encoding, not "instant".
+    expect(resolveStoredPaceMs(0)).toBe(DEFAULT_PACE_MS);
+    expect(resolveStoredPaceMs(null)).toBe(DEFAULT_PACE_MS);
+    expect(resolveStoredPaceMs(undefined)).toBe(DEFAULT_PACE_MS);
+    expect(resolveStoredPaceMs(-1)).toBe(DEFAULT_PACE_MS);
+  });
+
+  it('does not propagate a non-number', () => {
+    expect(resolveStoredPaceMs(Number.NaN)).toBe(DEFAULT_PACE_MS);
+    expect(resolveStoredPaceMs(Number.POSITIVE_INFINITY)).toBe(DEFAULT_PACE_MS);
+  });
+
+  it('returns whole milliseconds, which is what the column stores', () => {
+    expect(resolveStoredPaceMs(1_234.6)).toBe(1_235);
+  });
+});

--- a/packages/shared/playback-react/src/pace.ts
+++ b/packages/shared/playback-react/src/pace.ts
@@ -39,3 +39,23 @@ export function clampAuthoredPaceMs(paceMs: number): number {
   if (!Number.isFinite(paceMs)) return DEFAULT_PACE_MS;
   return Math.round(Math.min(Math.max(paceMs, MIN_AUTHORED_PACE_MS), MAX_PACE_MS));
 }
+
+/**
+ * Read a pace that came from storage — a synced climb, a server row, a restored
+ * draft — preserving whatever it holds.
+ *
+ * Deliberately NOT `clampAuthoredPaceMs`. That one bounds what the authoring
+ * CONTROL may produce, and its 10s ceiling is a property of the slider, not of
+ * the data: Aurora climbs are synced with whatever pace their setter chose, and
+ * the server accepts up to 30s precisely so those survive a round trip. Clamping
+ * on the way in would silently rewrite a 20s route to 10s the next time its
+ * owner opened and re-saved it, with nothing on screen to show a change — the
+ * pace would simply be halved.
+ *
+ * 0 and null both mean "never authored" in the Aurora encoding, so they resolve
+ * to the default rather than to a real value.
+ */
+export function resolveStoredPaceMs(paceMs: number | null | undefined): number {
+  if (paceMs == null || !Number.isFinite(paceMs) || paceMs <= 0) return DEFAULT_PACE_MS;
+  return Math.round(paceMs);
+}

--- a/packages/shared/playback-react/src/pace.ts
+++ b/packages/shared/playback-react/src/pace.ts
@@ -16,3 +16,26 @@ export const DEFAULT_PACE_MS = 750;
  * looking fast on a route.
  */
 export const MIN_PACE_MS = 200;
+
+/**
+ * Slowest pace a setter can author, in milliseconds. Matches the upper end of
+ * the "seconds per frame" control (#4633 asked for a linear range up to 10s).
+ */
+export const MAX_PACE_MS = 10_000;
+
+/**
+ * Fastest pace a setter can author, in milliseconds.
+ *
+ * Deliberately above `MIN_PACE_MS`, not equal to it. `MIN_PACE_MS` is the
+ * transport's own floor — the point below which the BLE writer physically
+ * cannot keep up — and sitting an authored value exactly on a hardware limit
+ * leaves the wall no headroom on a slow GATT link. 300ms keeps a 100ms margin
+ * while still reading as fast on a route.
+ */
+export const MIN_AUTHORED_PACE_MS = 300;
+
+/** Clamps an authored pace into the range the "seconds per frame" control offers. */
+export function clampAuthoredPaceMs(paceMs: number): number {
+  if (!Number.isFinite(paceMs)) return DEFAULT_PACE_MS;
+  return Math.round(Math.min(Math.max(paceMs, MIN_AUTHORED_PACE_MS), MAX_PACE_MS));
+}

--- a/path
+++ b/path
@@ -1,0 +1,1 @@
+https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/d6/cf/3c/d6cf3cc9-91c3-3174-1ab5-ed27d50cc9a8/02-board-view.png/400x800bb.png

--- a/path
+++ b/path
@@ -1,1 +1,0 @@
-https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/d6/cf/3c/d6cf3cc9-91c3-3174-1ab5-ed27d50cc9a8/02-board-view.png/400x800bb.png


### PR DESCRIPTION
## Summary

Closes #5189. Follow-up to #4761, which Marco approved with a cleanup condition: put route mode behind a meatballs menu, and integrate add/remove-frame with the rest of the UI.

I ran the two screenshots past three reviewers (information architecture, visual craft, and vertical space) before writing anything. They converged on one shape — **a boulder shows no route chrome at all, and a route's whole control set lives in one card** — and turned up two things that changed the design.

**A climb had no mode.** "Route" is inferred from `frames_count > 1` everywhere (search filters, the playback engine, the slot itself). That is *why* a boulder could not opt out — there was nothing to opt out of, and the only way to make the feature discoverable was to charge every climb for an advert. `routeMode` is now real state the overflow menu owns.

**Per-frame duration does not exist in any layer.** Aurora, Kilter and our own schema all store exactly one `frames_pace` per climb; Kilter's own player has a singular `_framePace`. So the "seconds for each frame" the Kilter app offers *is* this one value — and it was already plumbed end to end here (GraphQL input → zod → column → offline mirror → queue → engine). The creator just hardcoded `0`, so **every route published from Boardsesh has played at the 750 ms default no matter what the transport said.** The pill authored nothing. Fixing that is a UI change, not a schema change.

### What moved

- **⋯ menu in the header, left of the lightbulb.** Not the action bar: its middle is a horizontal `ScrollView`, so a command placed there can scroll off-screen — which is exactly how the bare `copy` glyph went unfound twice. Rows are built by a pure function so "which rows exist when" is unit-tested; the lightbulb keeps its slot because it is a stateful toggle whose position people track.
- **One transport card.** A frame strip replaces the `1 / 4` text (tap a chip to seek, a sliding underline replaces the top progress bar so there is one position cue), with a labelled **+ Add frame** chip pinned outside the scroller. The detached Delete/Add pill row is gone. Play drops from a 42 pt bare glyph to a 44 dp button in a `GlassCluster`, so the sheet keeps exactly one brand-filled control — Save.
- **Delete frame** is in the menu, named by ordinal ("Delete frame 3") because "Delete frame" beside a strip of four makes you guess. **Start a new climb** moved there too: on a route screen a `+` that discarded the climb sat ~60 dp above the `+` that added a frame to it.
- **Route → boulder is blocked above one frame**, not silently lossy. The issue text said "keeps frame 1", but frames are absolute snapshots — frame 1 is only the start position, so that would throw away almost every hold. Flattening would rewrite the climb without asking. The row stays visible, disabled, and says to delete frames first.

### Seconds per frame

The creator's pill reads `0.8s` and the value is saved as `frames_pace`; the long-press slider retargets to 0.3–10 s (closing most of #4633). The play drawer keeps its ×multiplier — the setter authors content, a reader applies a lens. A boulder still publishes `0`, which is load-bearing rather than tidy: `assertWoodsSingleFrame` rejects a non-zero pace outright. 0.3 s stays clear of the 200 ms `MIN_PACE_MS` BLE floor, so no new GATT pressure. `framesPace` also gained a server-side upper bound (it had none).

### The board got bigger

Two layout constants were wrong and nothing in the code showed it. `ROUTE_STRIP_RESERVE` claimed 52 dp while the strip rendered 69, and `ABOVE_FOLD_CHROME` over-reserved by 46 dp on every screen in every state. The arithmetic now lives in a pure module with a test.

| iPhone SE (375×667) | before #4761 | on main | this PR |
|---|---|---|---|
| Boulder | 323 | 271 | **357** |
| Route | 239 | 200 (clamped on the floor) | **229** |

A route on an SE was hitting the `Math.max(200, …)` floor, which made the reserve a lie: the sheet then wanted a taller peek than `MAX_PEEK_FRACTION` allows and clamped, dropping the draft-status line and part of the Save row below the fold. That is fixed.

The route card is 128 dp rather than the 116 I first specced, deliberately: the strip row is 44 so **+ Add frame** clears the touch floor. `Button` sizes from `minHeight` and exposes no `hitSlop`, so unlike the frame chips it cannot borrow the extra 12 dp — and shipping the strip's primary action at 32 dp would have traded one touch-target violation for another on the screen this issue exists to fix them on. The pace pill also went 28 → 44 for the same reason.

**Author verification** — `vp run test:mobile` (817 files, 8477 tests), `vp test run --project backend climbs`, `vp test run --project i18n`, `vp run typecheck:mobile`, `vp run typecheck:backend`, `vp check` (0 errors), `vp run check:i18n:orphans`, `vp run check:mobile-bundle`. Pre-commit hook on the commit; no `--no-verify`.

**Not verified:** no simulator or device run — see the test plan. The Add-frame chip sitting flush in the 44 dp strip row is derived from the styles, not observed.

### Found on the way, filed separately

The space review measured **iOS filled `Button` rendering ~24 pt tall despite `minHeight={44}`** — Save and Add frame both, 45% under the HIG floor, with ~10 pt of invisible-but-live frame around each. Cause is modifier order in `Button.ios.tsx` (`.frame(minHeight:)` applied after `controlSize('small')`, so it centres an already-sized capsule). Android is correct. That affects every small filled button in the app, so it is not in this diff.

## Test plan

1. New climb → tap ⋯ → **Make it a route**. Transport appears.
2. Tap **+** under the board twice. Strip shows three chips.
3. Tap chip 2, then tap **−**. That chip goes.
4. Tap the seconds pill. Playback pace changes.
5. Save, reopen the climb. Same pace.

## Risk

Risk: 3/5 — creator UI rework plus a newly persisted climb field.

## Release Notes

- Set the seconds each move is lit, and it sticks. Routes used to play back at one fixed speed no matter what you picked.
- Routes are something you turn on now, from the ⋯ menu. Build one from the first frame instead of hunting for a hidden button.
- Frames live in one strip under the board — tap any move to jump to it, then + or − right beside it to add or drop one.
- More board on screen while you set, on every phone. Small screens gained the most.
- The frame you are on is easier to pick out in the dark, and the card has an edge again.
- Want one move held longer? Add the same frame twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cBLJFskzJXxBFE6mfMBT4

