### PR TITLE
fix(mobile): schedule board renders so the play board stops waiting behind thumbnails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,7 @@ For any list, provider, gesture, or board-art change, confirm:
 - **Provider value memoized & state/actions split?** Context `value` is `useMemo`'d; a volatile array (logbook, reducer state, roster) is not bundled with the stable callbacks consumers depend on. Enforced for `packages/mobile/**` + `packages/shared/**` by `react/jsx-no-constructed-context-values` (error).
 - **Per-row hook O(1)?** Reads a pre-built index (`Map`), never `array.filter`/scan per row.
 - **Worklet `runOnJS` gated?** No `runOnJS(setState)` per frame — gate on a value change; mirror read JS values into shared values instead of listing them in the gesture `useMemo` deps.
+- **Board overlay requested through the scheduler?** New board surfaces use `useNativeClimbRender`; `playSurface` only on the climber's current board; nothing calls `renderHoldsOverlay` directly.
 - **New effect bounded?** No unbounded `loadMore` loops or per-frame state churn.
 
 Full rationale + repo examples: `docs/react-native-performance.md`.

--- a/docs/board-render-analytics.md
+++ b/docs/board-render-analytics.md
@@ -257,13 +257,26 @@ stuck, not just slow. If the timer fires, the event carries `stall_state`:
 
 **Observation only, play-board only**, like the paint watchdog: the render is
 never abandoned or retried, and a thumbnail or preview card would arm one of
-these per row for no reason. It counts toward `failures_this_session` the same
-as `paint_timeout`.
+these per row for no reason. It lives under `stage: 'native'` because that is
+the stage being waited on, even when `stall_state` says the wait is still in
+our own queue.
 
-### Two session caps, not one
+A stall is late, not failed, so it has its own budget of 10 events per JS
+lifetime and does NOT advance `failures_this_session` (it reports the running
+count as it stands). A throttled phone can be late on every swipe of a long
+session; sharing the 25-event budget would let one slow evening silence the
+genuine failures that follow, and sharing the counter would make a slow
+session read as a broken one. Two more guards: `ms_waiting` counts from when
+the request was FIRST asked for (a joined request inherits the first asker's
+clock), and a timer that lands more than 10 s past its schedule is dropped,
+because iOS suspends JS with the app and a watchdog armed just before
+backgrounding would otherwise report the whole background stretch as a stall.
+
+### Three session caps, not one
 
 The hook counts every failure in a module-scoped counter and stops firing after
-25 per JS lifetime — with the config stage on its own separate budget of 10.
+25 per JS lifetime — with the config stage on its own separate budget of 10,
+and `render_stalled` on a third budget of 10 (see the stall watchdog above).
 
 The split is load-bearing. A config mismatch is a property of a climb-and-board
 pair, so a board whose sets do not cover a climb's holds produces one on every

--- a/docs/board-render-analytics.md
+++ b/docs/board-render-analytics.md
@@ -49,7 +49,7 @@ event's name.
 | `Board Render Preset Applied`  | `surface` (`'settings'` \| `'onboarding'`, optional) — otherwise the common props ARE the event | `trackBoardLookApplied` in `packages/mobile/src/lib/board-render/board-look-analytics.ts`, from the board-look carousel on both its surfaces |
 | `Board Look Step Shown`        | `options_shown`                                        | The one-time board-look step (`BoardLookStep.tsx`), once per presentation |
 | `Board Look Step Resolved`     | `outcome` (`'saved'` \| `'customized'` \| `'skipped'`), `selected_option`, `cards_viewed`, `ms_to_resolve` | The same step — exactly once per Shown, including the unmount-without-choosing path |
-| `Board Render Failed`          | `surface`, `stage`, `failure_kind`, `error_code`, `render_width`, `frames_length`, `failures_this_session`, plus `lit_count` / `unmatched_count` on the config stage | `noteRenderFailure` in `packages/mobile/src/hooks/use-native-climb-render.ts` — the hold-match check before the render, the native render's `.catch` (real failures and the capability fallbacks), `reportOverlayLoadFailure` (every expo-image load failure) and the paint watchdog |
+| `Board Render Failed`          | `surface`, `stage`, `failure_kind`, `error_code`, `render_width`, `frames_length`, `failures_this_session`, plus `lit_count` / `unmatched_count` on the config stage, plus `stall_state` / `queue_depth` / `dispatched_count` / `ms_waiting` on `render_stalled` | `noteRenderFailure` in `packages/mobile/src/hooks/use-native-climb-render.ts` — the hold-match check before the render, the native render's `.catch` (real failures and the capability fallbacks), `reportOverlayLoadFailure` (every expo-image load failure), the paint watchdog, and the render stall watchdog |
 
 ### The common properties every event carries
 
@@ -97,7 +97,7 @@ had anything at all. A session where every render failed after the seventh swipe
 (the Aura 12x12 blank-overlay report) looked exactly like a session that never
 failed.
 
