### PR TITLE
fix(backend): answer a masked database failure with an honest 503

### DIFF
--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -315,6 +315,12 @@ through an outage.
   failures that outlive the retry.
 - Sustained retries with no errors = the fix is working and the network is
   flaky. Retries _plus_ errors = an outage; check `/health/db`.
+- Since #4862 a connection-class database failure (SQLSTATE class 08/53, the
+  57P0x shutdown codes, `CONNECT_TIMEOUT`/`ECONNREFUSED`-style driver codes)
+  reaches GraphQL clients as an **HTTP 503**, not a 200 with a masked error body
+  (`graphql/mask-error.ts`, `isDatabaseUnavailableCode`). A 5xx rate on
+  `POST /graphql` is therefore real outage signal; constraint, data and syntax
+  errors still ride the masked 200 so clients can give up on them.
 - **Alerting is dashboard configuration, not repo code.** Create a Sentry cron /
   uptime monitor against `https://<backend>/health/db` and alert on a non-200.
   Boardsesh's Sentry access from CI is read-only, so this has to be done by hand.

--- a/packages/backend/src/__tests__/mask-error.test.ts
+++ b/packages/backend/src/__tests__/mask-error.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { GraphQLError } from 'graphql';
-import { isDatabaseLeakError, maskDatabaseError } from '../graphql/mask-error';
+import { isDatabaseLeakError, isDatabaseUnavailableCode, maskDatabaseError } from '../graphql/mask-error';
 import { markErrorReported, wasErrorReported } from '../utils/sentry-dedupe';
 
 const { sentryCaptureMock } = vi.hoisted(() => ({ sentryCaptureMock: vi.fn() }));
