### PR TITLE
feat(mobile): warm the next three queue climbs' board renders while the renderer is idle

### DIFF
--- a/docs/board-render-analytics.md
+++ b/docs/board-render-analytics.md
@@ -291,8 +291,11 @@ pair, so a board whose sets do not cover a climb's holds produces one on every
 row of a list. Sharing a budget would let a single scroll spend the whole
 session's telemetry on one unchanging answer and silence the native and
 image_load signals, which are the ones that move. Config events are also deduped
-by cache key across every hook instance (a bounded 200-key set, so a recycled
-FlashList row cannot re-report a climb it already answered for).
+by surface + cache key across every hook instance (a bounded 200-key set, so a
+recycled FlashList row cannot re-report a climb it already answered for). The
+surface is part of the claim because the queue prefetch warms the SAME key the
+play board asks for next; a claim shared between them would report the mismatch
+as `prefetch` and leave the play view a climber actually saw silent.
 
 On the 25 for the other stages: The failure this event exists for is a device that fails
 EVERY render from some point on, and `getOrStartInflightRender` drops the settled

--- a/docs/board-render-analytics.md
+++ b/docs/board-render-analytics.md
@@ -117,7 +117,7 @@ Common props (the table above) plus:
 
 | Property                | Values                                                                                                                                   |
 | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `surface`               | `play` \| `full` \| `thumbnail` — see below; `play` is opt-in, not derived                                                                 |
+| `surface`               | `play` \| `full` \| `thumbnail` \| `prefetch` — see below; `play` and `prefetch` are opt-in, not derived                                  |
 | `stage`                 | `config` \| `native` \| `image_load` — which part of the path gave up                                                                       |
 | `failure_kind`          | on `config`: `no_matching_holds` \| `partial_hold_match`. On `native`: `render_failed` \| `disk_full` \| `capability_fallback` \| `render_stalled`. On `image_load`: `cache_entry_missing` \| `retry_exhausted` \| `cache_entry_present` \| `validation_failed` \| `validation_unsupported` \| `paint_timeout` |
 | `error_code`            | `code_<n>` \| `png` \| `cgimage` \| `write` \| `module` \| `capability` \| `no_matching_holds` \| `partial_hold_match` \| `paint_timeout` \| `render_stalled` \| `other` |
@@ -148,6 +148,14 @@ Do not collapse the two. `full` covers surfaces that are off-screen, behind a
 sheet, or one of a dozen preview cards drawn at once, so a failure rate pooled
 across `play` and `full` would not describe anything a climber experienced.
 `thumbnail` is still just the filled style the list and accessory rows ask for.
+
+`prefetch` is the fourth, and it is opt-in the same way: `UpcomingBoardPrefetch`
+warms the board renders for the next few climbs in the queue while the drawer is
+open, at the render scheduler's idle-only `prefetch` rank. Nobody is looking at
+those renders, so their failures belong in their own bucket — pooled into `full`
+they would inflate a rate no climber experienced, and on their own they answer
+the one question this rank raises: whether the warm-up fails while the visible
+board is fine.
 
 #### What this event still cannot see
 

--- a/docs/react-native-performance.md
+++ b/docs/react-native-performance.md
@@ -350,7 +350,9 @@ real risk; the OOM actually reproduces on 4 GB iPhones.
 **Rule:** Any surface that draws a board overlay requests it through `useNativeClimbRender`
 (which calls `requestRender`), never the native module directly. Pass `playSurface: true` only for
 the one board the climber is actually looking at — never a preview card, a rail, or the carousel's
-off-screen peek. Never hold a render request past your effect's cleanup.
+off-screen peek. Never hold a render request past your effect's cleanup. Warm-up renders nobody is
+looking at yet — the play drawer's next few queue items — pass `prefetch: true` instead, and pass it
+for nothing that is on screen.
 
 **Why:** `renderHoldsOverlay` runs on expo-modules-core's one shared serial queue per platform, so
 every render — play board, carousel peek, every FlashList thumbnail — used to queue behind whatever
