### PR TITLE
feat(mobile): [native-train] give board renders their own queue and tag events with low power mode

### DIFF
--- a/docs/board-render-analytics.md
+++ b/docs/board-render-analytics.md
@@ -87,6 +87,13 @@ the existing `connectivity` / `offline_engine_state` super properties. That
 means every OTHER event fired for the rest of the launch, not just the ones
 above, can be sliced by which drawing and which falloff this climber is on.
 
+`low_power_mode` (boolean) is a super property too, registered by
+`LowPowerModeTracker` from expo-battery on launch and on every power-state
+change, and restored after `analytics.reset()` like the others (issue #5187:
+holds drew seconds late only in Low Power Mode, and no event could say which
+sessions were in it). Split `Board Render Failed` by it before reading a
+`render_stalled` or `paint_timeout` rate as a fleet-wide number.
+
 ## `Board Render Failed` — when the board does not draw
 
 Every other event on this page describes a render that worked. This one is the

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -92,6 +92,7 @@ import { AnalyticsGymProperties } from '../src/components/analytics/AnalyticsGym
 import { AnalyticsPersonProperties } from '../src/components/analytics/AnalyticsPersonProperties';
 import { BoardOpenRecorder } from '../src/components/board-activity/BoardOpenRecorder';
 import { OtaUpdateTracker } from '../src/components/analytics/OtaUpdateTracker';
+import { LowPowerModeTracker } from '../src/components/analytics/LowPowerModeTracker';
 import { InstallReferrerTracker } from '../src/components/analytics/InstallReferrerTracker';
 import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
 import { AccessoryOnboardingTip } from '../src/components/onboarding/AccessoryOnboardingTip';
