### PR TITLE
fix(backend): alias entity_type/entity_id so notification enrichment runs at all

### DIFF
--- a/packages/backend/src/__tests__/grouped-notifications-enrichment.test.ts
+++ b/packages/backend/src/__tests__/grouped-notifications-enrichment.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { socialNotificationQueries } from '../graphql/resolvers/social/notifications';
+
+// #5192 QA: "I don't see the previews of the climbs in the notifications screen?
+// Pressing a created climb notification doesn't open it in the drawer."
+//
+// Both symptoms share one input — the climb fields the grouped resolver hangs
+// off `notifications.entity_id`. The sibling suite (`notifications.test.ts`)
+// mocks the db entirely, so it proves the MAPPING and nothing about the SQL:
+// a wrong column, a join that misses, or a type that arrives as a string all
+// pass there. This one runs the resolver against real Postgres so the query
+// itself is under test.
+//
+// FIXTURE_RUN_ID keeps rows unique across parallel workers sharing the worker
+// DB — no TRUNCATE of shared tables, only scoped INSERT/DELETE by uuid prefix.
+
+const FIXTURE_RUN_ID = crypto.randomUUID().slice(0, 8);
+const RECIPIENT_ID = `gn5192-me-${FIXTURE_RUN_ID}`;
+const SETTER_ID = `gn5192-setter-${FIXTURE_RUN_ID}`;
+const CLIMB_UUID = `gn5192-climb-${FIXTURE_RUN_ID}`;
+const CLIMB_FRAMES = 'p1080r12p1122r13';
+const NEW_CLIMB_NOTIFICATION = `gn5192-n-climb-${FIXTURE_RUN_ID}`;
+const TICK_UUID = `gn5192-tick-${FIXTURE_RUN_ID}`;
+const TICK_COMMENT_NOTIFICATION = `gn5192-n-tick-${FIXTURE_RUN_ID}`;
+
+function makeCtx(): ConnectionContext {
+  return {
+    connectionId: `gn5192-${FIXTURE_RUN_ID}`,
+    isAuthenticated: true,
+    userId: RECIPIENT_ID,
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+  } as unknown as ConnectionContext;
+}
+
+describe('groupedNotifications climb enrichment against real Postgres (#5192)', () => {
+  beforeAll(async () => {
+    await db.execute(sql`
+      INSERT INTO users (id, email, name)
+      VALUES
+        (${RECIPIENT_ID}, ${`${RECIPIENT_ID}@test.invalid`}, 'Notification reader'),
+        (${SETTER_ID}, ${`${SETTER_ID}@test.invalid`}, 'Climb setter')
+      ON CONFLICT (id) DO NOTHING
+    `);
+
+    // A climb with everything a thumbnail needs. `compatible_size_ids` is the
+    // column the row uses to pick a size on boards that number holds per size.
+    await db.execute(sql`
+      INSERT INTO board_climbs (uuid, board_type, layout_id, angle, setter_username, name, frames, compatible_size_ids, is_listed)
+      VALUES (${CLIMB_UUID}, 'kilter', 8, 40, 'setter', 'QA preview climb', ${CLIMB_FRAMES}, ARRAY[17, 18]::int[], true)
+      ON CONFLICT (uuid) DO NOTHING
+    `);
+
+    // An ascent on that climb, so a comment on it resolves through the tick.
+    await db.execute(sql`
+      INSERT INTO boardsesh_ticks (uuid, user_id, board_type, climb_uuid, angle, status, climbed_at)
+      VALUES (${TICK_UUID}, ${RECIPIENT_ID}, 'kilter', ${CLIMB_UUID}, 40, 'send', now())
+      ON CONFLICT (uuid) DO NOTHING
+    `);
+
+    // Exactly what handleClimbCreated and handleCommentCreated write.
+    await db.execute(sql`
+      INSERT INTO notifications (uuid, recipient_id, actor_id, type, entity_type, entity_id)
+      VALUES
+        (${NEW_CLIMB_NOTIFICATION}, ${RECIPIENT_ID}, ${SETTER_ID}, 'new_climb', 'climb', ${CLIMB_UUID}),
+        (${TICK_COMMENT_NOTIFICATION}, ${RECIPIENT_ID}, ${SETTER_ID}, 'comment_on_tick', 'tick', ${TICK_UUID})
+      ON CONFLICT (uuid) DO NOTHING
+    `);
+  });
+
+  afterAll(async () => {
+    await db.execute(sql`DELETE FROM notifications WHERE recipient_id = ${RECIPIENT_ID}`);
+    await db.execute(sql`DELETE FROM boardsesh_ticks WHERE uuid = ${TICK_UUID}`);
+    await db.execute(sql`DELETE FROM board_climbs WHERE uuid = ${CLIMB_UUID}`);
+    await db.execute(sql`DELETE FROM users WHERE id IN (${RECIPIENT_ID}, ${SETTER_ID})`);
+  });
+
+  it('hangs the climb off entity_id so the row can both draw and open', async () => {
+    const { groups } = await socialNotificationQueries.groupedNotifications(null, {}, makeCtx());
+    const group = groups.find((candidate) => candidate.type === 'new_climb');
+
+    expect(group).toBeDefined();
+    // Opening the climb needs these three; the QA report was that pressing did
+    // nothing, which is exactly what a missing climbUuid or boardType looks like.
+    expect(group!.climbUuid).toBe(CLIMB_UUID);
+    expect(group!.boardType).toBe('kilter');
+    expect(group!.climbLayoutId).toBe(8);
+    // Drawing the board art needs these two.
+    expect(group!.climbFrames).toBe(CLIMB_FRAMES);
+    expect(group!.climbCompatibleSizeIds).toEqual([17, 18]);
+  });
+
+  it('carries the entity key the client marks read and re-queries by', async () => {
+    // entityType/entityId are not decoration: the client sends them straight
+    // back to markGroupNotificationsRead, and notificationActors matches on the
+    // same triple. Undefined here marked the wrong group read (the query
+    // matches entity_id IS NULL) and returned an empty actor list.
+    const { groups } = await socialNotificationQueries.groupedNotifications(null, {}, makeCtx());
+    const group = groups.find((candidate) => candidate.type === 'new_climb')!;
+
+    expect(group.entityType).toBe('climb');
+    expect(group.entityId).toBe(CLIMB_UUID);
+  });
+
+  it('resolves an ascent comment to its thread and its climb', async () => {
+    // The whole point of the thread fields — a comment row that cannot name its
+    // thread opens nothing when tapped.
+    const { groups } = await socialNotificationQueries.groupedNotifications(null, {}, makeCtx());
+    const group = groups.find((candidate) => candidate.type === 'comment_on_tick')!;
+
+    expect(group.threadEntityType).toBe('tick');
+    expect(group.threadEntityId).toBe(TICK_UUID);
+    // And the tick walks to its climb, which is what lets the row draw art.
+    expect(group.climbUuid).toBe(CLIMB_UUID);
+    expect(group.climbFrames).toBe(CLIMB_FRAMES);
+  });
+
+  it('returns climbLayoutId as a number, not a string', async () => {
+    // A layout arriving as "8" would pass the `!= null` guard, then fail
+    // `toBoardName`-adjacent numeric use downstream and silently draw nothing.
+    const { groups } = await socialNotificationQueries.groupedNotifications(null, {}, makeCtx());
+    const group = groups.find((candidate) => candidate.type === 'new_climb')!;
+
+    expect(typeof group.climbLayoutId).toBe('number');
+    expect(typeof group.climbFrames).toBe('string');
+    expect(Array.isArray(group.climbCompatibleSizeIds)).toBe(true);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/social/notifications.ts
+++ b/packages/backend/src/graphql/resolvers/social/notifications.ts
@@ -202,8 +202,14 @@ export const socialNotificationQueries = {
       WITH all_groups AS (
         SELECT
           n."type",
-          n."entity_type",
-          n."entity_id",
+          -- Aliased, like every other column in this CTE. Unaliased, Postgres
+          -- returns entity_type / entity_id while the row mapper reads
+          -- entityType / entityId, so BOTH were silently undefined -- the
+          -- enrichment loop skipped every group on its entityId guard and no
+          -- climb, proposal or gym data was ever attached. Nothing errored:
+          -- rows just arrived with null climb fields for ever (#5192 QA).
+          n."entity_type" as "entityType",
+          n."entity_id" as "entityId",
           COUNT(DISTINCT n."actor_id") as "actorCount",
           (array_agg(n."uuid" ORDER BY n."created_at" DESC))[1] as "latestUuid",
           MAX(n."created_at") as "latestCreatedAt",


### PR DESCRIPTION
## Summary

QA on #5192 reported two things: climb notifications don't open when tapped, and the new board-art previews never render. Both are one **pre-existing** bug, not a regression — and it has been silently degrading notifications on the shipped app.

The grouped-notifications CTE selected `entity_type` and `entity_id` unaliased, while every other computed column in the same SELECT carried a camelCase alias:

```sql
n."entity_type",                     -- comes back as entity_type
n."entity_id",                       -- comes back as entity_id
COUNT(DISTINCT n."actor_id") as "actorCount",   -- aliased
(array_agg(...))[1] as "latestUuid",            -- aliased
```

The row mapper reads `row.entityType` / `row.entityId`, so both were always `undefined`. The enrichment loop opens with `if (!group.entityId) continue;` — so it **skipped every group** and attached no climb, proposal or gym data at all. Nothing errored; rows just arrived with null climb fields forever.

What that was breaking on the currently shipped app:

- **Tapping a new-climb notification did nothing** — the client needs `climbUuid` + `boardType` to route, and neither was ever set
- **`gym_claim_approved` fell back to its generic copy** — no `gymName`
- **`markGroupNotificationsRead` marked the wrong group read** — it received null `entityType`/`entityId` and matched `entity_id IS NULL`, which is a different set of rows than the one tapped

The flat `notifications` query (`:137-138`) has aliased these correctly all along; only the grouped CTE missed it. Two-line fix.

Split out of #5192 rather than folded into it: this is backend-only, fixes a live bug independently of any client change, and API-first is the rule here anyway. #5192's features need it to be useful, but tolerate its absence — a row with no climb fields just renders an avatar, which is exactly today's behaviour.

## Why the tests didn't catch it

`notifications.test.ts` mocks `db` entirely, so it validates the row **mapping** and can say nothing about the **SQL** — it fed `entityId` straight in and passed throughout, including on my own new assertions in #5190. This adds `grouped-notifications-enrichment.test.ts`, which runs the resolver against real Postgres and covers all four enrichment paths: the climb fields, the entity key the client sends back, the thread resolution, and the column types. Removing the alias again turns all four red — verified.

**Author-side verification:** `vp run typecheck:backend` clean, `vp check` 0 errors, `vp test run --project backend notification` → 47 passing across 4 files.

## Release Notes

- Tapping a notification about a new climb now opens that climb
- Marking a notification read no longer clears a different one

## Test plan

1. Open Home → bell.
2. Tap a "created a new climb" row.
3. The climb opens.
4. Back out; only that row is marked read.

## Risk

Risk: 3/5 — backend resolver, two column aliases, no schema or migration. Widely reachable (every notification list read), but the change strictly adds data to rows that were arriving empty, and it's covered by a new real-database test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaBF6eEAz23MpFTDYtUP3R