@@ -358,8 +360,10 @@ was already running, and a scrolled-past row never gave its slot back. On a phon
 that stretched the wait for the board a climber was staring at from a fraction of a second to
 several seconds, and nothing measured it (issue #5187). `render-scheduler.ts`
 (`packages/mobile/src/lib/board-render/render-scheduler.ts`) now queues renders in JS, orders them
-`play` > `full` > `thumbnail`, and drops a request the moment its last consumer stops wanting it —
-but only if every caller goes through it. A play-board render that is still waiting after 6s fires
+`play` > `full` > `thumbnail` > `prefetch`, and drops a request the moment its last consumer stops
+wanting it — but only if every caller goes through it. The `prefetch` rank is idle-only: it
+dispatches when nothing else is queued and native is empty, so warming the climbs ahead can never
+cost a render somebody is waiting on more than the one prefetch already inside native. A play-board render that is still waiting after 6s fires
 the `render_stalled` event (`docs/board-render-analytics.md`), which is how to tell whether a slow
 render is stuck in our queue or stuck in native.
 

--- a/packages/mobile/src/components/play-drawer/DeferredBoard.tsx
+++ b/packages/mobile/src/components/play-drawer/DeferredBoard.tsx
@@ -26,6 +26,8 @@ type DeferredBoardProps = {
   currentFrameOverride?: string | null;
   nextFrames: string | null;
   prevFrames: string | null;
+  /** Frames for the climbs a few swipes ahead; warmed while the renderer is idle. */
+  prefetchFrames?: string[];
   mirrored: boolean;
   canSwipeNext: boolean;
   canSwipePrevious: boolean;

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -26,7 +26,11 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
 import { randomUUID } from 'expo-crypto';
-import { computeNavigationStateWithSuggestions, boardSupportsMirroring } from '@boardsesh/play-view';
+import {
+  computeNavigationStateWithSuggestions,
+  findUpcomingQueueItemsWithSuggestions,
+  boardSupportsMirroring,
+} from '@boardsesh/play-view';
 import { climbToQueueItem } from '../../lib/climb-to-queue-item';
 import { formatRenderBoardLabel, resolveClimbRenderBoard, sameRenderBoard } from '../../lib/boards/climb-render-board';
 import type { ActiveSubDrawer } from '@boardsesh/play-view';
@@ -208,6 +212,18 @@ function peekFramesOnBoard(
   const resolved = resolveClimbRenderBoard(peek, activeBoardConfig);
   return sameRenderBoard(resolved?.boardConfig ?? activeBoardConfig, renderBoardConfig) ? peek.frames : null;
 }
+
+/**
+ * How many climbs ahead of the displayed one get their board render warmed
+ * while the drawer is open. Three covers a normal run of swipes without piling
+ * up work: these renders only ever run when the renderer is idle, but each one
+ * still costs a cached PNG on disk and a slot in the overlay index.
+ */
+const PREFETCH_AHEAD = 3;
+/** Joins the prefetch list into one memo key. Never appears in a frames string. */
+const PREFETCH_FRAMES_SEPARATOR = '\n';
+/** Hoisted so "nothing to warm" keeps one array identity across renders. */
+const NO_PREFETCH_FRAMES: string[] = [];
 
 // Fallback used for the first-screen reserve before the Logbook header has
 // been measured, so the board fits without a visible jump on first open.
@@ -532,6 +548,36 @@ export function PlayDrawer({
   const prevPeekFrames = useMemo(
     () => peekFramesOnBoard(navigationState.prevItem?.climb, boardConfig, renderBoardConfig),
     [navigationState.prevItem, boardConfig, renderBoardConfig],
+  );
+
+  // The climbs a few swipes ahead, warmed while the renderer is idle so getting
+  // to them is a cache hit (#5187). Same board filter as the peeks: a climb on
+  // another wall has nothing to draw here, and would warm a render the carousel
+  // never asks for. The displayed climb is dropped (it is already on screen) and
+  // duplicate frames collapse, since one render serves every climb that lights
+  // the same holds.
+  const displayedClimbFrames = displayedClimb?.frames;
+  const upcomingPrefetchFramesKey = useMemo(() => {
+    const upcomingItems = findUpcomingQueueItemsWithSuggestions(
+      queue,
+      displayedQueueItem,
+      navigationSuggestionSource,
+      PREFETCH_AHEAD,
+    );
+    const framesToWarm: string[] = [];
+    for (const item of upcomingItems) {
+      const frames = peekFramesOnBoard(item.climb, boardConfig, renderBoardConfig);
+      if (!frames || frames === displayedClimbFrames || framesToWarm.includes(frames)) continue;
+      framesToWarm.push(frames);
+    }
+    return framesToWarm.join(PREFETCH_FRAMES_SEPARATOR);
+  }, [queue, displayedQueueItem, navigationSuggestionSource, boardConfig, renderBoardConfig, displayedClimbFrames]);
+  // Split back out of the joined key rather than memoized on the walk's inputs:
+  // the queue gets a fresh array identity on every broadcast, and a new array
+  // here would remount every warmed render for a list that hasn't changed.
+  const upcomingPrefetchFrames = useMemo(
+    () => (upcomingPrefetchFramesKey ? upcomingPrefetchFramesKey.split(PREFETCH_FRAMES_SEPARATOR) : NO_PREFETCH_FRAMES),
+    [upcomingPrefetchFramesKey],
   );
 
   // Host-owned post-fling reset: once the swiped-to climb has actually rendered
@@ -1247,6 +1293,7 @@ export function PlayDrawer({
                             currentFrameOverride={playback.isAnimatable ? playback.currentFrameString : null}
                             nextFrames={nextPeekFrames}
                             prevFrames={prevPeekFrames}
+                            prefetchFrames={upcomingPrefetchFrames}
                             mirrored={isMirrored}
                             canSwipeNext={navigationState.canNext}
                             canSwipePrevious={navigationState.canPrevious}

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -564,18 +564,18 @@ export function PlayDrawer({
       navigationSuggestionSource,
       PREFETCH_AHEAD,
     );
-    const framesToWarm: string[] = [];
+    const framesToWarm = new Set<string>();
     for (const item of upcomingItems) {
       const frames = peekFramesOnBoard(item.climb, boardConfig, renderBoardConfig);
-      if (!frames || frames === displayedClimbFrames || framesToWarm.includes(frames)) continue;
+      if (!frames || frames === displayedClimbFrames || framesToWarm.has(frames)) continue;
       // A multi-frame route plays back frame by frame once it is current
       // (`playback.currentFrameString`), and its first accumulated frame is a
       // different cache key from the flattened union the catalog string would
       // warm. Nothing worth warming there; boulders are the 99.9% case anyway.
       if (frames.includes(',')) continue;
-      framesToWarm.push(frames);
+      framesToWarm.add(frames);
     }
-    return framesToWarm.join(PREFETCH_FRAMES_SEPARATOR);
+    return [...framesToWarm].join(PREFETCH_FRAMES_SEPARATOR);
   }, [queue, displayedQueueItem, navigationSuggestionSource, boardConfig, renderBoardConfig, displayedClimbFrames]);
   // Split back out of the joined key rather than memoized on the walk's inputs:
   // the queue gets a fresh array identity on every broadcast, and a new array

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -568,6 +568,11 @@ export function PlayDrawer({
     for (const item of upcomingItems) {
       const frames = peekFramesOnBoard(item.climb, boardConfig, renderBoardConfig);
       if (!frames || frames === displayedClimbFrames || framesToWarm.includes(frames)) continue;
+      // A multi-frame route plays back frame by frame once it is current
+      // (`playback.currentFrameString`), and its first accumulated frame is a
+      // different cache key from the flattened union the catalog string would
+      // warm. Nothing worth warming there; boulders are the 99.9% case anyway.
+      if (frames.includes(',')) continue;
       framesToWarm.push(frames);
     }
     return framesToWarm.join(PREFETCH_FRAMES_SEPARATOR);

--- a/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
+++ b/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
@@ -25,6 +25,7 @@ import { useZoomPanGesture } from './use-zoom-pan-gesture';
 import { computeContainedBoardSize, CAROUSEL_LAYER_Z } from './play-drawer-layout';
 import { ResetZoomButton } from '../board-controls/ResetZoomButton';
 import { useEffectiveBoardRenderSettings } from '../../hooks/use-native-climb-render';
+import { UpcomingBoardPrefetch } from './UpcomingBoardPrefetch';
 
 type BoardRenderData = {
   boardWidth: number;
@@ -47,6 +48,12 @@ type SwipeBoardCarouselProps = {
   currentFrameOverride?: string | null;
   nextFrames: string | null;
   prevFrames: string | null;
+  /**
+   * Frames for the climbs a few swipes ahead, warmed while the renderer is idle
+   * (see UpcomingBoardPrefetch). Nothing is drawn from these. Pass a stable
+   * array identity across renders when the contents haven't changed.
+   */
+  prefetchFrames?: string[];
   mirrored: boolean;
   canSwipeNext: boolean;
   canSwipePrevious: boolean;
@@ -69,6 +76,9 @@ type SwipeBoardCarouselProps = {
   swipeIsAnimating?: SharedValue<boolean>;
 };
 
+/** Hoisted so an omitted `prefetchFrames` doesn't remount the prefetch every render. */
+const NO_PREFETCH_FRAMES: string[] = [];
+
 export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
   boardName,
   boardRenderData,
@@ -79,6 +89,7 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
   currentFrameOverride,
   nextFrames,
   prevFrames,
+  prefetchFrames = NO_PREFETCH_FRAMES,
   mirrored,
   canSwipeNext,
   canSwipePrevious,
@@ -253,10 +264,12 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
     );
   }, []);
 
+  const isScreenshotMode = process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1';
+
   return (
     <GestureDetector gesture={composedGesture}>
       <View style={styles.container} onLayout={handleLayout}>
-        {process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1' ? (
+        {isScreenshotMode ? (
           // Screenshot mode: render the board in PLAIN (non-reanimated) Views.
           // The swipe/zoom `Animated.View` wrappers promote the board to a render
           // layer that Android's `adb screencap` (Maestro's capture) intermittently
@@ -340,6 +353,21 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
             />
           )}
         </Animated.View>
+
+        {/* Draws nothing: warms the renders for the climbs a few swipes ahead
+            while the renderer is idle, so those swipes are cache hits. Skipped
+            in screenshot mode, where the only render that matters is the one
+            board the capture is waiting on. */}
+        {isScreenshotMode ? null : (
+          <UpcomingBoardPrefetch
+            frames={prefetchFrames}
+            boardName={boardName}
+            layoutId={layoutId}
+            sizeId={sizeId}
+            setIds={setIds}
+            renderWidth={overlayRenderWidth}
+          />
+        )}
 
         {/* Pan-while-zoomed overlay: only mounted when zoomed so it doesn't
             claim 1-finger touches in the idle state (which would block

--- a/packages/mobile/src/components/play-drawer/UpcomingBoardPrefetch.tsx
+++ b/packages/mobile/src/components/play-drawer/UpcomingBoardPrefetch.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import type { BoardName } from '@boardsesh/shared-schema';
+import { useNativeClimbRender } from '../../hooks/use-native-climb-render';
+
+type UpcomingBoardPrefetchProps = {
+  /** Frames strings for the climbs just ahead in the queue, in swipe order. */
+  frames: string[];
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  /**
+   * The carousel's measured overlay width. Undefined until the board has been
+   * laid out — and a render at the board's native width would land under a
+   * different cache key (see `buildCacheKey`'s width token), so there is
+   * nothing worth warming yet.
+   */
+  renderWidth: number | undefined;
+};
+
+type PrefetchedBoardRenderProps = Omit<UpcomingBoardPrefetchProps, 'frames'> & { frames: string };
+
+/**
+ * One warmed render. Draws nothing: the hook writes the finished PNG into the
+ * overlay index and the disk cache, which is the whole product of this mount.
+ */
+const PrefetchedBoardRender = React.memo(function PrefetchedBoardRender({
+  frames,
+  boardName,
+  layoutId,
+  sizeId,
+  setIds,
+  renderWidth,
+}: PrefetchedBoardRenderProps) {
+  useNativeClimbRender({
+    frames,
+    boardName,
+    layoutId,
+    sizeId,
+    setIds,
+    // Every input that feeds the cache key has to match what the carousel will
+    // ask for, or this warms a PNG nobody looks up: stroke-only (the play
+    // board's default `filledStyle`, so it is left unset here) at the
+    // carousel's `overlayRenderWidth`. `mirrored` is not in the key — one PNG
+    // serves both orientations — and `backgroundVariant` picks the shared board
+    // photo rather than the overlay, but it is pinned to the play board's
+    // `full` anyway so a prefetch can't warm the wrong photo either.
+    renderWidth,
+    backgroundVariant: 'full',
+    prefetch: true,
+  });
+  return null;
+});
+
+/**
+ * Warms the board renders for the next few climbs in the queue while the play
+ * drawer is open, so swiping to them paints from cache instead of waiting on a
+ * native render (issue #5187). Renders nothing.
+ *
+ * Safe to mount because of where it sits in the render scheduler: `prefetch` is
+ * the lowest rank there, and it dispatches ONLY when nothing else is queued and
+ * native is empty. A render somebody is waiting on therefore never queues
+ * behind more than one prefetch already inside native, and on a busy drawer
+ * these requests simply sit in the queue until the renderer goes idle.
+ *
+ * They do not accumulate: each child holds at most one undispatched request and
+ * the hook's effect cleanup releases it, so a changed `frames` list or an
+ * unmounted drawer withdraws the renders that never started.
+ */
+export const UpcomingBoardPrefetch = React.memo(function UpcomingBoardPrefetch({
+  frames,
+  boardName,
+  layoutId,
+  sizeId,
+  setIds,
+  renderWidth,
+}: UpcomingBoardPrefetchProps) {
+  if (renderWidth === undefined) return null;
+
+  return (
+    <>
+      {frames.map((climbFrames) => (
+        <PrefetchedBoardRender
+          // Keyed on the frames, not the index, so reordering the list (the
+          // usual case: the climber swiped one along) moves the mounted child
+          // instead of remounting it onto different frames.
+          key={climbFrames}
+          frames={climbFrames}
+          boardName={boardName}
+          layoutId={layoutId}
+          sizeId={sizeId}
+          setIds={setIds}
+          renderWidth={renderWidth}
+        />
+      ))}
+    </>
+  );
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/UpcomingBoardPrefetch.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/UpcomingBoardPrefetch.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+//
+// The prefetch only pays off if it warms the SAME cache key the carousel will
+// ask for — a mismatched width or hold style renders a second PNG nobody looks
+// up, at the cost of a native render. So the props handed to the render hook
+// are the contract under test here, not any pixels (this component draws none).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import type { BoardName } from '@boardsesh/shared-schema';
+
+type RecordedRenderParams = {
+  frames: string;
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+  filledStyle?: boolean;
+  renderWidth?: number;
+  backgroundVariant?: string;
+  prefetch?: boolean;
+};
+
+const renderParams = vi.hoisted(() => [] as RecordedRenderParams[]);
+/** The frames of every child that actually MOUNTED, in mount order. */
+const mountedFrames = vi.hoisted(() => [] as string[]);
+
+vi.mock('../../../hooks/use-native-climb-render', async () => {
+  const { useEffect } = await import('react');
+  return {
+    useNativeClimbRender: (params: RecordedRenderParams) => {
+      renderParams.push(params);
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only, on purpose: this is the remount probe.
+      useEffect(() => {
+        mountedFrames.push(params.frames);
+      }, []);
+      return { overlayUri: null };
+    },
+  };
+});
+
+const { UpcomingBoardPrefetch } = await import('../UpcomingBoardPrefetch');
+
+const BOARD = { boardName: 'kilter' as BoardName, layoutId: 1, sizeId: 10, setIds: '26,27' };
+const FIRST = 'p1100r12';
+const SECOND = 'p1200r13';
+const THIRD = 'p1300r12';
+
+beforeEach(() => {
+  renderParams.length = 0;
+  mountedFrames.length = 0;
+});
+
+describe('UpcomingBoardPrefetch', () => {
+  it('warms one render per upcoming climb, at the play board’s own cache key', () => {
+    render(<UpcomingBoardPrefetch frames={[FIRST, SECOND]} {...BOARD} renderWidth={880} />);
+
+    expect(renderParams).toHaveLength(2);
+    expect(renderParams.map(({ frames }) => frames)).toEqual([FIRST, SECOND]);
+    for (const params of renderParams) {
+      expect(params).toMatchObject({
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '26,27',
+        renderWidth: 880,
+        backgroundVariant: 'full',
+        prefetch: true,
+      });
+      // Stroke-only, like the play board — a filled render is a different PNG.
+      expect(params.filledStyle).toBeUndefined();
+    }
+  });
+
+  it('warms nothing before the board has been measured', () => {
+    render(<UpcomingBoardPrefetch frames={[FIRST, SECOND]} {...BOARD} renderWidth={undefined} />);
+
+    expect(renderParams).toEqual([]);
+  });
+
+  it('warms nothing for an empty list', () => {
+    render(<UpcomingBoardPrefetch frames={[]} {...BOARD} renderWidth={880} />);
+
+    expect(renderParams).toEqual([]);
+  });
+
+  it('keeps the already-warmed climbs mounted when the list moves along', () => {
+    const { rerender } = render(<UpcomingBoardPrefetch frames={[FIRST, SECOND, THIRD]} {...BOARD} renderWidth={880} />);
+    expect(mountedFrames).toEqual([FIRST, SECOND, THIRD]);
+
+    // The climber swiped one along: the same climbs shift down a slot and one
+    // new one joins. Keyed on the frames, so only the newcomer mounts.
+    const FOURTH = 'p1400r13';
+    rerender(<UpcomingBoardPrefetch frames={[SECOND, THIRD, FOURTH]} {...BOARD} renderWidth={880} />);
+
+    expect(mountedFrames).toEqual([FIRST, SECOND, THIRD, FOURTH]);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-anonymous.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-anonymous.test.tsx
@@ -93,6 +93,9 @@ vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ t
 
 // --- Shared packages ---------------------------------------------------------
 vi.mock('@boardsesh/play-view', () => ({
+  // The prefetch walk: these suites assert on the displayed board, not on
+  // what is warmed ahead, so nothing is ahead.
+  findUpcomingQueueItemsWithSuggestions: () => [],
   computeNavigationStateWithSuggestions: () => ({
     nextItem: null,
     prevItem: null,

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
@@ -89,6 +89,9 @@ vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ t
 // `@boardsesh/board-config` and `lib/board-details` stay REAL: the resolver
 // reads real layouts, sizes and hold placements, which is the whole question.
 vi.mock('@boardsesh/play-view', () => ({
+  // The prefetch walk: these suites assert on the displayed board, not on
+  // what is warmed ahead, so nothing is ahead.
+  findUpcomingQueueItemsWithSuggestions: () => [],
   computeNavigationStateWithSuggestions: () => navigation.state,
   boardSupportsMirroring: () => true,
 }));

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
@@ -38,6 +38,9 @@ const queueState = vi.hoisted(() => ({
   queue: [] as unknown[],
   currentClimbQueueItem: null as unknown,
 }));
+// What the prefetch walk hands back, per case. Empty by default: most cases here
+// assert on the displayed board, not on what is warmed ahead of it.
+const prefetchWalk = vi.hoisted(() => ({ items: [] as unknown[] }));
 const navigation = vi.hoisted(() => ({
   state: {
     nextItem: null as unknown,
@@ -89,9 +92,7 @@ vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ t
 // `@boardsesh/board-config` and `lib/board-details` stay REAL: the resolver
 // reads real layouts, sizes and hold placements, which is the whole question.
 vi.mock('@boardsesh/play-view', () => ({
-  // The prefetch walk: these suites assert on the displayed board, not on
-  // what is warmed ahead, so nothing is ahead.
-  findUpcomingQueueItemsWithSuggestions: () => [],
+  findUpcomingQueueItemsWithSuggestions: () => prefetchWalk.items,
   computeNavigationStateWithSuggestions: () => navigation.state,
   boardSupportsMirroring: () => true,
 }));
@@ -269,6 +270,7 @@ beforeEach(() => {
   queueState.queue = [];
   queueState.currentClimbQueueItem = null;
   navigation.state = { nextItem: null, prevItem: null, canNext: false, canPrevious: false };
+  prefetchWalk.items = [];
 });
 
 describe('PlayDrawer draws the climb on its own board (#5099)', () => {
@@ -385,6 +387,32 @@ describe('PlayDrawer draws the climb on its own board (#5099)', () => {
     expect(board.nextFrames).toBeNull();
     // The same-board neighbour still peeks — this must not blanket-disable peeks.
     expect(board.prevFrames).toBe(TWELVE_CLIMB.frames);
+  });
+
+  it('warms the upcoming boulders and leaves multi-frame routes alone', () => {
+    const firstBoulder = { ...TWELVE_CLIMB, uuid: 'twelve-b1', frames: 'p1145r15p1146r13' };
+    // A route: the drawer plays this one frame by frame once it is current, so
+    // the flattened catalog string is not a key anything will ask for.
+    const route = { ...TWELVE_CLIMB, uuid: 'twelve-route', frames: 'p1145r15,p1200r13' };
+    const secondBoulder = { ...TWELVE_CLIMB, uuid: 'twelve-b2', frames: 'p1300r15' };
+    queueState.currentClimbQueueItem = queueItem(TWELVE_CLIMB, 'queue-twelve');
+    prefetchWalk.items = [
+      queueItem(firstBoulder as Climb, 'queue-b1'),
+      queueItem(route as Climb, 'queue-route'),
+      queueItem(secondBoulder as Climb, 'queue-b2'),
+    ];
+    renderDrawer(vi.fn());
+
+    expect(lastBoardProps().prefetchFrames).toEqual([firstBoulder.frames, secondBoulder.frames]);
+  });
+
+  it('warms nothing for a climb that lives on another board', () => {
+    queueState.currentClimbQueueItem = queueItem(TWELVE_CLIMB, 'queue-twelve');
+    prefetchWalk.items = [queueItem(HOMEWALL_CLIMB, 'queue-homewall')];
+    renderDrawer(vi.fn());
+
+    // Same rule as the peeks: a Homewall climb has no holds on the 12x12 art.
+    expect(lastBoardProps().prefetchFrames).toEqual([]);
   });
 
   it('keeps the below-fold sections and the tick sheet on the climb board', () => {

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-disk-full.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-disk-full.test.tsx
@@ -123,6 +123,11 @@ function renderRow(index: number) {
   return renderHook(() => useNativeClimbRender({ ...BASE, frames: `p${1000 + index}r12` }));
 }
 
+/** The same row, warmed speculatively for a climb nobody has swiped to yet. */
+function renderPrefetchRow(index: number) {
+  return renderHook(() => useNativeClimbRender({ ...BASE, frames: `p${1000 + index}r12`, prefetch: true }));
+}
+
 beforeEach(() => {
   renderOutcome.mode = 'disk-full';
   // Default: a platform that won't say, so the message match stands alone.
@@ -256,6 +261,34 @@ describe('out-of-space render storm', () => {
       expect(fakeNativeModule.renderHoldsOverlay.mock.calls.length).toBeGreaterThan(callsWhileLatched);
       // Still the missing-layer contract while it retries, never a blank screen.
       expect(stationary.result.current.backgroundPaths).toEqual(['file:///bg.png']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // The play drawer warms three climbs ahead. Each one resuming its PNG write
+  // the moment the back-off lifts is the storm the latch exists to stop — and
+  // nobody is waiting on any of them, so the climb that IS swiped to makes its
+  // own attempt anyway (the visible-surface recovery is asserted above).
+  it('never schedules a recovery for a prefetch, unlike a surface on screen', async () => {
+    vi.useFakeTimers();
+    try {
+      renderRow(0);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(sweepBoardArtCache).toHaveBeenCalledWith({ trigger: 'disk-pressure' });
+
+      renderPrefetchRow(1);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      const callsWhileLatched = fakeNativeModule.renderHoldsOverlay.mock.calls.length;
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_001);
+      });
+      expect(fakeNativeModule.renderHoldsOverlay.mock.calls.length).toBe(callsWhileLatched);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
@@ -257,6 +257,15 @@ describe('Board Render Failed — the native stage', () => {
     expect(failureEvents()[0].surface).toBe('prefetch');
   });
 
+  // No caller sets both today; the contract in the params doc is that the
+  // board the climber is looking at wins if one ever does.
+  it('lets playSurface win over prefetch when a caller sets both', async () => {
+    renderRow({ prefetch: true, playSurface: true });
+    await waitFor(() => expect(failureEvents()).toHaveLength(1));
+
+    expect(failureEvents()[0].surface).toBe('play');
+  });
+
   // The message interpolates the cache key and the cache path. Neither may
   // reach an event property — it is the climb the climber is looking at, and it
   // would shatter the event into one group per file.

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
@@ -447,6 +447,24 @@ describe('one bounded self-retry after a native render failure', () => {
     expect(fakeNativeModule.renderHoldsOverlay.mock.calls.length).toBe(callsAfterFirstFailure);
   });
 
+  // A prefetch is a warm-up nobody is waiting on, and the play board that wants
+  // the same key asks for it again anyway — so a retry here only spends native
+  // time the visible board could have had.
+  it('never retries a prefetch, unlike the same failure on a visible surface', async () => {
+    vi.useFakeTimers();
+    renderRow({ prefetch: true });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+
+    // Well past the 1.5s the visible surfaces retry after (asserted above).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+  });
+
   it('drops a pending retry when the surface unmounts', async () => {
     vi.useFakeTimers();
     const { unmount } = renderRow();
@@ -520,6 +538,22 @@ describe('Board Render Failed — the config stage', () => {
     });
 
     expect(failureEvents().filter((event) => event.stage === 'config')).toHaveLength(1);
+  });
+
+  // The claim is per SURFACE as well as per key. The prefetch warms exactly the
+  // key the play board asks for next, so a shared claim would let the warm-up
+  // spend the report — and the mismatch the climber actually ran into would be
+  // filed as `surface: 'prefetch'`, or not at all.
+  it('reports the mismatch once per surface, so a prefetch cannot eat the play board’s report', async () => {
+    renderRow({ frames: OFF_BOARD_FRAMES, prefetch: true });
+    await waitFor(() => expect(failureEvents()).toHaveLength(1));
+
+    renderRow({ frames: OFF_BOARD_FRAMES, playSurface: true });
+    await waitFor(() => expect(failureEvents()).toHaveLength(2));
+
+    const configEvents = failureEvents().filter((event) => event.stage === 'config');
+    expect(configEvents.map(({ surface }) => surface)).toEqual(['prefetch', 'play']);
+    expect(configEvents.every(({ failure_kind }) => failure_kind === 'no_matching_holds')).toBe(true);
   });
 
   // The regression that would have shipped: builds before this fix cached

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
@@ -146,7 +146,13 @@ function failureEvents(): FailureProperties[] {
 }
 
 function renderRow(
-  overrides: { frames?: string; filledStyle?: boolean; renderWidth?: number; playSurface?: boolean } = {},
+  overrides: {
+    frames?: string;
+    filledStyle?: boolean;
+    renderWidth?: number;
+    playSurface?: boolean;
+    prefetch?: boolean;
+  } = {},
 ) {
   return renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES, ...overrides }));
 }
@@ -238,6 +244,17 @@ describe('Board Render Failed — the native stage', () => {
     renderRow({ frames: 'p1500r12p1600r13' });
     await waitFor(() => expect(failureEvents()).toHaveLength(1));
     expect(failureEvents()[0].surface).toBe('full');
+  });
+
+  // The queue-ahead warm-up nobody is looking at. Pooling its failures with the
+  // full-size surfaces would inflate a rate no climber experienced — and hide
+  // the one thing this rank can actually break, which is warming a render that
+  // fails every time while the visible board is fine.
+  it('names the idle prefetch surface separately', async () => {
+    renderRow({ prefetch: true });
+    await waitFor(() => expect(failureEvents()).toHaveLength(1));
+
+    expect(failureEvents()[0].surface).toBe('prefetch');
   });
 
   // The message interpolates the cache key and the cache path. Neither may

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -166,6 +166,13 @@ type NativeClimbRenderParams = {
    */
   playSurface?: boolean;
   /**
+   * A render nobody is looking at yet — the play drawer warming the next few
+   * queue items. Requests at the scheduler's `prefetch` rank (runs only when
+   * the renderer is otherwise idle) and reports failures as `surface:
+   * 'prefetch'`. Mutually exclusive with `playSurface`; `playSurface` wins.
+   */
+  prefetch?: boolean;
+  /**
    * Draw under a DIFFERENT board-render settings bundle than the climber's
    * stored one — the board-look carousel, whose cards each show the same climb
    * under a different preset.
@@ -1718,6 +1725,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     holdColorOverride,
     verifyOverlayFile = false,
     playSurface = false,
+    prefetch = false,
     maxVeilOpacity,
   } = params;
   const {
@@ -1974,7 +1982,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       layoutId,
       sizeId,
       effective: effectiveRenderSettings,
-      surface: playSurface ? 'play' : filledStyle ? 'thumbnail' : 'full',
+      surface: playSurface ? 'play' : prefetch ? 'prefetch' : filledStyle ? 'thumbnail' : 'full',
       renderWidth: renderWidth ?? null,
       framesLength: frames.length,
     }),
@@ -1982,7 +1990,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     // effect below already depends on the whole string, so keying on the length
     // would save nothing and would put a `.length` dep in a hot hook — the one
     // shape docs/react-native-performance.md tells reviewers to reject.
-    [boardName, layoutId, sizeId, effectiveRenderSettings, filledStyle, playSurface, renderWidth, frames],
+    [boardName, layoutId, sizeId, effectiveRenderSettings, filledStyle, playSurface, prefetch, renderWidth, frames],
   );
 
   useEffect(() => {
@@ -2254,7 +2262,13 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     // thumbnails, and a request this surface abandons (the cleanup below) before
     // its turn is never asked for at all. The config JSON is built inside
     // `start`, so an abandoned request never pays for it either.
-    const renderPriority: RenderPriority = playSurface ? 'play' : filledStyle ? 'thumbnail' : 'full';
+    const renderPriority: RenderPriority = playSurface
+      ? 'play'
+      : prefetch
+        ? 'prefetch'
+        : filledStyle
+          ? 'thumbnail'
+          : 'full';
     const renderRequest = requestRender(currentCacheKey, renderPriority, () =>
       getOrStartInflightRender(currentCacheKey, () => {
         const configJson = JSON.stringify({

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -2136,7 +2136,11 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       const unmatchedCount = litHoldIds.size - matchedCount;
       if (unmatchedCount > 0) {
         const noMatches = matchedCount === 0;
-        if (claimConfigMismatchKey(currentCacheKey)) {
+        // Claimed per surface as well as per key: the prefetch warms the SAME
+        // key the play board asks for next, and a claim shared between them
+        // would let the warm-up report the mismatch as `surface: 'prefetch'`
+        // and leave the play view — the one a climber actually saw — silent.
+        if (claimConfigMismatchKey(`${failureTelemetryContext.surface}:${currentCacheKey}`)) {
           noteRenderFailure({
             stage: 'config',
             failureKind: noMatches ? 'no_matching_holds' : 'partial_hold_match',
@@ -2410,7 +2414,9 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
         // above owns that, and retrying a write on a full volume is the storm)
         // and NOT for a capability fallback (the degraded re-render IS the
         // retry). The keyed guard is what makes a recycled row safe.
-        if (kind === 'render_failed' && !retriedCacheKeysRef.current.has(currentCacheKey)) {
+        // ...and never for a prefetch: nobody is waiting on it, and the play
+        // view that follows makes its own attempt under the same key.
+        if (kind === 'render_failed' && !prefetch && !retriedCacheKeysRef.current.has(currentCacheKey)) {
           retriedCacheKeysRef.current.add(currentCacheKey);
           if (renderRetryTimerRef.current !== null) clearTimeout(renderRetryTimerRef.current);
           renderRetryTimerRef.current = setTimeout(() => {

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -2253,6 +2253,10 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       // effect, and would sit with no overlay for the rest of the mount even
       // though the sweep this back-off kicked off may have freed the space.
       if (diskPressureRetriesRef.current >= DISK_PRESSURE_MAX_RETRIES) return;
+      // Never for a prefetch: three speculative children each resuming PNG
+      // writes on a full disk is the storm the latch exists to stop, and the
+      // play view will make its own attempt when the climb is swiped to.
+      if (prefetch) return;
       diskPressureRetriesRef.current += 1;
       // +1ms so the latch has certainly expired by the time the effect re-runs.
       const retryTimer = setTimeout(() => {

--- a/packages/mobile/src/lib/board-render/__tests__/render-scheduler.test.ts
+++ b/packages/mobile/src/lib/board-render/__tests__/render-scheduler.test.ts
@@ -273,7 +273,7 @@ describe('ordering the queue', () => {
     await expect(occupantHandle.promise).resolves.toBe('file:///occupant.png');
   });
 
-  it('promotes a queued full surface that becomes the play board, and never demotes it again', async () => {
+  it('promotes a queued full surface that becomes the play board while the play consumer holds it', async () => {
     const occupant = controlledRender();
     const olderFull = controlledRender();
     const peekBecomingPlay = controlledRender();
@@ -283,9 +283,7 @@ describe('ordering the queue', () => {
 
     // The carousel commits: the same key is now the board the climber is
     // looking at, so a second consumer asks for it as `play`.
-    const playConsumer = requestRender('key-peek', 'play', peekBecomingPlay.start);
-    // …and swipes on, releasing that consumer while the peek row stays mounted.
-    playConsumer.release();
+    requestRender('key-peek', 'play', peekBecomingPlay.start);
 
     occupant.settlement.resolve('file:///occupant.png');
     await expect(occupantHandle.promise).resolves.toBe('file:///occupant.png');
@@ -295,6 +293,53 @@ describe('ordering the queue', () => {
       queuedKeys: ['key-older-full'],
     });
     expect(olderFull.startCount()).toBe(0);
+  });
+
+  it('drops a released play consumer to the rank the remaining consumer holds', async () => {
+    const occupant = controlledRender();
+    const shared = controlledRender();
+    const otherPlay = controlledRender();
+    const occupantHandle = requestRender('key-occupant', 'full', occupant.start);
+    // The peek is drawing this key while the committed board also asks for it…
+    requestRender('key-shared', 'full', shared.start);
+    const playConsumer = requestRender('key-shared', 'play', shared.start);
+    // …then a different climb becomes the play board.
+    requestRender('key-other-play', 'play', otherPlay.start);
+    playConsumer.release();
+
+    occupant.settlement.resolve('file:///occupant.png');
+    await expect(occupantHandle.promise).resolves.toBe('file:///occupant.png');
+
+    // Back at `full` — not still `play` on a consumer that let go — so the board
+    // the climber is actually looking at goes first despite arriving later.
+    expect(_renderSchedulerStateForTests()).toMatchObject({
+      dispatchedKeys: ['key-other-play'],
+      queuedKeys: ['key-shared'],
+    });
+  });
+
+  it('lets the priority follow the consumers still holding a queued request', async () => {
+    const occupant = controlledRender();
+    const olderFull = controlledRender();
+    const shared = controlledRender();
+    const occupantHandle = requestRender('key-occupant', 'full', occupant.start);
+    requestRender('key-older-full', 'full', olderFull.start);
+    // A prefetch child warms the next climb…
+    requestRender('key-shared', 'prefetch', shared.start);
+    // …the peek turns toward it (`full`), then turns away again.
+    const peekConsumer = requestRender('key-shared', 'full', shared.start);
+    peekConsumer.release();
+
+    occupant.settlement.resolve('file:///occupant.png');
+    await expect(occupantHandle.promise).resolves.toBe('file:///occupant.png');
+
+    // Back at `prefetch`, the abandoned peek's key waits behind the real
+    // request instead of jumping ahead of it on the peek's old rank.
+    expect(_renderSchedulerStateForTests()).toMatchObject({
+      dispatchedKeys: ['key-older-full'],
+      queuedKeys: ['key-shared'],
+    });
+    expect(shared.startCount()).toBe(0);
   });
 });
 

--- a/packages/mobile/src/lib/board-render/__tests__/render-scheduler.test.ts
+++ b/packages/mobile/src/lib/board-render/__tests__/render-scheduler.test.ts
@@ -388,3 +388,88 @@ describe('the snapshot the stall telemetry reads', () => {
     expect(waitingSnapshot.msWaiting).toBeGreaterThanOrEqual(0);
   });
 });
+
+// `prefetch` warms the climbs a few swipes ahead in the play drawer. Nobody is
+// looking at those renders, so the rank's whole contract is that they never
+// cost a render somebody IS waiting on more than the one already inside native.
+describe('the prefetch rank', () => {
+  it('waits in the queue while native is busy, even with a spare dispatch slot', () => {
+    setRenderConcurrency(2);
+    const busy = controlledRender();
+    const warmed = controlledRender();
+    requestRender('key-busy', 'full', busy.start);
+    requestRender('key-warmed', 'prefetch', warmed.start);
+
+    expect(warmed.startCount()).toBe(0);
+    expect(_renderSchedulerStateForTests()).toMatchObject({
+      dispatchedKeys: ['key-busy'],
+      queuedKeys: ['key-warmed'],
+    });
+  });
+
+  it('goes last, and only once nothing else is queued and native is empty', async () => {
+    const occupant = controlledRender();
+    const thumbnail = controlledRender();
+    const warmed = controlledRender();
+    const occupantHandle = requestRender('key-occupant', 'full', occupant.start);
+    requestRender('key-warmed', 'prefetch', warmed.start);
+    requestRender('key-thumbnail', 'thumbnail', thumbnail.start);
+
+    occupant.settlement.resolve('file:///occupant.png');
+    await expect(occupantHandle.promise).resolves.toBe('file:///occupant.png');
+
+    // The thumbnail was asked for last and still goes first.
+    expect(_renderSchedulerStateForTests()).toMatchObject({
+      dispatchedKeys: ['key-thumbnail'],
+      queuedKeys: ['key-warmed'],
+    });
+    expect(warmed.startCount()).toBe(0);
+
+    thumbnail.settlement.resolve('file:///thumbnail.png');
+    await flushMicrotasks();
+
+    expect(warmed.startCount()).toBe(1);
+    expect(_renderSchedulerStateForTests()).toMatchObject({
+      dispatchedKeys: ['key-warmed'],
+      queuedKeys: [],
+    });
+  });
+
+  it('costs a later play board exactly the one prefetch already inside native', async () => {
+    const warmed = controlledRender();
+    const playBoard = controlledRender();
+    // Nothing else is running, so the prefetch goes — and native renders cannot
+    // be cancelled, so the play board that arrives next waits it out.
+    const warmedHandle = requestRender('key-warmed', 'prefetch', warmed.start);
+    requestRender('key-play', 'play', playBoard.start);
+
+    expect(playBoard.startCount()).toBe(0);
+    expect(_renderSchedulerStateForTests()).toMatchObject({
+      dispatchedKeys: ['key-warmed'],
+      queuedKeys: ['key-play'],
+    });
+
+    warmed.settlement.resolve('file:///warmed.png');
+    await expect(warmedHandle.promise).resolves.toBe('file:///warmed.png');
+
+    expect(playBoard.startCount()).toBe(1);
+  });
+
+  it('hands a play request the render a prefetch already started, rather than a second one', async () => {
+    const warmed = controlledRender();
+    const warmedHandle = requestRender('key-shared', 'prefetch', warmed.start);
+    // The climber swiped to the climb that was being warmed: same cache key, so
+    // the play board joins the render in flight.
+    const playHandle = requestRender('key-shared', 'play', warmed.start);
+
+    expect(warmed.startCount()).toBe(1);
+    expect(_renderSchedulerStateForTests()).toMatchObject({
+      dispatchedKeys: ['key-shared'],
+      queuedKeys: [],
+    });
+
+    warmed.settlement.resolve('file:///shared.png');
+    await expect(playHandle.promise).resolves.toBe('file:///shared.png');
+    await expect(warmedHandle.promise).resolves.toBe('file:///shared.png');
+  });
+});

--- a/packages/mobile/src/lib/board-render/__tests__/render-scheduler.test.ts
+++ b/packages/mobile/src/lib/board-render/__tests__/render-scheduler.test.ts
@@ -473,3 +473,43 @@ describe('the prefetch rank', () => {
     await expect(warmedHandle.promise).resolves.toBe('file:///shared.png');
   });
 });
+
+// The upgrade path had to learn to pump: a queued prefetch is holding back from
+// a slot it is not allowed to take, so the moment it becomes a real request the
+// slot is its — waiting for the occupant to settle would make the swipe the
+// climber just made slower than if nothing had been warmed at all.
+describe('upgrading a queued prefetch', () => {
+  it('dispatches it into a free slot immediately, without waiting for the occupant', () => {
+    setRenderConcurrency(2);
+    const occupant = controlledRender();
+    const warmed = controlledRender();
+    requestRender('key-occupant', 'full', occupant.start);
+    requestRender('key-warmed', 'prefetch', warmed.start);
+    expect(warmed.startCount()).toBe(0);
+
+    // The climber swiped to the climb being warmed.
+    requestRender('key-warmed', 'play', warmed.start);
+
+    expect(warmed.startCount()).toBe(1);
+    expect(_renderSchedulerStateForTests()).toMatchObject({
+      dispatchedKeys: ['key-occupant', 'key-warmed'],
+      queuedKeys: [],
+    });
+  });
+
+  it('still waits its turn when every slot is taken', () => {
+    const occupant = controlledRender();
+    const warmed = controlledRender();
+    requestRender('key-occupant', 'full', occupant.start);
+    requestRender('key-warmed', 'prefetch', warmed.start);
+
+    requestRender('key-warmed', 'play', warmed.start);
+
+    // One slot, and the occupant is inside native — the upgrade cannot evict it.
+    expect(warmed.startCount()).toBe(0);
+    expect(_renderSchedulerStateForTests()).toMatchObject({
+      dispatchedKeys: ['key-occupant'],
+      queuedKeys: ['key-warmed'],
+    });
+  });
+});

--- a/packages/mobile/src/lib/board-render/render-scheduler.ts
+++ b/packages/mobile/src/lib/board-render/render-scheduler.ts
@@ -281,7 +281,7 @@ export function requestRender<T>(
     request = {
       key,
       priority,
-      consumersByRank: [0, 0, 0, 0],
+      consumersByRank: new Array<number>(PRIORITY_BY_RANK.length).fill(0),
       sequence: nextSequence++,
       requestedAtMs: nowMs(),
       consumers: 0,

--- a/packages/mobile/src/lib/board-render/render-scheduler.ts
+++ b/packages/mobile/src/lib/board-render/render-scheduler.ts
@@ -282,8 +282,11 @@ export function requestRender<T>(
     }
   } else if (PRIORITY_RANK[priority] < PRIORITY_RANK[request.priority]) {
     // Sticky upgrade: the peek that became the play board. Selection scans the
-    // queue on every dispatch, so nothing needs re-sorting here.
+    // queue on every dispatch, so nothing needs re-sorting here — but a queued
+    // PREFETCH may have been holding back from a free slot (its idle rule), and
+    // as a real request it is entitled to that slot now, so pump.
     request.priority = priority;
+    if (request.start !== null) pump();
   }
   const joined = request;
   joined.consumers += 1;

--- a/packages/mobile/src/lib/board-render/render-scheduler.ts
+++ b/packages/mobile/src/lib/board-render/render-scheduler.ts
@@ -27,9 +27,12 @@
  *   already inside native runs to completion regardless (native cannot be
  *   cancelled) and its result still lands in the overlay index for the next
  *   visit.
- * - Priority upgrades are sticky. The real case is the carousel: a neighbour's
- *   overlay is requested as `full` while it peeks, then the same key becomes
- *   the `play` board on commit; a release never downgrades.
+ * - A request's priority is the best one among the consumers still holding
+ *   it. The carousel's peek asks for a neighbour as `full`; when that key
+ *   becomes the `play` board on commit it goes up, and when the peek turns the
+ *   other way while a prefetch child still holds the key it goes back down to
+ *   `prefetch` — so an abandoned peek can never dispatch ahead of the one now
+ *   facing the climber.
  * - `prefetch` — the next few queue items, warmed for later swipes — only ever
  *   runs when nothing else is queued and native is empty (see `RenderPriority`).
  * - The at-rest peek ranks as `full`, ABOVE visible accessory-strip thumbnails,
@@ -117,7 +120,15 @@ const PRIORITY_RANK: Record<RenderPriority, number> = { play: 0, full: 1, thumbn
 
 type RenderRequest<T> = {
   key: string;
+  /**
+   * The best priority among the consumers still holding this request —
+   * recomputed on every join and release (see `consumersByRank`), so a peek
+   * that let go of a key it shared with a prefetch leaves the prefetch at
+   * `prefetch`, not at the peek's `full`.
+   */
   priority: RenderPriority;
+  /** Consumers currently attached, counted per priority rank. */
+  consumersByRank: number[];
   /** Arrival order; the FIFO tiebreaker inside a priority level. */
   sequence: number;
   requestedAtMs: number;
@@ -155,6 +166,16 @@ export function setRenderConcurrency(concurrency: number): void {
 
 export function getRenderConcurrency(): number {
   return maxDispatched;
+}
+
+const PRIORITY_BY_RANK: RenderPriority[] = ['play', 'full', 'thumbnail', 'prefetch'];
+
+/** The best priority still held by at least one consumer. */
+function effectivePriority(consumersByRank: number[]): RenderPriority {
+  for (let rank = 0; rank < PRIORITY_BY_RANK.length; rank += 1) {
+    if (consumersByRank[rank] > 0) return PRIORITY_BY_RANK[rank];
+  }
+  return 'prefetch';
 }
 
 /** Index of the queued request that should go next: lowest priority rank, then oldest. */
@@ -260,6 +281,7 @@ export function requestRender<T>(
     request = {
       key,
       priority,
+      consumersByRank: [0, 0, 0, 0],
       sequence: nextSequence++,
       requestedAtMs: nowMs(),
       consumers: 0,
@@ -280,35 +302,49 @@ export function requestRender<T>(
     } else {
       queued.push(request as RenderRequest<unknown>);
     }
-  } else if (PRIORITY_RANK[priority] < PRIORITY_RANK[request.priority]) {
-    // Sticky upgrade: the peek that became the play board. Selection scans the
-    // queue on every dispatch, so nothing needs re-sorting here — but a queued
+  }
+  // `request` keeps the caller's `T` for the returned promise; `joined` is the
+  // same object under the map's erased type for the bookkeeping below.
+  const typedRequest = request;
+  const joined = request as RenderRequest<unknown>;
+  const joinedRank = PRIORITY_RANK[priority];
+  joined.consumers += 1;
+  joined.consumersByRank[joinedRank] += 1;
+  if (joinedRank < PRIORITY_RANK[joined.priority]) {
+    // Upgrade: the peek that became the play board. Selection scans the queue
+    // on every dispatch, so nothing needs re-sorting here — but a queued
     // PREFETCH may have been holding back from a free slot (its idle rule), and
     // as a real request it is entitled to that slot now, so pump.
-    request.priority = priority;
-    if (request.start !== null) pump();
+    joined.priority = priority;
+    if (joined.start !== null) pump();
   }
-  const joined = request;
-  joined.consumers += 1;
   let released = false;
   return {
-    promise: joined.promise,
+    promise: typedRequest.promise,
     release: () => {
       if (released) return;
       released = true;
       joined.consumers -= 1;
-      if (joined.consumers > 0) return;
+      joined.consumersByRank[joinedRank] -= 1;
+      if (joined.consumers > 0) {
+        // Priority follows whoever is still waiting. A queued request the
+        // carousel peek shared with a prefetch child drops back to `prefetch`
+        // when the peek turns the other way, so it cannot dispatch ahead of
+        // the peek now facing the climber.
+        joined.priority = effectivePriority(joined.consumersByRank);
+        return;
+      }
       // Only an undispatched request can be withdrawn. `start` still being
       // set is exactly "not dispatched": dispatch nulls it first thing.
       if (joined.start === null) return;
-      const queueIndex = queued.indexOf(joined as RenderRequest<unknown>);
+      const queueIndex = queued.indexOf(joined);
       if (queueIndex !== -1) queued.splice(queueIndex, 1);
-      if (requests.get(key) === (joined as RenderRequest<unknown>)) requests.delete(key);
+      if (requests.get(key) === joined) requests.delete(key);
       joined.start = null;
       joined.reject(new RenderCancelledError(key));
     },
     snapshot: () => ({
-      state: dispatched.get(key) === (joined as RenderRequest<unknown>) ? 'dispatched' : 'queued',
+      state: dispatched.get(key) === joined ? 'dispatched' : 'queued',
       queueDepth: queued.length,
       dispatchedCount: dispatched.size,
       msWaiting: Math.max(0, Math.round(nowMs() - joined.requestedAtMs)),

--- a/packages/mobile/src/lib/board-render/render-scheduler.ts
+++ b/packages/mobile/src/lib/board-render/render-scheduler.ts
@@ -30,6 +30,8 @@
  * - Priority upgrades are sticky. The real case is the carousel: a neighbour's
  *   overlay is requested as `full` while it peeks, then the same key becomes
  *   the `play` board on commit; a release never downgrades.
+ * - `prefetch` — the next few queue items, warmed for later swipes — only ever
+ *   runs when nothing else is queued and native is empty (see `RenderPriority`).
  * - The at-rest peek ranks as `full`, ABOVE visible accessory-strip thumbnails,
  *   on purpose. The peek is what lets the next swipe show holds mid-drag, while
  *   the accessory thumbnails are queue items that are nearly always cached from
@@ -44,7 +46,15 @@
  * hook without a cycle.
  */
 
-export type RenderPriority = 'play' | 'full' | 'thumbnail';
+/**
+ * `prefetch` is the rank for renders nobody is looking at yet — the next few
+ * queue items, warmed so a later swipe is a cache hit. It dispatches only when
+ * the renderer is otherwise IDLE: nothing else queued at any rank and nothing
+ * inside native. A prefetch already inside native runs to completion like any
+ * other dispatched render, so at most one render's worth of delay can ever
+ * land on a real request.
+ */
+export type RenderPriority = 'play' | 'full' | 'thumbnail' | 'prefetch';
 
 /** Where a request is waiting; the discriminator the stall telemetry reports. */
 export type RenderStallState = 'queued' | 'dispatched';
@@ -103,7 +113,7 @@ export function isRenderCancelled(error: unknown): error is RenderCancelledError
 const DEFAULT_MAX_DISPATCHED = 1;
 const MAX_DISPATCHED_CEILING = 4;
 
-const PRIORITY_RANK: Record<RenderPriority, number> = { play: 0, full: 1, thumbnail: 2 };
+const PRIORITY_RANK: Record<RenderPriority, number> = { play: 0, full: 1, thumbnail: 2, prefetch: 3 };
 
 type RenderRequest<T> = {
   key: string;
@@ -147,9 +157,8 @@ export function getRenderConcurrency(): number {
   return maxDispatched;
 }
 
-/** The queued request that should go next: lowest priority rank, then oldest. */
-function takeNextQueued(): RenderRequest<unknown> | undefined {
-  if (queued.length === 0) return undefined;
+/** Index of the queued request that should go next: lowest priority rank, then oldest. */
+function nextQueuedIndex(): number {
   let bestIndex = 0;
   for (let index = 1; index < queued.length; index += 1) {
     const candidate = queued[index];
@@ -160,6 +169,20 @@ function takeNextQueued(): RenderRequest<unknown> | undefined {
       bestIndex = index;
     }
   }
+  return bestIndex;
+}
+
+/**
+ * The queued request to dispatch now, or undefined when nothing may go. A
+ * prefetch goes only when the renderer is idle: it is the best candidate ONLY
+ * if no real request is queued (they outrank it), and it additionally waits for
+ * native to be empty, so a prefetch never shares the dispatch window with a
+ * render somebody is waiting on.
+ */
+function takeNextQueued(): RenderRequest<unknown> | undefined {
+  if (queued.length === 0) return undefined;
+  const bestIndex = nextQueuedIndex();
+  if (queued[bestIndex].priority === 'prefetch' && dispatched.size > 0) return undefined;
   return queued.splice(bestIndex, 1)[0];
 }
 
@@ -246,7 +269,13 @@ export function requestRender<T>(
       reject,
     };
     requests.set(key, request as RenderRequest<unknown>);
-    if (dispatched.size < maxDispatched) {
+    // A prefetch also yields to anything already queued: a free slot with a
+    // real request waiting cannot happen (the invariant below), but a prefetch
+    // arriving while native is busy must queue rather than take the second
+    // slot on a binary that offers one.
+    const canDispatchNow =
+      dispatched.size < maxDispatched && (priority !== 'prefetch' || (dispatched.size === 0 && queued.length === 0));
+    if (canDispatchNow) {
       dispatch(request as RenderRequest<unknown>);
     } else {
       queued.push(request as RenderRequest<unknown>);

--- a/packages/shared/analytics/src/board-render-events.ts
+++ b/packages/shared/analytics/src/board-render-events.ts
@@ -290,8 +290,13 @@ export function boardLookStepResolved(
  * The `play` / `full` split is not cosmetic: `full` covers surfaces that are
  * off-screen, behind a sheet, or one of a dozen preview cards, so a rate
  * measured across both would not describe anything a climber experienced.
+ *
+ * `prefetch` is a render nobody has asked to see: the play drawer warming the
+ * next few queue items while the renderer is idle. Its failures are worth
+ * counting (the same climb fails the same way when it is swiped to) but must
+ * never pool with a surface a climber was looking at.
  */
-export type BoardRenderFailureSurface = 'play' | 'full' | 'thumbnail';
+export type BoardRenderFailureSurface = 'play' | 'full' | 'thumbnail' | 'prefetch';
 
 /**
  * Which part of the render path gave up.

--- a/packages/shared/play-view/src/__tests__/queue-navigation.test.ts
+++ b/packages/shared/play-view/src/__tests__/queue-navigation.test.ts
@@ -8,6 +8,7 @@ import {
   findNextQueueItemWithSuggestions,
   findPreviousQueueItemWithSuggestions,
   computeNavigationStateWithSuggestions,
+  findUpcomingQueueItemsWithSuggestions,
 } from '../queue-navigation';
 
 function makeClimb(uuid: string): Climb {
@@ -466,5 +467,78 @@ describe('computeNavigationStateWithSuggestions', () => {
     expect(state.canPrevious).toBe(true);
     expect(state.prevItem?.climb.uuid).toBe('x');
     expect(state.prevItem?.suggested).toBe(true);
+  });
+});
+
+describe('findUpcomingQueueItemsWithSuggestions', () => {
+  it('returns the next `count` queue items in swipe order', () => {
+    const items = [makeItem('a'), makeItem('b'), makeItem('c'), makeItem('d')];
+    expect(findUpcomingQueueItemsWithSuggestions(items, items[0], null, 3)).toEqual([items[1], items[2], items[3]]);
+  });
+
+  it('returns fewer than asked for at the end of the queue', () => {
+    const items = [makeItem('a'), makeItem('b'), makeItem('c')];
+    expect(findUpcomingQueueItemsWithSuggestions(items, items[1], null, 3)).toEqual([items[2]]);
+    expect(findUpcomingQueueItemsWithSuggestions(items, items[2], null, 3)).toEqual([]);
+  });
+
+  it('starts at the head of the queue when there is no current item', () => {
+    const items = [makeItem('a'), makeItem('b'), makeItem('c')];
+    expect(findUpcomingQueueItemsWithSuggestions(items, null, null, 2)).toEqual([items[0], items[1]]);
+  });
+
+  it('returns nothing for a count of zero (or less)', () => {
+    const items = [makeItem('a'), makeItem('b')];
+    expect(findUpcomingQueueItemsWithSuggestions(items, items[0], null, 0)).toEqual([]);
+    expect(findUpcomingQueueItemsWithSuggestions(items, items[0], null, -1)).toEqual([]);
+  });
+
+  it('walks the suggestion source in list order, as peeks (#4829)', () => {
+    const x = makeClimb('x');
+    const y = makeClimb('y');
+    const z = makeClimb('z');
+    const queue = [itemFor(x)];
+    const source = makeSource(x, [x, y, z]);
+
+    const upcoming = findUpcomingQueueItemsWithSuggestions(queue, queue[0], source, 3);
+
+    expect(upcoming.map(({ climb }) => climb.uuid)).toEqual(['y', 'z']);
+    expect(upcoming.map(({ uuid }) => uuid)).toEqual([
+      getPlaylistPeekQueueItemUuid('y'),
+      getPlaylistPeekQueueItemUuid('z'),
+    ]);
+    expect(upcoming.every(({ suggested }) => suggested === true)).toBe(true);
+  });
+
+  it('prefers a real adjacent queue item over minting a duplicate peek', () => {
+    const x = makeClimb('x');
+    const y = makeClimb('y');
+    const queue = [itemFor(x), itemFor(y)];
+    const source = makeSource(x, [x, y]);
+
+    expect(findUpcomingQueueItemsWithSuggestions(queue, queue[0], source, 2)).toEqual([queue[1]]);
+  });
+
+  it('stops instead of looping when the walk comes back to a climb it already returned', () => {
+    const a = makeClimb('a');
+    const b = makeClimb('b');
+    // The list ends where it began, so step three would hand back `a` — the
+    // climb the walk started on — and the walk would circle forever.
+    const queue = [itemFor(a)];
+    const source = makeSource(a, [a, b, a]);
+
+    expect(findUpcomingQueueItemsWithSuggestions(queue, queue[0], source, 5).map(({ climb }) => climb.uuid)).toEqual([
+      'b',
+    ]);
+  });
+
+  it('stops at a climb the queue holds twice, whose render is already warm', () => {
+    const a = makeClimb('a');
+    const b = makeClimb('b');
+    // Re-activating a playlist appends a fresh pass, so the same climb can sit
+    // in the queue more than once.
+    const queue = [itemFor(a), itemFor(b), { uuid: 'item-a-second-pass', climb: a }];
+
+    expect(findUpcomingQueueItemsWithSuggestions(queue, queue[0], null, 3)).toEqual([queue[1]]);
   });
 });

--- a/packages/shared/play-view/src/__tests__/queue-navigation.test.ts
+++ b/packages/shared/play-view/src/__tests__/queue-navigation.test.ts
@@ -532,7 +532,7 @@ describe('findUpcomingQueueItemsWithSuggestions', () => {
     ]);
   });
 
-  it('stops at a climb the queue holds twice, whose render is already warm', () => {
+  it('skips a climb the queue holds twice, whose render is already warm', () => {
     const a = makeClimb('a');
     const b = makeClimb('b');
     // Re-activating a playlist appends a fresh pass, so the same climb can sit
@@ -540,5 +540,30 @@ describe('findUpcomingQueueItemsWithSuggestions', () => {
     const queue = [itemFor(a), itemFor(b), { uuid: 'item-a-second-pass', climb: a }];
 
     expect(findUpcomingQueueItemsWithSuggestions(queue, queue[0], null, 3)).toEqual([queue[1]]);
+  });
+
+  it('walks past a repeated climb rather than ending the walk there', () => {
+    const a = makeClimb('a');
+    const b = makeClimb('b');
+    const c = makeClimb('c');
+    // The second `a` is a different queue item with the same climb: its render
+    // is already warm, but the climbs behind it are not.
+    const queue = [itemFor(a), { uuid: 'item-a-again', climb: a }, itemFor(b), itemFor(c)];
+
+    expect(findUpcomingQueueItemsWithSuggestions(queue, queue[0], null, 3)).toEqual([queue[2], queue[3]]);
+  });
+
+  it('ends the walk when a list loops back to a target it already returned', () => {
+    const a = makeClimb('a');
+    const b = makeClimb('b');
+    const c = makeClimb('c');
+    // The list ends where it began, so a fourth step would hand back `b`.
+    const queue = [itemFor(a)];
+    const source = makeSource(a, [a, b, c, a]);
+
+    expect(findUpcomingQueueItemsWithSuggestions(queue, queue[0], source, 10).map(({ climb }) => climb.uuid)).toEqual([
+      'b',
+      'c',
+    ]);
   });
 });

--- a/packages/shared/play-view/src/queue-navigation.ts
+++ b/packages/shared/play-view/src/queue-navigation.ts
@@ -239,3 +239,52 @@ export function computeNavigationStateWithSuggestions(
     remainingCount,
   };
 }
+
+/**
+ * The next `count` swipe targets after `currentClimbQueueItem`, in the order a
+ * climber would reach them — the same walk `findNextQueueItemWithSuggestions`
+ * does for one step, repeated with each result as the next step's current item.
+ *
+ * Written for the play drawer's render prefetch (issue #5187): warming the
+ * board renders for the climbs just ahead turns the next few swipes into cache
+ * hits. Nothing here mutates the queue and nothing is committed — a peek item
+ * this returns is the same transient item a swipe would have minted.
+ *
+ * Stops early at the end of the walk (fewer than `count` items), and at the
+ * first target it has already returned. Both an item uuid and a climb uuid
+ * count as "already seen": a playlist peek's uuid is derived from its climb, so
+ * a list that loops back would otherwise walk forever, and a queue that holds
+ * the same climb twice (re-activating a playlist appends a fresh pass) would
+ * hand back a duplicate whose render is already warm.
+ */
+export function findUpcomingQueueItemsWithSuggestions(
+  queue: ClimbQueue,
+  currentClimbQueueItem: ClimbQueueItem | null,
+  source: PlaylistSuggestionSource | null,
+  count: number,
+): ClimbQueueItem[] {
+  const upcomingItems: ClimbQueueItem[] = [];
+  if (count <= 0) return upcomingItems;
+
+  const seenItemUuids = new Set<string>();
+  const seenClimbUuids = new Set<string>();
+  if (currentClimbQueueItem) {
+    seenItemUuids.add(currentClimbQueueItem.uuid);
+    const currentClimbUuid = currentClimbQueueItem.climb?.uuid;
+    if (currentClimbUuid) seenClimbUuids.add(currentClimbUuid);
+  }
+
+  let walkFrom = currentClimbQueueItem;
+  while (upcomingItems.length < count) {
+    const nextItem = findNextQueueItemWithSuggestions(queue, walkFrom, source);
+    if (!nextItem) break;
+    const nextClimbUuid = nextItem.climb?.uuid;
+    if (seenItemUuids.has(nextItem.uuid) || (nextClimbUuid !== undefined && seenClimbUuids.has(nextClimbUuid))) break;
+    seenItemUuids.add(nextItem.uuid);
+    if (nextClimbUuid) seenClimbUuids.add(nextClimbUuid);
+    upcomingItems.push(nextItem);
+    walkFrom = nextItem;
+  }
+
+  return upcomingItems;
+}

--- a/packages/shared/play-view/src/queue-navigation.ts
+++ b/packages/shared/play-view/src/queue-navigation.ts
@@ -252,10 +252,13 @@ export function computeNavigationStateWithSuggestions(
  *
  * Stops early at the end of the walk (fewer than `count` items), and at the
  * first target it has already returned. Both an item uuid and a climb uuid
- * count as "already seen": a playlist peek's uuid is derived from its climb, so
- * a list that loops back would otherwise walk forever, and a queue that holds
- * the same climb twice (re-activating a playlist appends a fresh pass) would
- * hand back a duplicate whose render is already warm.
+ * count as "already seen". A repeated ITEM uuid ends the walk: a playlist
+ * peek's uuid is derived from its climb, so a list that loops back would
+ * otherwise walk forever. A repeated CLIMB uuid is skipped, not fatal: a queue
+ * that holds the same climb twice (re-activating a playlist appends a fresh
+ * pass) still has new climbs past the duplicate, whose renders are worth
+ * warming; the duplicate itself is already warm. The walk is bounded by
+ * `count + queue.length` steps so a skipped duplicate can never loop.
  */
 export function findUpcomingQueueItemsWithSuggestions(
   queue: ClimbQueue,
@@ -275,15 +278,18 @@ export function findUpcomingQueueItemsWithSuggestions(
   }
 
   let walkFrom = currentClimbQueueItem;
-  while (upcomingItems.length < count) {
+  let stepsLeft = count + queue.length;
+  while (upcomingItems.length < count && stepsLeft > 0) {
+    stepsLeft -= 1;
     const nextItem = findNextQueueItemWithSuggestions(queue, walkFrom, source);
     if (!nextItem) break;
-    const nextClimbUuid = nextItem.climb?.uuid;
-    if (seenItemUuids.has(nextItem.uuid) || (nextClimbUuid !== undefined && seenClimbUuids.has(nextClimbUuid))) break;
+    if (seenItemUuids.has(nextItem.uuid)) break;
     seenItemUuids.add(nextItem.uuid);
+    walkFrom = nextItem;
+    const nextClimbUuid = nextItem.climb?.uuid;
+    if (nextClimbUuid !== undefined && seenClimbUuids.has(nextClimbUuid)) continue;
     if (nextClimbUuid) seenClimbUuids.add(nextClimbUuid);
     upcomingItems.push(nextItem);
-    walkFrom = nextItem;
   }
 
   return upcomingItems;


### PR DESCRIPTION
## Summary

Follow-up to #5208 for #5187, stacked on it (base is the scheduler branch; merge #5208 first). JS only, ships OTA.

With renders going through the JS scheduler, the play drawer can warm the climbs a few swipes ahead without getting in anyone's way.

- **Idle-only `prefetch` rank** in the render scheduler, below `thumbnail`. It dispatches only when nothing else is queued at any rank AND nothing is inside native, so a prefetch never shares the dispatch window with a render someone is waiting on. A prefetch already inside native finishes like any other dispatched render, so at most one render's worth of delay can land on a real request. A `play` request for a key already dispatched as `prefetch` joins it.
- **`prefetch: true`** on `useNativeClimbRender` requests at that rank and reports failures as `surface: 'prefetch'`, so they never pool with a board a climber looked at.
- **`findUpcomingQueueItemsWithSuggestions`** in `@boardsesh/play-view` walks the queue (or the active playlist order) N items ahead, cycle-guarded. The play drawer warms the next 3, runs them through the same cross-board filter as the swipe peeks, drops the displayed climb and duplicates, and keeps the array identity stable so a queue broadcast does not remount anything.
- **`UpcomingBoardPrefetch`** mounts one headless render per climb at the carousel's measured overlay width with the play board's exact render props, so the cache key matches the swipe that follows. Nothing until the board is measured; skipped in screenshot mode.

Author-side verification: 17 new tests (8 queue-walk cases, 4 scheduler idle-rule cases, 4 component cases, 1 telemetry surface case); the touched play-drawer and render suites pass.

## Release Notes

- The next few climbs in your queue are drawn ahead of time, so swiping to them is instant

## Test plan

1. Build a queue of 6+ unseen climbs. Open the first in the play drawer.
2. Wait two seconds, then swipe next three times → holds appear instantly each time.
3. Swipe next again quickly three more times → holds still land right after each swipe.
4. Scroll the Climbs list hard while the drawer is open → the list fills as before.
5. Add a climb from a different board size to the queue → nothing breaks, it still shows the wall.

## Risk

Risk: 3/5 — new idle-time work in the play drawer's render path; bounded to three climbs and gated to an idle renderer, covered by scheduler and component tests, but the timing only shows on a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SncFBP8umBH1LzvdRVThJD