@@ -838,6 +839,7 @@ function RootLayout() {
                                                               <AnalyticsScreenTracker />
                                                               <ImageCacheTabSweeper />
                                                               <OtaUpdateTracker />
+                                                              <LowPowerModeTracker />
                                                               <InstallReferrerTracker />
                                                             </ShareTargetProvider>
                                                           </DeepLinkProvider>

--- a/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
+++ b/packages/mobile/modules/board-renderer/android/src/main/java/com/boardsesh/boardrenderer/BoardRendererModule.kt
@@ -5,8 +5,26 @@ import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import java.io.File
 import java.nio.ByteBuffer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 
 class BoardRendererModule : Module() {
+    /**
+     * Renders run on this scope, not on expo-modules-core's default
+     * `AsyncFunction` queue. That default is ONE `HandlerThread` shared by every
+     * Expo module (`expo.modules.AsyncFunctionQueue`), so a play-board render
+     * used to wait behind every list thumbnail already in line and behind any
+     * other module's pending call; a throttled CPU stretched that line to
+     * seconds (issue #5187). `Dispatchers.Default` is the CPU-bound pool, which
+     * is what a raster + PNG encode is. The JS render scheduler bounds how many
+     * renders it sends at once (`renderConcurrency`), so this never means "every
+     * mounted row at once". Cancelled with the module so a torn-down React
+     * context does not keep rendering into a dead cache dir.
+     */
+    private val renderScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
     private val cacheDir: File by lazy {
         val reactCacheDir = appContext.reactContext?.cacheDir
             ?: throw IllegalStateException("BoardRenderer: reactContext.cacheDir unavailable")
@@ -152,22 +170,40 @@ class BoardRendererModule : Module() {
     override fun definition() = ModuleDefinition {
         Name("BoardRenderer")
 
+        // Read by the JS render scheduler (`getNativeRenderConcurrency`) to size
+        // its dispatch window. Absent on binaries that still render on the shared
+        // serial queue, where the scheduler keeps its one-at-a-time default.
+        Constants(
+            "renderConcurrency" to RENDER_CONCURRENCY,
+        )
+
+        OnDestroy {
+            renderScope.cancel()
+        }
+
         // Renders just the climb's hold overlay — a transparent-background
         // PNG containing only the hold markers. The RN component stacks
         // bundled board backgrounds underneath this overlay, so backgrounds
         // aren't passed in here anymore.
         AsyncFunction("renderHoldsOverlay") { configJson: String, cacheKey: String ->
             renderOverlay(configJson, cacheKey)
-        }
+        }.runOnQueue(renderScope)
 
         // Same renderer as renderHoldsOverlay, but the method's presence is a
         // native capability signal for marker shape, brush, and size overrides.
         AsyncFunction("renderHoldsOverlayWithMarkers") { configJson: String, cacheKey: String ->
             renderOverlay(configJson, cacheKey)
-        }
+        }.runOnQueue(renderScope)
     }
 
     private companion object {
+        /**
+         * How many renders the JS scheduler may keep inside this module at once.
+         * Two: the current play board plus one neighbour or thumbnail. Matches
+         * the iOS module.
+         */
+        const val RENDER_CONCURRENCY = 2
+
         // Cap the on-disk PNG cache so heavy users don't accumulate hundreds
         // of MB of stale renders. The cache lives in context.cacheDir, which
         // Android may also reclaim on its own under storage pressure — this

--- a/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
+++ b/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
@@ -49,7 +49,10 @@ public class BoardRendererModule: Module {
 
   // Initialized once per process (i.e. once per app launch), thread-safe for
   // the same reason as `cacheDir`. Accessing it from renderHoldsOverlay
-  // triggers the prune on the first call.
+  // triggers the prune on the first call. It reads `cacheDir` inside its own
+  // initializer; Swift initializes each static lazily and under its own lock,
+  // so that nested first access is fine — keep it that way (never touch
+  // `pruneOnce` from `cacheDir`'s initializer, which would deadlock).
   private static let pruneOnce: Void = {
     pruneCacheIfNeeded(at: cacheDir, maxBytes: cacheCapBytes)
   }()

--- a/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
+++ b/packages/mobile/modules/board-renderer/ios/BoardRendererModule.swift
@@ -2,13 +2,39 @@ import ExpoModulesCore
 import UIKit
 
 public class BoardRendererModule: Module {
+  /// Renders run here, not on expo-modules-core's default `AsyncFunction` queue.
+  ///
+  /// That default is ONE serial queue shared by every Expo module in the app
+  /// (`expo.modules.AsyncFunctionQueue`), so before this a play-board render
+  /// waited behind every list thumbnail already in line AND behind any other
+  /// module's pending call — and Low Power Mode's lower CPU clock stretched that
+  /// line to seconds (issue #5187). A concurrent queue of our own keeps renders
+  /// off that shared line and lets two run at once on multi-core phones. The JS
+  /// render scheduler bounds how many it sends (`renderConcurrency` below), so
+  /// "concurrent" never means "every mounted row at once".
+  private static let renderQueue = DispatchQueue(
+    label: "com.boardsesh.board-renderer.render",
+    qos: .userInitiated,
+    attributes: .concurrent
+  )
+
+  /// How many renders the JS scheduler may keep inside this module at once.
+  /// Two: the current play board plus one neighbour or thumbnail. A third rarely
+  /// finishes sooner on a phone core budget and would only compete with the UI
+  /// thread for the same cores the PNG encode needs.
+  private static let renderConcurrency = 2
+
   // Cap the on-disk PNG cache so heavy users don't accumulate hundreds of
   // MB of stale renders. The cache lives in Library/Caches, which iOS may
   // also reclaim on its own under storage pressure — this is just our
   // explicit upper bound.
   private static let cacheCapBytes: Int = 200 * 1024 * 1024
 
-  private lazy var cacheDir: URL = {
+  // `static let`, not `lazy var`: renders now run two at a time on
+  // `renderQueue`, and a Swift `lazy var` is not thread-safe — two first calls
+  // racing its initializer is a data race. A static stored property is
+  // initialized exactly once, under a lock, by the runtime.
+  private static let cacheDir: URL = {
     let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
       .appendingPathComponent("board-thumbnails", isDirectory: true)
     do {
@@ -19,10 +45,13 @@ public class BoardRendererModule: Module {
     return dir
   }()
 
-  // Lazy-initialized once per module lifetime (i.e. once per app launch).
-  // Accessing it from renderHoldsOverlay triggers the prune on first call.
-  private lazy var pruneOnce: Void = {
-    pruneCacheIfNeeded(maxBytes: BoardRendererModule.cacheCapBytes)
+  private var cacheDir: URL { BoardRendererModule.cacheDir }
+
+  // Initialized once per process (i.e. once per app launch), thread-safe for
+  // the same reason as `cacheDir`. Accessing it from renderHoldsOverlay
+  // triggers the prune on the first call.
+  private static let pruneOnce: Void = {
+    pruneCacheIfNeeded(at: cacheDir, maxBytes: cacheCapBytes)
   }()
 
   /// `Library/Caches` is reclaimable: iOS can delete our cache directory at any
@@ -56,7 +85,7 @@ public class BoardRendererModule: Module {
     }
   }
 
-  private func pruneCacheIfNeeded(maxBytes: Int) {
+  private static func pruneCacheIfNeeded(at cacheDir: URL, maxBytes: Int) {
     // Sort by modificationDate (not contentAccessDate) because that's what
     // we can reliably bump on a cache hit via setAttributes(.modificationDate:).
     // contentAccessDate is read-only via URLResourceKey on most volumes, so
@@ -127,7 +156,7 @@ public class BoardRendererModule: Module {
   }
 
   private func renderOverlayOnce(configJson: String, cacheKey: String) throws -> String {
-    _ = self.pruneOnce
+    _ = BoardRendererModule.pruneOnce
     let outputUrl = self.cacheDir.appendingPathComponent("\(cacheKey).png")
 
     if let attributes = try? FileManager.default.attributesOfItem(atPath: outputUrl.path),
@@ -221,6 +250,13 @@ public class BoardRendererModule: Module {
   public func definition() -> ModuleDefinition {
     Name("BoardRenderer")
 
+    // Read by the JS render scheduler (`getNativeRenderConcurrency`) to size its
+    // dispatch window. Absent on binaries that still render on the shared
+    // serial queue, where the scheduler keeps its one-at-a-time default.
+    Constants([
+      "renderConcurrency": BoardRendererModule.renderConcurrency
+    ])
+
     // Renders just the climb's hold overlay — a transparent-background PNG
     // containing only the hold markers. The RN component stacks bundled
     // board background images underneath this overlay, mirroring the web
@@ -231,6 +267,7 @@ public class BoardRendererModule: Module {
       (configJson: String, cacheKey: String) throws -> String in
       try self.renderOverlay(configJson: configJson, cacheKey: cacheKey)
     }
+    .runOnQueue(BoardRendererModule.renderQueue)
 
     // Same renderer as renderHoldsOverlay, but the method's presence is a
     // native capability signal for marker shape, brush, and size overrides.
@@ -238,5 +275,6 @@ public class BoardRendererModule: Module {
       (configJson: String, cacheKey: String) throws -> String in
       try self.renderOverlay(configJson: configJson, cacheKey: cacheKey)
     }
+    .runOnQueue(BoardRendererModule.renderQueue)
   }
 }

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -56,6 +56,7 @@
     "expo-apple-authentication": "57.0.1",
     "expo-application": "57.0.2",
     "expo-asset": "57.0.15",
+    "expo-battery": "57.0.2",
     "expo-clipboard": "57.0.1",
     "expo-constants": "57.0.16",
     "expo-crypto": "57.0.2",

--- a/packages/mobile/src/components/analytics/LowPowerModeTracker.tsx
+++ b/packages/mobile/src/components/analytics/LowPowerModeTracker.tsx
@@ -14,9 +14,12 @@ import { registerLowPowerMode } from '../../lib/analytics-low-power-mode';
 export function LowPowerModeTracker(): null {
   useEffect(() => {
     let cancelled = false;
+    // A listener event that lands while the initial read is still in flight is
+    // the newer fact; the read must not overwrite it when it finally resolves.
+    let heardFromListener = false;
     isLowPowerModeEnabledAsync()
       .then((lowPowerMode) => {
-        if (!cancelled) registerLowPowerMode(lowPowerMode);
+        if (!cancelled && !heardFromListener) registerLowPowerMode(lowPowerMode);
       })
       .catch(() => {
         // No power-state API on this platform: leave the property unset rather
@@ -27,6 +30,7 @@ export function LowPowerModeTracker(): null {
     let subscription: { remove(): void } | undefined;
     try {
       subscription = addLowPowerModeListener(({ lowPowerMode }) => {
+        heardFromListener = true;
         registerLowPowerMode(lowPowerMode);
       });
     } catch {

--- a/packages/mobile/src/components/analytics/LowPowerModeTracker.tsx
+++ b/packages/mobile/src/components/analytics/LowPowerModeTracker.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { addLowPowerModeListener, isLowPowerModeEnabledAsync } from 'expo-battery';
+import { registerLowPowerMode } from '../../lib/analytics-low-power-mode';
+
+/**
+ * Keeps the `low_power_mode` super property in step with the phone's power
+ * state (issue #5187). Reads it once on mount, then follows the OS event for
+ * the rest of the launch. Renders nothing; mounted once near the app root
+ * beside OtaUpdateTracker.
+ *
+ * Both calls are best effort. Expo web has no power-mode API and answers
+ * `false`; a simulator answers `false` too. Neither is worth a warning.
+ */
+export function LowPowerModeTracker(): null {
+  useEffect(() => {
+    let cancelled = false;
+    isLowPowerModeEnabledAsync()
+      .then((lowPowerMode) => {
+        if (!cancelled) registerLowPowerMode(lowPowerMode);
+      })
+      .catch(() => {
+        // No power-state API on this platform: leave the property unset rather
+        // than registering a guess.
+      });
+    const subscription = addLowPowerModeListener(({ lowPowerMode }) => {
+      registerLowPowerMode(lowPowerMode);
+    });
+    return () => {
+      cancelled = true;
+      subscription.remove();
+    };
+  }, []);
+  return null;
+}

--- a/packages/mobile/src/components/analytics/LowPowerModeTracker.tsx
+++ b/packages/mobile/src/components/analytics/LowPowerModeTracker.tsx
@@ -22,12 +22,19 @@ export function LowPowerModeTracker(): null {
         // No power-state API on this platform: leave the property unset rather
         // than registering a guess.
       });
-    const subscription = addLowPowerModeListener(({ lowPowerMode }) => {
-      registerLowPowerMode(lowPowerMode);
-    });
+    // Same posture as the read above: a platform without the listener must
+    // not turn into a thrown effect at the root layout.
+    let subscription: { remove(): void } | undefined;
+    try {
+      subscription = addLowPowerModeListener(({ lowPowerMode }) => {
+        registerLowPowerMode(lowPowerMode);
+      });
+    } catch {
+      // No listener on this platform; the one-off read above is all there is.
+    }
     return () => {
       cancelled = true;
-      subscription.remove();
+      subscription?.remove();
     };
   }, []);
   return null;

--- a/packages/mobile/src/components/analytics/__tests__/low-power-mode-tracker.test.tsx
+++ b/packages/mobile/src/components/analytics/__tests__/low-power-mode-tracker.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const batteryMocks = vi.hoisted(() => ({
+  isLowPowerModeEnabledAsync: vi.fn<() => Promise<boolean>>(),
+  addLowPowerModeListener: vi.fn<(listener: (event: { lowPowerMode: boolean }) => void) => { remove: () => void }>(),
+}));
+const registerLowPowerMode = vi.hoisted(() => vi.fn<(lowPowerMode: boolean) => void>());
+
+vi.mock('expo-battery', () => ({
+  isLowPowerModeEnabledAsync: batteryMocks.isLowPowerModeEnabledAsync,
+  addLowPowerModeListener: batteryMocks.addLowPowerModeListener,
+}));
+vi.mock('../../../lib/analytics-low-power-mode', () => ({ registerLowPowerMode }));
+
+// Imported after the mocks (vi.mock is hoisted above imports).
+import { LowPowerModeTracker } from '../LowPowerModeTracker';
+
+type Deferred = { promise: Promise<boolean>; resolve: (value: boolean) => void };
+function deferred(): Deferred {
+  let resolve!: (value: boolean) => void;
+  const promise = new Promise<boolean>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe('LowPowerModeTracker', () => {
+  let listener: ((event: { lowPowerMode: boolean }) => void) | null;
+  const remove = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listener = null;
+    batteryMocks.addLowPowerModeListener.mockImplementation((nextListener) => {
+      listener = nextListener;
+      return { remove };
+    });
+  });
+
+  it('registers the initial read, then follows the listener', async () => {
+    batteryMocks.isLowPowerModeEnabledAsync.mockResolvedValue(true);
+    render(createElement(LowPowerModeTracker));
+    await vi.waitFor(() => expect(registerLowPowerMode).toHaveBeenCalledWith(true));
+
+    listener?.({ lowPowerMode: false });
+    expect(registerLowPowerMode).toHaveBeenLastCalledWith(false);
+  });
+
+  // The initial read is async; a power-state change that lands while it is in
+  // flight is the newer fact, and the read must not overwrite it on resolve.
+  it('drops an initial read that resolves after a listener event', async () => {
+    const initialRead = deferred();
+    batteryMocks.isLowPowerModeEnabledAsync.mockReturnValue(initialRead.promise);
+    render(createElement(LowPowerModeTracker));
+
+    listener?.({ lowPowerMode: true });
+    initialRead.resolve(false);
+    await initialRead.promise;
+    await Promise.resolve();
+
+    expect(registerLowPowerMode).toHaveBeenCalledTimes(1);
+    expect(registerLowPowerMode).toHaveBeenCalledWith(true);
+  });
+
+  it('removes the listener and ignores a late read on unmount', async () => {
+    const initialRead = deferred();
+    batteryMocks.isLowPowerModeEnabledAsync.mockReturnValue(initialRead.promise);
+    const { unmount } = render(createElement(LowPowerModeTracker));
+    unmount();
+    expect(remove).toHaveBeenCalledOnce();
+
+    initialRead.resolve(true);
+    await initialRead.promise;
+    await Promise.resolve();
+    expect(registerLowPowerMode).not.toHaveBeenCalled();
+  });
+
+  it('survives a platform without the listener API', async () => {
+    batteryMocks.isLowPowerModeEnabledAsync.mockResolvedValue(false);
+    batteryMocks.addLowPowerModeListener.mockImplementation(() => {
+      throw new Error('not available');
+    });
+    expect(() => render(createElement(LowPowerModeTracker))).not.toThrow();
+    await vi.waitFor(() => expect(registerLowPowerMode).toHaveBeenCalledWith(false));
+  });
+});

--- a/packages/mobile/src/lib/__tests__/analytics-low-power-mode.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-low-power-mode.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const posthogClientMocks = vi.hoisted(() => ({ getPostHogClient: vi.fn() }));
+
+vi.mock('../posthog-client', () => ({
+  getPostHogClient: posthogClientMocks.getPostHogClient,
+}));
+
+describe('low power mode super property', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { _resetLowPowerModeForTests } = await import('../analytics-low-power-mode');
+    _resetLowPowerModeForTests();
+  });
+
+  it('registers the value once per change, not once per read', async () => {
+    const fakeClient = { register: vi.fn() };
+    posthogClientMocks.getPostHogClient.mockReturnValue(fakeClient);
+    const { registerLowPowerMode } = await import('../analytics-low-power-mode');
+
+    registerLowPowerMode(true);
+    registerLowPowerMode(true);
+    registerLowPowerMode(false);
+
+    expect(fakeClient.register).toHaveBeenCalledTimes(2);
+    expect(fakeClient.register).toHaveBeenNthCalledWith(1, { low_power_mode: true });
+    expect(fakeClient.register).toHaveBeenNthCalledWith(2, { low_power_mode: false });
+  });
+
+  it('is a silent no-op without an analytics client, and still remembers the value', async () => {
+    posthogClientMocks.getPostHogClient.mockReturnValue(null);
+    const { registerLowPowerMode, reregisterLowPowerMode } = await import('../analytics-low-power-mode');
+
+    expect(() => registerLowPowerMode(true)).not.toThrow();
+
+    const lateClient = { register: vi.fn() };
+    reregisterLowPowerMode(lateClient);
+    expect(lateClient.register).toHaveBeenCalledWith({ low_power_mode: true });
+  });
+
+  it('never throws when register rejects', async () => {
+    const fakeClient = { register: vi.fn(() => Promise.reject(new Error('offline'))) };
+    posthogClientMocks.getPostHogClient.mockReturnValue(fakeClient);
+    const { registerLowPowerMode } = await import('../analytics-low-power-mode');
+
+    expect(() => registerLowPowerMode(true)).not.toThrow();
+    await Promise.resolve();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/analytics-reset.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-reset.test.ts
@@ -91,6 +91,37 @@ describe('analytics reset', () => {
     );
   });
 
+  // #5187: `low_power_mode` only moves on a power-state transition, so a
+  // sign-out that dropped it would leave every later event of the launch
+  // unattributable to Low Power Mode until the climber plugged in.
+  it('re-registers low power mode after resetting the client', async () => {
+    const fakeClient = { register: vi.fn() };
+    posthogClientMocks.getPostHogClient.mockReturnValue(fakeClient);
+    const { registerLowPowerMode, _resetLowPowerModeForTests } = await import('../analytics-low-power-mode');
+    _resetLowPowerModeForTests();
+    registerLowPowerMode(true);
+    fakeClient.register.mockClear();
+    const { reset } = await import('../analytics');
+
+    expect(reset()).toBe(true);
+
+    expect(fakeClient.register).toHaveBeenCalledWith({ low_power_mode: true });
+  });
+
+  it('registers no low power mode when the tracker has not read one yet', async () => {
+    const fakeClient = { register: vi.fn() };
+    posthogClientMocks.getPostHogClient.mockReturnValue(fakeClient);
+    const { _resetLowPowerModeForTests } = await import('../analytics-low-power-mode');
+    _resetLowPowerModeForTests();
+    const { reset } = await import('../analytics');
+
+    expect(reset()).toBe(true);
+
+    expect(fakeClient.register).not.toHaveBeenCalledWith(
+      expect.objectContaining({ low_power_mode: expect.anything() }),
+    );
+  });
+
   // The active board does not change on sign-out, so AnalyticsGymProperties'
   // effect will not re-run — without this restore, every event for the rest of
   // the launch loses its venue and the gym leaderboard under-counts whoever

--- a/packages/mobile/src/lib/analytics-low-power-mode.ts
+++ b/packages/mobile/src/lib/analytics-low-power-mode.ts
@@ -1,0 +1,57 @@
+import type { PostHog } from 'posthog-react-native';
+import { getPostHogClient } from './posthog-client';
+
+/**
+ * The `low_power_mode` super property: whether the phone was in iOS Low Power
+ * Mode / Android Battery Saver when an event fired, stamped onto every event.
+ *
+ * Added for issue #5187, where holds drew seconds late only in Low Power Mode
+ * and nothing in the data could say which sessions were in it. With this on
+ * every event, `Board Render Failed` (and anything else) can be split by it.
+ *
+ * Own module, same shape as `analytics-offline-engine-state.ts`, because it
+ * has to survive `analytics.reset()`: PostHog's reset clears every registered
+ * super property, and the mode only changes on a power-state transition, so a
+ * sign-out would otherwise drop it for the rest of the launch.
+ */
+export const LOW_POWER_MODE_SUPER_PROPERTY = 'low_power_mode';
+
+let lastRegisteredValue: boolean | undefined;
+
+function register(lowPowerMode: boolean, client?: Pick<PostHog, 'register'> | null): void {
+  const target = client ?? getPostHogClient();
+  if (!target) return;
+  try {
+    void Promise.resolve(target.register({ [LOW_POWER_MODE_SUPER_PROPERTY]: lowPowerMode })).catch((error: unknown) => {
+      if (__DEV__) console.warn('[analytics] failed to register low power mode', error);
+    });
+  } catch (error) {
+    if (__DEV__) console.warn('[analytics] failed to register low power mode', error);
+  }
+}
+
+/**
+ * Registers the value now and remembers it for the rest of the launch. Best
+ * effort: a failure never breaks the caller, and it is a silent no-op when
+ * analytics is disabled. Skips the write when the value has not changed, since
+ * every `register()` is a persisted write.
+ */
+export function registerLowPowerMode(lowPowerMode: boolean): void {
+  if (lastRegisteredValue === lowPowerMode) return;
+  lastRegisteredValue = lowPowerMode;
+  register(lowPowerMode);
+}
+
+/**
+ * Puts the remembered value back after `analytics.reset()` wiped it. No-op
+ * before the tracker has published anything.
+ */
+export function reregisterLowPowerMode(client?: Pick<PostHog, 'register'> | null): void {
+  if (lastRegisteredValue === undefined) return;
+  register(lastRegisteredValue, client);
+}
+
+/** Test-only: forget the remembered value. */
+export function _resetLowPowerModeForTests(): void {
+  lastRegisteredValue = undefined;
+}

--- a/packages/mobile/src/lib/analytics.ts
+++ b/packages/mobile/src/lib/analytics.ts
@@ -4,6 +4,7 @@ import { getPostHogClient, registerAppSuperProperties } from './posthog-client';
 import { registerConnectivitySuperProperty } from './analytics-connectivity';
 import { reregisterOfflineEngineState } from './analytics-offline-engine-state';
 import { reregisterActiveGym } from './analytics-gym';
+import { reregisterLowPowerMode } from './analytics-low-power-mode';
 
 // `sendEvent: false` suppresses the SDK's `$feature_flag_called` capture. Verified
 // in @posthog/core 1.46.1 (shared by posthog-react-native and posthog-js-lite):
@@ -220,6 +221,9 @@ export function registerRenderSuperProperties(effective: {
 // `gym_uuid` / `gym_name` are restored for the same reason: the active board
 // does not change on sign-out, so AnalyticsGymProperties' effect will not re-run
 // and every remaining event of the launch would lose its venue.
+//
+// `low_power_mode` too: it only moves on a power-state transition, so a
+// sign-out would strip it from every event until the climber plugs in.
 export function reset(): boolean {
   const didReset = analytics.reset();
   const client = getClient();
@@ -228,6 +232,7 @@ export function reset(): boolean {
     registerConnectivitySuperProperty(client);
     reregisterOfflineEngineState(client);
     reregisterActiveGym(client);
+    reregisterLowPowerMode(client);
   }
   return didReset;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,6 +631,9 @@ importers:
       expo-asset:
         specifier: 57.0.15
         version: 57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@7.0.2)
+      expo-battery:
+        specifier: 57.0.2
+        version: 57.0.2(expo@57.0.18)(react@19.2.3)
       expo-clipboard:
         specifier: 57.0.1
         version: 57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -7706,6 +7709,12 @@ packages:
       expo: '*'
       react: '*'
       react-native: '*'
+
+  expo-battery@57.0.2:
+    resolution: {integrity: sha512-3++v5kSUj4aOKKTkLtJwU57UOrC0GORj4eM2Tcg2mJjdUNHHxxBes4x6w/D5LAOQmvgVsHF1Z5CP8TfQe4rsQw==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
 
   expo-clipboard@57.0.1:
     resolution: {integrity: sha512-HWICri4+1ao7S6QEfcorxVumXDiDnx1guGGewjZgGJWLGxFYs0RgH8ujBs+lkTzBkMmlwADaWSlaesR+nDJt5Q==}
@@ -18346,6 +18355,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  expo-battery@57.0.2(expo@57.0.18)(react@19.2.3):
+    dependencies:
+      expo: 57.0.18(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.14)(bufferutil@4.1.0)(expo-router@57.0.17)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@7.0.2)
+      react: 19.2.3
 
   expo-clipboard@57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
     dependencies:


### PR DESCRIPTION
## Summary

Native half of #5187, stacked on #5208 (merge that first; this PR's base is its branch). Moves the native fingerprint, so it rides the next native train and stays a draft until then.

#5208 stops the play board from waiting behind thumbnails, but every render still runs on expo-modules-core's single shared serial `AsyncFunction` queue, behind whatever other module call is pending. This PR:

- **iOS**: `renderHoldsOverlay` / `renderHoldsOverlayWithMarkers` run on a dedicated concurrent `userInitiated` queue (`com.boardsesh.board-renderer.render`). The module's cache-dir and prune-once state move from `lazy var` to `static let`, because a Swift `lazy var` is not thread-safe and two first renders could race its initializer. The Rust renderer has no global state, so concurrent calls are safe.
- **Android**: the same two functions run on a `Dispatchers.Default` coroutine scope, cancelled in `OnDestroy`. Kotlin's `by lazy` and the existing double-checked prune guard are already thread-safe.
- Both report `Constants { renderConcurrency: 2 }`. The JS scheduler from #5208 already reads that through `getNativeRenderConcurrency()` and widens its dispatch window to two on binaries that carry this change; older binaries keep one.
- **`low_power_mode` PostHog super property** from `expo-battery` (pinned 57.0.2): read on launch, followed on every power-state change, restored after `analytics.reset()` like `connectivity` and `offline_engine_state`. This is the dimension the #5187 investigation could not slice by.

Author-side verification: 5 new tests (reset re-registration, change-only registration, no-client and rejecting-client paths). No native tests exist for the renderer module; the queue change is exercised by every board render on the device build.

## Release Notes

- Holds draw faster: the board renderer no longer shares a line with the rest of the app

## Test plan

1. Install this build (not an OTA). Turn Low Power Mode on.
2. Flick the Climbs list hard three times → rows fill with holds within a second.
3. Open a climb from the bottom of the list → holds appear within a second.
4. Swipe next five times fast → each board's holds land right after it settles.
5. Switch Low Power Mode off and on while on a board → nothing flickers or crashes.

## Risk

Risk: 5/5 — native queue change on both platforms plus a new native dependency; moves the fingerprint, so store binaries cannot receive it by OTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SncFBP8umBH1LzvdRVThJD