-It fires from four places, all in
+It fires from five places, all in
 `packages/mobile/src/hooks/use-native-climb-render.ts`:
 
 - the hold-match check, run just before the native call (see "The config stage"
@@ -106,7 +106,10 @@ It fires from four places, all in
   fallbacks that Sentry is deliberately never told about (#4240);
 - `reportOverlayLoadFailure`, the single writer behind every `onOverlayError`
   path, so a load failure cannot be handled without being counted;
-- the paint watchdog, for an overlay expo-image never answered about.
+- the paint watchdog, for an overlay expo-image never answered about;
+- the render stall watchdog, for a play-board render the JS render scheduler or
+  native itself has not answered in time (see "The render stall watchdog"
+  below).
 
 ### Properties
 
@@ -116,13 +119,17 @@ Common props (the table above) plus:
 | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `surface`               | `play` \| `full` \| `thumbnail` — see below; `play` is opt-in, not derived                                                                 |
 | `stage`                 | `config` \| `native` \| `image_load` — which part of the path gave up                                                                       |
-| `failure_kind`          | on `config`: `no_matching_holds` \| `partial_hold_match`. On `native`: `render_failed` \| `disk_full` \| `capability_fallback`. On `image_load`: `cache_entry_missing` \| `retry_exhausted` \| `cache_entry_present` \| `validation_failed` \| `validation_unsupported` \| `paint_timeout` |
-| `error_code`            | `code_<n>` \| `png` \| `cgimage` \| `write` \| `module` \| `capability` \| `no_matching_holds` \| `partial_hold_match` \| `paint_timeout` \| `other` |
+| `failure_kind`          | on `config`: `no_matching_holds` \| `partial_hold_match`. On `native`: `render_failed` \| `disk_full` \| `capability_fallback` \| `render_stalled`. On `image_load`: `cache_entry_missing` \| `retry_exhausted` \| `cache_entry_present` \| `validation_failed` \| `validation_unsupported` \| `paint_timeout` |
+| `error_code`            | `code_<n>` \| `png` \| `cgimage` \| `write` \| `module` \| `capability` \| `no_matching_holds` \| `partial_hold_match` \| `paint_timeout` \| `render_stalled` \| `other` |
 | `render_width`          | requested overlay width in pixels, or `null` for a native-width render                                                                     |
 | `frames_length`         | length of the frames string — a cheap proxy for climb complexity                                                                          |
 | `failures_this_session` | running count for this JS lifetime, INCLUDING this event                                                                                   |
 | `lit_count`             | config stage only: how many placements frame 0 lights. A count, never the ids — the ids are the climb                                     |
 | `unmatched_count`       | config stage only: how many of those the board config has no hold for                                                                     |
+| `stall_state`           | `render_stalled` only, absent elsewhere: `queued` \| `dispatched` — where the render was waiting when the watchdog fired                    |
+| `queue_depth`           | `render_stalled` only, absent elsewhere: renders waiting in the JS render scheduler, this one included when queued                          |
+| `dispatched_count`      | `render_stalled` only, absent elsewhere: renders handed to native and not yet answered                                                     |
+| `ms_waiting`            | `render_stalled` only, absent elsewhere: milliseconds since this surface asked for the render                                              |
 
 `stage` and `failure_kind` are one discriminated pair in
 `BoardRenderFailedInput`, not two free fields: a native rejection can never be
@@ -224,6 +231,35 @@ that renders correctly but never paints is a different fault from one that
 failed to load, and handling it as the latter — null the overlay, spend the
 once-per-key retry budget — is exactly what would hide it again.
 
+### The render stall watchdog
+
+Added for issue #5187: a phone in Low Power Mode could sit for seconds with no
+holds drawn, and nothing measured the stage before the paint watchdog above —
+the render request itself, waiting to be answered. Every `renderHoldsOverlay`
+call used to run on expo-modules-core's one shared serial queue, so the play
+board's render could queue behind every off-screen thumbnail a fast scroll had
+already started, and a throttled CPU stretched that wait past what anyone
+noticed.
+
+Renders now go through a JS scheduler (`packages/mobile/src/lib/board-render/render-scheduler.ts`)
+before they reach native. So the play board — `surface: 'play'` only — arms a
+6s timer when it asks for a render. 6s is well past what even a throttled
+device needs for a single overlay, so a fire means something is actually
+stuck, not just slow. If the timer fires, the event carries `stall_state`:
+
+- `'queued'` — the request is still sitting in our own JS queue. The fix is on
+  our side: shorten the queue (fewer surfaces requesting renders at once,
+  cheaper priorities) or raise the dispatch window.
+- `'dispatched'` — native already has the request and has not answered. The
+  fix is native: the `[native-train]` follow-up moves the board renderer onto
+  its own concurrent queue (and reports `renderConcurrency`, which widens the
+  scheduler's dispatch window on those binaries).
+
+**Observation only, play-board only**, like the paint watchdog: the render is
+never abandoned or retried, and a thumbnail or preview card would arm one of
+these per row for no reason. It counts toward `failures_this_session` the same
+as `paint_timeout`.
+
 ### Two session caps, not one
 
 The hook counts every failure in a module-scoped counter and stops firing after
@@ -267,6 +303,9 @@ Stratify the same way as everything else on this page: never pool across
 - `stage` × `failure_kind` × `error_code` for one board, which is what separates
   "this climb does not belong to this board" from "the renderer is rejecting"
   from "the PNG will not load back" from "iOS never painted it".
+- `Board Render Failed` broken down by `failure_kind` and `stall_state` — the
+  queued-vs-dispatched split that says whether a stall run is a queue problem
+  or a native problem.
 
 ## The builder rule
 

--- a/docs/react-native-performance.md
+++ b/docs/react-native-performance.md
@@ -219,7 +219,7 @@ gesture must resolve taps itself. Two non-obvious choices there:
 
 **Rule:** Any board-art surface that appears while scrolling, swiping, or inside always-mounted
 chrome (the list thumbnail, the play-drawer board, the accessory bar) renders through the native-PNG
-path: `useNativeClimbRender` + `LayeredClimbImage` with `cachePolicy="memory-disk"` on bundled
+path: `useNativeClimbRender` + `LayeredClimbImage` with `cachePolicy="memory"` on bundled
 assets. Do not render mobile board backgrounds through `react-native-svg` `<Image href>` or any
 remote URL.
 
@@ -228,10 +228,13 @@ and painted N `<Circle>`s in `react-native-svg` on every render, on top of a rem
 board art that should be on disk. The native path renders the holds once into a cached PNG (deduped
 by cache key, warmed from disk on launch — see the generation-tracked, 200-entry JS LRU and
 `warmupRenderedOverlaysOnce` in `use-native-climb-render.ts`) and stacks
-it over bundled background images via `expo-image` with `cachePolicy="memory-disk"`, so a scrolled-
+it over bundled background images via `expo-image` with `cachePolicy="memory"`, so a scrolled-
 past climb is an instant cache hit with zero network and zero per-row SVG work. It also satisfies
 the no-network offline rule — missing layers render as visible gray blocks rather than silently
-fetching.
+fetching. `cachePolicy="memory"`, not `"memory-disk"`: the overlay and the background are already
+files we own on disk (the native renderer's own PNG cache, and the bundled asset), so asking
+expo-image to also keep a disk copy made SDWebImage query its own disk cache and write a second
+copy of a file already on disk, on its own serial `ioQueue` — pure duplicate I/O (issue #5187).
 
 The JS LRU is only a fast-path hint; native cache pruning or the OS can remove a PNG after warm-up.
 If expo-image reports an overlay load failure, the hook validates that exact managed file URI. A
@@ -267,7 +270,7 @@ surface the previous size's bundled background paths.
 **Examples in this repo:**
 
 - Warm path (use this): `packages/mobile/src/hooks/use-native-climb-render.ts` +
-  `packages/mobile/src/components/LayeredClimbImage.tsx` (`cachePolicy="memory-disk"`), wired up in
+  `packages/mobile/src/components/LayeredClimbImage.tsx` (`cachePolicy="memory"`), wired up in
   `packages/mobile/src/components/ClimbListThumbnail.tsx` and `BoardImageNative.tsx`.
 - Static diagrams should still avoid network board art. Use bundled background paths through
   `background-image-cache.ts` or draw diagram-only shapes; the old `react-native-svg` background
@@ -339,6 +342,26 @@ real risk; the OOM actually reproduces on 4 GB iPhones.
   `packages/mobile/src/hooks/use-image-cache-memory-management.ts` — the cache ceiling.
 - `packages/mobile/modules/memory-trim/` (Android-only) — native Glide full-clear at
   `TRIM_MEMORY_UI_HIDDEN`; policy in `MemoryTrimPolicy.kt`, activation import in `app/_layout.tsx`.
+
+---
+
+## 8. Board renders go through the render scheduler
+
+**Rule:** Any surface that draws a board overlay requests it through `useNativeClimbRender`
+(which calls `requestRender`), never the native module directly. Pass `playSurface: true` only for
+the one board the climber is actually looking at — never a preview card, a rail, or the carousel's
+off-screen peek. Never hold a render request past your effect's cleanup.
+
+**Why:** `renderHoldsOverlay` runs on expo-modules-core's one shared serial queue per platform, so
+every render — play board, carousel peek, every FlashList thumbnail — used to queue behind whatever
+was already running, and a scrolled-past row never gave its slot back. On a phone in Low Power Mode
+that stretched the wait for the board a climber was staring at from a fraction of a second to
+several seconds, and nothing measured it (issue #5187). `render-scheduler.ts`
+(`packages/mobile/src/lib/board-render/render-scheduler.ts`) now queues renders in JS, orders them
+`play` > `full` > `thumbnail`, and drops a request the moment its last consumer stops wanting it —
+but only if every caller goes through it. A play-board render that is still waiting after 6s fires
+the `render_stalled` event (`docs/board-render-analytics.md`), which is how to tell whether a slow
+render is stuck in our queue or stuck in native.
 
 ---
 

--- a/packages/mobile/modules/board-renderer/src/index.ts
+++ b/packages/mobile/modules/board-renderer/src/index.ts
@@ -21,6 +21,12 @@ type BoardRendererNativeModule = {
   renderHoldsOverlayWithMarkers?(configJson: string, cacheKey: string): Promise<string>;
   renderHoldsOverlay?(configJson: string, cacheKey: string): Promise<string>;
   renderComposite?(configJson: string, backgroundPaths: string[], cacheKey: string): Promise<string>;
+  /**
+   * How many renders the binary can run at once — a `Constants` entry on
+   * binaries whose renderer has its own concurrent queue. Absent on binaries
+   * that still render on Expo's shared serial queue.
+   */
+  renderConcurrency?: number;
 };
 
 // requireOptionalNativeModule returns null (silently) when the module
@@ -30,6 +36,18 @@ type BoardRendererNativeModule = {
 // module 'BoardRenderer'` error in the JS console even though the
 // hook's fallback path handles it gracefully.
 export const boardRendererNative = requireOptionalNativeModule<BoardRendererNativeModule>('BoardRenderer');
+
+/**
+ * Renders the installed binary can run at once. 1 for every binary that renders
+ * on Expo's shared serial `AsyncFunction` queue (the store fleet at the time of
+ * issue #5187); a binary with its own concurrent render queue says so through
+ * the `renderConcurrency` constant. The JS render scheduler sizes its dispatch
+ * window from this.
+ */
+export function getNativeRenderConcurrency(): number {
+  const reported = boardRendererNative?.renderConcurrency;
+  return typeof reported === 'number' && Number.isFinite(reported) && reported >= 1 ? Math.floor(reported) : 1;
+}
 export const MARKER_RENDERER_UNAVAILABLE_MESSAGE =
   'Marker shape, size, and brush overrides require a rebuilt BoardRenderer native binary';
 export const BOARDSESH_RENDERER_UNAVAILABLE_MESSAGE =

--- a/packages/mobile/modules/board-renderer/src/index.web.ts
+++ b/packages/mobile/modules/board-renderer/src/index.web.ts
@@ -45,6 +45,15 @@ import {
 // no native module object to mirror on web.
 export const boardRendererNative: { readonly platform: 'web' } = { platform: 'web' };
 
+/**
+ * The browser renders through WASM on the JS thread; one render at a time is
+ * all that can happen anyway. Mirrors the native wrapper's export so the JS
+ * render scheduler sizes itself the same way on every platform.
+ */
+export function getNativeRenderConcurrency(): number {
+  return 1;
+}
+
 export const MARKER_RENDERER_UNAVAILABLE_MESSAGE =
   'Marker shape, size, and brush overrides require a rebuilt BoardRenderer native binary';
 

--- a/packages/mobile/src/components/LayeredClimbImage.tsx
+++ b/packages/mobile/src/components/LayeredClimbImage.tsx
@@ -204,7 +204,14 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
           source={{ uri: backgroundImageUri(path) }}
           style={styles.layer}
           contentFit="contain"
-          cachePolicy="memory-disk"
+          // `memory`, not `memory-disk`: every layer in this stack is already a
+          // file on disk that we own (bundled board photos, the renderer's
+          // overlay PNGs). `memory-disk` made SDWebImage look the file up in
+          // ITS disk cache and then write a second copy there, on a serial I/O
+          // queue shared with every other image — duplicate work that piled up
+          // on a throttled CPU (issue #5187). A memory miss re-reads our file,
+          // which is exactly what the disk copy would have done.
+          cachePolicy="memory"
           // Skip expo-image's main-thread downscale resample (the iOS app
           // hang). Sources are already sized to the surface — thumb-variant
           // backgrounds for the list, native-res for the play view — so
@@ -239,7 +246,7 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
           source={{ uri: bridgeOverlay }}
           style={styles.layer}
           contentFit="contain"
-          cachePolicy="memory-disk"
+          cachePolicy="memory"
           transition={0}
           allowDownscaling={false}
           pointerEvents="none"
@@ -255,7 +262,7 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
           style={styles.layer}
           contentFit="contain"
           recyclingKey={recyclingKey}
-          cachePolicy="memory-disk"
+          cachePolicy="memory"
           // Forced instant while retaining: a hold erased on this tap would
           // otherwise stay visible on the bridge layer for the whole fade.
           transition={suppressOverlayTransition || retainPreviousOverlayFor != null ? 0 : 150}

--- a/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
+++ b/packages/mobile/src/components/__tests__/layered-climb-image.test.tsx
@@ -23,6 +23,7 @@ vi.mock('expo-image', () => ({
     testID,
     transition,
     recyclingKey,
+    cachePolicy,
     onLoad,
     onError,
   }: {
@@ -30,6 +31,7 @@ vi.mock('expo-image', () => ({
     testID?: string;
     transition?: number;
     recyclingKey?: string;
+    cachePolicy?: string;
     onLoad?: () => void;
     onError?: (event: { error: string }) => void;
   }) => {
@@ -39,6 +41,7 @@ vi.mock('expo-image', () => ({
       'data-testid': testID ?? 'expo-image',
       'data-transition': transition,
       'data-recycling-key': recyclingKey,
+      'data-cache-policy': cachePolicy,
       onLoad,
       onError: () => onError?.({ error: 'mock image failure' }),
     });
@@ -305,6 +308,24 @@ describe('LayeredClimbImage', () => {
     );
 
     expect(container.querySelector('[data-testid="layered-climb-image-empty-fallback"]')).toBeNull();
+  });
+
+  // Issue #5187: every layer here is already a file we own — a bundled board
+  // photo or the renderer's own overlay PNG. `memory-disk` made SDWebImage look
+  // each one up in ITS disk cache and then write a second copy there, on a
+  // serial I/O queue shared with every other image on screen.
+  it('caches every layer in memory only, never writing a second copy to disk', () => {
+    const { container } = render(
+      createElement(LayeredClimbImage, {
+        overlayUri: 'file:///overlay.png',
+        backgroundPaths: ['/bundled/kilter.webp'],
+      }),
+    );
+
+    expect(container.querySelector('img[src="file:///overlay.png"]')?.getAttribute('data-cache-policy')).toBe('memory');
+    expect(container.querySelector('img[src="file:///bundled/kilter.webp"]')?.getAttribute('data-cache-policy')).toBe(
+      'memory',
+    );
   });
 
   it('cross-fades the holds overlay by default', () => {

--- a/packages/mobile/src/components/playlist/PlaylistBoardBackdrop.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistBoardBackdrop.tsx
@@ -68,7 +68,9 @@ function PlaylistBoardBackdropImpl({ boardType, layoutId }: PlaylistBoardBackdro
       style={[StyleSheet.absoluteFill, styles.image]}
       contentFit="cover"
       blurRadius={12}
-      cachePolicy="memory-disk"
+      // The source is a bundled file we already have on disk; see the
+      // LayeredClimbImage note for why the expo-image disk copy is skipped.
+      cachePolicy="memory"
       transition={0}
       // Decorative backdrop from a small thumb source — no main-thread resize.
       allowDownscaling={false}

--- a/packages/mobile/src/components/queue-control/AccessoryClimbThumbnail.tsx
+++ b/packages/mobile/src/components/queue-control/AccessoryClimbThumbnail.tsx
@@ -42,7 +42,7 @@ function getAccessoryThumbnailBoardSize(boardWidth: number, boardHeight: number,
  * board config or render data isn't available.
  *
  * Uses the rasterized native-PNG path (BoardImageNative -> useNativeClimbRender
- * + LayeredClimbImage, `cachePolicy="memory-disk"` over bundled `file://`
+ * + LayeredClimbImage, `cachePolicy="memory"` over bundled `file://`
  * backgrounds) — the same warm path the list thumbnails use. The accessory bar
  * is always mounted and re-renders on every queue swipe, so the cheap cached-PNG
  * path matters here.

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
@@ -115,6 +115,7 @@ const {
   _setNativeModuleForTests,
   _RENDER_FAILURE_EVENT_CAP_FOR_TESTS,
   _CONFIG_FAILURE_EVENT_CAP_FOR_TESTS,
+  _STALL_EVENT_CAP_FOR_TESTS,
   _MARKER_RENDERER_UNAVAILABLE_MESSAGE_FOR_TESTS,
 } = await import('../use-native-climb-render');
 
@@ -791,13 +792,21 @@ describe('the per-lifetime event caps', () => {
 // wait, was the render sitting in OUR queue behind other surfaces, or inside
 // native? The two call for opposite fixes.
 describe('the render stall watchdog', () => {
-  /** Resolvers for renders the native fake has been asked for, by cache key. */
-  const stalledRenders = new Map<string, ((uri: string) => void)[]>();
+  /** Settlers for renders the native fake has been asked for, by cache key. */
+  const stalledRenders = new Map<string, { resolve: (uri: string) => void; reject: (error: Error) => void }[]>();
 
-  function resolveStalledRender(cacheKey: string, uri: string): void {
+  function takeStalledRender(cacheKey: string) {
     const pending = stalledRenders.get(cacheKey)?.shift();
     if (!pending) throw new Error(`No pending render for ${cacheKey}`);
-    pending(uri);
+    return pending;
+  }
+
+  function resolveStalledRender(cacheKey: string, uri: string): void {
+    takeStalledRender(cacheKey).resolve(uri);
+  }
+
+  function rejectStalledRender(cacheKey: string, message: string): void {
+    takeStalledRender(cacheKey).reject(new Error(message));
   }
 
   type StallProperties = FailureProperties & {
@@ -820,9 +829,9 @@ describe('the render stall watchdog', () => {
     // field report, where the play board's overlay simply never arrived.
     fakeNativeModule.renderHoldsOverlay.mockImplementation(
       (_configJson: string, cacheKey: string) =>
-        new Promise<string>((resolve) => {
+        new Promise<string>((resolve, reject) => {
           const pendingForKey = stalledRenders.get(cacheKey) ?? [];
-          pendingForKey.push(resolve);
+          pendingForKey.push({ resolve, reject });
           stalledRenders.set(cacheKey, pendingForKey);
         }),
     );
@@ -963,5 +972,79 @@ describe('the render stall watchdog', () => {
     expect(failureEvents()).toHaveLength(0);
     expect(addErrorBreadcrumbMock).not.toHaveBeenCalled();
     expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  // A stall is a render that is LATE, not one that failed. If it advanced
+  // `failures_this_session`, a slow evening on a throttled phone would read in
+  // every dashboard exactly like a device whose renderer is broken.
+  it('does not count a stall as a failure of the session', async () => {
+    renderRow({ playSurface: true });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000);
+    });
+    expect(stallEvents()).toHaveLength(1);
+    expect(stallEvents()[0].failures_this_session).toBe(0);
+
+    // The stalled render finally lands; a second row then fails for real.
+    await act(async () => {
+      resolveStalledRender(cacheKeyFor(FRAMES), 'file:///overlay-late.png');
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    renderRow({ frames: OTHER_FRAMES });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+      rejectStalledRender(cacheKeyFor(OTHER_FRAMES), 'Rust render failed with code -2');
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const realFailures = failureEvents().filter((event) => event.failure_kind === 'render_failed');
+    expect(realFailures).toHaveLength(1);
+    // The first real failure of the session is the first, stall or no stall.
+    expect(realFailures[0].failures_this_session).toBe(1);
+    // And a real rejection knows nothing about a queue position, so those keys
+    // must be absent rather than present as a meaningless zero-length wait.
+    const realFailureProperties = realFailures[0] as StallProperties;
+    expect('stall_state' in realFailureProperties).toBe(false);
+    expect('queue_depth' in realFailureProperties).toBe(false);
+    expect('dispatched_count' in realFailureProperties).toBe(false);
+    expect('ms_waiting' in realFailureProperties).toBe(false);
+  });
+
+  it('spends its own budget on stalls and leaves the failure budget alone', async () => {
+    const stallCap = _STALL_EVENT_CAP_FOR_TESTS;
+    // One play row per distinct climb — a long session of swipes on a phone
+    // whose renders are all late.
+    const stalledFrames = Array.from({ length: stallCap + 1 }, (_, index) => `p${2000 + index}r12`);
+    for (const frames of stalledFrames) renderRow({ playSurface: true, frames });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000);
+    });
+
+    expect(stallEvents()).toHaveLength(stallCap);
+
+    // The one dispatched render rejects for real. Its event still gets through:
+    // the 25-event failure budget was never touched by the stalls.
+    await act(async () => {
+      rejectStalledRender(cacheKeyFor(stalledFrames[0]), 'Rust render failed with code -2');
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(failureEvents().filter((event) => event.failure_kind === 'render_failed')).toHaveLength(1);
+  });
+
+  // iOS suspends JS with the app, so a watchdog armed just before backgrounding
+  // fires on resume with the whole background stretch as its wait. That is a
+  // sleeping phone, not a slow render, and reporting it would drown the signal.
+  it('says nothing about a timer that only fired because the app came back', async () => {
+    renderRow({ playSurface: true });
+
+    // The app is suspended for 20s: the wall clock moves, the JS thread does not.
+    vi.setSystemTime(new Date(Date.now() + 20_000));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000);
+    });
+
+    expect(stallEvents()).toHaveLength(0);
   });
 });

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
@@ -97,7 +97,10 @@ const renderRejection = vi.hoisted(() => ({ message: 'Rust render failed with co
 
 const fakeNativeModule = {
   boardRendererNative: {},
-  renderHoldsOverlay: vi.fn((_configJson: string, _cacheKey: string) =>
+  // Typed rather than inferred: the default implementation only ever rejects,
+  // so an inferred `Promise<never>` would reject any suite that installs a
+  // render which actually resolves (or never settles at all).
+  renderHoldsOverlay: vi.fn<(configJson: string, cacheKey: string) => Promise<string>>(() =>
     Promise.reject(new Error(renderRejection.message)),
   ),
 };
@@ -774,5 +777,191 @@ describe('the per-lifetime event caps', () => {
     // so a stream that stops at the cap reads as truncated rather than as a
     // device that failed exactly `cap` times.
     expect(failureEvents().at(-1)?.failures_this_session).toBe(cap);
+  });
+});
+
+// Issue #5187: the render that never comes back. Every board surface used to
+// hand its render straight to Expo's shared serial queue, so a fast scroll
+// queued one native render per row and the play board a climber then opened
+// waited behind all of them — for minutes, on a Low Power Mode CPU. Nothing
+// measured it: the only render telemetry starts once the overlay <Image>
+// mounts, and an overlay that is never produced never mounts one.
+//
+// The watchdog answers the question that investigation could not: after a fixed
+// wait, was the render sitting in OUR queue behind other surfaces, or inside
+// native? The two call for opposite fixes.
+describe('the render stall watchdog', () => {
+  /** Resolvers for renders the native fake has been asked for, by cache key. */
+  const stalledRenders = new Map<string, ((uri: string) => void)[]>();
+
+  function resolveStalledRender(cacheKey: string, uri: string): void {
+    const pending = stalledRenders.get(cacheKey)?.shift();
+    if (!pending) throw new Error(`No pending render for ${cacheKey}`);
+    pending(uri);
+  }
+
+  type StallProperties = FailureProperties & {
+    stall_state?: string;
+    queue_depth?: number;
+    dispatched_count?: number;
+    ms_waiting?: number;
+  };
+
+  function stallEvents(): StallProperties[] {
+    return failureEvents().filter((event) => event.failure_kind === 'render_stalled');
+  }
+
+  const OTHER_FRAMES = 'p1500r12p1600r13';
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stalledRenders.clear();
+    // A render that answers only when this test says so — the shape of the
+    // field report, where the play board's overlay simply never arrived.
+    fakeNativeModule.renderHoldsOverlay.mockImplementation(
+      (_configJson: string, cacheKey: string) =>
+        new Promise<string>((resolve) => {
+          const pendingForKey = stalledRenders.get(cacheKey) ?? [];
+          pendingForKey.push(resolve);
+          stalledRenders.set(cacheKey, pendingForKey);
+        }),
+    );
+  });
+
+  afterEach(() => {
+    // Hand the file's default rejecting renderer back to the suites after this
+    // one; leaving a never-settling render installed would hang them.
+    fakeNativeModule.renderHoldsOverlay.mockImplementation((_configJson: string, _cacheKey: string) =>
+      Promise.reject(new Error(renderRejection.message)),
+    );
+  });
+
+  it('reports a play board whose render is still inside native after six seconds', async () => {
+    renderRow({ playSurface: true });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5999);
+    });
+    expect(stallEvents()).toHaveLength(0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    expect(stallEvents()).toHaveLength(1);
+    expect(stallEvents()[0]).toMatchObject({
+      stage: 'native',
+      failure_kind: 'render_stalled',
+      error_code: 'render_stalled',
+      surface: 'play',
+      board_name: 'kilter',
+      stall_state: 'dispatched',
+    });
+    expect(typeof stallEvents()[0].queue_depth).toBe('number');
+    expect(typeof stallEvents()[0].dispatched_count).toBe('number');
+    expect(typeof stallEvents()[0].ms_waiting).toBe('number');
+  });
+
+  // The distinction the event exists for: this render never reached native at
+  // all, so a native profile would show nothing wrong.
+  it('says a second board was waiting in our own queue, not inside native', async () => {
+    renderRow({ playSurface: true });
+    renderRow({ playSurface: true, frames: OTHER_FRAMES });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000);
+    });
+
+    expect(stallEvents().map((event) => event.stall_state)).toEqual(['dispatched', 'queued']);
+    expect(stallEvents()[1].queue_depth).toBeGreaterThanOrEqual(1);
+  });
+
+  it('stays quiet when the render lands in time', async () => {
+    renderRow({ playSurface: true });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await act(async () => {
+      resolveStalledRender(cacheKeyFor(FRAMES), 'file:///overlay-in-time.png');
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(stallEvents()).toHaveLength(0);
+  });
+
+  // Twelve call sites render a board at full size and none of them opts in —
+  // a stalled thumbnail is the queue working as designed, not a defect.
+  it('never watches a surface that did not opt in', async () => {
+    renderRow();
+    renderRow({ filledStyle: true, frames: OTHER_FRAMES });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000);
+    });
+
+    expect(stallEvents()).toHaveLength(0);
+  });
+
+  it('drops the watch when the climber swipes to another climb', async () => {
+    const { rerender } = renderHook(({ frames }) => useNativeClimbRender({ ...BASE, frames, playSurface: true }), {
+      initialProps: { frames: FRAMES },
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    rerender({ frames: OTHER_FRAMES });
+
+    // The first climb's watchdog was due at t=6000 and the second's at t=9000.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5999);
+    });
+    expect(stallEvents()).toHaveLength(0);
+
+    // Exactly one watch per mounted key — the new one, on its own schedule.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(stallEvents()).toHaveLength(1);
+  });
+
+  it('reports nothing at all once the surface unmounts', async () => {
+    const { unmount } = renderRow({ playSurface: true });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(stallEvents()).toHaveLength(0);
+    expect(addErrorBreadcrumbMock).not.toHaveBeenCalled();
+  });
+
+  // The whole point of queueing in JS rather than in native: a row the climber
+  // scrolled past takes its render back with it.
+  it('never asks native for a queued render whose surface went away first', async () => {
+    renderRow({ playSurface: true });
+    const scrolledAway = renderRow({ frames: OTHER_FRAMES, filledStyle: true });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+
+    scrolledAway.unmount();
+    await act(async () => {
+      resolveStalledRender(cacheKeyFor(FRAMES), 'file:///overlay-play.png');
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // The freed slot found nothing to take: the withdrawn request was dropped
+    // rather than run for a row nobody is looking at.
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+    expect(failureEvents()).toHaveLength(0);
+    expect(addErrorBreadcrumbMock).not.toHaveBeenCalled();
+    expect(reportErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
@@ -523,6 +523,71 @@ describe('useNativeClimbRender in-flight race', () => {
     expect(JSON.stringify(reportErrorMock.mock.calls)).not.toContain(overlayUri);
     expect(JSON.stringify(reportErrorMock.mock.calls)).not.toContain(cacheKey);
   });
+
+  // Issue #5187: renders wait in JS now, where a surface can take one back.
+  // Before this, a row that scrolled past still had its render run — inside
+  // Expo's shared serial queue, ahead of the board the climber went on to open.
+  it('drops a queued render when its consumer moves on to a cached climb', async () => {
+    const dispatchedFrames = 'p1100r12';
+    const queuedFrames = 'p1200r13';
+    const abandonedFrames = 'p1500r13';
+    _cacheRenderedOverlayForTests(cacheKeyFor(FRAMES_CACHED), 'file:///overlay-cached.png');
+
+    renderHook(() => useNativeClimbRender({ ...BASE, frames: dispatchedFrames }));
+    renderHook(() => useNativeClimbRender({ ...BASE, frames: queuedFrames }));
+    const scrollingRow = renderHook((props: { frames: string }) => useNativeClimbRender({ ...BASE, ...props }), {
+      initialProps: { frames: abandonedFrames },
+    });
+
+    // One slot, so only the first row is inside native.
+    await waitFor(() => expect(pendingRenders.has(cacheKeyFor(dispatchedFrames))).toBe(true));
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+
+    // The third row is recycled onto a climb whose overlay is already on disk,
+    // so its queued render is withdrawn and nothing replaces it.
+    scrollingRow.rerender({ frames: FRAMES_CACHED });
+    await waitFor(() => expect(scrollingRow.result.current.overlayUri).toBe('file:///overlay-cached.png'));
+
+    await act(async () => {
+      resolveNextRender(cacheKeyFor(dispatchedFrames), 'file:///overlay-dispatched.png');
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(pendingRenders.has(cacheKeyFor(queuedFrames))).toBe(true));
+    await act(async () => {
+      resolveNextRender(cacheKeyFor(queuedFrames), 'file:///overlay-queued.png');
+      await Promise.resolve();
+    });
+
+    // Two renders for the two rows that stayed; the abandoned one was never
+    // asked for, even after the slot it was waiting for came free twice.
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(2);
+    expect(pendingRenders.has(cacheKeyFor(abandonedFrames))).toBe(false);
+  });
+
+  it('sends the play board into native ahead of thumbnails that asked first', async () => {
+    const thumbnailKeyFor = (frames: string) =>
+      buildCacheKey(BASE.boardName, BASE.layoutId, BASE.sizeId, BASE.setIds, frames, true);
+    const dispatchedThumbnailFrames = 'p1100r12';
+    const playFrames = 'p1400r15';
+
+    renderHook(() => useNativeClimbRender({ ...BASE, frames: dispatchedThumbnailFrames, filledStyle: true }));
+    renderHook(() => useNativeClimbRender({ ...BASE, frames: 'p1200r13', filledStyle: true }));
+    renderHook(() => useNativeClimbRender({ ...BASE, frames: 'p1500r13', filledStyle: true }));
+    await waitFor(() => expect(pendingRenders.has(thumbnailKeyFor(dispatchedThumbnailFrames))).toBe(true));
+
+    // The climber opens the play drawer while the list is still catching up.
+    renderHook(() => useNativeClimbRender({ ...BASE, frames: playFrames, playSurface: true }));
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveNextRender(thumbnailKeyFor(dispatchedThumbnailFrames), 'file:///overlay-thumbnail.png');
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(2));
+    const [, secondCacheKey] = fakeNativeModule.renderHoldsOverlay.mock.calls[1];
+    expect(secondCacheKey).toBe(cacheKeyFor(playFrames));
+  });
 });
 
 // Issue #4240: a renderer that cannot honour a config's marker overrides is a

--- a/packages/mobile/src/hooks/use-image-cache-memory-management.ts
+++ b/packages/mobile/src/hooks/use-image-cache-memory-management.ts
@@ -30,6 +30,12 @@ export const IMAGE_MEMORY_CACHE_MAX_BYTES = 256 * 1024 * 1024;
  * unbounded cache on this device: `{cache}/board-thumbnails` has had a 200 MB cap
  * in the native renderer all along.
  *
+ * Board art (LayeredClimbImage, PlaylistBoardBackdrop) has since moved to
+ * `cachePolicy="memory"` (issue #5187): those PNGs are files we already own on
+ * disk, so a second SDWebImage disk copy was duplicate I/O on a serial queue.
+ * This disk cache is now fed only by the photo surfaces — feed, beta,
+ * avatars — that still ask for `memory-disk`.
+ *
  * 150 MB is several thousand list thumbnails and a few hundred full-width photos
  * — far past a session's working set, so the cap bites on accumulation rather
  * than on use, and what it evicts re-downloads only if you scroll back to it.

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -38,6 +38,14 @@ import { track } from '../lib/analytics';
 import { sweepBoardArtCache } from '../lib/sweep-caches';
 import { measureFreeCacheSpaceBytes } from '../lib/cache-dir-io';
 import {
+  isRenderCancelled,
+  requestRender,
+  setRenderConcurrency,
+  _resetRenderSchedulerForTests,
+  type RenderPriority,
+  type RenderQueueSnapshot,
+} from '../lib/board-render/render-scheduler';
+import {
   cacheRenderedOverlay,
   getRenderedOverlay,
   invalidateRenderedOverlay,
@@ -579,6 +587,8 @@ type RenderFailureNote = {
   context: RenderFailureTelemetryContext;
   /** `config`-stage only: how frame 0's lit ids lined up with the board. */
   holdMatch?: { litCount: number; unmatchedCount: number };
+  /** `render_stalled` only: where the render was waiting when the watchdog fired. */
+  stall?: RenderQueueSnapshot;
 } & (
   | { stage: 'native'; failureKind: BoardRenderNativeFailureKind }
   | { stage: 'image_load'; failureKind: BoardRenderImageLoadFailureKind }
@@ -641,6 +651,16 @@ function noteRenderFailure(note: RenderFailureNote): number {
     // Omitted entirely off the config stage, so a `native` event never carries
     // a meaningless zero that a query would have to special-case.
     ...(note.holdMatch ? { lit_count: note.holdMatch.litCount, unmatched_count: note.holdMatch.unmatchedCount } : {}),
+    // Same rule for the stall watchdog's position report: only `render_stalled`
+    // carries it, so a real native rejection never reads as a zero-length wait.
+    ...(note.stall
+      ? {
+          stall_state: note.stall.state,
+          queue_depth: note.stall.queueDepth,
+          dispatched_count: note.stall.dispatchedCount,
+          ms_waiting: note.stall.msWaiting,
+        }
+      : {}),
   };
   // Branch rather than spread a `{ stage, failure_kind }` pair: the two are one
   // discriminated pair in `BoardRenderFailedInput`, and keeping the branch is
@@ -856,6 +876,27 @@ const RENDER_RETRY_DELAY_MS = 1500;
  */
 const OVERLAY_PAINT_TIMEOUT_MS = 4000;
 
+/**
+ * How long the play board waits for its native render before the stall
+ * watchdog reports `render_stalled` (issue #5187).
+ *
+ * The paint watchdog above arms only once the overlay `<Image>` mounts, i.e.
+ * once the render has ALREADY answered. The stage before it — the render
+ * scheduler holding the request, or native holding it — had no telemetry at
+ * all, which is why a phone in Low Power Mode drawing its holds seconds late
+ * looked, in every dashboard, exactly like a phone that never had a problem.
+ *
+ * 6s: a full-size Aura render is ~30ms of raster plus PNG encode and a disk
+ * write, so even a throttled phone finishes a handful of queued renders well
+ * inside this, and the event still lands in the session that caused it.
+ *
+ * Observation only, like the paint watchdog: the render is not abandoned and
+ * nothing is retried. The event carries where the request was waiting
+ * (`stall_state`), which is the question this investigation could not answer.
+ * Play board only — a list of thumbnails would arm one per row.
+ */
+const RENDER_STALL_TIMEOUT_MS = 6000;
+
 function latchDiskPressure(): void {
   diskPressureUntilMs = Date.now() + DISK_PRESSURE_BACKOFF_MS;
   // Free what we can while we are backed off. The sweeper's own per-trigger rate
@@ -954,6 +995,10 @@ export function _resetWarmupForTests(): void {
   _resetOverlayIndexForTests();
   reportedOverlayLoadTelemetry.clear();
   _resetRenderFailureStateForTests();
+  // The suites' fake native modules leave renders pending on purpose; a
+  // dispatched slot that never settles would otherwise carry into the next test
+  // and, after two of them, hold every render of the file in the queue.
+  _resetRenderSchedulerForTests();
 }
 
 /** Test-only handle to invoke the warm-up explicitly (it normally runs lazily on first render). */
@@ -1583,6 +1628,13 @@ function getNativeModule() {
     if (loaded?.boardRendererNative) {
       renderModule = loaded;
       moduleLoadAttempted = true;
+      // How many renders this binary can take at once. Store binaries without
+      // a renderer queue of their own report nothing, and the scheduler keeps
+      // its serial default; the getter is optional so an older wrapper (an OTA
+      // landing on a binary that predates it) cannot throw here.
+      if (typeof loaded.getNativeRenderConcurrency === 'function') {
+        setRenderConcurrency(loaded.getNativeRenderConcurrency());
+      }
       return renderModule;
     }
   } catch {
@@ -2164,16 +2216,54 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       return () => clearTimeout(retryTimer);
     }
 
-    const renderPromise = getOrStartInflightRender(currentCacheKey, () => {
-      const configJson = JSON.stringify({
-        ...boardConfig.configBase,
-        frames: flatFrames,
-      });
-      return nativeModule.renderHoldsOverlay(configJson, currentCacheKey);
-    });
+    // Through the scheduler, not straight to native: only a bounded number of
+    // renders are inside native at once, the play board goes ahead of queued
+    // thumbnails, and a request this surface abandons (the cleanup below) before
+    // its turn is never asked for at all. The config JSON is built inside
+    // `start`, so an abandoned request never pays for it either.
+    const renderPriority: RenderPriority = playSurface ? 'play' : filledStyle ? 'thumbnail' : 'full';
+    const renderRequest = requestRender(currentCacheKey, renderPriority, () =>
+      getOrStartInflightRender(currentCacheKey, () => {
+        const configJson = JSON.stringify({
+          ...boardConfig.configBase,
+          frames: flatFrames,
+        });
+        return nativeModule.renderHoldsOverlay(configJson, currentCacheKey);
+      }),
+    );
 
-    renderPromise
+    // Per effect run, not a ref: a previous run's render can settle after this
+    // run armed its own watchdog, and its settle handler must clear only the
+    // timer that belongs to it.
+    let renderStallTimer: ReturnType<typeof setTimeout> | null = null;
+    const clearRenderStallWatchdog = () => {
+      if (renderStallTimer !== null) {
+        clearTimeout(renderStallTimer);
+        renderStallTimer = null;
+      }
+    };
+    if (playSurface) {
+      renderStallTimer = setTimeout(() => {
+        renderStallTimer = null;
+        if (!mountedRef.current) return;
+        const stall = renderRequest.snapshot();
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[useNativeClimbRender] render still ${stall.state} after ${RENDER_STALL_TIMEOUT_MS}ms (queue ${stall.queueDepth}, dispatched ${stall.dispatchedCount})`,
+        );
+        noteRenderFailure({
+          stage: 'native',
+          failureKind: 'render_stalled',
+          errorCode: 'render_stalled',
+          context: failureTelemetryContext,
+          stall,
+        });
+      }, RENDER_STALL_TIMEOUT_MS);
+    }
+
+    renderRequest.promise
       .then((renderedEntry) => {
+        clearRenderStallWatchdog();
         // Discard a stale resolution (props moved on while this render was in
         // flight) — see latestCacheKeyRef. The sync map above still keeps the
         // file, so swiping back to this climb is an instant cache hit.
@@ -2186,6 +2276,12 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
         }
       })
       .catch((error: unknown) => {
+        clearRenderStallWatchdog();
+        // Withdrawn before dispatch — this surface moved on (or unmounted) while
+        // the request was still in the scheduler's queue. Not a failure: the
+        // render was never attempted, so nothing below applies. First, before
+        // the log line and both telemetry paths.
+        if (isRenderCancelled(error)) return;
         const message = error instanceof Error ? error.message : String(error);
         // A renderer that cannot honour this config's marker overrides is a
         // designed capability fallback (a native binary that predates marker
@@ -2274,6 +2370,12 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       });
 
     return () => {
+      // This surface no longer wants THIS render: its key moved on (a recycled
+      // list row, a swipe) or it unmounted. If the request is still queued and
+      // nobody else shares it, the scheduler drops it unasked; a render already
+      // inside native finishes and is cached for the next visit regardless.
+      renderRequest.release();
+      clearRenderStallWatchdog();
       // A retry armed by the run being torn down is stale: the effect is about
       // to run again anyway (a dep changed) or the surface is unmounting. The
       // timer that just fired has already nulled this, so the common case is a

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -545,6 +545,19 @@ const RENDER_FAILURE_EVENT_CAP = 25;
 const CONFIG_FAILURE_EVENT_CAP = 10;
 
 /**
+ * Per-lifetime budget for `render_stalled`, separate from the other two.
+ *
+ * A stall is a render that is LATE, not one that failed, and a throttled phone
+ * can be late on every swipe of a long session. Sharing the 25-event budget
+ * would let one slow evening spend it all and silence the genuine native and
+ * image_load failures that follow; sharing the running `failures_this_session`
+ * counter would make a slow session read as a broken one. So stalls have their
+ * own cap and report the counter without advancing it.
+ */
+const STALL_EVENT_CAP = 10;
+let stallEventsSent = 0;
+
+/**
  * Render failures seen this JS lifetime, ALL stages. Keeps counting past every
  * cap, and rides along on every event and Sentry report as
  * `failures_this_session` / `failuresThisSession` — so a stream that stops reads
@@ -610,7 +623,10 @@ type RenderFailureNote = {
  */
 function noteRenderFailure(note: RenderFailureNote): number {
   const { errorCode, context } = note;
-  renderFailuresThisSession += 1;
+  const isStall = note.stage === 'native' && note.failureKind === 'render_stalled';
+  // A stall is late, not failed: it reads the running count but never advances
+  // it (see STALL_EVENT_CAP).
+  if (!isStall) renderFailuresThisSession += 1;
   const failuresThisSession = renderFailuresThisSession;
 
   addErrorBreadcrumb({
@@ -627,11 +643,15 @@ function noteRenderFailure(note: RenderFailureNote): number {
     },
   });
 
-  // Two independent budgets — see CONFIG_FAILURE_EVENT_CAP for why the config
-  // stage must not be able to spend the one the other stages rely on.
+  // Three independent budgets — see CONFIG_FAILURE_EVENT_CAP and
+  // STALL_EVENT_CAP for why neither the config stage nor a slow session may
+  // spend the one the real failures rely on.
   if (note.stage === 'config') {
     if (configFailureEventsSent >= CONFIG_FAILURE_EVENT_CAP) return failuresThisSession;
     configFailureEventsSent += 1;
+  } else if (isStall) {
+    if (stallEventsSent >= STALL_EVENT_CAP) return failuresThisSession;
+    stallEventsSent += 1;
   } else {
     if (renderFailureEventsSent >= RENDER_FAILURE_EVENT_CAP) return failuresThisSession;
     renderFailureEventsSent += 1;
@@ -897,6 +917,17 @@ const OVERLAY_PAINT_TIMEOUT_MS = 4000;
  */
 const RENDER_STALL_TIMEOUT_MS = 6000;
 
+/**
+ * How late the stall timer may land and still be believed. iOS suspends JS
+ * with the app, so a watchdog armed just before backgrounding fires on resume
+ * with the whole background stretch as its wait — bogus by construction, the
+ * same trap the paint watchdog avoids by arming off the mount signal. A timer
+ * that runs this far past its schedule did not wait through a slow render; it
+ * slept. A busy JS thread lands a timer late by tens or hundreds of
+ * milliseconds, not by ten seconds, so a real stall is never dropped here.
+ */
+const RENDER_STALL_TIMER_SLACK_MS = 10_000;
+
 function latchDiskPressure(): void {
   diskPressureUntilMs = Date.now() + DISK_PRESSURE_BACKOFF_MS;
   // Free what we can while we are backed off. The sweeper's own per-trigger rate
@@ -914,12 +945,14 @@ export function _resetRenderFailureStateForTests(): void {
   renderFailuresThisSession = 0;
   configFailureEventsSent = 0;
   renderFailureEventsSent = 0;
+  stallEventsSent = 0;
   reportedConfigMismatchKeys.clear();
 }
 
 /** Test-only view of the two per-lifetime event budgets. */
 export const _RENDER_FAILURE_EVENT_CAP_FOR_TESTS = RENDER_FAILURE_EVENT_CAP;
 export const _CONFIG_FAILURE_EVENT_CAP_FOR_TESTS = CONFIG_FAILURE_EVENT_CAP;
+export const _STALL_EVENT_CAP_FOR_TESTS = STALL_EVENT_CAP;
 
 /**
  * One-time eager scan of the native module's PNG cache directory. The
@@ -2243,9 +2276,13 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       }
     };
     if (playSurface) {
+      const stallArmedAtMs = Date.now();
       renderStallTimer = setTimeout(() => {
         renderStallTimer = null;
         if (!mountedRef.current) return;
+        // Wall clock, not the request's monotonic wait: it keeps counting while
+        // the app is suspended, which is exactly the case being excluded.
+        if (Date.now() - stallArmedAtMs > RENDER_STALL_TIMEOUT_MS + RENDER_STALL_TIMER_SLACK_MS) return;
         const stall = renderRequest.snapshot();
         // eslint-disable-next-line no-console
         console.warn(

--- a/packages/mobile/src/lib/board-render/__tests__/render-scheduler.test.ts
+++ b/packages/mobile/src/lib/board-render/__tests__/render-scheduler.test.ts
@@ -1,0 +1,367 @@
+// The JS-side line for native board renders (issue #5187).
+//
+// The bug this module exists for: every mounted board surface handed its render
+// straight to Expo's shared serial queue, and a row that scrolled away never
+// took its render back. So the four properties asserted here are the whole
+// point — only `maxDispatched` renders are inside native at once, the play
+// board goes ahead of queued thumbnails, a request whose consumers all let go
+// before dispatch is never asked for at all, and a slot is freed no matter how
+// its render ended.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  requestRender,
+  isRenderCancelled,
+  RenderCancelledError,
+  setRenderConcurrency,
+  getRenderConcurrency,
+  _resetRenderSchedulerForTests,
+  _renderSchedulerStateForTests,
+} from '../render-scheduler';
+
+type Deferred<TValue> = {
+  promise: Promise<TValue>;
+  resolve: (value: TValue) => void;
+  reject: (reason: unknown) => void;
+};
+
+function deferred<TValue>(): Deferred<TValue> {
+  let resolve!: (value: TValue) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<TValue>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+/** A render the test settles by hand, plus the record of whether it was started. */
+type ControlledRender = {
+  settlement: Deferred<string>;
+  start: () => Promise<string>;
+  startCount: () => number;
+};
+
+function controlledRender(): ControlledRender {
+  const settlement = deferred<string>();
+  let starts = 0;
+  return {
+    settlement,
+    start: () => {
+      starts += 1;
+      return settlement.promise;
+    },
+    startCount: () => starts,
+  };
+}
+
+/** Let the scheduler's settle → pump chain run to completion. */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  _resetRenderSchedulerForTests();
+});
+
+describe('dispatching under the one-render cap', () => {
+  it('starts the first render on the spot and holds the second in the queue', () => {
+    const first = controlledRender();
+    let startedBeforeRequestReturned = false;
+    requestRender('key-first', 'full', () => {
+      startedBeforeRequestReturned = true;
+      return first.settlement.promise;
+    });
+    // The whole reason dispatch is synchronous: the first render on a surface
+    // must start on the same tick it always did.
+    expect(startedBeforeRequestReturned).toBe(true);
+
+    const second = controlledRender();
+    requestRender('key-second', 'full', second.start);
+
+    expect(second.startCount()).toBe(0);
+    expect(_renderSchedulerStateForTests()).toEqual({
+      dispatchedKeys: ['key-first'],
+      queuedKeys: ['key-second'],
+      maxDispatched: 1,
+    });
+  });
+
+  it('dispatches the queued render as soon as the running one resolves', async () => {
+    const first = controlledRender();
+    const second = controlledRender();
+    const firstHandle = requestRender('key-first', 'full', first.start);
+    requestRender('key-second', 'full', second.start);
+
+    first.settlement.resolve('file:///first.png');
+    await expect(firstHandle.promise).resolves.toBe('file:///first.png');
+
+    expect(second.startCount()).toBe(1);
+    expect(_renderSchedulerStateForTests()).toMatchObject({
+      dispatchedKeys: ['key-second'],
+      queuedKeys: [],
+    });
+  });
+
+  it('frees the slot when the running render rejects, not only when it succeeds', async () => {
+    const failing = controlledRender();
+    const next = controlledRender();
+    const failingHandle = requestRender('key-failing', 'full', failing.start);
+    requestRender('key-next', 'full', next.start);
+
+    failing.settlement.reject(new Error('Rust render failed with code -2'));
+    await expect(failingHandle.promise).rejects.toThrow('Rust render failed with code -2');
+
+    expect(next.startCount()).toBe(1);
+    expect(_renderSchedulerStateForTests().dispatchedKeys).toEqual(['key-next']);
+  });
+
+  it('rejects and frees the slot when start throws synchronously', async () => {
+    const next = controlledRender();
+    const throwingHandle = requestRender('key-throwing', 'full', () => {
+      throw new Error('renderHoldsOverlay is not a function');
+    });
+    requestRender('key-next', 'full', next.start);
+
+    await expect(throwingHandle.promise).rejects.toThrow('renderHoldsOverlay is not a function');
+
+    // Without this the scheduler would hold its only slot for the rest of the
+    // JS lifetime and no board would ever draw again.
+    expect(next.startCount()).toBe(1);
+    expect(_renderSchedulerStateForTests().dispatchedKeys).toEqual(['key-next']);
+  });
+});
+
+describe('joining one request per cache key', () => {
+  it('starts one render for two consumers and hands both the same result', async () => {
+    const shared = controlledRender();
+    const firstConsumer = requestRender('key-shared', 'thumbnail', shared.start);
+    const secondConsumer = requestRender('key-shared', 'thumbnail', shared.start);
+
+    expect(shared.startCount()).toBe(1);
+
+    shared.settlement.resolve('file:///shared.png');
+    await expect(firstConsumer.promise).resolves.toBe('file:///shared.png');
+    await expect(secondConsumer.promise).resolves.toBe('file:///shared.png');
+    expect(shared.startCount()).toBe(1);
+  });
+});
+
+describe('withdrawing a request that has not been dispatched', () => {
+  it('never asks for a queued render whose last consumer let go', async () => {
+    const running = controlledRender();
+    const abandoned = controlledRender();
+    requestRender('key-running', 'full', running.start);
+    const abandonedHandle = requestRender('key-abandoned', 'full', abandoned.start);
+
+    abandonedHandle.release();
+
+    await expect(abandonedHandle.promise).rejects.toBeInstanceOf(RenderCancelledError);
+    await abandonedHandle.promise.catch((error: unknown) => {
+      expect(isRenderCancelled(error)).toBe(true);
+    });
+    expect(_renderSchedulerStateForTests().queuedKeys).toEqual([]);
+
+    // …and it stays unasked once the slot frees up. This is the scroll-away
+    // row whose render used to run anyway, ahead of the play board.
+    running.settlement.resolve('file:///running.png');
+    await flushMicrotasks();
+    expect(abandoned.startCount()).toBe(0);
+  });
+
+  it('keeps a queued request alive while another consumer still wants it', async () => {
+    const running = controlledRender();
+    const shared = controlledRender();
+    requestRender('key-running', 'full', running.start);
+    const leavingConsumer = requestRender('key-shared', 'full', shared.start);
+    const stayingConsumer = requestRender('key-shared', 'full', shared.start);
+
+    leavingConsumer.release();
+    // Idempotent: a second release from the same consumer must not take the
+    // other consumer's claim with it (a hook effect cleanup can run twice).
+    leavingConsumer.release();
+
+    expect(_renderSchedulerStateForTests().queuedKeys).toEqual(['key-shared']);
+
+    running.settlement.resolve('file:///running.png');
+    await flushMicrotasks();
+    expect(shared.startCount()).toBe(1);
+    shared.settlement.resolve('file:///shared.png');
+    await expect(stayingConsumer.promise).resolves.toBe('file:///shared.png');
+  });
+
+  it('lets a dispatched render finish even after its consumer releases it', async () => {
+    const running = controlledRender();
+    const runningHandle = requestRender('key-running', 'play', running.start);
+
+    runningHandle.release();
+
+    // Native cannot be cancelled, so the result still lands — and is cached for
+    // the next visit rather than thrown away.
+    running.settlement.resolve('file:///running.png');
+    await expect(runningHandle.promise).resolves.toBe('file:///running.png');
+  });
+
+  // Vitest fails the run on an unhandled rejection, so the assertion here is
+  // the test passing at all: the scheduler attaches its own no-op catch, and
+  // nothing below ever attaches one.
+  it('does not surface a cancelled request as an unhandled rejection', async () => {
+    const running = controlledRender();
+    const abandoned = controlledRender();
+    requestRender('key-running', 'full', running.start);
+    const abandonedHandle = requestRender('key-abandoned', 'thumbnail', abandoned.start);
+
+    abandonedHandle.release();
+    await flushMicrotasks();
+
+    expect(abandoned.startCount()).toBe(0);
+  });
+});
+
+describe('ordering the queue', () => {
+  it('draws the play board first, then full surfaces, then thumbnails in arrival order', async () => {
+    const occupant = controlledRender();
+    const firstThumbnail = controlledRender();
+    const fullSurface = controlledRender();
+    const secondThumbnail = controlledRender();
+    const playBoard = controlledRender();
+    const occupantHandle = requestRender('key-occupant', 'full', occupant.start);
+    requestRender('key-thumbnail-first', 'thumbnail', firstThumbnail.start);
+    requestRender('key-full', 'full', fullSurface.start);
+    requestRender('key-thumbnail-second', 'thumbnail', secondThumbnail.start);
+    requestRender('key-play', 'play', playBoard.start);
+
+    const dispatchOrder: string[] = [];
+    const settleAndRecord = async (render: ControlledRender, uri: string) => {
+      render.settlement.resolve(uri);
+      await flushMicrotasks();
+      dispatchOrder.push(..._renderSchedulerStateForTests().dispatchedKeys);
+    };
+
+    await settleAndRecord(occupant, 'file:///occupant.png');
+    await settleAndRecord(playBoard, 'file:///play.png');
+    await settleAndRecord(fullSurface, 'file:///full.png');
+    await settleAndRecord(firstThumbnail, 'file:///thumbnail-first.png');
+
+    // FIFO inside a level, not LIFO: FlashList's newest rows are the
+    // below-viewport prefetch rows, so newest-first would draw the wrong ones.
+    expect(dispatchOrder).toEqual(['key-play', 'key-full', 'key-thumbnail-first', 'key-thumbnail-second']);
+    await expect(occupantHandle.promise).resolves.toBe('file:///occupant.png');
+  });
+
+  it('promotes a queued full surface that becomes the play board, and never demotes it again', async () => {
+    const occupant = controlledRender();
+    const olderFull = controlledRender();
+    const peekBecomingPlay = controlledRender();
+    const occupantHandle = requestRender('key-occupant', 'full', occupant.start);
+    requestRender('key-older-full', 'full', olderFull.start);
+    requestRender('key-peek', 'full', peekBecomingPlay.start);
+
+    // The carousel commits: the same key is now the board the climber is
+    // looking at, so a second consumer asks for it as `play`.
+    const playConsumer = requestRender('key-peek', 'play', peekBecomingPlay.start);
+    // …and swipes on, releasing that consumer while the peek row stays mounted.
+    playConsumer.release();
+
+    occupant.settlement.resolve('file:///occupant.png');
+    await expect(occupantHandle.promise).resolves.toBe('file:///occupant.png');
+
+    expect(_renderSchedulerStateForTests()).toMatchObject({
+      dispatchedKeys: ['key-peek'],
+      queuedKeys: ['key-older-full'],
+    });
+    expect(olderFull.startCount()).toBe(0);
+  });
+});
+
+describe('the dispatch window', () => {
+  it('lets a second queued render through the moment the window widens', async () => {
+    const first = controlledRender();
+    const second = controlledRender();
+    requestRender('key-first', 'full', first.start);
+    requestRender('key-second', 'full', second.start);
+    expect(second.startCount()).toBe(0);
+
+    setRenderConcurrency(2);
+
+    expect(second.startCount()).toBe(1);
+    expect(getRenderConcurrency()).toBe(2);
+    expect(_renderSchedulerStateForTests()).toMatchObject({
+      dispatchedKeys: ['key-first', 'key-second'],
+      queuedKeys: [],
+    });
+  });
+
+  it('clamps a bad constant instead of letting it turn the queue back off', () => {
+    setRenderConcurrency(0);
+    expect(getRenderConcurrency()).toBe(1);
+
+    setRenderConcurrency(-5);
+    expect(getRenderConcurrency()).toBe(1);
+
+    setRenderConcurrency(99);
+    expect(getRenderConcurrency()).toBe(4);
+
+    setRenderConcurrency(2.9);
+    expect(getRenderConcurrency()).toBe(2);
+  });
+
+  it('ignores a non-finite report rather than adopting it', () => {
+    setRenderConcurrency(3);
+    setRenderConcurrency(Number.NaN);
+    expect(getRenderConcurrency()).toBe(3);
+
+    setRenderConcurrency(Number.POSITIVE_INFINITY);
+    expect(getRenderConcurrency()).toBe(3);
+  });
+});
+
+describe('a settle that arrives after a reset', () => {
+  it('leaves the request that came after the reset dispatched and counted once', async () => {
+    const beforeReset = controlledRender();
+    requestRender('key-before-reset', 'play', beforeReset.start);
+
+    _resetRenderSchedulerForTests();
+
+    const afterReset = controlledRender();
+    const afterResetHandle = requestRender('key-after-reset', 'play', afterReset.start);
+    expect(afterReset.startCount()).toBe(1);
+
+    // The forgotten render finally answers. It must not delete the new entry or
+    // free a slot it no longer owns.
+    beforeReset.settlement.resolve('file:///before-reset.png');
+    await flushMicrotasks();
+
+    expect(_renderSchedulerStateForTests()).toEqual({
+      dispatchedKeys: ['key-after-reset'],
+      queuedKeys: [],
+      maxDispatched: 1,
+    });
+    expect(afterResetHandle.snapshot().dispatchedCount).toBe(1);
+
+    afterReset.settlement.resolve('file:///after-reset.png');
+    await expect(afterResetHandle.promise).resolves.toBe('file:///after-reset.png');
+    expect(_renderSchedulerStateForTests().dispatchedKeys).toEqual([]);
+  });
+});
+
+describe('the snapshot the stall telemetry reads', () => {
+  it('separates a render inside native from one still waiting in the queue', () => {
+    const running = controlledRender();
+    const waiting = controlledRender();
+    const runningHandle = requestRender('key-running', 'play', running.start);
+    const waitingHandle = requestRender('key-waiting', 'play', waiting.start);
+
+    const runningSnapshot = runningHandle.snapshot();
+    expect(runningSnapshot.state).toBe('dispatched');
+    expect(runningSnapshot.dispatchedCount).toBe(1);
+    expect(runningSnapshot.msWaiting).toBeGreaterThanOrEqual(0);
+
+    const waitingSnapshot = waitingHandle.snapshot();
+    expect(waitingSnapshot.state).toBe('queued');
+    expect(waitingSnapshot.queueDepth).toBeGreaterThanOrEqual(1);
+    expect(waitingSnapshot.dispatchedCount).toBe(1);
+    expect(waitingSnapshot.msWaiting).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/mobile/src/lib/board-render/__tests__/render-scheduler.test.ts
+++ b/packages/mobile/src/lib/board-render/__tests__/render-scheduler.test.ts
@@ -131,6 +131,29 @@ describe('dispatching under the one-render cap', () => {
     expect(next.startCount()).toBe(1);
     expect(_renderSchedulerStateForTests().dispatchedKeys).toEqual(['key-next']);
   });
+
+  // A native module method that hands back a bare string rather than a promise
+  // (an older binary, a web shim) would blow up on `.then` and wedge the only
+  // slot for the rest of the JS lifetime — every board on the device, blank.
+  it('resolves a start that returns a plain value instead of a promise', async () => {
+    const nonThenableHandle = requestRender(
+      'key-non-thenable',
+      'full',
+      () => 'file:///non-thenable.png' as unknown as Promise<string>,
+    );
+    const queued = controlledRender();
+    requestRender('key-queued', 'full', queued.start);
+    expect(queued.startCount()).toBe(0);
+
+    await expect(nonThenableHandle.promise).resolves.toBe('file:///non-thenable.png');
+
+    expect(queued.startCount()).toBe(1);
+    expect(_renderSchedulerStateForTests().dispatchedKeys).toEqual(['key-queued']);
+
+    queued.settlement.resolve('file:///queued.png');
+    await flushMicrotasks();
+    expect(_renderSchedulerStateForTests().dispatchedKeys).toEqual([]);
+  });
 });
 
 describe('joining one request per cache key', () => {

--- a/packages/mobile/src/lib/board-render/render-scheduler.ts
+++ b/packages/mobile/src/lib/board-render/render-scheduler.ts
@@ -1,0 +1,297 @@
+/**
+ * The JS-side line for native board renders (issue #5187).
+ *
+ * Every Expo `AsyncFunction` without its own queue runs on ONE shared serial
+ * queue per platform (`expo.modules.AsyncFunctionQueue` on iOS, a single
+ * HandlerThread on Android), and `renderHoldsOverlay` is one of them. Before
+ * this module, every mounted board surface — the play board, the carousel's
+ * peek, and every list thumbnail — handed its render to native the moment it
+ * mounted, and a row that scrolled away never took its render back. A fast
+ * scroll through unseen climbs therefore queued one native render per row,
+ * and the play board a climber then opened waited behind all of them. Low
+ * Power Mode lowers the CPU clock, which stretched that line from "a second"
+ * to "the holds never seem to come"; nothing measured it, because the only
+ * render telemetry starts once the overlay `<Image>` mounts.
+ *
+ * So renders now wait HERE, where they can be ordered and withdrawn, and only
+ * `maxDispatched` of them are inside native at a time:
+ *
+ * - `play` before `full` before `thumbnail`, FIFO within a level. Not LIFO for
+ *   thumbnails: the queue only ever holds requests from currently mounted
+ *   instances (each hook instance holds at most one undispatched request, and
+ *   releases it when its key moves on), and FlashList's most recently mounted
+ *   rows are the below-viewport prefetch rows, so newest-first would draw
+ *   those before the rows the climber is looking at.
+ * - A request whose last consumer releases it before dispatch is dropped and
+ *   its `start` closure freed — the render is never asked for. A request
+ *   already inside native runs to completion regardless (native cannot be
+ *   cancelled) and its result still lands in the overlay index for the next
+ *   visit.
+ * - Priority upgrades are sticky. The real case is the carousel: a neighbour's
+ *   overlay is requested as `full` while it peeks, then the same key becomes
+ *   the `play` board on commit; a release never downgrades.
+ * - Dispatch is synchronous when a slot is free, so the first render on a
+ *   surface starts on the same tick it always did; only requests past the cap
+ *   wait. Invariant: the queue is non-empty only while every slot is taken.
+ *
+ * Pure TypeScript, no React, generic over the result — this module knows
+ * nothing about overlay files or the native module, so it can sit below the
+ * hook without a cycle.
+ */
+
+export type RenderPriority = 'play' | 'full' | 'thumbnail';
+
+/** Where a request is waiting; the discriminator the stall telemetry reports. */
+export type RenderStallState = 'queued' | 'dispatched';
+
+export type RenderQueueSnapshot = {
+  /** Whether this request is still in our queue or already inside native. */
+  state: RenderStallState;
+  /** Requests waiting in the queue, this one included when it is queued. */
+  queueDepth: number;
+  /** Requests handed to native and not yet answered. */
+  dispatchedCount: number;
+  /** Milliseconds since this request was first asked for. */
+  msWaiting: number;
+};
+
+export type RenderRequestHandle<T> = {
+  promise: Promise<T>;
+  /**
+   * This consumer no longer wants the result. Idempotent. When the last
+   * consumer of a QUEUED request releases it, the request is dropped and the
+   * promise rejects with `RenderCancelledError`.
+   */
+  release: () => void;
+  /** Read the request's position for telemetry; cheap and side-effect free. */
+  snapshot: () => RenderQueueSnapshot;
+};
+
+/**
+ * The rejection a consumer sees when it (or a sibling consumer) released a
+ * queued request. Never a failure: the render was not attempted. Consumers
+ * check `isRenderCancelled` FIRST in their catch, before any logging or
+ * telemetry.
+ */
+export class RenderCancelledError extends Error {
+  constructor(key: string) {
+    super(`render cancelled before dispatch: ${key}`);
+    this.name = 'RenderCancelledError';
+  }
+}
+
+export function isRenderCancelled(error: unknown): error is RenderCancelledError {
+  return error instanceof RenderCancelledError;
+}
+
+/**
+ * Native renders outstanding at once. Today's store binaries run
+ * `renderHoldsOverlay` on Expo's shared SERIAL queue, so a second dispatched
+ * render only ever waits behind the first inside native — and a play board
+ * that arrives while two thumbnails are dispatched waits behind both. One slot
+ * keeps the play board's worst case at a single thumbnail; the cost is one JS
+ * round-trip of idle native time between renders (tens of milliseconds at
+ * most, and less than a thumbnail render). A binary whose renderer runs on its
+ * own concurrent queue raises this through `setRenderConcurrency` (the module
+ * reports its `renderConcurrency` constant).
+ */
+const DEFAULT_MAX_DISPATCHED = 1;
+const MAX_DISPATCHED_CEILING = 4;
+
+const PRIORITY_RANK: Record<RenderPriority, number> = { play: 0, full: 1, thumbnail: 2 };
+
+type RenderRequest<T> = {
+  key: string;
+  priority: RenderPriority;
+  /** Arrival order; the FIFO tiebreaker inside a priority level. */
+  sequence: number;
+  requestedAtMs: number;
+  consumers: number;
+  /** Nulled on dispatch and on cancel so the config closure is not retained. */
+  start: (() => Promise<T>) | null;
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+};
+
+// One request per key, whether queued or dispatched. `unknown` because the
+// scheduler is generic per call; a key always maps back to the type its first
+// caller used (the hook only ever renders overlay entries).
+const requests = new Map<string, RenderRequest<unknown>>();
+const queued: RenderRequest<unknown>[] = [];
+const dispatched = new Map<string, RenderRequest<unknown>>();
+let maxDispatched = DEFAULT_MAX_DISPATCHED;
+let nextSequence = 0;
+
+function nowMs(): number {
+  return typeof performance !== 'undefined' && typeof performance.now === 'function' ? performance.now() : Date.now();
+}
+
+/**
+ * Raise (or lower) how many renders may be inside native at once. Called once
+ * the native module reports what its queue can take; clamped so a bad constant
+ * cannot turn the scheduler back into "everything at once".
+ */
+export function setRenderConcurrency(concurrency: number): void {
+  if (!Number.isFinite(concurrency)) return;
+  maxDispatched = Math.min(MAX_DISPATCHED_CEILING, Math.max(1, Math.floor(concurrency)));
+  pump();
+}
+
+export function getRenderConcurrency(): number {
+  return maxDispatched;
+}
+
+/** The queued request that should go next: lowest priority rank, then oldest. */
+function takeNextQueued(): RenderRequest<unknown> | undefined {
+  if (queued.length === 0) return undefined;
+  let bestIndex = 0;
+  for (let index = 1; index < queued.length; index += 1) {
+    const candidate = queued[index];
+    const best = queued[bestIndex];
+    const candidateRank = PRIORITY_RANK[candidate.priority];
+    const bestRank = PRIORITY_RANK[best.priority];
+    if (candidateRank < bestRank || (candidateRank === bestRank && candidate.sequence < best.sequence)) {
+      bestIndex = index;
+    }
+  }
+  return queued.splice(bestIndex, 1)[0];
+}
+
+function settle(request: RenderRequest<unknown>): void {
+  // Guarded exactly like `getOrStartInflightRender`: a settle that arrives
+  // after a test reset (or after the key was re-requested fresh) must not
+  // remove the newer request or free a slot it does not own.
+  if (dispatched.get(request.key) === request) dispatched.delete(request.key);
+  if (requests.get(request.key) === request) requests.delete(request.key);
+  pump();
+}
+
+function dispatch(request: RenderRequest<unknown>): void {
+  const start = request.start;
+  request.start = null;
+  dispatched.set(request.key, request);
+  let started: Promise<unknown>;
+  try {
+    // A `start` that throws synchronously (a native module method that is not
+    // a function, a JSON.stringify that blows up) must still free the slot, or
+    // the scheduler stalls for the rest of the JS lifetime.
+    started = start ? start() : Promise.reject(new Error('render request has no start'));
+  } catch (error) {
+    started = Promise.reject(error);
+  }
+  started.then(
+    (value) => {
+      settle(request);
+      request.resolve(value);
+    },
+    (error: unknown) => {
+      settle(request);
+      request.reject(error);
+    },
+  );
+}
+
+/** Fill free slots from the queue. Synchronous; never defers to a timer. */
+function pump(): void {
+  while (dispatched.size < maxDispatched) {
+    const next = takeNextQueued();
+    if (!next) return;
+    dispatch(next);
+  }
+}
+
+/**
+ * Ask for the render behind `key`, joining an existing request for the same
+ * key if there is one. `start` is only ever called once per request, and only
+ * when a slot is free; a request released by all its consumers before then
+ * never calls it.
+ */
+export function requestRender<T>(
+  key: string,
+  priority: RenderPriority,
+  start: () => Promise<T>,
+): RenderRequestHandle<T> {
+  let request = requests.get(key) as RenderRequest<T> | undefined;
+  if (!request) {
+    let resolve!: (value: T) => void;
+    let reject!: (reason: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    // The scheduler's own handler, so a request every consumer released (and
+    // therefore nobody is listening to) cannot surface as an unhandled
+    // rejection. Consumers still observe rejections through `promise`.
+    promise.catch(() => {});
+    request = {
+      key,
+      priority,
+      sequence: nextSequence++,
+      requestedAtMs: nowMs(),
+      consumers: 0,
+      start,
+      promise,
+      resolve,
+      reject,
+    };
+    requests.set(key, request as RenderRequest<unknown>);
+    if (dispatched.size < maxDispatched) {
+      dispatch(request as RenderRequest<unknown>);
+    } else {
+      queued.push(request as RenderRequest<unknown>);
+    }
+  } else if (PRIORITY_RANK[priority] < PRIORITY_RANK[request.priority]) {
+    // Sticky upgrade: the peek that became the play board. Selection scans the
+    // queue on every dispatch, so nothing needs re-sorting here.
+    request.priority = priority;
+  }
+  const joined = request;
+  joined.consumers += 1;
+  let released = false;
+  return {
+    promise: joined.promise,
+    release: () => {
+      if (released) return;
+      released = true;
+      joined.consumers -= 1;
+      if (joined.consumers > 0) return;
+      // Only an undispatched request can be withdrawn. `start` still being
+      // set is exactly "not dispatched": dispatch nulls it first thing.
+      if (joined.start === null) return;
+      const queueIndex = queued.indexOf(joined as RenderRequest<unknown>);
+      if (queueIndex !== -1) queued.splice(queueIndex, 1);
+      if (requests.get(key) === (joined as RenderRequest<unknown>)) requests.delete(key);
+      joined.start = null;
+      joined.reject(new RenderCancelledError(key));
+    },
+    snapshot: () => ({
+      state: dispatched.get(key) === (joined as RenderRequest<unknown>) ? 'dispatched' : 'queued',
+      queueDepth: queued.length,
+      dispatchedCount: dispatched.size,
+      msWaiting: Math.max(0, Math.round(nowMs() - joined.requestedAtMs)),
+    }),
+  };
+}
+
+/** Test-only: forget every request. Late settles of dropped requests are ignored. */
+export function _resetRenderSchedulerForTests(): void {
+  requests.clear();
+  queued.length = 0;
+  dispatched.clear();
+  maxDispatched = DEFAULT_MAX_DISPATCHED;
+  nextSequence = 0;
+}
+
+/** Test-only: the scheduler's current shape. */
+export function _renderSchedulerStateForTests(): {
+  queuedKeys: string[];
+  dispatchedKeys: string[];
+  maxDispatched: number;
+} {
+  return {
+    queuedKeys: queued.map((request) => request.key),
+    dispatchedKeys: [...dispatched.keys()],
+    maxDispatched,
+  };
+}

--- a/packages/mobile/src/lib/board-render/render-scheduler.ts
+++ b/packages/mobile/src/lib/board-render/render-scheduler.ts
@@ -171,15 +171,15 @@ function dispatch(request: RenderRequest<unknown>): void {
   const start = request.start;
   request.start = null;
   dispatched.set(request.key, request);
-  let started: Promise<unknown>;
-  try {
-    // A `start` that throws synchronously (a native module method that is not
-    // a function, a JSON.stringify that blows up) must still free the slot, or
-    // the scheduler stalls for the rest of the JS lifetime.
-    started = start ? start() : Promise.reject(new Error('render request has no start'));
-  } catch (error) {
-    started = Promise.reject(error);
-  }
+  // Wrapped in a Promise constructor rather than called bare: a `start` that
+  // throws synchronously (a native module method that is not a function, a
+  // JSON.stringify that blows up) becomes a rejection, and a `start` that
+  // returns a non-thenable resolves instead of throwing on `.then`. Either
+  // would otherwise leave this slot taken for the rest of the JS lifetime.
+  const started = new Promise<unknown>((resolveStarted) => {
+    if (!start) throw new Error('render request has no start');
+    resolveStarted(start());
+  });
   started.then(
     (value) => {
       settle(request);
@@ -206,6 +206,11 @@ function pump(): void {
  * key if there is one. `start` is only ever called once per request, and only
  * when a slot is free; a request released by all its consumers before then
  * never calls it.
+ *
+ * On a join the incoming `start` is IGNORED: the first requester's closure is
+ * the one that runs. That is safe because a key encodes everything the render
+ * depends on (board, frames, width, colours, marker and glow settings — see
+ * `buildCacheKey`), so two closures for one key describe the same PNG.
  */
 export function requestRender<T>(
   key: string,

--- a/packages/mobile/src/lib/board-render/render-scheduler.ts
+++ b/packages/mobile/src/lib/board-render/render-scheduler.ts
@@ -30,6 +30,11 @@
  * - Priority upgrades are sticky. The real case is the carousel: a neighbour's
  *   overlay is requested as `full` while it peeks, then the same key becomes
  *   the `play` board on commit; a release never downgrades.
+ * - The at-rest peek ranks as `full`, ABOVE visible accessory-strip thumbnails,
+ *   on purpose. The peek is what lets the next swipe show holds mid-drag, while
+ *   the accessory thumbnails are queue items that are nearly always cached from
+ *   the list already. If `render_stalled` events ever show deep thumbnail
+ *   queues behind an idle peek, a `prefetch` rank below `thumbnail` is the fix.
  * - Dispatch is synchronous when a slot is free, so the first render on a
  *   surface starts on the same tick it always did; only requests past the cap
  *   wait. Invariant: the queue is non-empty only while every slot is taken.

--- a/packages/mobile/src/lib/sweep-caches.ts
+++ b/packages/mobile/src/lib/sweep-caches.ts
@@ -8,6 +8,11 @@
 //    only by SDWebImage's 7-day age default. The ceiling now lives in
 //    use-image-cache-memory-management.ts; this module measures it and clears it
 //    on request. Android runs on Glide, which bounds its own disk cache.
+//    Board art (LayeredClimbImage, PlaylistBoardBackdrop) moved to
+//    `cachePolicy="memory"` for issue #5187 — the overlay and background are
+//    already files we own on disk, so a second SDWebImage disk copy was just
+//    duplicate I/O. This disk cache is now fed only by the photo surfaces:
+//    feed, beta thumbnails, avatars.
 // 2. `{cache}/board-thumbnails/*.png`. Already capped at 200 MB by the native
 //    modules — but the cap is enforced once per cold launch, so a long-lived
 //    foreground session grows past it unchecked.

--- a/packages/shared/analytics/src/__tests__/board-render-events.test.ts
+++ b/packages/shared/analytics/src/__tests__/board-render-events.test.ts
@@ -391,4 +391,35 @@ describe('boardRenderFailed — the config stage', () => {
     expect(payload.properties.failure_kind).toBe('paint_timeout');
     expect(payload.properties.error_code).toBe('paint_timeout');
   });
+
+  // Issue #5187. A stalled render is the one failure that has not happened yet,
+  // and the only thing worth knowing about it is WHERE it is waiting: our own
+  // queue behind other surfaces, or inside native. Pooling the two would
+  // describe nothing, so all four position fields ride the event verbatim.
+  it('carries the stall position under a native render_stalled', () => {
+    const commonProps = buildBoardRenderTelemetryProps(EFFECTIVE_AURA, CONTEXT);
+    const payload = boardRenderFailed({
+      ...commonProps,
+      ...BASE_FIELDS,
+      surface: 'play',
+      stage: 'native',
+      failure_kind: 'render_stalled',
+      error_code: 'render_stalled',
+      stall_state: 'queued',
+      queue_depth: 3,
+      dispatched_count: 1,
+      ms_waiting: 6001,
+    });
+
+    expect(payload.properties).toMatchObject({
+      stage: 'native',
+      failure_kind: 'render_stalled',
+      error_code: 'render_stalled',
+      surface: 'play',
+      stall_state: 'queued',
+      queue_depth: 3,
+      dispatched_count: 1,
+      ms_waiting: 6001,
+    });
+  });
 });

--- a/packages/shared/analytics/src/board-render-events.ts
+++ b/packages/shared/analytics/src/board-render-events.ts
@@ -307,13 +307,28 @@ export type BoardRenderFailureSurface = 'play' | 'full' | 'thumbnail';
 export type BoardRenderFailureStage = 'native' | 'image_load' | 'config';
 
 /**
- * Why the native renderer rejected.
+ * Why the native renderer rejected — or, for `render_stalled`, why it has not
+ * answered yet.
  *
  * `capability_fallback` is a binary that predates a config's marker overrides or
  * the Aura drawing refusing them by design — the hook re-renders degraded, so
  * this is a "the climber saw the other drawing" signal rather than a defect.
+ *
+ * `render_stalled` is the render stall watchdog (issue #5187): the play board
+ * asked for an overlay and, after a fixed wait, neither the JS render scheduler
+ * nor the native module has answered. Observation only — the render is not
+ * abandoned and usually lands later. It carries the `stall_*` fields below,
+ * which say whether the wait was spent in our own queue or inside native.
  */
-export type BoardRenderNativeFailureKind = 'render_failed' | 'disk_full' | 'capability_fallback';
+export type BoardRenderNativeFailureKind = 'render_failed' | 'disk_full' | 'capability_fallback' | 'render_stalled';
+
+/**
+ * Where a stalled render was waiting when the watchdog fired. `queued` is the
+ * JS scheduler holding it behind other renders; `dispatched` is the native
+ * module holding it. The two call for different fixes, which is why the event
+ * exists.
+ */
+export type BoardRenderStallState = 'queued' | 'dispatched';
 
 /**
  * Why the generated PNG would not load. Mirrors the mobile hook's
@@ -375,6 +390,7 @@ export type BoardRenderErrorCode =
   | 'no_matching_holds'
   | 'partial_hold_match'
   | 'paint_timeout'
+  | 'render_stalled'
   | 'other';
 
 /**
@@ -439,6 +455,17 @@ export type BoardRenderFailureFields = {
   lit_count?: number;
   /** How many of those the board config has no hold for. Same stage, same rule. */
   unmatched_count?: number;
+  /**
+   * `render_stalled` only, absent elsewhere: where the render was waiting when
+   * the watchdog fired (see `BoardRenderStallState`).
+   */
+  stall_state?: BoardRenderStallState;
+  /** `render_stalled` only: renders waiting in the JS scheduler, this one included when queued. */
+  queue_depth?: number;
+  /** `render_stalled` only: renders handed to native and not yet answered. */
+  dispatched_count?: number;
+  /** `render_stalled` only: milliseconds since this surface asked for the render. */
+  ms_waiting?: number;
 };
 
 /**

--- a/packages/shared/analytics/src/index.ts
+++ b/packages/shared/analytics/src/index.ts
@@ -53,6 +53,7 @@ export {
   type BoardRenderFailureSurface,
   type BoardRenderFailureStage,
   type BoardRenderNativeFailureKind,
+  type BoardRenderStallState,
   type BoardRenderImageLoadFailureKind,
   type BoardRenderConfigFailureKind,
   type BoardRenderFailureKind,


### PR DESCRIPTION
## Summary

Closes #5187.

In Low Power Mode the hold overlay showed up seconds late, or only after swiping away and back. The telemetry saw nothing: the reporter's account has 71 `Climb View Opened` and zero `Board Render Failed` events that day, because the stage that was slow had no watchdog.

**Root cause.** `renderHoldsOverlay` is a plain Expo `AsyncFunction`, so it runs on expo-modules-core's single shared serial queue (`expo.modules.AsyncFunctionQueue`; one HandlerThread on Android). JS handed every board surface's render to native the moment it mounted and never took it back when a list row scrolled away. A fast scroll through unseen climbs queued one native render per row, the play board's ~1200 px render queued behind all of them, and Low Power Mode's lower CPU clock stretched that line from about a second to many seconds. Separately, `cachePolicy="memory-disk"` on `file://` sources made SDWebImage look each overlay up in its own disk cache and then write a second copy there, on a serial I/O queue.

**What changes (JS only, ships OTA):**

- **Render scheduler** (`packages/mobile/src/lib/board-render/render-scheduler.ts`). Renders wait in a JS queue; one is inside native at a time (widened by an optional `renderConcurrency` constant a future binary can report). Order is play board, then full-size previews, then thumbnails, FIFO within a level. Priority upgrades are sticky, which covers the carousel peek becoming the current board. A request whose surface moves on before dispatch is dropped and never rendered; a dispatched render finishes and is cached for the next visit. The first render on a surface still starts on the same tick it always did.
- **Render stall watchdog.** The play board arms a 6 s timer when it asks for a render. On fire it sends `Board Render Failed` with `failure_kind: render_stalled` and `stall_state: queued | dispatched`, plus `queue_depth`, `dispatched_count`, `ms_waiting`. Observation only, like the paint watchdog. `queued` means our JS line is long; `dispatched` means native itself is slow and the `[native-train]` follow-up is the fix.
- **`cachePolicy="memory"`** on the board-art layers in `LayeredClimbImage` and `PlaylistBoardBackdrop`. The sources are files we already own on disk; a memory miss re-reads that file, which is what the SDWebImage disk copy did anyway.

**Author-side verification.** 27 new tests (16 scheduler unit tests, 7 stall-watchdog cases, 2 queue-order cases in the race suite, 1 analytics contract case, 1 `cachePolicy` assertion). The seven existing `use-native-climb-render` suites pass unchanged. Desktop calibration via the glow lab: the Rust raster is ~30 ms at 1080×1504 and ~1.5 ms at 200 px, so per-render cost on device is PNG encode and I/O; the fix is the queue, not the rasterizer.

Follow-up: a `[native-train]` PR moves the renderer onto its own concurrent queue, reports `renderConcurrency: 2`, and registers a `low_power_mode` PostHog super property.

## Release Notes

- Holds show up faster when your phone is in Low Power Mode or the climbs list is filling in
- The board you open no longer waits behind thumbnails you already scrolled past

## Test plan

1. Turn on Low Power Mode. Flick the Climbs list hard three times, stop.
2. Rows on screen fill with holds top-down within about a second.
3. Tap a climb near the bottom right away → holds appear within a second.
4. Swipe next five times fast → each board's holds land shortly after it.
5. Swipe back to a climb you just saw → holds appear instantly.

## Risk

Risk: 3/5 — every board surface (list, play drawer, previews, kiosk) now renders through the scheduler; covered by 27 new tests plus the existing render suites, but the timing change only shows on a real phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SncFBP8umBH1LzvdRVThJD
