### PR TITLE
refactor(mobile): send null, not [], for a verdict with no screenshots

### DIFF
--- a/packages/mobile/src/components/user-drawer/QaVerdictSheet.tsx
+++ b/packages/mobile/src/components/user-drawer/QaVerdictSheet.tsx
@@ -153,7 +153,9 @@ export function QaVerdictSheet({ sheetRef }: QaVerdictSheetProps) {
         branch,
         verdict,
         comment: trimmedComment.length > 0 ? trimmedComment : null,
-        screenshotKeys,
+        // null, not [], for "none" — the same shape FeedbackSheet sends down the
+        // same path, and the same shape the column stores.
+        screenshotKeys: screenshotKeys.length > 0 ? screenshotKeys : null,
       });
       // Written before the dismissal so a relaunch that beats the surf still
       // knows this bundle is signed off — leaving usually can't reload the app,

--- a/packages/mobile/src/components/user-drawer/__tests__/QaVerdictSheet.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/QaVerdictSheet.test.tsx
@@ -236,7 +236,7 @@ describe('QaVerdictSheet approve path', () => {
       branch: 'pr-4792',
       verdict: 'approved',
       comment: null,
-      screenshotKeys: [],
+      screenshotKeys: null,
     });
     expect(uploadFeedbackScreenshots).not.toHaveBeenCalled();
   });
@@ -313,7 +313,7 @@ describe('QaVerdictSheet decline path', () => {
       branch: 'pr-4792',
       verdict: 'declined',
       comment: 'the board never lights up',
-      screenshotKeys: [],
+      screenshotKeys: null,
     });
   });
 });

--- a/packages/mobile/src/lib/qa/__tests__/use-qa-previews.test.ts
+++ b/packages/mobile/src/lib/qa/__tests__/use-qa-previews.test.ts
@@ -45,7 +45,7 @@ vi.mock('../../feedback/use-submit-app-feedback', () => ({
   getNativeAppVersion: () => '2.3.1',
 }));
 
-import { useQaPreviews, useSubmitQaVerdict } from '../use-qa-previews';
+import { useQaPreviews, useSubmitQaVerdict, type QaVerdictSubmission } from '../use-qa-previews';
 
 type CapturedVariables = { prNumbers: number[]; includeBuilding: boolean };
 
@@ -65,7 +65,13 @@ beforeEach(() => {
 });
 
 describe('useSubmitQaVerdict', () => {
-  const submission = { prNumber: 4792, branch: 'pr-4792', verdict: 'approved' as const, comment: null };
+  const submission: QaVerdictSubmission = {
+    prNumber: 4792,
+    branch: 'pr-4792',
+    verdict: 'approved' as const,
+    comment: null,
+    screenshotKeys: null,
+  };
 
   it('sends the handset alongside the bundle identity', async () => {
     request.mockResolvedValue({ submitQaVerdict: { id: '17' } });

--- a/packages/mobile/src/lib/qa/use-qa-previews.ts
+++ b/packages/mobile/src/lib/qa/use-qa-previews.ts
@@ -63,8 +63,12 @@ export type QaVerdictSubmission = {
   branch: string;
   verdict: QaVerdictKind;
   comment: string | null;
-  /** Storage keys minted by `uploadFeedbackScreenshots`, in the order picked. */
-  screenshotKeys?: string[];
+  /**
+   * Storage keys minted by `uploadFeedbackScreenshots`, in the order picked;
+   * null when none were attached. Required-and-nullable like `comment` above,
+   * rather than optional, so a caller cannot silently drop the shots it staged.
+   */
+  screenshotKeys: string[] | null;
 };
 
 /**
@@ -84,7 +88,7 @@ export function useSubmitQaVerdict() {
           branch: submission.branch,
           verdict: submission.verdict,
           comment: submission.comment,
-          screenshotKeys: submission.screenshotKeys ?? null,
+          screenshotKeys: submission.screenshotKeys,
           platform: getMobilePlatform(),
           // The handset, so a PR author reading the comment knows an iPhone 17
           // Pro pass says nothing about a Pixel. Null on a simulator without a


### PR DESCRIPTION
## Summary

Follow-up to #5197, which landed the shared screenshot path for QA verdicts and bug reports. The two sheets on that path disagreed on what "no screenshots" looks like: `FeedbackSheet` sends `null`, `QaVerdictSheet` sent an empty array that `useSubmitQaVerdict` then coerced with `?? null`. Both worked. A shared path should have one shape, and it should be the one the column stores.

`QaVerdictSubmission.screenshotKeys` becomes required-and-nullable like its sibling `comment`, rather than optional. That is the part with teeth: the hook's own test fixture was omitting the field entirely, which an optional type let through silently. A caller can no longer drop the shots it staged and still typecheck.

The review bot on #5197 flagged the inconsistency twice and called it non-blocking, so it was left out of that PR rather than held up. It was written while #5197 was being merged, hence the separate PR.

`vp run typecheck:mobile` and `vp run test:mobile` (8449 tests) pass locally.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — mobile-only type narrowing, no wire-format or behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNq8iB5xDnVh8UVJKX3t7t
