### PR TITLE
fix(web): move <lastmod> when a setter's identity changes, not just their climbs

### DIFF
--- a/packages/web/app/lib/seo/sitemap/__tests__/setter-query.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/setter-query.test.ts
@@ -97,7 +97,8 @@ describe('the setters shard query', () => {
     // NOT `board_setter_stats.updated_at`, which is `now()` at nightly refresh —
     // publishing that as <lastmod> claims every setter changed every night.
     expect(normalised).not.toContain('board_setter_stats');
-    expect(normalised).toContain(`to_char(max(content_clock), 'yyyy-mm-dd"t"hh24:mi:ss.ms"z"')`);
+    expect(normalised).toContain(`'yyyy-mm-dd"t"hh24:mi:ss.ms"z"'`);
+    expect(normalised).toContain('max(content_clock) as content_clock');
   });
 
   it('moves <lastmod> when anything the page renders moves, not just linkable climbs', () => {
@@ -113,6 +114,24 @@ describe('the setters shard query', () => {
     // The CTE is over every visible climb; linkability is an eligibility
     // condition applied later, not a filter on the clock.
     expect(normalised).toContain('as is_linkable');
+
+    // The page's <h1>, summary, avatar and ProfilePage JSON-LD are
+    // `users.name` / `user_profiles.display_name` / `avatar_url`. Rename a
+    // mapped setter and all four change while every climb row sits still, so
+    // the identity clock has to be in the aggregate or <lastmod> goes stale on
+    // exactly the edit a reader would notice first.
+    expect(normalised).toContain('left join lateral');
+    expect(normalised).toContain('from user_board_mappings ubm');
+    expect(normalised).toContain('join users u on u.id = ubm.user_id');
+    expect(normalised).toContain('left join user_profiles p on p.user_id = ubm.user_id');
+    expect(normalised).toContain(
+      'greatest(eligible.content_clock, coalesce(identity.updated_at, eligible.content_clock))',
+    );
+
+    // Once per ELIGIBLE setter, not once per visible climb: the join sits
+    // outside the GROUP BY, on a query already close to SHARD_DEADLINE_MS.
+    expect(normalised).toContain('from eligible');
+    expect(normalised).toContain('where ubm.board_username = eligible.setter_username');
     expect(normalised).not.toContain('and (board_type = $1 and layout_id = $2');
   });
 
@@ -150,7 +169,7 @@ describe('the setters shard query', () => {
   });
 
   it('orders deterministically so a page is the same page between crawls', () => {
-    expect(normalised).toContain('order by setter_username asc');
+    expect(normalised).toContain('order by eligible.setter_username asc');
   });
 
   it('refuses to render at all when no board configuration resolves', () => {

--- a/packages/web/app/lib/seo/sitemap/__tests__/setter-query.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/setter-query.test.ts
@@ -97,7 +97,16 @@ describe('the setters shard query', () => {
     // NOT `board_setter_stats.updated_at`, which is `now()` at nightly refresh —
     // publishing that as <lastmod> claims every setter changed every night.
     expect(normalised).not.toContain('board_setter_stats');
-    expect(normalised).toContain(`'yyyy-mm-dd"t"hh24:mi:ss.ms"z"'`);
+
+    // One assertion over the whole projection rather than three containment
+    // checks: separate ones would still pass if `to_char` stopped wrapping the
+    // clock fold and formatted something else in the same statement.
+    expect(normalised).toContain(
+      `to_char( greatest(eligible.content_clock, coalesce(identity.updated_at, eligible.content_clock)), ` +
+        `'yyyy-mm-dd"t"hh24:mi:ss.ms"z"' ) as last_modified`,
+    );
+    // ...and that the climb half of that fold is a real aggregate, not a scalar
+    // that happens to be in scope.
     expect(normalised).toContain('max(content_clock) as content_clock');
   });
 

--- a/packages/web/app/lib/seo/sitemap/__tests__/setter-query.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/setter-query.test.ts
@@ -141,6 +141,12 @@ describe('the setters shard query', () => {
     // outside the GROUP BY, on a query already close to SHARD_DEADLINE_MS.
     expect(normalised).toContain('from eligible');
     expect(normalised).toContain('where ubm.board_username = eligible.setter_username');
+
+    // Deterministic, and byte-identical to the page's own lookup. The unique
+    // index is (user_id, board_type), NOT board_username, so two different
+    // users can carry one setter name — a bare LIMIT 1 then picks either, their
+    // `users.updated_at` differ, and <lastmod> drifts between refreshes.
+    expect(normalised).toContain('order by p.user_id is null, ubm.user_id limit 1');
     expect(normalised).not.toContain('and (board_type = $1 and layout_id = $2');
   });
 

--- a/packages/web/app/lib/seo/sitemap/setter-query.ts
+++ b/packages/web/app/lib/seo/sitemap/setter-query.ts
@@ -226,6 +226,7 @@ export function buildSetterSitemapSql(groups: readonly ClimbConfigGroup[]): SQL 
       JOIN users u ON u.id = ubm.user_id
       LEFT JOIN user_profiles p ON p.user_id = ubm.user_id
       WHERE ubm.board_username = eligible.setter_username
+      ORDER BY p.user_id IS NULL, ubm.user_id
       LIMIT 1
     ) AS identity ON true
     ORDER BY eligible.setter_username ASC

--- a/packages/web/app/lib/seo/sitemap/setter-query.ts
+++ b/packages/web/app/lib/seo/sitemap/setter-query.ts
@@ -154,6 +154,14 @@ export function buildSetterSitemapSql(groups: readonly ClimbConfigGroup[]): SQL 
   // of the submitted subset: where a climb lands in page one's ordering, and
   // when the page last changed.
   //
+  // The identity clock joins AFTER the aggregate, once per ELIGIBLE setter
+  // (~31k lookups) rather than once per visible climb (~10x that). It has to be
+  // in here at all because the page's `<h1>`, summary, avatar and `ProfilePage`
+  // JSON-LD are `users.name` / `user_profiles.display_name` / `avatar_url` —
+  // rename a mapped setter and every one of those changes while the climb rows
+  // sit still. `LIMIT 1` mirrors `fetchSetterIdentity`'s own lookup, so the
+  // clock describes the row the page actually renders.
+  //
   // `page_rank_ascents` reproduces the page's sort key. The page joins stats at
   // `mostAscendedAngle` and orders on `COALESCE(stats.ascensionist_count, 0)
   // DESC, uuid`; that angle is chosen by `ascensionist_count desc nulls last`
@@ -195,15 +203,32 @@ export function buildSetterSitemapSql(groups: readonly ClimbConfigGroup[]): SQL 
           ORDER BY page_rank_ascents DESC, uuid
         ) AS page_position
       FROM visible
+    ),
+    eligible AS (
+      SELECT
+        setter_username,
+        max(content_clock) AS content_clock
+      FROM ranked
+      GROUP BY setter_username
+      HAVING count(*) FILTER (WHERE is_linkable) >= ${SETTER_MIN_VISIBLE_CLIMBS}
+         AND count(*) FILTER (WHERE is_linkable AND page_position <= ${SETTER_PAGE_SIZE}) >= 1
     )
     SELECT
-      setter_username,
-      to_char(max(content_clock), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS last_modified
-    FROM ranked
-    GROUP BY setter_username
-    HAVING count(*) FILTER (WHERE is_linkable) >= ${SETTER_MIN_VISIBLE_CLIMBS}
-       AND count(*) FILTER (WHERE is_linkable AND page_position <= ${SETTER_PAGE_SIZE}) >= 1
-    ORDER BY setter_username ASC
+      eligible.setter_username,
+      to_char(
+        GREATEST(eligible.content_clock, COALESCE(identity.updated_at, eligible.content_clock)),
+        'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+      ) AS last_modified
+    FROM eligible
+    LEFT JOIN LATERAL (
+      SELECT GREATEST(u.updated_at, COALESCE(p.updated_at, u.updated_at)) AS updated_at
+      FROM user_board_mappings ubm
+      JOIN users u ON u.id = ubm.user_id
+      LEFT JOIN user_profiles p ON p.user_id = ubm.user_id
+      WHERE ubm.board_username = eligible.setter_username
+      LIMIT 1
+    ) AS identity ON true
+    ORDER BY eligible.setter_username ASC
   `;
 }
 

--- a/packages/web/app/setter/[setter_username]/server-setter-data.ts
+++ b/packages/web/app/setter/[setter_username]/server-setter-data.ts
@@ -211,6 +211,11 @@ async function fetchSetterIdentity(username: string): Promise<SetterIdentity> {
       JOIN users u ON u.id = ubm.user_id
       LEFT JOIN user_profiles p ON p.user_id = ubm.user_id
       WHERE ubm.board_username = ${username}
+      -- Deterministic, and the setters shard sorts identically. The unique
+      -- index is (user_id, board_type), so two different users can share a
+      -- setter name; a bare LIMIT 1 renders whichever the planner happened to
+      -- reach, and the shard's <lastmod> could describe the other one.
+      ORDER BY p.user_id IS NULL, ubm.user_id
       LIMIT 1
     ) AS profile ON true
   `,


### PR DESCRIPTION
## Summary

The last of Codex's three `<lastmod>` findings on #4579, which merged before the fix could land — so it comes as a follow-up rather than another round on that PR.

The setter page's `<h1>`, summary paragraph, avatar and `ProfilePage` JSON-LD are `users.name` / `user_profiles.display_name` / `avatar_url`, reached through `user_board_mappings`. Both tables carry `updated_at`. `content_clock` aggregated climb and climb-stats rows only, so **renaming a mapped setter changed every visible thing on the page while `<lastmod>` sat still** — stale on exactly the edit a reader notices first.

### Why the join sits after the aggregate

Once per **eligible setter** (~31k lookups), not once per visible climb (~10x that). The summary scan already sits close to `SHARD_DEADLINE_MS` — that is #4583, and this PR must not make it materially worse. `LIMIT 1` mirrors `fetchSetterIdentity`'s own lookup, so the clock describes the row the page actually renders rather than an arbitrary mapping.

### The verification that matters here

**An earlier draft of this change was missing the comma between the `ranked` and `eligible` CTEs, and the whole web suite passed — 303 assertions, green, on SQL that Postgres rejects outright.**

```
ERROR:  syntax error at or near "eligible"
LINE 44:     eligible AS (
```

The `.toSQL()` seam these tests are built on renders the statement and asserts on the text. It proves what we *built*; it cannot prove the database *accepts* it. So this change was checked by dumping the rendered SQL and running `PREPARE` against a real Postgres with the schema — which parses, resolves every column, and plans, without executing. Confirmed load-bearing by re-running it with the comma removed: `PREPARE` fails where the unit tests do not.

Worth generalising into a standing test; filed separately rather than bolted on here, since it needs a database and these tests deliberately run without one.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. Rename a setter's display name.
2. Their sitemap entry's date moves within the refresh window.

## Risk

Risk: 2/5 — one extra indexed lookup per eligible setter on the setters summary
scan, which is the shard already closest to `SHARD_DEADLINE_MS` (#4583). If it
tips over, the failure is the one that surface already has and self-heals: a
cold `/sitemap.xml` reports `X-Sitemap-Degraded: setters` until the cache warms.
No other shard is touched, nothing is written, and the change is a revert away.

## Author verification

- `vp check` — clean · `vp test run --project web app/lib/seo app/sitemaps` — 303 tests green.
- `PREPARE` of the rendered SQL against a real Postgres carrying the schema — succeeds; fails as expected when the CTE comma is removed.
- Tests assert the join shape, the `GREATEST` fold, and that it reads from `eligible` rather than per-climb.

## Production targets

**`www.boardsesh.com` only.** No `packages/mobile` changes, no native fingerprint change, no OTA.

Follow-up to #4579. Part of #4358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5Jti1UCBFtwGaJswYKY5Z
