### PR TITLE
fix(backend): give the test qa_verdicts table its device and OS columns

### DIFF
--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -1230,6 +1230,8 @@ export const schemaSQL = `
     "by_tester" boolean DEFAULT true NOT NULL,
     "comment" text,
     "platform" text NOT NULL,
+    "device_model" text,
+    "os_version" text,
     "app_version" text,
     "update_id" text,
     "runtime_version" text,


### PR DESCRIPTION
## Summary

`main` is red and has been since #5173 merged. Every `submitQaVerdict` insert in the backend suite fails with:

```
PostgresError: column "device_model" of relation "qa_verdicts" does not exist
```

Backend tests don't run the drizzle migrations — they build their schema from the hand-maintained `packages/backend/src/__tests__/schema-sql.ts`. #5173 added `deviceModel` / `osVersion` to the ORM schema (`packages/db/src/schema/app/qa-verdicts.ts:59`) and shipped migration `0215_silky_prowler.sql`, but the test DDL still declares the pre-#5173 table. So the ORM writes two columns the test database has never had.

Two columns, matching the migration exactly. Found while diagnosing a `test-backend` failure on #5195; it is unrelated to that PR, so it lands on its own rather than riding a feature branch.

Worth a follow-up (not here): nothing guards this pair. `schema-sql.ts` is a second source of truth for the same tables, and drifting from it fails at INSERT time in an unrelated suite rather than anywhere near the change that caused it. A parity check between the drizzle schema and the test DDL would have caught #5173 on its own PR.

## Test plan

1. CI green.

## Risk

Risk: 1/5 — two columns in a test-only DDL fixture, matching an already-merged migration. No production schema or app code touched.

## Release Notes

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cBLJFskzJXxBFE6mfMBT4
