### PR TITLE
fix(mobile): only offer Woods holds that are on the wall

### DIFF
--- a/docs/woods-climb-rules.md
+++ b/docs/woods-climb-rules.md
@@ -58,6 +58,16 @@ request. Board size is mandatory and immutable because the two physical sizes
 reuse hold numbers at different positions. Creation uses existing geometry and
 Woods role codes, one static frame, and normal ownership/edit-window rules.
 
+A Woods hold id names a mounting slot, not a hold. 106 of the 8x10's 485 slots
+and 169 of the 12x12's 894 carry no hold at all, so `WOODS_OCCUPIED_HOLD_IDS` is
+what separates something a climber can pull on from a bare bolt hole. The
+geometry tables keep every slot on purpose — a frames string may name any of
+them and the renderer falls back to a ring for one it has no silhouette for — so
+occupancy is enforced separately, in two places: the editor only offers occupied
+slots as tap targets (`getCreateBoardHolds`), and `parseWoodsFrames` rejects a
+climb that names an empty one. Before that gate existed, the create board drew a
+dot on every slot and a climber could paint bare plywood (issue #5185).
+
 New clients send explicit `noMatch` and `anyFeet` booleans. Omission preserves
 the existing rule on update. The older characteristics input continues to own
 only campus and no-kickboard, so an old client cannot clear any-feet by sending

--- a/packages/backend/src/__tests__/woods-climb-authoring.test.ts
+++ b/packages/backend/src/__tests__/woods-climb-authoring.test.ts
@@ -115,12 +115,11 @@ describe('validateWoodsClimb', () => {
     // A Woods hold id is a T-nut position, and 169 of the 12x12's 894 carry no
     // hold. 808 is one of them; 807 and 809 beside it are real (#5185).
     expect(() => publishable({ frames: 'p807r4p809r2p30r3' })).not.toThrow();
+    // The whole message, not a fragment: the slot DOES exist on this wall, it
+    // just carries no hold, so this must not fall through to "does not exist".
     expect(() => publishable({ frames: `p${EMPTY_LARGE_SLOT}r4p20r2p30r3` })).toThrow(
-      new RegExp(`Hold ${EMPTY_LARGE_SLOT} is an empty mounting slot on the 12x12`),
+      `Hold ${EMPTY_LARGE_SLOT} is an empty mounting slot on the 12x12 Woods board`,
     );
-    // A slot empty on one wall can be a hold on the other, so the message must
-    // not be reused as "does not exist".
-    expect(() => publishable({ frames: `p${EMPTY_LARGE_SLOT}r4p20r2p30r3` })).not.toThrow(/does not exist/);
   });
 
   it('rejects a repeated hold id', () => {

--- a/packages/backend/src/__tests__/woods-climb-authoring.test.ts
+++ b/packages/backend/src/__tests__/woods-climb-authoring.test.ts
@@ -20,6 +20,12 @@ const START_HAND_FINISH = 'p10r4p20r2p30r3';
 // asymmetry is the whole reason Woods climbs carry a size.
 const LARGE_ONLY_HOLD = 600;
 
+// Mounting slots with no hold bolted on: 808 on the 12x12 (its neighbours 807
+// and 809 are real holds), 12 on the 8x10 — which IS a hold on the 12x12, so it
+// also proves the check is per-size.
+const EMPTY_LARGE_SLOT = 808;
+const EMPTY_SMALL_SLOT = 12;
+
 function publishable(overrides: Partial<Parameters<typeof validateWoodsClimb>[0]> = {}) {
   return validateWoodsClimb({
     layoutId: WOODS_LAYOUT_ID,
@@ -105,6 +111,18 @@ describe('validateWoodsClimb', () => {
     );
   });
 
+  it('rejects a hold id that names an empty mounting slot', () => {
+    // A Woods hold id is a T-nut position, and 169 of the 12x12's 894 carry no
+    // hold. 808 is one of them; 807 and 809 beside it are real (#5185).
+    expect(() => publishable({ frames: 'p807r4p809r2p30r3' })).not.toThrow();
+    expect(() => publishable({ frames: `p${EMPTY_LARGE_SLOT}r4p20r2p30r3` })).toThrow(
+      new RegExp(`Hold ${EMPTY_LARGE_SLOT} is an empty mounting slot on the 12x12`),
+    );
+    // A slot empty on one wall can be a hold on the other, so the message must
+    // not be reused as "does not exist".
+    expect(() => publishable({ frames: `p${EMPTY_LARGE_SLOT}r4p20r2p30r3` })).not.toThrow(/does not exist/);
+  });
+
   it('rejects a repeated hold id', () => {
     // board_climb_holds is keyed on (board, climb, hold) and inserts with ON
     // CONFLICT DO NOTHING, so a repeat would leave frames, the hold rows and the
@@ -128,6 +146,27 @@ describe('parseWoodsFrames', () => {
     // The frames string is what the BLE encoder reads back, so the parse must be
     // a faithful read of it, not a normalisation.
     expect(parseWoodsFrames('p30r3p10r4', '12x12').map((hold) => hold.holdId)).toEqual([30, 10]);
+  });
+
+  it('accepts every hold of the climbs already set on real Woods walls', () => {
+    // The three production 12x12 climbs pinned by the board-render regression
+    // suite (#4971). The occupancy gate must not reject a climb the wall has
+    // already lit.
+    const shipped = [
+      'p11r3p30r2p172r2p337r2p436r1p464r2p567r1p569r2p670r2p805r4p807r4p822r1p825r1p892r1',
+      'p12r3p47r2p179r2p341r2p342r2p401r2p446r1p537r2p578r1p666r2p677r1p803r4p807r4p819r1p855r1',
+      'p11r3p44r2p208r2p334r2p435r2p571r1p722r4p730r4p737r1p822r1p884r1',
+    ];
+    for (const frames of shipped) {
+      expect(() => parseWoodsFrames(frames, '12x12')).not.toThrow();
+    }
+  });
+
+  it('rejects an empty mounting slot on either wall', () => {
+    expect(() => parseWoodsFrames(`p${EMPTY_LARGE_SLOT}r4`, '12x12')).toThrow(/empty mounting slot/);
+    expect(() => parseWoodsFrames(`p${EMPTY_SMALL_SLOT}r4`, '8x10')).toThrow(/empty mounting slot/);
+    // 12 is empty on the 8x10 but a real hold on the 12x12.
+    expect(() => parseWoodsFrames(`p${EMPTY_SMALL_SLOT}r4`, '12x12')).not.toThrow();
   });
 });
 

--- a/packages/backend/src/graphql/resolvers/climbs/woods-authoring.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/woods-authoring.ts
@@ -8,6 +8,7 @@ import {
   type WoodsBoardSize,
 } from '@boardsesh/board-config';
 import { HOLD_STATE_MAP, WOODS_WIRE_ROLE } from '@boardsesh/board-constants';
+import { WOODS_OCCUPIED_HOLD_IDS } from '@boardsesh/board-constants/woods';
 import type { HoldState } from '@boardsesh/shared-schema';
 
 /**
@@ -25,7 +26,8 @@ import type { HoldState } from '@boardsesh/shared-schema';
  *  - one static frame — no animation, no `x` off-tokens;
  *  - every hold id present on the SELECTED size (the two walls number their
  *    holds from their own origins, so an id valid on the 12x12 is very often a
- *    different hold, or no hold at all, on the 8x10);
+ *    different hold, or no hold at all, on the 8x10), and physically occupied —
+ *    a Woods id names a mounting slot, and about a fifth of them carry no hold;
  *  - roles drawn from `WOODS_WIRE_ROLE`, so the stored frames feed the BLE
  *    encoder unchanged;
  *  - a start and a finish before it can be published.
@@ -64,6 +66,21 @@ const WOODS_ROLE_STATES: ReadonlyMap<number, HoldState> = new Map(
 );
 
 const WOODS_SIZE_IDS: ReadonlyArray<number> = Object.values(WOODS_SIZES).map((size) => size.id);
+
+/**
+ * The mounting slots that actually carry a hold, per size.
+ *
+ * A Woods hold id is a T-nut position, and 106 of the 8x10's 485 slots and 169
+ * of the 12x12's 894 are empty — no hold, no traced silhouette, nothing to pull
+ * on. `getWoodsHoldGridPosition` answers for every slot (frames consumers and
+ * the renderer's ring fallback need it to), so occupancy is a separate rule, and
+ * this is where it is enforced: a climb naming an empty slot would light an
+ * empty bolt hole on the wall. Built once — `parseWoodsFrames` runs per mutation.
+ */
+const WOODS_OCCUPIED_HOLD_ID_SETS: Record<WoodsBoardSize, ReadonlySet<number>> = {
+  '8x10': new Set(WOODS_OCCUPIED_HOLD_IDS['8x10']),
+  '12x12': new Set(WOODS_OCCUPIED_HOLD_IDS['12x12']),
+};
 
 /** Only `p<holdId>r<roleCode>` pairs, at least one, and nothing else. */
 const WOODS_FRAMES_PATTERN = /^(?:p\d+r\d+)+$/;
@@ -166,6 +183,9 @@ export function parseWoodsFrames(frames: string, dimension: WoodsBoardSize): Woo
     }
     if (!getWoodsHoldGridPosition(holdId, dimension)) {
       throw invalid(`Hold ${holdId} does not exist on the ${dimension} Woods board`);
+    }
+    if (!WOODS_OCCUPIED_HOLD_ID_SETS[dimension].has(holdId)) {
+      throw invalid(`Hold ${holdId} is an empty mounting slot on the ${dimension} Woods board`);
     }
     if (seenHoldIds.has(holdId)) {
       throw invalid(`Hold ${holdId} is listed more than once`);

--- a/packages/mobile/src/lib/__tests__/create-board-holds.test.ts
+++ b/packages/mobile/src/lib/__tests__/create-board-holds.test.ts
@@ -107,7 +107,7 @@ describe('getCreateBoardHolds', () => {
     ).toEqual([807, 809]);
   });
 
-  it('keeps 8x10 holds the catalog never uses', () => {
+  it('keeps 8x10 holds the catalog never uses, and still drops its empty slots', () => {
     mockedGetBoardRenderData.mockReturnValue({
       boardWidth: 720,
       boardHeight: 1000,

--- a/packages/mobile/src/lib/__tests__/create-board-holds.test.ts
+++ b/packages/mobile/src/lib/__tests__/create-board-holds.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WOODS_OCCUPIED_HOLD_IDS } from '@boardsesh/board-constants/woods';
 
 vi.mock('../board-details', () => ({
   getBoardRenderData: vi.fn(),
@@ -57,20 +58,87 @@ describe('getCreateBoardHolds', () => {
     });
   });
 
+  // A Woods hold id is a mounting slot, and 106 of the 8x10's 485 and 169 of the
+  // 12x12's 894 carry no hold. Only the occupied ones may become tap targets or
+  // discoverability dots (#5185).
   it.each([
-    { sizeId: 1, holds: 485, width: 720, height: 1000 },
-    { sizeId: 2, holds: 894, width: 1225, height: 1400 },
-  ])('uses real Woods geometry for size $sizeId, including hold zero', async ({ sizeId, holds, width, height }) => {
-    const actual = await vi.importActual<typeof import('../board-details')>('../board-details');
-    mockedGetBoardRenderData.mockImplementation(actual.getBoardRenderData);
-    const result = getCreateBoardHolds({ boardName: 'woods', layoutId: 1, sizeId, setIds: [1] });
-    expect(result).toMatchObject({ family: 'woods', boardWidth: width, boardHeight: height });
-    expect(result?.holdTargets).toHaveLength(holds);
-    expect(result?.holdTargets.some((hold) => hold.id === 0)).toBe(true);
-    expect(new Set(result?.holdTargets.map((hold) => hold.id)).size).toBe(holds);
+    { sizeId: 1, dimension: '8x10' as const, slots: 485, width: 720, height: 1000 },
+    { sizeId: 2, dimension: '12x12' as const, slots: 894, width: 1225, height: 1400 },
+  ])(
+    'uses real Woods geometry for size $sizeId, occupied slots only, including hold zero',
+    async ({ sizeId, dimension, slots, width, height }) => {
+      const actual = await vi.importActual<typeof import('../board-details')>('../board-details');
+      mockedGetBoardRenderData.mockImplementation(actual.getBoardRenderData);
+      const occupied = WOODS_OCCUPIED_HOLD_IDS[dimension];
+
+      const result = getCreateBoardHolds({ boardName: 'woods', layoutId: 1, sizeId, setIds: [1] });
+
+      expect(result).toMatchObject({ family: 'woods', boardWidth: width, boardHeight: height });
+      expect(result?.holdTargets).toHaveLength(occupied.length);
+      expect(occupied.length).toBeLessThan(slots);
+      expect(result?.holdTargets.map((hold) => hold.id)).toEqual([...occupied]);
+      expect(result?.holdTargets.some((hold) => hold.id === 0)).toBe(true);
+      expect(
+        result?.holdTargets.every((hold) => Number.isFinite(hold.cx) && Number.isFinite(hold.cy) && hold.r > 0),
+      ).toBe(true);
+    },
+  );
+
+  it('drops the empty 12x12 mounting slot beside the rail and keeps its neighbours', () => {
+    mockedGetBoardRenderData.mockReturnValue({
+      boardWidth: 1225,
+      boardHeight: 1400,
+      edgeLeft: 0,
+      edgeRight: 33,
+      edgeBottom: 0,
+      edgeTop: 31,
+      backgroundImageKeys: ['woods/woods-12x12-bg.webp'],
+      holdsData: [
+        { id: 807, mirroredHoldId: null, cx: 1106, cy: 1026, r: 13.5 },
+        { id: 808, mirroredHoldId: null, cx: 1123, cy: 1026, r: 13.5 },
+        { id: 809, mirroredHoldId: null, cx: 1140, cy: 1020, r: 13.5 },
+      ],
+    });
+
     expect(
-      result?.holdTargets.every((hold) => Number.isFinite(hold.cx) && Number.isFinite(hold.cy) && hold.r > 0),
-    ).toBe(true);
+      getCreateBoardHolds({ boardName: 'woods', layoutId: 1, sizeId: 2, setIds: [1] })?.holdTargets.map(
+        (hold) => hold.id,
+      ),
+    ).toEqual([807, 809]);
+  });
+
+  it('keeps 8x10 holds the catalog never uses', () => {
+    mockedGetBoardRenderData.mockReturnValue({
+      boardWidth: 720,
+      boardHeight: 1000,
+      edgeLeft: 0,
+      edgeRight: 21,
+      edgeBottom: 0,
+      edgeTop: 25,
+      backgroundImageKeys: ['woods/woods-8x10-bg.webp'],
+      holdsData: [25, 112, 131, 12].map((id) => ({ id, mirroredHoldId: null, cx: id, cy: id, r: 11.5 })),
+    });
+
+    expect(
+      getCreateBoardHolds({ boardName: 'woods', layoutId: 1, sizeId: 1, setIds: [1] })?.holdTargets.map(
+        (hold) => hold.id,
+      ),
+    ).toEqual([25, 112, 131]);
+  });
+
+  it('reports no Woods holds for a size id that is not a Woods board', () => {
+    mockedGetBoardRenderData.mockReturnValue({
+      boardWidth: 1225,
+      boardHeight: 1400,
+      edgeLeft: 0,
+      edgeRight: 33,
+      edgeBottom: 0,
+      edgeTop: 31,
+      backgroundImageKeys: ['woods/woods-12x12-bg.webp'],
+      holdsData: [{ id: 807, mirroredHoldId: null, cx: 1106, cy: 1026, r: 13.5 }],
+    });
+
+    expect(getCreateBoardHolds({ boardName: 'woods', layoutId: 1, sizeId: 27, setIds: [1] })).toBeNull();
   });
 
   it('returns null when render data is unavailable', () => {

--- a/packages/mobile/src/lib/create-board-holds.ts
+++ b/packages/mobile/src/lib/create-board-holds.ts
@@ -1,5 +1,7 @@
 import type { BoardName } from '@boardsesh/shared-schema';
 import type { BoardEdges } from '@boardsesh/climb-filters';
+import { WOODS_OCCUPIED_HOLD_IDS } from '@boardsesh/board-constants/woods';
+import { woodsSizeIdToDimension } from '@boardsesh/board-config';
 import { getBoardRenderData } from './board-details';
 
 /**
@@ -56,10 +58,76 @@ function resolveCreateBoardFamily(boardName: BoardName): CreateBoardFamily {
   return 'aurora';
 }
 
+const woodsOccupiedIdsBySizeId = new Map<number, ReadonlySet<number>>();
+
 /**
- * Resolve the full set of tappable holds for a board configuration, board-family
+ * The mounting slots of a Woods size that actually carry a hold, as a lookup
+ * set, or `null` for a size id that is not a Woods board.
+ *
+ * A Woods hold id is a slot — a T-nut — and roughly a fifth of them carry no
+ * hold: 106 of the 485 slots on the 8x10, 169 of the 894 on the 12x12. The
+ * geometry tables deliberately keep every slot (a frames string may name any of
+ * them, and the renderer falls back to a ring for one it has no silhouette for),
+ * so `WOODS_OCCUPIED_HOLD_IDS` is the only thing that separates a hold you can
+ * pull on from a bare bolt hole. Aurora and MoonBoard need no equivalent: their
+ * placements are holds.
+ *
+ * Memoized per size id — the tables are static, and this runs on the
+ * drawer-open path.
+ */
+function woodsOccupiedHoldIds(sizeId: number): ReadonlySet<number> | null {
+  const cached = woodsOccupiedIdsBySizeId.get(sizeId);
+  if (cached) return cached;
+
+  const dimension = woodsSizeIdToDimension(sizeId);
+  if (!dimension) return null;
+
+  const occupied = new Set(WOODS_OCCUPIED_HOLD_IDS[dimension]);
+  woodsOccupiedIdsBySizeId.set(sizeId, occupied);
+  return occupied;
+}
+
+type BoardRenderData = NonNullable<ReturnType<typeof getBoardRenderData>>;
+
+/**
+ * Narrow a board's render geometry to the holds an editor may make interactive.
+ *
+ * Only Woods narrows anything: an empty mounting slot must never become a tap
+ * target. A dot painted on bare plywood reads as a hold that isn't there
+ * (boardsesh/boardsesh#5185), and its hit circle sits in the same nearest-centre
+ * partition as the real holds, so it also steals taps aimed at the hold beside
+ * it. A size id that is not one of the two Woods boards means the caller
+ * resolved this config against some other board: report no holds at all, the way
+ * `getWoodsRenderData` rejects a foreign layout id rather than drawing a
+ * plausible-looking wall.
+ */
+function buildCreateBoardHolds(cfg: CreateBoardHoldsConfig, data: BoardRenderData): CreateBoardHolds | null {
+  const family = resolveCreateBoardFamily(cfg.boardName);
+
+  let holdsData = data.holdsData;
+  if (family === 'woods') {
+    const occupiedHoldIds = woodsOccupiedHoldIds(cfg.sizeId);
+    if (!occupiedHoldIds) return null;
+    holdsData = holdsData.filter((hold) => occupiedHoldIds.has(hold.id));
+  }
+
+  return {
+    holdTargets: holdsData.map((hold) => ({ id: hold.id, cx: hold.cx, cy: hold.cy, r: hold.r })),
+    boardWidth: data.boardWidth,
+    boardHeight: data.boardHeight,
+    edgeLeft: data.edgeLeft,
+    edgeRight: data.edgeRight,
+    edgeBottom: data.edgeBottom,
+    edgeTop: data.edgeTop,
+    family,
+  };
+}
+
+/**
+ * Resolve the set of tappable holds for a board configuration, board-family
  * agnostic. Aurora boards come from the hole-placement pipeline; MoonBoard and
- * Woods come from their code-driven render-data branches.
+ * Woods come from their code-driven render-data branches. Woods is then narrowed
+ * to the slots that actually carry a hold — see {@link buildCreateBoardHolds}.
  */
 export function getCreateBoardHolds(cfg: CreateBoardHoldsConfig): CreateBoardHolds | null {
   const cacheKey = createBoardHoldsCacheKey(cfg);
@@ -71,18 +139,7 @@ export function getCreateBoardHolds(cfg: CreateBoardHoldsConfig): CreateBoardHol
   }
 
   const data = getBoardRenderData(cfg);
-  const result = data
-    ? {
-        holdTargets: data.holdsData.map((hold) => ({ id: hold.id, cx: hold.cx, cy: hold.cy, r: hold.r })),
-        boardWidth: data.boardWidth,
-        boardHeight: data.boardHeight,
-        edgeLeft: data.edgeLeft,
-        edgeRight: data.edgeRight,
-        edgeBottom: data.edgeBottom,
-        edgeTop: data.edgeTop,
-        family: resolveCreateBoardFamily(cfg.boardName),
-      }
-    : null;
+  const result = data ? buildCreateBoardHolds(cfg, data) : null;
 
   if (createBoardHoldsCache.size >= CREATE_BOARD_HOLDS_CACHE_LIMIT) {
     const oldestKey = createBoardHoldsCache.keys().next().value;


### PR DESCRIPTION
## Summary

Closes #5185.

On Woods, a hold id names a **mounting slot** (a T-nut), not a hold — and a fifth of them
carry no hold at all: 106 of the 8×10's 485, 169 of the 12×12's 894. The create-climb board
drew a discoverability dot on every slot and made every slot tappable, so the reporter saw
grey circles floating on bare plywood, and could paint and save a climb using a hold that
isn't on the wall.

`WOODS_OCCUPIED_HOLD_IDS` — the curated, art-verified occupancy table — already existed, but
had **zero runtime consumers**: only the silhouette tracer and tests read it. This wires it
into the two places that need it.

- `getCreateBoardHolds` narrows Woods to occupied slots. That is the single entry point for
  every surface that makes holds interactive, so it fixes the create board, the hold-filter
  and zone search boards, and the outline editor at once. Aurora and MoonBoard are untouched
  — their placements are holds.
- `parseWoodsFrames` rejects a hold id that names an empty slot, so no client (including the
  already-shipped 2.4.0 binaries) can write a phantom hold. Distinct message from the
  existing "does not exist", because a slot empty on one wall is often a hold on the other.

Deliberately **not** filtered at the geometry source. `getWoodsBoardDetails().holdsData` also
positions *lit* holds for the play renderer, wall kiosk, thumbnails and BLE cards (14
`getBoardRenderData` call sites), and the generator is explicit that empty ids stay available
to frame consumers and fall back to a ring. Existing rows are left alone: the read path is
unchanged, so a climb that already carries a phantom hold still renders.

Likely helps #4794 ("adjacent holds are circled instead of the correct one") as a side
effect: those 169 phantom targets sit in the same nearest-centre partition as the real holds
and can steal a tap from the hold beside them. Not claiming it closed without device QA.

**Author-side verification.** Regenerated the occupancy table and diffed it (byte-identical,
379 / 725 physical holds), then rendered the calibration overlay and inspected the empty
slots that measure closest to real art. Every one is a bare T-nut that a neighbouring hold
overhangs — e.g. slot 808 sits under the lip of the big 12×12 jug, with 807 and 809 beside it
real. So the table isn't hiding a hold a climber could use. `vp run typecheck:mobile`,
`typecheck:backend`, `typecheck:shared`, `vp check`, the mobile suite and the backend Woods
suites all pass.

Not indexed as a web change: the web Woods renderer has the same shape, but the web climbing
surface was retired in W-16 (#4435).

## Release Notes

- Woods: the climb creator only offers holds that are really on your wall — no more tapping bare plywood.

## Test plan

Needs a Woods board picked (both sizes if you have them).

1. Climbs → Create on a Woods 12×12.
2. Every grey dot sits on a hold.
3. Zoom into a big jug: no dots on bare wood.
4. Paint a start, hands, a finish. Save works.
5. Repeat on a Woods 8×10.

## Risk

Risk: 2/5 — client-side hold filtering plus one new server-side rejection, on a board whose authoring shipped this week. No BLE, native, or migration changes.