@@ -62,11 +62,9 @@ describe('maskDatabaseError', () => {
     expect(masked).toBeInstanceOf(GraphQLError);
     expect(masked.message).not.toMatch(/select|Failed query|users/i);
     expect((masked as GraphQLError).extensions?.code).toBe('INTERNAL_SERVER_ERROR');
-    // An honest 503 on the wire (#4862). Today's mobile drainer already treats
-    // a 5xx as retryable instead of dead-lettering the masked 200 shape on the
-    // first attempt; the follow-up mobile PR makes a 503 end the drain cycle
-    // without charging the queued write at all.
-    expect((masked as GraphQLError).extensions?.http).toEqual({ status: 503 });
+    // 57014 (statement timeout) is a verdict on this one statement, not an
+    // outage, so it keeps the plain masked 200 — no http status override.
+    expect((masked as GraphQLError).extensions?.http).toBeUndefined();
 
     // Captured the real pg cause with the code as a tag, and marked reported.
     expect(sentryCaptureMock).toHaveBeenCalledTimes(1);
@@ -116,6 +114,45 @@ describe('maskDatabaseError', () => {
  * and no field path. These assert the evidence is attached to the event while
  * the client-facing message stays SQL-free (#3183).
  */
+describe('maskDatabaseError http status (#4862)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(['08006', '08001', '53300', '57P01', 'CONNECT_TIMEOUT', 'ECONNREFUSED', 'EAI_AGAIN'])(
+    'answers a connection-class failure (%s) with an honest 503',
+    (code) => {
+      const drizzle = makeDrizzleError(makePgError(code));
+      const masked = maskDatabaseError(new GraphQLError(drizzle.message, { originalError: drizzle }));
+      expect((masked as GraphQLError).extensions?.code).toBe('INTERNAL_SERVER_ERROR');
+      // graphql-yoga turns this into the response status. The mobile outbox
+      // drainer reads a 503 as "server unavailable, end the cycle" instead of
+      // charging the queued write, and the client fix for the masked 200 shape
+      // lands separately in the #4862 mobile PR.
+      expect((masked as GraphQLError).extensions?.http).toEqual({ status: 503 });
+      expect(masked.message).not.toMatch(/select|Failed query|users/i);
+    },
+  );
+
+  it.each(['23505', '23503', '22P02', '42703', '40P01', '57014'])(
+    'keeps a per-statement verdict (%s) on the masked 200 so clients can still give up on it',
+    (code) => {
+      const drizzle = makeDrizzleError(makePgError(code));
+      const masked = maskDatabaseError(new GraphQLError(drizzle.message, { originalError: drizzle }));
+      expect((masked as GraphQLError).extensions?.code).toBe('INTERNAL_SERVER_ERROR');
+      expect((masked as GraphQLError).extensions?.http).toBeUndefined();
+    },
+  );
+
+  it('classifies codes without a driver error in the way', () => {
+    expect(isDatabaseUnavailableCode('08P01')).toBe(true);
+    expect(isDatabaseUnavailableCode('53200')).toBe(true);
+    expect(isDatabaseUnavailableCode('ENOTFOUND')).toBe(true);
+    expect(isDatabaseUnavailableCode('23505')).toBe(false);
+    expect(isDatabaseUnavailableCode(undefined)).toBe(false);
+  });
+});
+
 describe('maskDatabaseError diagnostic context (#4105)', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/backend/src/__tests__/mask-error.test.ts
+++ b/packages/backend/src/__tests__/mask-error.test.ts
@@ -62,6 +62,9 @@ describe('maskDatabaseError', () => {
     expect(masked).toBeInstanceOf(GraphQLError);
     expect(masked.message).not.toMatch(/select|Failed query|users/i);
     expect((masked as GraphQLError).extensions?.code).toBe('INTERNAL_SERVER_ERROR');
+    // An honest 503 on the wire (#4862): the mobile outbox drainer treats it as
+    // "server unavailable, stop the cycle" instead of charging the queued write.
+    expect((masked as GraphQLError).extensions?.http).toEqual({ status: 503 });
 
     // Captured the real pg cause with the code as a tag, and marked reported.
     expect(sentryCaptureMock).toHaveBeenCalledTimes(1);

--- a/packages/backend/src/__tests__/mask-error.test.ts
+++ b/packages/backend/src/__tests__/mask-error.test.ts
@@ -62,8 +62,10 @@ describe('maskDatabaseError', () => {
     expect(masked).toBeInstanceOf(GraphQLError);
     expect(masked.message).not.toMatch(/select|Failed query|users/i);
     expect((masked as GraphQLError).extensions?.code).toBe('INTERNAL_SERVER_ERROR');
-    // An honest 503 on the wire (#4862): the mobile outbox drainer treats it as
-    // "server unavailable, stop the cycle" instead of charging the queued write.
+    // An honest 503 on the wire (#4862). Today's mobile drainer already treats
+    // a 5xx as retryable instead of dead-lettering the masked 200 shape on the
+    // first attempt; the follow-up mobile PR makes a 503 end the drain cycle
+    // without charging the queued write at all.
     expect((masked as GraphQLError).extensions?.http).toEqual({ status: 503 });
 
     // Captured the real pg cause with the code as a tag, and marked reported.

--- a/packages/backend/src/__tests__/mask-error.test.ts
+++ b/packages/backend/src/__tests__/mask-error.test.ts
@@ -119,7 +119,7 @@ describe('maskDatabaseError http status (#4862)', () => {
     vi.clearAllMocks();
   });
 
-  it.each(['08006', '08001', '53300', '57P01', 'CONNECT_TIMEOUT', 'ECONNREFUSED', 'EAI_AGAIN'])(
+  it.each(['08006', '08001', '53300', '57P01', '57P04', 'CONNECT_TIMEOUT', 'ECONNREFUSED', 'ECONNABORTED', 'EPIPE', 'EAI_AGAIN'])(
     'answers a connection-class failure (%s) with an honest 503',
     (code) => {
       const drizzle = makeDrizzleError(makePgError(code));

--- a/packages/backend/src/__tests__/mask-error.test.ts
+++ b/packages/backend/src/__tests__/mask-error.test.ts
@@ -119,20 +119,28 @@ describe('maskDatabaseError http status (#4862)', () => {
     vi.clearAllMocks();
   });
 
-  it.each(['08006', '08001', '53300', '57P01', '57P04', 'CONNECT_TIMEOUT', 'ECONNREFUSED', 'ECONNABORTED', 'EPIPE', 'EAI_AGAIN'])(
-    'answers a connection-class failure (%s) with an honest 503',
-    (code) => {
-      const drizzle = makeDrizzleError(makePgError(code));
-      const masked = maskDatabaseError(new GraphQLError(drizzle.message, { originalError: drizzle }));
-      expect((masked as GraphQLError).extensions?.code).toBe('INTERNAL_SERVER_ERROR');
-      // graphql-yoga turns this into the response status. The mobile outbox
-      // drainer reads a 503 as "server unavailable, end the cycle" instead of
-      // charging the queued write, and the client fix for the masked 200 shape
-      // lands separately in the #4862 mobile PR.
-      expect((masked as GraphQLError).extensions?.http).toEqual({ status: 503 });
-      expect(masked.message).not.toMatch(/select|Failed query|users/i);
-    },
-  );
+  it.each([
+    '08006',
+    '08001',
+    '53300',
+    '57P01',
+    '57P04',
+    'CONNECT_TIMEOUT',
+    'ECONNREFUSED',
+    'ECONNABORTED',
+    'EPIPE',
+    'EAI_AGAIN',
+  ])('answers a connection-class failure (%s) with an honest 503', (code) => {
+    const drizzle = makeDrizzleError(makePgError(code));
+    const masked = maskDatabaseError(new GraphQLError(drizzle.message, { originalError: drizzle }));
+    expect((masked as GraphQLError).extensions?.code).toBe('INTERNAL_SERVER_ERROR');
+    // graphql-yoga turns this into the response status. The mobile outbox
+    // drainer reads a 503 as "server unavailable, end the cycle" instead of
+    // charging the queued write, and the client fix for the masked 200 shape
+    // lands separately in the #4862 mobile PR.
+    expect((masked as GraphQLError).extensions?.http).toEqual({ status: 503 });
+    expect(masked.message).not.toMatch(/select|Failed query|users/i);
+  });
 
   it.each(['23505', '23503', '22P02', '42703', '40P01', '57014'])(
     'keeps a per-statement verdict (%s) on the masked 200 so clients can still give up on it',

--- a/packages/backend/src/graphql/mask-error.ts
+++ b/packages/backend/src/graphql/mask-error.ts
@@ -116,8 +116,16 @@ export function maskDatabaseError(error: unknown): Error {
       });
       markErrorReported(error);
     }
+    // `http.status: 503` makes the masked failure an honest Service Unavailable
+    // on the wire instead of a 200 with an error body. graphql-yoga reads
+    // `extensions.http.status` when it builds the response (issue #4862): the
+    // mobile outbox drainer classifies a 503 as "server unavailable, stop the
+    // cycle" rather than a verdict on the queued write, and the web/mobile
+    // reachability probes get a status they can act on without parsing bodies.
+    // Clients keep reading the same `extensions.code`; graphql-request wraps a
+    // non-2xx GraphQL body in the same ClientError shape as a 2xx one.
     return new GraphQLError('Something went wrong on our end. Please try again.', {
-      extensions: { code: 'INTERNAL_SERVER_ERROR' },
+      extensions: { code: 'INTERNAL_SERVER_ERROR', http: { status: 503 } },
     });
   }
 

--- a/packages/backend/src/graphql/mask-error.ts
+++ b/packages/backend/src/graphql/mask-error.ts
@@ -77,6 +77,38 @@ function unwrapCause(error: unknown): unknown {
   return original;
 }
 
+// Postgres SQLSTATE classes and driver codes that mean "the database could not
+// be reached or is out of capacity" — the outage shape #4862 is about — as
+// opposed to a verdict on one statement. Class 08 is connection_exception,
+// class 53 is insufficient_resources (53300 too_many_connections is the one the
+// 2026-08-29 incident produced), 57P01-57P03 are the operator-intervention
+// shutdown/cannot-connect codes. The rest are postgres.js and Node socket codes
+// for a connect that never completed (see packages/db connect-retry.ts and
+// docs/db-connectivity.md). 57014 query_canceled is deliberately NOT here: a
+// statement timeout on one heavy query is that query's problem.
+const UNAVAILABLE_DRIVER_CODES = new Set([
+  'CONNECT_TIMEOUT',
+  'CONNECTION_CLOSED',
+  'CONNECTION_ENDED',
+  'CONNECTION_DESTROYED',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'EAI_AGAIN',
+  'EAI_NODATA',
+  'ENOTFOUND',
+]);
+
+export function isDatabaseUnavailableCode(pgCode: string | undefined): boolean {
+  if (!pgCode) return false;
+  if (UNAVAILABLE_DRIVER_CODES.has(pgCode)) return true;
+  const sqlStateClass = pgCode.slice(0, 2);
+  if (sqlStateClass === '08' || sqlStateClass === '53') return true;
+  return pgCode === '57P01' || pgCode === '57P02' || pgCode === '57P03';
+}
+
 /**
  * graphql-yoga `maskError` that sanitizes ONLY the raw-database-error class so
  * internal SQL and schema never reach clients (issue #3183), while every other
@@ -92,11 +124,12 @@ function unwrapCause(error: unknown): unknown {
  */
 export function maskDatabaseError(error: unknown): Error {
   if (isDatabaseLeakError(error)) {
+    // Resolve the pg code through the GraphQL `originalError` wrapper too, so
+    // it lands on the Sentry tag even when the top-level error is the located
+    // GraphQLError (whose own cause chain doesn't reach the driver error), and
+    // so the response status below can tell an outage from a bad statement.
+    const pgCode = getPostgresErrorCode(getOriginalError(error) ?? error);
     if (!wasErrorReported(error)) {
-      // Resolve the pg code through the GraphQL `originalError` wrapper too, so
-      // it lands on the tag even when the top-level error is the located
-      // GraphQLError (whose own cause chain doesn't reach the driver error).
-      const pgCode = getPostgresErrorCode(getOriginalError(error) ?? error);
       // We still capture the unwrapped driver error, so Sentry's fingerprint (and
       // therefore the existing issue's history) is unchanged — tags and extra do
       // not affect grouping. But reporting the cause alone is what made
@@ -116,16 +149,20 @@ export function maskDatabaseError(error: unknown): Error {
       });
       markErrorReported(error);
     }
-    // `http.status: 503` makes the masked failure an honest Service Unavailable
-    // on the wire instead of a 200 with an error body. graphql-yoga reads
-    // `extensions.http.status` when it builds the response (issue #4862): the
-    // mobile outbox drainer classifies a 503 as "server unavailable, stop the
-    // cycle" rather than a verdict on the queued write, and the web/mobile
-    // reachability probes get a status they can act on without parsing bodies.
-    // Clients keep reading the same `extensions.code`; graphql-request wraps a
-    // non-2xx GraphQL body in the same ClientError shape as a 2xx one.
+    // A database that could not be reached is an honest 503 on the wire, not a
+    // 200 with an error body: graphql-yoga reads `extensions.http.status` when
+    // it builds the response (issue #4862), the mobile outbox drainer classifies
+    // a 503 as "server unavailable, stop the cycle" rather than a verdict on the
+    // queued write, and reachability probes get a status they can act on without
+    // parsing bodies. The status is deliberately scoped to connection-class
+    // failures: a constraint, data or syntax error is a permanent verdict on THAT
+    // request, and a 503 there would tell every client to retry it forever
+    // (the drainer would never dead-letter it). Those keep the plain masked 200.
+    // Clients read the same `extensions.code` either way; graphql-request wraps
+    // a non-2xx GraphQL body in the same ClientError shape as a 2xx one.
+    const http = isDatabaseUnavailableCode(pgCode) ? { http: { status: 503 } } : {};
     return new GraphQLError('Something went wrong on our end. Please try again.', {
-      extensions: { code: 'INTERNAL_SERVER_ERROR', http: { status: 503 } },
+      extensions: { code: 'INTERNAL_SERVER_ERROR', ...http },
     });
   }
 

--- a/packages/backend/src/graphql/mask-error.ts
+++ b/packages/backend/src/graphql/mask-error.ts
@@ -81,8 +81,8 @@ function unwrapCause(error: unknown): unknown {
 // be reached or is out of capacity" — the outage shape #4862 is about — as
 // opposed to a verdict on one statement. Class 08 is connection_exception,
 // class 53 is insufficient_resources (53300 too_many_connections is the one the
-// 2026-08-29 incident produced), 57P01-57P03 are the operator-intervention
-// shutdown/cannot-connect codes. The rest are postgres.js and Node socket codes
+// 2026-08-29 incident produced), 57P01-57P04 are the operator-intervention
+// shutdown / cannot-connect / database-dropped codes. The rest are postgres.js and Node socket codes
 // for a connect that never completed (see packages/db connect-retry.ts and
 // docs/db-connectivity.md). 57014 query_canceled is deliberately NOT here: a
 // statement timeout on one heavy query is that query's problem.
@@ -93,6 +93,8 @@ const UNAVAILABLE_DRIVER_CODES = new Set([
   'CONNECTION_DESTROYED',
   'ECONNREFUSED',
   'ECONNRESET',
+  'ECONNABORTED',
+  'EPIPE',
   'ETIMEDOUT',
   'EHOSTUNREACH',
   'ENETUNREACH',
@@ -106,7 +108,8 @@ export function isDatabaseUnavailableCode(pgCode: string | undefined): boolean {
   if (UNAVAILABLE_DRIVER_CODES.has(pgCode)) return true;
   const sqlStateClass = pgCode.slice(0, 2);
   if (sqlStateClass === '08' || sqlStateClass === '53') return true;
-  return pgCode === '57P01' || pgCode === '57P02' || pgCode === '57P03';
+  // admin_shutdown, crash_shutdown, cannot_connect_now, database_dropped.
+  return pgCode === '57P01' || pgCode === '57P02' || pgCode === '57P03' || pgCode === '57P04';
 }
 
 /**
@@ -160,9 +163,9 @@ export function maskDatabaseError(error: unknown): Error {
     // (the drainer would never dead-letter it). Those keep the plain masked 200.
     // Clients read the same `extensions.code` either way; graphql-request wraps
     // a non-2xx GraphQL body in the same ClientError shape as a 2xx one.
-    const http = isDatabaseUnavailableCode(pgCode) ? { http: { status: 503 } } : {};
+    const statusOverride = isDatabaseUnavailableCode(pgCode) ? { http: { status: 503 } } : {};
     return new GraphQLError('Something went wrong on our end. Please try again.', {
-      extensions: { code: 'INTERNAL_SERVER_ERROR', ...http },
+      extensions: { code: 'INTERNAL_SERVER_ERROR', ...statusOverride },
     });
   }
 


### PR DESCRIPTION
## Summary

Part of #4862. During the 2026-08-29 Postgres outage the backend kept answering `POST /graphql` with **HTTP 200** and a masked `INTERNAL_SERVER_ERROR` body (`maskDatabaseError` in `packages/backend/src/graphql/mask-error.ts`). The mobile outbox drainer reads that as "the server answered, the write was rejected" and dead-letters a queued tick on its first attempt, and nothing that looks at status codes (reachability probes, edge logs) can tell an outage from a healthy response.

This sets `extensions.http.status = 503` on the masked error **only for connection-class failures** (SQLSTATE classes 08/53, the 57P0x shutdown codes, and the postgres.js / socket connect codes such as `CONNECT_TIMEOUT` and `ECONNREFUSED`). A constraint, data or syntax error is a permanent verdict on one statement, so those keep the masked 200: a 503 there would tell every client to retry forever and the mobile outbox drainer would never dead-letter the write. graphql-yoga (5.22) reads `extensions.http.status` when it builds the response, so a masked database failure is now an honest Service Unavailable on the wire. The message and `extensions.code` are unchanged, and graphql-request wraps a non-2xx GraphQL body in the same `ClientError` the clients already handle. The client-side classification fix (retry the masked shape, stop the drain on 502/503/504) lands separately in the mobile PR for #4862, so old and new backends both behave.

Verified: `mask-error.test.ts` (29 tests) passes, including the per-code matrix. `docs/db-connectivity.md` runbook notes the new 5xx signal on `POST /graphql`.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — one status code on an already-masked error path, covered by the existing unit test
