### PR TITLE
fix(mobile): enable mirrored climbs on the Woods board

### DIFF
--- a/packages/shared/board-config/src/__tests__/woods-config.test.ts
+++ b/packages/shared/board-config/src/__tests__/woods-config.test.ts
@@ -174,9 +174,8 @@ describe('getWoodsBoardDetails', () => {
     expect(details.size_id).toBe(1);
     expect(details.layout_name).toBe('Original');
     expect(details.size_name).toBe(WOODS_SIZES['8x10'].name);
-    // Mirroring is not wired end-to-end (the BLE send path ignores `mirrored`),
-    // so the descriptor must not offer it — matching `boardSupportsMirroring`.
-    expect(details.supportsMirroring).toBe(false);
+    // Mirroring is wired end-to-end for Woods — matches `boardSupportsMirroring`.
+    expect(details.supportsMirroring).toBe(true);
     expect(details.boardWidth).toBe(WOODS_GEOMETRY['8x10'].width);
     expect(details.boardHeight).toBe(WOODS_GEOMETRY['8x10'].height);
     expect(details.edge_right).toBe(WOODS_GEOMETRY['8x10'].maxColumns);

--- a/packages/shared/board-config/src/woods-config.ts
+++ b/packages/shared/board-config/src/woods-config.ts
@@ -263,9 +263,9 @@ export function woodsHoldIdsInZone(sizeId: number, box: WoodsZoneBox): number[] 
  * the input location for the centre hold of an odd-width row (it mirrors to itself)
  * and undefined for a location past the board.
  *
- * Woods does not offer mirrored climbs yet (`supportsMirroring` is false below);
- * this is the geometry half of that feature, ready for the follow-up that threads
- * `mirrored` through the BLE send path.
+ * This is the geometry Woods mirroring is built on: every hold in
+ * {@link getWoodsBoardDetails}'s `holdsData` carries the result as its
+ * `mirroredHoldId`, which the BLE send path uses to build mirrored frames.
  */
 export function getWoodsMirroredHoldLocation(baseHoldLocation: number, size: WoodsBoardSize): number | undefined {
   const rowColumn = getWoodsHoldRowColumn(baseHoldLocation, size);
@@ -320,13 +320,13 @@ export function getWoodsBoardDetails({ size_id }: { size_id: number }) {
     set_names: WOODS_SETS.map((set) => set.name),
     boardWidth: geometry.width,
     boardHeight: geometry.height,
-    // Mirroring is not wired end-to-end for Woods, so don't offer it: the BLE
-    // send path ignores `mirrored` and lights the unmirrored holds, and
-    // `boardSupportsMirroring('woods', …)` already answers false. The geometry
-    // half exists — `getWoodsMirroredHoldLocation` and the `mirroredHoldId` on
-    // each hold below — so a follow-up only has to thread the flag through the
-    // send path. MoonBoard, the other code-driven board, reports false too.
-    supportsMirroring: false,
+    // Mirroring is wired end-to-end: `boardSupportsMirroring('woods', …)`
+    // answers true, and the BLE send path's board-agnostic mirrored-hold map
+    // (`convertToMirroredFramesString`) already builds itself from the
+    // `mirroredHoldId` on each hold below, computed by
+    // `getWoodsMirroredHoldLocation`. MoonBoard, the other code-driven board,
+    // still reports false — it has no mirror geometry.
+    supportsMirroring: true,
     edge_left: 0,
     edge_right: geometry.maxColumns,
     edge_bottom: 0,

--- a/packages/shared/play-view/src/__tests__/types.test.ts
+++ b/packages/shared/play-view/src/__tests__/types.test.ts
@@ -22,6 +22,10 @@ describe('boardSupportsMirroring', () => {
     expect(boardSupportsMirroring('moonboard', 1)).toBe(false);
   });
 
+  it('returns true for woods board', () => {
+    expect(boardSupportsMirroring('woods', 1)).toBe(true);
+  });
+
   it('returns true for tension with other layout ids', () => {
     expect(boardSupportsMirroring('tension', 5)).toBe(true);
     expect(boardSupportsMirroring('tension', 99)).toBe(true);

--- a/packages/shared/play-view/src/board-utils.ts
+++ b/packages/shared/play-view/src/board-utils.ts
@@ -1,7 +1,9 @@
 /**
  * Whether a board supports mirroring climbs.
- * Tension boards support mirroring (except layout 11), and Decoy boards support it.
+ * Tension boards support mirroring (except layout 11), Decoy boards support it,
+ * and Woods supports it via its own row-reflection geometry
+ * (`getWoodsMirroredHoldLocation`/`mirroredHoldId`). MoonBoard does not.
  */
 export function boardSupportsMirroring(boardName: string, layoutId: number): boolean {
-  return (boardName === 'tension' && layoutId !== 11) || boardName === 'decoy';
+  return (boardName === 'tension' && layoutId !== 11) || boardName === 'decoy' || boardName === 'woods';
 }

--- a/packages/web/app/components/climb-card/__tests__/ascent-status.test.tsx
+++ b/packages/web/app/components/climb-card/__tests__/ascent-status.test.tsx
@@ -255,6 +255,49 @@ describe('AscentStatus', () => {
     expect(screen.getByTestId('ascent-badge-mirrored').getAttribute('data-status')).toBe('flash');
   });
 
+  it('renders separate mirrored and regular statuses on Woods, same as Tension', () => {
+    renderWithLogbook({
+      boardName: 'woods',
+      logbook: [
+        {
+          uuid: '1',
+          climb_uuid: 'climb-1',
+          angle: 40,
+          is_mirror: false,
+          tries: 2,
+          quality: null,
+          difficulty: null,
+          comment: '',
+          climbed_at: '2025-01-01T00:00:00.000Z',
+          is_ascent: true,
+          status: 'send',
+          upvotes: 0,
+          downvotes: 0,
+          commentCount: 0,
+        },
+        {
+          uuid: '2',
+          climb_uuid: 'climb-1',
+          angle: 40,
+          is_mirror: true,
+          tries: 1,
+          quality: null,
+          difficulty: null,
+          comment: '',
+          climbed_at: '2025-01-02T00:00:00.000Z',
+          is_ascent: true,
+          status: 'flash',
+          upvotes: 0,
+          downvotes: 0,
+          commentCount: 0,
+        },
+      ],
+    });
+
+    expect(screen.getByTestId('ascent-badge').getAttribute('data-status')).toBe('send');
+    expect(screen.getByTestId('ascent-badge-mirrored').getAttribute('data-status')).toBe('flash');
+  });
+
   it('renders the badge immediately from accumulated logbook cache updates without a refetch', async () => {
     mockRequest.mockResolvedValue({ ticks: [] });
 

--- a/packages/web/app/components/climb-card/ascent-status.tsx
+++ b/packages/web/app/components/climb-card/ascent-status.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo } from 'react';
 import type { LogbookEntry } from '@boardsesh/board-react';
+import { boardSupportsMirroring } from '@boardsesh/play-view';
 import { AscentStatusIcon } from '@/app/components/ascent-status/ascent-status-icon';
 import {
   normalizeAscentStatus,
@@ -22,6 +23,10 @@ type AscentStatusProps = {
   logbook?: readonly LogbookEntry[];
   /** Board being viewed; decides whether mirrored ticks get their own badge. */
   boardName?: BoardName;
+  /** Layout on that board — only matters for Tension's non-mirroring layout 11.
+   *  Omit when the caller doesn't have it; every other board/layout mirrors
+   *  the same regardless. */
+  layoutId?: number;
   fontSize?: number;
   /** Class for the badge wrapper (e.g. positioning on a thumbnail).
    *  For mirroring boards this is applied to each individual badge. */
@@ -49,6 +54,7 @@ export const AscentStatus = ({
   // 'kilter' keeps the pre-props behaviour for a caller that has no board in
   // hand: a non-mirroring board, so one badge.
   boardName = 'kilter',
+  layoutId,
   fontSize,
   className,
   mirroredClassName,
@@ -69,7 +75,9 @@ export const AscentStatus = ({
     () => getHighestStatus(ascentsForClimb.filter(({ is_mirror }) => is_mirror)),
     [ascentsForClimb],
   );
-  const supportsMirroring = boardName === 'tension' || boardName === 'decoy' || boardName === 'woods';
+  // layoutId only matters for Tension's non-mirroring layout 11; a caller
+  // without it (no layout in scope) gets the common case for every board.
+  const supportsMirroring = boardSupportsMirroring(boardName, layoutId ?? 1);
 
   if (supportsMirroring) {
     if (!regularStatus && !mirroredStatus) return null;

--- a/packages/web/app/components/climb-card/ascent-status.tsx
+++ b/packages/web/app/components/climb-card/ascent-status.tsx
@@ -69,7 +69,7 @@ export const AscentStatus = ({
     () => getHighestStatus(ascentsForClimb.filter(({ is_mirror }) => is_mirror)),
     [ascentsForClimb],
   );
-  const supportsMirroring = boardName === 'tension' || boardName === 'decoy';
+  const supportsMirroring = boardName === 'tension' || boardName === 'decoy' || boardName === 'woods';
 
   if (supportsMirroring) {
     if (!regularStatus && !mirroredStatus) return null;

--- a/packages/web/app/components/climb-list/static-climb-row.tsx
+++ b/packages/web/app/components/climb-list/static-climb-row.tsx
@@ -118,6 +118,7 @@ const StaticClimbRow = ({
           angle={climb.angle}
           logbook={logbook}
           boardName={boardDetails.board_name}
+          layoutId={boardDetails.layout_id}
           fontSize={12}
           className={ascentStyles.badge}
           mirroredClassName={ascentStyles.badgeMirrored}


### PR DESCRIPTION
## Summary

Woods board climbs couldn't be mirrored — no toggle to display or log a mirror ascent, unlike Tension/Decoy (#4795). The geometry for Woods mirroring already existed (`getWoodsMirroredHoldLocation`, `mirroredHoldId` on every hold, from #3306) but was never turned on (#4754):

- `boardSupportsMirroring()` in `packages/shared/play-view/src/board-utils.ts` hardcoded `tension`/`decoy` only.
- `getWoodsBoardDetails()` in `packages/shared/board-config/src/woods-config.ts` hardcoded `supportsMirroring: false`.
- A duplicate hardcoded check in `packages/web/app/components/climb-card/ascent-status.tsx` (regular vs. mirrored ascent badge) also didn't know about Woods.

Both the BLE mirrored-frame builder (`convertToMirroredFramesString` in `packages/mobile/src/lib/ble/use-board-bluetooth.ts`) and the ascent-status badge already build their mirrored-hold maps generically from each hold's `mirroredHoldId` — no board-specific logic needed there. So this change is just flipping the three flags above; no BLE send-path code changed.

**Note for reviewers:** per `CLAUDE.md`, changes touching Bluetooth send behavior need a Fable or Astra review before merge — flagging this because it unlocks a new code path in `use-board-bluetooth.ts`'s existing mirrored-send branch, even though the diff itself doesn't touch BLE files.

Verified locally: `vp check` (0 errors), `vp run typecheck` (repo-wide, green), `vp test run --project board-config --project play-view` (487 tests), `vp test run --project web` (4514 tests), `vp test run --project mobile` (8451 tests) — all green.

## Release Notes

- Mirror your Woods board climbs — toggle Mirror in the play drawer to light and log a mirrored send, same as Tension.

## Test plan

1. Needs a Woods board connected over Bluetooth, and a Woods climb open.
2. Tap the Mirror icon → wall lights the flipped holds, not the original.
3. Log the ascent as mirrored → logbook shows a separate mirrored badge.

## Risk

Risk: 5/5 — enables an existing BLE mirrored-send code path for a new board; needs a Fable/Astra review before merge.

Closes #4795
Closes #4754

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hrgnf7tAXhLFneHUiuVCvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hrgnf7tAXhLFneHUiuVCvr)_