### PR TITLE
feat(mobile): Offline mode toggle

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -513,6 +513,26 @@ short-circuit, keeps the timeouts. A dev/tester-only More → Development row, *
 unreachable**, pins the store for QA (`BACKEND_URL` is inlined at build time, so there is no other way
 to simulate an outage on a device).
 
+**Offline mode.** The climber's own switch, first row of More → Offline ("Offline mode"), with two
+shortcuts on the banner: "Stay offline" during an outage, "Go online" to leave. It is a persisted MMKV
+setting (`offlineMode`, native only — Expo web has no storage behind it and the row is not drawn
+there), seeded into the store at launch by `start-connectivity.ts` and mirrored both ways, so a phone
+left offline in the gym is still offline the next morning. It gates the backend GraphQL/WS traffic and
+the sync engine — `effectiveOffline` goes true, `reason` reads `offline_mode`, the probe ladder stops,
+and the ConnectivityBridge disposes the graphql-ws client. That dispose is a **cut, not a gate**: the next
+`getWsClient()` opens a fresh socket, so each realtime consumer still owns its own gate —
+`use-session-realtime` parks its join and re-joins on the store edge, and `board-presence-provider` hands
+the shared presence hook a `null` client (its inert state) until offline mode goes back off.
+It does **not** touch analytics, Sentry, OTA updates, the board-snapshot CDN or sign-in. Turning it
+back off resets `backend` to `unknown` and re-asks the server rather than trusting anything concluded
+while nobody was talking to it. Sign-out resets it (`source: 'sign_out'`): a signed-out phone with the
+switch still on would show a login screen whose own request is gated. The manual path flips it **before**
+the best-effort queue drain, not just in `runSignedOutCleanup` — the drainer returns immediately when
+`onlineManager` reads offline, and the wipe that follows deletes the writes the confirm dialog promised to
+try first. Every flip files one
+`Offline Mode Toggled { enabled, source, reasonBefore }` from the store binding — `reasonBefore`
+separates "I chose this while everything was fine" from the banner's escape hatch during an outage.
+
 **Sign-out and queued writes.** A manual sign-out best-effort drains the queue first (bounded at 3s so sign-out never hangs on a bad connection) after the confirm dialog. A **forced** sign-out — the auth interceptor's failed-refresh 401 or checkAuth's proactive-expiry path — deliberately skips both: the token is already dead, so the drain's requests could only fail, and there is no meaningful moment to show a dialog. Queued writes not yet flushed at that point are wiped with the rest of the local user data. This is the accepted trade-off for keeping the user-data wipe (a cross-account safety boundary on shared devices) unconditional.
 
 **Two wipes, and which sign-out runs which** (issue #3621). `clearUserData` (`packages/mobile/src/db/connection.ts`) clears the user's own tables, the mutation queue and the user-scoped checkpoints, and deliberately keeps the downloaded board catalogs — that is what every sign-out the user did NOT choose runs: the forced 401, checkAuth's expiry, the web identity change, the confirmed-identity-changed branch. A token-refresh glitch must not cost someone a 271MB download. `purgeLocalDataForSignOut` is the **full** wipe an explicit sign-out runs (`signOut('manual')` behind the confirm, and `signOut('account_deleted')`): the same user tables **plus** `BOARD_DATA_TABLES`, then `deleteAllSyncMeta` — a whole-table `DELETE FROM sync_meta` rather than a prefix sweep, because the marker families sit across two prefix conventions and rows plus the markers describing them must die together (a surviving `scope-complete:` makes `isBoardDownloadedLocally` serve an empty catalog to local-first search as a whole board; a surviving checkpoint makes the strict `>` delta pull resume past rows that are gone) — then a `VACUUM` so the freed pages actually leave the file. It is one exclusive transaction inside AuthProvider's `setSigningOut(true)` window, so an in-flight pull page can't land after the delete. It reports `Offline Data Wiped On Sign Out` with the exact post-drain outbox depth it discarded, split into `pendingDiscarded` (writes the drain got a shot at) and `deadLettersDiscarded` (writes whose retries were already spent) — one `DELETE FROM pending_mutations` takes both, so reporting only the pending half told us zero for the loss this wipe is most likely to cause.

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -459,6 +459,14 @@ All board-presence reads (`boardNowPlaying`, `boardRecentClimbs`, `boardHistory`
 
 `boardClimbRecentSenders(boardId, climbUuid, angle)` backs the wall's "Sent by" byline: the five most recent distinct climbers who flashed or sent the displayed climb on this exact board and angle. It resolves the canonical climb id and fans out to its aliases in one subquery, so a merged climb still matches ticks logged under either uuid, and it reads through `boardsesh_ticks_board_climbed_at_idx` — there is no dedicated covering index. Rate-limited at 60/min like the other hot-feed reads, and the client throttles its own stats-driven refreshes to one per 2s so a busy wall cannot spend that budget on a single kiosk.
 
+**Offline mode contract for WebSocket consumers (#4862).** When the climber's Offline mode is on, the
+connectivity store reports `effectiveOffline` with reason `offline_mode` and `ConnectivityBridge`
+disposes the cached graphql-ws client once. That dispose is a **cut, not a gate**: any consumer that
+calls `getWsClient()` afterwards opens a fresh socket. Every live consumer therefore parks itself —
+`use-session-realtime` defers the join, `board-presence-provider` hands the shared provider
+`client={null}` (its documented inert state) — and re-attaches on the store's back-online edge. A new
+consumer must do the same rather than call `getWsClient()` unguarded, or it reopens the hole.
+
 ### Board Queue Preview ("Up next" for gym kiosks)
 
 Party queues live in membership-gated sessions keyed by session UUID; a public gym kiosk is anonymous and only knows a boardId. The bridge is a **redacted, board-keyed queue preview**: `boardQueuePreview(boardId)` (query + subscription), implemented in `packages/backend/src/services/board-queue-preview.ts` and `graphql/resolvers/board-presence/queue-preview.ts`.

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -461,11 +461,26 @@ All board-presence reads (`boardNowPlaying`, `boardRecentClimbs`, `boardHistory`
 
 **Offline mode contract for WebSocket consumers (#4862).** When the climber's Offline mode is on, the
 connectivity store reports `effectiveOffline` with reason `offline_mode` and `ConnectivityBridge`
-disposes the cached graphql-ws client once. That dispose is a **cut, not a gate**: any consumer that
-calls `getWsClient()` afterwards opens a fresh socket. Every live consumer therefore parks itself —
-`use-session-realtime` defers the join, `board-presence-provider` hands the shared provider
-`client={null}` (its documented inert state) — and re-attaches on the store's back-online edge. A new
-consumer must do the same rather than call `getWsClient()` unguarded, or it reopens the hole.
+disposes the cached graphql-ws client once. **The dispose is the cut; the gate is the factory.** A
+dispose alone only drops the cached client, and the next `getWsClient()` would open a fresh socket —
+which is exactly what a cold launch with the mode restored does through `DrawerHostProvider`'s
+active-board restore, a BLE auto-connect bind, or a party-queue mutation. So `ws-client-core`'s
+`createWsClientModule` takes an injected `isOfflineModeOn()` (native reads the connectivity store; Expo
+web passes `() => false`) and, while it returns true, `getWsClient()` hands back a module-level **inert
+client**: `Client`-shaped, opens no socket, and answers `subscribe`/`iterate` with a fresh
+`BackendUnavailableError('offline_mode')` — the same transport-classified rejection PR-A's HTTP
+chokepoint throws, so the drainer takes no `retry_count` strike, `reportHandledError` drops it and React
+Query will not retry it. The stub is never cached as the client, so the first call after the switch goes
+off builds a real one.
+
+The gate reads `offlineMode` **only**, never `effectiveOffline`: a tunnel or a backend blip must keep
+graphql-ws's own retry ladder, which recovers a live subscription with nobody re-subscribing. Swapping
+in the inert client there would kill the party session on every lift.
+
+New consumers get the gate for free, but **parking is still the polite behaviour** and the live
+consumers do it — `use-session-realtime` defers its join, `board-presence-provider` hands the shared
+provider `client={null}` (its documented inert state) — because a parked consumer produces no rejection
+noise and resumes with a catch-up instead of a retry storm.
 
 ### Board Queue Preview ("Up next" for gym kiosks)
 

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -26,7 +26,7 @@ import {
   forgetDownloadAllTap,
 } from '../../../src/settings';
 import { useConnectivity } from '../../../src/lib/connectivity/use-connectivity';
-import { setDevForcedUnreachable } from '../../../src/lib/connectivity/connectivity-store';
+import { isOfflineModeSupported, setDevForcedUnreachable } from '../../../src/lib/connectivity/connectivity-store';
 import { notifyOutboxChanged, useOutboxSummary } from '../../../src/offline/outbox-store';
 import { RECLAIMABLE_VISIBLE_BYTES } from '../../../src/db/storage-usage';
 import {
@@ -41,6 +41,7 @@ import { useDownloadedScopeKeys } from '../../../src/offline/use-downloaded-scop
 import { getHttpClient } from '../../../src/lib/graphql/client';
 import { hapticLight, hapticSelection } from '../../../src/lib/haptics';
 import { getDevMetadataSection } from '../../../src/components/dev-metadata-section';
+import { buildOfflineModeRow } from '../../../src/components/offline-mode-row';
 import { useBottomChromeDiagnosticsEligible } from '../../../src/components/BottomChromeDebugOverlay';
 import { MoreForm } from '../../../src/components/MoreForm';
 import type { MoreButtonRow, MoreFormModel, MoreRow, MoreSection } from '../../../src/components/MoreForm.types';
@@ -174,7 +175,7 @@ export default function MoreScreen() {
   // signal, our backend being unreachable, and Offline mode alike, which is
   // exactly the "nothing is going out right now" the two offline surfaces below
   // branch on. `devForcedUnreachable` drives the tester switch in Development.
-  const { effectiveOffline, devForcedUnreachable } = useConnectivity();
+  const { effectiveOffline, devForcedUnreachable, offlineMode } = useConnectivity();
   const { data: deadLetterCount = 0, refetch: refetchDeadLetters } = useQuery({
     queryKey: ['deadLetters', 'count', schemaReady],
     queryFn: () => getDeadLetterCount(db),
@@ -638,15 +639,26 @@ export default function MoreScreen() {
     ],
   });
 
-  // Offline — keep boards available with no signal. Gated by the offline feature
-  // flag (the whole offline surface is flag-gated). Turning it on downloads every
-  // current board now; future boards auto-download via the adopt-on-select flow.
+  // Offline — the switch that stops every request, then keeping boards available
+  // with no signal. Gated by the offline feature flag (the whole offline surface
+  // is flag-gated). Turning auto-download on downloads every current board now;
+  // future boards auto-download via the adopt-on-select flow.
   if (offlineEnabled) {
     sections.push({
       key: 'offline',
       title: t('mobile.more.offline.title'),
       footer: offlineFooter,
       rows: [
+        // First, because it decides whether anything below it can reach the
+        // network at all. Native only: on Expo web there is no storage behind
+        // the switch and `setOfflineMode` is inert, and a row that did nothing
+        // would be worse than no row.
+        //
+        // It sits inside the `offlineEnabled` gate with the rest of the section.
+        // That gate is a constant today, but if it ever went false with the mode
+        // ON, the climber is not stranded: the connectivity banner is up the
+        // whole time offline mode is on, and its "Go online" turns it back off.
+        ...(isOfflineModeSupported() ? [buildOfflineModeRow(t, offlineMode)] : []),
         {
           kind: 'toggle',
           key: 'autoOfflineBoards',

--- a/packages/mobile/src/components/__tests__/connectivity-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/connectivity-bridge.test.tsx
@@ -20,6 +20,21 @@ vi.mock('../../providers/feature-flags-provider', () => ({
   useInteractiveRequestDeadlineEnabled: () => flagState.deadlineEnabled,
 }));
 
+// Only the one field the bridge reads, through the same narrowed subscription
+// it uses in the app. The store behind the real hook is the singleton this
+// suite deliberately never touches.
+const connectivity = vi.hoisted(() => ({ offlineMode: false }));
+vi.mock('../../lib/connectivity/use-connectivity', () => ({
+  selectOfflineMode: (snapshot: { offlineMode: boolean }) => snapshot.offlineMode,
+  useConnectivityField: (select: (snapshot: { offlineMode: boolean }) => boolean) =>
+    select({ offlineMode: connectivity.offlineMode }),
+}));
+
+const disposeWsClient = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/graphql/ws-client', () => ({
+  disposeWsClient: () => disposeWsClient(),
+}));
+
 import { ConnectivityBridge } from '../connectivity-bridge';
 
 describe('ConnectivityBridge', () => {
@@ -27,6 +42,7 @@ describe('ConnectivityBridge', () => {
     vi.clearAllMocks();
     flagState.detectionEnabled = true;
     flagState.deadlineEnabled = true;
+    connectivity.offlineMode = false;
   });
 
   it('publishes the interactive deadline switch independently of detection', () => {
@@ -73,5 +89,49 @@ describe('ConnectivityBridge', () => {
     rerender(createElement(ConnectivityBridge));
 
     expect(setOutageDetectionEnabled).toHaveBeenCalledTimes(1);
+  });
+
+  // graphql-ws reconnects on its own schedule and knows nothing about the store,
+  // so "stop every request" would leave exactly one kind of traffic running.
+  it('closes the realtime socket when offline mode is switched on', () => {
+    const { rerender } = render(createElement(ConnectivityBridge));
+    expect(disposeWsClient).not.toHaveBeenCalled();
+
+    connectivity.offlineMode = true;
+    rerender(createElement(ConnectivityBridge));
+
+    expect(disposeWsClient).toHaveBeenCalledTimes(1);
+  });
+
+  // The client is lazy and PR-A's deferred join re-subscribes on the online
+  // edge, so tearing it down again here would only cost a reconnect.
+  it('leaves the socket alone on the way back online', () => {
+    connectivity.offlineMode = true;
+    const { rerender } = render(createElement(ConnectivityBridge));
+
+    connectivity.offlineMode = false;
+    rerender(createElement(ConnectivityBridge));
+
+    expect(disposeWsClient).not.toHaveBeenCalled();
+  });
+
+  // A launch that restored offline mode from the persisted setting has no socket
+  // yet — disposing one nobody opened would be pure noise.
+  it('does not dispose on a mount that starts in offline mode', () => {
+    connectivity.offlineMode = true;
+
+    render(createElement(ConnectivityBridge));
+
+    expect(disposeWsClient).not.toHaveBeenCalled();
+  });
+
+  it('does not dispose again while offline mode simply stays on', () => {
+    const { rerender } = render(createElement(ConnectivityBridge));
+    connectivity.offlineMode = true;
+    rerender(createElement(ConnectivityBridge));
+
+    rerender(createElement(ConnectivityBridge));
+
+    expect(disposeWsClient).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/components/__tests__/connectivity-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/connectivity-bridge.test.tsx
@@ -92,7 +92,7 @@ describe('ConnectivityBridge', () => {
   });
 
   // graphql-ws reconnects on its own schedule and knows nothing about the store,
-  // so "stop every request" would leave exactly one kind of traffic running.
+  // so "stop talking to the server" would leave one kind of traffic running.
   it('closes the realtime socket when offline mode is switched on', () => {
     const { rerender } = render(createElement(ConnectivityBridge));
     expect(disposeWsClient).not.toHaveBeenCalled();

--- a/packages/mobile/src/components/__tests__/offline-mode-row.test.ts
+++ b/packages/mobile/src/components/__tests__/offline-mode-row.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { TFunction } from 'i18next';
+
+const setOfflineMode = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/connectivity/connectivity-store', () => ({
+  setOfflineMode: (enabled: boolean, source: string) => setOfflineMode(enabled, source),
+}));
+
+const hapticSelection = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/haptics', () => ({ hapticSelection: () => hapticSelection() }));
+
+import { buildOfflineModeRow } from '../offline-mode-row';
+
+// The screen's real `t` resolves the catalog; here the key itself is the useful
+// assertion, because what can silently break is the key, not the translation.
+const translate = ((key: string) => key) as unknown as TFunction<'common'>;
+
+describe('buildOfflineModeRow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is a switch labelled from the catalog', () => {
+    const row = buildOfflineModeRow(translate, false);
+
+    expect(row).toMatchObject({
+      kind: 'toggle',
+      key: 'offlineMode',
+      label: 'mobile.more.offline.offlineMode',
+      subtitle: 'mobile.more.offline.offlineModeDescription',
+      value: false,
+    });
+  });
+
+  it('shows the store as the source of truth, not a local setting read', () => {
+    expect(buildOfflineModeRow(translate, true).value).toBe(true);
+  });
+
+  // Through the store, with the source attached: `setSetting` would still reach
+  // the store (it subscribes) but would file an event nobody could attribute.
+  it('routes the flip through the store, tagged as the More screen', () => {
+    buildOfflineModeRow(translate, false).onValueChange(true);
+
+    expect(setOfflineMode).toHaveBeenCalledExactlyOnceWith(true, 'more');
+  });
+
+  it('turns it back off the same way', () => {
+    buildOfflineModeRow(translate, true).onValueChange(false);
+
+    expect(setOfflineMode).toHaveBeenCalledExactlyOnceWith(false, 'more');
+  });
+
+  it('taps back, like every other switch on the screen', () => {
+    buildOfflineModeRow(translate, false).onValueChange(true);
+
+    expect(hapticSelection).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/mobile/src/components/connectivity-bridge.tsx
+++ b/packages/mobile/src/components/connectivity-bridge.tsx
@@ -29,16 +29,24 @@ import {
  * It also closes the realtime socket when a climber switches offline mode ON.
  * graphql-ws reconnects on its own schedule and knows nothing about the store,
  * so without this a phone in offline mode would keep dialling the party/comment
- * subscriptions forever — the one flavour of traffic "stop every request"
- * would not actually stop. Nothing happens on the way back: the client is lazy,
+ * subscriptions forever — the one flavour of traffic "stop talking to the
+ * server" would not actually stop. Nothing happens on the way back: the client is lazy,
  * so the next consumer that needs it builds a fresh one.
  *
- * That dispose is a CUT, not a gate. `disposeWsClient()` only drops the cached
- * client; the very next `getWsClient()` opens a new socket, so every realtime
- * consumer still owns its own offline gate — `use-session-realtime` parks its
- * join and re-joins on the store edge, and `board-presence-provider` hands the
- * shared presence hook a null client while offline mode is on. Adding a
- * consumer that calls `getWsClient()` unguarded re-opens this hole.
+ * The dispose is the CUT; the GATE lives one layer down. `disposeWsClient()`
+ * only drops the cached client, so on its own the next `getWsClient()` would
+ * open a fresh socket — which is what a cold launch with the mode restored, a
+ * BLE auto-connect bind or the drawer host's active-board restore would do.
+ * `ws-client-core` therefore hands out an INERT client while offline mode is on:
+ * every operation fails locally with `BackendUnavailableError('offline_mode')`
+ * and no socket is created. A new consumer that calls `getWsClient()` gets that
+ * for free.
+ *
+ * Parking is still the polite behaviour, and the live consumers do it —
+ * `use-session-realtime` defers its join and re-joins on the store edge,
+ * `board-presence-provider` hands the shared hook a null client — because a
+ * parked consumer produces no rejection noise and resumes with a catch-up
+ * instead of a retry storm.
  *
  * Renders nothing.
  */

--- a/packages/mobile/src/components/connectivity-bridge.tsx
+++ b/packages/mobile/src/components/connectivity-bridge.tsx
@@ -1,6 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { setOutageDetectionEnabled } from '../lib/connectivity/connectivity-store';
 import { setInteractiveRequestDeadlineEnabled } from '../lib/graphql/request-timeout';
+import { selectOfflineMode, useConnectivityField } from '../lib/connectivity/use-connectivity';
+import { disposeWsClient } from '../lib/graphql/ws-client';
 import {
   useBackendOutageDetectionEnabled,
   useInteractiveRequestDeadlineEnabled,
@@ -24,11 +26,31 @@ import {
  * `unknown` and cancels the probe ladder, so a late kill switch fully undoes
  * whatever the store concluded before it arrived.
  *
+ * It also closes the realtime socket when a climber switches offline mode ON.
+ * graphql-ws reconnects on its own schedule and knows nothing about the store,
+ * so without this a phone in offline mode would keep dialling the party/comment
+ * subscriptions forever — the one flavour of traffic "stop every request"
+ * would not actually stop. Nothing happens on the way back: the client is lazy,
+ * so the next consumer that needs it builds a fresh one.
+ *
+ * That dispose is a CUT, not a gate. `disposeWsClient()` only drops the cached
+ * client; the very next `getWsClient()` opens a new socket, so every realtime
+ * consumer still owns its own offline gate — `use-session-realtime` parks its
+ * join and re-joins on the store edge, and `board-presence-provider` hands the
+ * shared presence hook a null client while offline mode is on. Adding a
+ * consumer that calls `getWsClient()` unguarded re-opens this hole.
+ *
  * Renders nothing.
  */
 export function ConnectivityBridge() {
   const detectionEnabled = useBackendOutageDetectionEnabled();
   const deadlineEnabled = useInteractiveRequestDeadlineEnabled();
+  // Narrowed to the one field: the full snapshot changes twice per probe rung,
+  // and re-rendering a component that renders nothing on every tick is pure cost.
+  const offlineMode = useConnectivityField(selectOfflineMode);
+  // Seeded from the first render rather than `false`, so a launch that ALREADY
+  // restored offline mode does not dispose a socket nobody has opened yet.
+  const previousOfflineModeRef = useRef(offlineMode);
 
   useEffect(() => {
     setOutageDetectionEnabled(detectionEnabled);
@@ -40,6 +62,12 @@ export function ConnectivityBridge() {
   useEffect(() => {
     setInteractiveRequestDeadlineEnabled(deadlineEnabled);
   }, [deadlineEnabled]);
+
+  useEffect(() => {
+    const wasOfflineMode = previousOfflineModeRef.current;
+    previousOfflineModeRef.current = offlineMode;
+    if (offlineMode && !wasOfflineMode) disposeWsClient();
+  }, [offlineMode]);
 
   return null;
 }

--- a/packages/mobile/src/components/offline-mode-row.ts
+++ b/packages/mobile/src/components/offline-mode-row.ts
@@ -1,0 +1,39 @@
+import type { TFunction } from 'i18next';
+import { setOfflineMode } from '../lib/connectivity/connectivity-store';
+import { hapticSelection } from '../lib/haptics';
+import type { MoreToggleRow } from './MoreForm.types';
+
+/**
+ * The Offline section's first row: the climber's deliberate "use only what's on
+ * this phone" switch (issue #4862).
+ *
+ * Extracted from `app/(tabs)/profile/more.tsx` the same way
+ * `buildFeatureFlagRows` and `getDevMetadataSection` were — the More screen
+ * hands its model to a platform-split native form that cannot mount under
+ * Vitest, and this row's wiring (which `source` the toggle files, that it goes
+ * through the store rather than writing the setting behind its back) is exactly
+ * the part worth a test.
+ *
+ * No confirm dialog and no toast on purpose. The connectivity banner appears the
+ * instant the store publishes, says "Offline mode is on" and offers "Go online",
+ * so a second confirmation would be one more tap between the climber and a
+ * choice that is already reversible in one.
+ *
+ * `setOfflineMode` — not `setSetting` — because the store owns the whole flip:
+ * persistence, the `Offline Mode Toggled` event, cancelling the probe ladder,
+ * and re-asking the server on the way back. Writing the setting directly would
+ * still reach the store (it subscribes), but with no `source` on the event.
+ */
+export function buildOfflineModeRow(t: TFunction<'common'>, offlineMode: boolean): MoreToggleRow {
+  return {
+    kind: 'toggle',
+    key: 'offlineMode',
+    label: t('mobile.more.offline.offlineMode'),
+    subtitle: t('mobile.more.offline.offlineModeDescription'),
+    value: offlineMode,
+    onValueChange: (next) => {
+      hapticSelection();
+      setOfflineMode(next, 'more');
+    },
+  };
+}

--- a/packages/mobile/src/lib/connectivity/__tests__/connectivity-store.test.ts
+++ b/packages/mobile/src/lib/connectivity/__tests__/connectivity-store.test.ts
@@ -10,6 +10,7 @@ import {
   type ConnectivityTransitionEvent,
   type DeviceReachability,
   type DeviceState,
+  type OfflineModeChange,
   type ProbeVerdict,
 } from '../connectivity-store';
 
@@ -40,6 +41,7 @@ function createHarness(options?: { random?: number }) {
   const pendingProbes: Deferred[] = [];
   const onlineWrites: boolean[] = [];
   const transitions: ConnectivityTransitionEvent[] = [];
+  const offlineModeChanges: OfflineModeChange[] = [];
   const deviceReading: { device: DeviceState; deviceReachability: DeviceReachability } = {
     device: 'unknown',
     deviceReachability: 'unknown',
@@ -70,6 +72,9 @@ function createHarness(options?: { random?: number }) {
     onTransition: (event) => {
       transitions.push(event);
     },
+    onOfflineModeChange: (change) => {
+      offlineModeChanges.push(change);
+    },
   });
 
   return {
@@ -78,6 +83,7 @@ function createHarness(options?: { random?: number }) {
     readDeviceState,
     onlineWrites,
     transitions,
+    offlineModeChanges,
     deviceReading,
     get time() {
       return currentTime;
@@ -543,6 +549,108 @@ describe('connectivity store — recovery', () => {
 });
 
 describe('connectivity store — offline mode, kill switch and dev override', () => {
+  // PR-B: the store stays pure, so persistence and the `Offline Mode Toggled`
+  // event both ride this one callback out to `start-connectivity.ts`.
+  it('hands the deliberate flip to the binding, with the source and the pre-flip reason', () => {
+    const harness = createHarness();
+
+    harness.store.setOfflineMode(true, 'more');
+
+    expect(harness.offlineModeChanges).toEqual([{ enabled: true, source: 'more', reasonBefore: null }]);
+  });
+
+  // The whole reason `reasonBefore` is captured before the flip: read afterwards
+  // it would say `offline_mode` on every event, and the banner's escape hatch
+  // during an outage would be indistinguishable from a calm deliberate choice.
+  it('reports the reason from BEFORE the flip, not the one the flip creates', async () => {
+    const harness = createHarness();
+    await forceOutage(harness);
+    expect(harness.store.getSnapshot().reason).toBe('backend_unreachable');
+
+    harness.store.setOfflineMode(true, 'banner');
+
+    expect(harness.offlineModeChanges).toEqual([
+      { enabled: true, source: 'banner', reasonBefore: 'backend_unreachable' },
+    ]);
+    expect(harness.store.getSnapshot().reason).toBe('offline_mode');
+  });
+
+  it('reports turning it back off too, so the event pairs up', () => {
+    const harness = createHarness();
+    harness.store.setOfflineMode(true, 'more');
+    harness.store.setOfflineMode(false, 'sign_out');
+
+    expect(harness.offlineModeChanges.map((change) => [change.enabled, change.source])).toEqual([
+      [true, 'more'],
+      [false, 'sign_out'],
+    ]);
+  });
+
+  it('says nothing when the switch was already where the caller asked for', () => {
+    const harness = createHarness();
+    harness.store.setOfflineMode(true, 'more');
+    harness.offlineModeChanges.length = 0;
+
+    harness.store.setOfflineMode(true, 'banner');
+
+    expect(harness.offlineModeChanges).toEqual([]);
+  });
+
+  // Seeding is the persisted value coming back in — at launch, or as the echo of
+  // our own write. Filing an event for it would double-count every toggle and
+  // stamp one on every cold start of a phone left in offline mode.
+  it('seeds the persisted value without persisting or reporting it again', () => {
+    const harness = createHarness();
+
+    harness.store.seedOfflineMode(true);
+
+    expect(harness.store.getSnapshot()).toMatchObject({ offlineMode: true, reason: 'offline_mode' });
+    expect(harness.offlineModeChanges).toEqual([]);
+  });
+
+  it('closes the write/echo loop: seeding the value we just set changes nothing', () => {
+    const harness = createHarness();
+    harness.store.setOfflineMode(true, 'more');
+    const listener = vi.fn();
+    harness.store.subscribe(listener);
+
+    harness.store.seedOfflineMode(true);
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(harness.offlineModeChanges).toHaveLength(1);
+  });
+
+  // A seed that turns the mode OFF is the same state machine as the toggle: the
+  // stale outage goes, and the server is asked again.
+  it('a seed that turns it off re-asks the server like the toggle does', async () => {
+    const harness = createHarness();
+    await forceOutage(harness);
+    harness.store.seedOfflineMode(true);
+    harness.probe.mockClear();
+
+    harness.store.seedOfflineMode(false);
+
+    expect(harness.store.getSnapshot()).toMatchObject({ backend: 'unknown', effectiveOffline: false });
+    expect(harness.probe).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the flip when the binding throws — the UI already moved', () => {
+    const store = createConnectivityStore({
+      now: () => 1_000,
+      schedule: () => () => undefined,
+      probe: () => Promise.resolve<ProbeVerdict>('healthy'),
+      readDeviceState: () => Promise.resolve({ device: 'unknown' as const, deviceReachability: 'unknown' as const }),
+      random: () => 0.5,
+      onOnlineChange: vi.fn(),
+      onOfflineModeChange: () => {
+        throw new Error('mmkv is on fire');
+      },
+    });
+
+    expect(() => store.setOfflineMode(true, 'more')).not.toThrow();
+    expect(store.getSnapshot()).toMatchObject({ offlineMode: true, effectiveOffline: true });
+  });
+
   it('re-asks the server the moment offline mode is turned back off', async () => {
     const harness = createHarness();
     await forceOutage(harness);

--- a/packages/mobile/src/lib/connectivity/__tests__/start-connectivity-offline-mode.test.ts
+++ b/packages/mobile/src/lib/connectivity/__tests__/start-connectivity-offline-mode.test.ts
@@ -11,7 +11,11 @@ const settingsStore = vi.hoisted(() => ({
   offlineMode: false,
   listeners: [] as Array<() => void>,
   writes: [] as Array<{ key: string; value: unknown }>,
+  // MMKV is a native module: a full disk or a corrupt store makes a write throw.
+  failWrites: false,
 }));
+
+const reportHandledError = vi.hoisted(() => vi.fn());
 
 const trackedEvents = vi.hoisted(() => [] as Array<{ name: string; properties: Record<string, unknown> }>);
 
@@ -46,7 +50,10 @@ vi.mock('../../analytics', () => ({
   },
 }));
 
-vi.mock('../../error-reporting', () => ({ addErrorBreadcrumb: () => undefined }));
+vi.mock('../../error-reporting', () => ({
+  addErrorBreadcrumb: () => undefined,
+  reportHandledError: (error: unknown, context?: unknown) => reportHandledError(error, context),
+}));
 
 // Turning offline mode OFF re-asks the server, and the store's default probe is
 // a real `fetch` at BACKEND_URL. Answer it here so no test in this file puts a
@@ -65,6 +72,7 @@ vi.mock('../../../settings/hooks', () => ({
     return settingsStore.offlineMode;
   },
   setSetting: (key: string, value: unknown) => {
+    if (settingsStore.failWrites) throw new Error('mmkv write failed');
     settingsStore.writes.push({ key, value });
     if (key === 'offlineMode') settingsStore.offlineMode = value === true;
     for (const listener of settingsStore.listeners) listener();
@@ -99,7 +107,9 @@ describe('start-connectivity — offline mode', () => {
     settingsStore.offlineMode = false;
     settingsStore.listeners = [];
     settingsStore.writes = [];
+    settingsStore.failWrites = false;
     trackedEvents.length = 0;
+    reportHandledError.mockClear();
     __resetConnectivityStoreForTests();
     __resetStartConnectivityForTests();
     // AFTER the resets: they close the previous test's subscriptions, and those
@@ -183,6 +193,27 @@ describe('start-connectivity — offline mode', () => {
       { key: 'offlineMode', value: true },
       { key: 'offlineMode', value: false },
     ]);
+  });
+
+  // A silent failure here is the nastiest kind: the switch moves, the banner says
+  // offline mode is on, and the next launch quietly comes back online with no
+  // record of why. Keep the flip (the climber asked for it, and it is honest for
+  // this launch) and file the write failure.
+  it('reports a failed persist without undoing the flip', () => {
+    startConnectivityStore();
+    settingsStore.failWrites = true;
+
+    setOfflineMode(true, 'more');
+
+    expect(getConnectivitySnapshot()).toMatchObject({ offlineMode: true, reason: 'offline_mode' });
+    expect(reportHandledError).toHaveBeenCalledTimes(1);
+    expect(reportHandledError.mock.calls[0]![1]).toMatchObject({
+      tags: { source: 'connectivity', kind: 'offline-mode-persist' },
+    });
+    // Nothing landed on disk — which is exactly what the report is for.
+    expect(settingsStore.offlineMode).toBe(false);
+    // The event still goes out: the toggle happened, whatever storage did.
+    expect(toggleEvents()).toEqual([{ enabled: true, source: 'more', reasonBefore: null }]);
   });
 
   // A listener kept past the reset would still fire on every later settings

--- a/packages/mobile/src/lib/connectivity/__tests__/start-connectivity-offline-mode.test.ts
+++ b/packages/mobile/src/lib/connectivity/__tests__/start-connectivity-offline-mode.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The platform half of offline mode (PR-B): the store is pure, so persistence
+// and the `Offline Mode Toggled` event only exist once this module binds them.
+// Every seam react-native owns is mocked here, exactly as
+// query-provider-connectivity.test.ts does for the same module.
+
+const platform = vi.hoisted(() => ({ OS: 'ios' as string }));
+
+const settingsStore = vi.hoisted(() => ({
+  offlineMode: false,
+  listeners: [] as Array<() => void>,
+  writes: [] as Array<{ key: string; value: unknown }>,
+}));
+
+const trackedEvents = vi.hoisted(() => [] as Array<{ name: string; properties: Record<string, unknown> }>);
+
+// Counted, not just stubbed: `__resetStartConnectivityForTests` has to CLOSE
+// every subscription a start opened, or each suite stacks listeners on the
+// platform modules that all point at handles the next reset disposed.
+const platformSubscriptions = vi.hoisted(() => ({ appStateRemovals: 0, netInfoRemovals: 0 }));
+
+vi.mock('react-native', () => ({
+  AppState: {
+    addEventListener: () => ({
+      remove: () => {
+        platformSubscriptions.appStateRemovals += 1;
+      },
+    }),
+  },
+  Platform: platform,
+}));
+
+vi.mock('@react-native-community/netinfo', () => ({
+  default: {
+    addEventListener: () => () => {
+      platformSubscriptions.netInfoRemovals += 1;
+    },
+    fetch: () => Promise.resolve({ isConnected: true, isInternetReachable: true }),
+  },
+}));
+
+vi.mock('../../analytics', () => ({
+  track: (name: string, properties: Record<string, unknown>) => {
+    trackedEvents.push({ name, properties });
+  },
+}));
+
+vi.mock('../../error-reporting', () => ({ addErrorBreadcrumb: () => undefined }));
+
+// Turning offline mode OFF re-asks the server, and the store's default probe is
+// a real `fetch` at BACKEND_URL. Answer it here so no test in this file puts a
+// request on the wire.
+vi.mock('../backend-reachability', () => ({
+  probeBackend: () => Promise.resolve('healthy' as const),
+  nextProbeDelayMs: () => 5_000,
+}));
+
+// A faithful stand-in for the MMKV store, including the part that matters most:
+// a write notifies every subscriber SYNCHRONOUSLY, so the echo of our own
+// persistence reaches the connectivity store inside the same tap.
+vi.mock('../../../settings/hooks', () => ({
+  getSetting: (key: string) => {
+    if (key !== 'offlineMode') throw new Error(`unexpected settings read: ${key}`);
+    return settingsStore.offlineMode;
+  },
+  setSetting: (key: string, value: unknown) => {
+    settingsStore.writes.push({ key, value });
+    if (key === 'offlineMode') settingsStore.offlineMode = value === true;
+    for (const listener of settingsStore.listeners) listener();
+  },
+  subscribeSettings: (listener: () => void) => {
+    settingsStore.listeners.push(listener);
+    return () => {
+      settingsStore.listeners = settingsStore.listeners.filter((candidate) => candidate !== listener);
+    };
+  },
+}));
+
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { getConnectivitySnapshot, setOfflineMode, __resetConnectivityStoreForTests } from '../connectivity-store';
+import { startConnectivityStore, __resetStartConnectivityForTests } from '../start-connectivity';
+
+/** The `setSetting` an unrelated screen would do — drives the subscription. */
+function writeSettingFromElsewhere(offlineMode: boolean): void {
+  settingsStore.offlineMode = offlineMode;
+  for (const listener of settingsStore.listeners) listener();
+}
+
+function toggleEvents(): Array<Record<string, unknown>> {
+  return trackedEvents
+    .filter((event) => event.name === SHARED_EVENTS.OfflineModeToggled)
+    .map(({ properties }) => properties);
+}
+
+describe('start-connectivity — offline mode', () => {
+  beforeEach(() => {
+    platform.OS = 'ios';
+    settingsStore.offlineMode = false;
+    settingsStore.listeners = [];
+    settingsStore.writes = [];
+    trackedEvents.length = 0;
+    __resetConnectivityStoreForTests();
+    __resetStartConnectivityForTests();
+    // AFTER the resets: they close the previous test's subscriptions, and those
+    // removals belong to that test, not this one.
+    platformSubscriptions.appStateRemovals = 0;
+    platformSubscriptions.netInfoRemovals = 0;
+  });
+
+  afterEach(() => {
+    __resetConnectivityStoreForTests();
+    __resetStartConnectivityForTests();
+  });
+
+  // The whole reason the setting exists: a climber who switched the phone
+  // offline in the gym expects it to still be offline the next morning, with no
+  // window where the first screen of the launch fires the requests they stopped.
+  it('restores a persisted offline mode before anything else asks', () => {
+    settingsStore.offlineMode = true;
+
+    startConnectivityStore();
+
+    expect(getConnectivitySnapshot()).toMatchObject({
+      offlineMode: true,
+      effectiveOffline: true,
+      reason: 'offline_mode',
+    });
+    // Seeding is not a toggle: no event, and nothing written back.
+    expect(toggleEvents()).toEqual([]);
+    expect(settingsStore.writes).toEqual([]);
+  });
+
+  it('starts online when nothing was persisted', () => {
+    startConnectivityStore();
+
+    expect(getConnectivitySnapshot()).toMatchObject({ offlineMode: false, effectiveOffline: false, reason: null });
+  });
+
+  it('persists the flip and files exactly one event, with the source and the pre-flip reason', () => {
+    startConnectivityStore();
+
+    setOfflineMode(true, 'more');
+
+    expect(settingsStore.writes).toEqual([{ key: 'offlineMode', value: true }]);
+    expect(toggleEvents()).toEqual([{ enabled: true, source: 'more', reasonBefore: null }]);
+    expect(getConnectivitySnapshot().offlineMode).toBe(true);
+  });
+
+  // The write echoes straight back through the settings subscription. If that
+  // echo were treated as a fresh toggle, every tap would persist and report
+  // twice — or spin.
+  it('absorbs the echo of its own write instead of reporting it twice', () => {
+    startConnectivityStore();
+
+    setOfflineMode(true, 'more');
+
+    expect(settingsStore.writes).toHaveLength(1);
+    expect(toggleEvents()).toHaveLength(1);
+  });
+
+  it('mirrors a write made from outside the store', () => {
+    startConnectivityStore();
+
+    writeSettingFromElsewhere(true);
+
+    expect(getConnectivitySnapshot()).toMatchObject({ offlineMode: true, reason: 'offline_mode' });
+    // Not a toggle anybody made: nothing to attribute a source to.
+    expect(toggleEvents()).toEqual([]);
+  });
+
+  it('carries the source through the banner and sign-out paths too', () => {
+    startConnectivityStore();
+
+    setOfflineMode(true, 'banner');
+    setOfflineMode(false, 'sign_out');
+
+    expect(toggleEvents()).toEqual([
+      { enabled: true, source: 'banner', reasonBefore: null },
+      { enabled: false, source: 'sign_out', reasonBefore: 'offline_mode' },
+    ]);
+    expect(settingsStore.writes).toEqual([
+      { key: 'offlineMode', value: true },
+      { key: 'offlineMode', value: false },
+    ]);
+  });
+
+  // A listener kept past the reset would still fire on every later settings
+  // write, driving a handle that was disposed two suites ago.
+  it('closes every subscription it opened when the launch guard is re-armed', () => {
+    startConnectivityStore();
+    expect(settingsStore.listeners).toHaveLength(1);
+
+    __resetStartConnectivityForTests();
+
+    expect(settingsStore.listeners).toEqual([]);
+    expect(platformSubscriptions.netInfoRemovals).toBe(1);
+    expect(platformSubscriptions.appStateRemovals).toBe(1);
+  });
+
+  // Expo web has no offline catalog to fall back on and no native store behind
+  // the switch, so the whole mechanism stays out of the way there — including
+  // a value some earlier native session might have left in a shared store.
+  it('is inert on Expo web', () => {
+    platform.OS = 'web';
+    settingsStore.offlineMode = true;
+
+    startConnectivityStore();
+    setOfflineMode(true, 'more');
+
+    expect(getConnectivitySnapshot().offlineMode).toBe(false);
+    expect(settingsStore.writes).toEqual([]);
+    expect(settingsStore.listeners).toEqual([]);
+    expect(toggleEvents()).toEqual([]);
+  });
+});

--- a/packages/mobile/src/lib/connectivity/connectivity-store.ts
+++ b/packages/mobile/src/lib/connectivity/connectivity-store.ts
@@ -42,6 +42,27 @@ export type BackendState = 'reachable' | 'unreachable' | 'unknown';
 export type OfflineModeSource = 'more' | 'banner' | 'sign_out';
 
 /**
+ * One deliberate flip of the offline-mode switch, handed to the platform
+ * binding so persistence and the `Offline Mode Toggled` event happen in ONE
+ * place — `start-connectivity.ts` — instead of at each of the three call sites.
+ *
+ * `reasonBefore` is the snapshot's `reason` from BEFORE the flip, which is the
+ * only thing that separates "I chose to go offline while everything was fine"
+ * from "I took the banner's escape hatch during an outage". Read it off the
+ * event: by the time a listener runs, the flip has already rewritten it.
+ *
+ * There is deliberately no pending-write count here. The outbox lives in
+ * SQLite, so the store would have to run a query — on the UI tap, from a module
+ * that owns no database handle — to fill it in, and the same number is already
+ * on `Offline Read Served` and the drain events. Not worth a query per toggle.
+ */
+export type OfflineModeChange = {
+  enabled: boolean;
+  source: OfflineModeSource;
+  reasonBefore: ConnectivityReason | null;
+};
+
+/**
  * What moved the machine. Read as the CHANNEL, not the polarity: `failure` is
  * the request-outcome channel (`reportBackendOutcome`), so a recovery confirmed
  * by a request that finally succeeded also arrives with `failure`.
@@ -101,6 +122,8 @@ export type ConnectivityStoreDeps = {
   /** The ONE place React Query's `onlineManager.setOnline` is called. */
   onOnlineChange: (online: boolean) => void;
   onTransition?: (event: ConnectivityTransitionEvent) => void;
+  /** Fires only for a DELIBERATE toggle, never for `seedOfflineMode`. */
+  onOfflineModeChange?: (change: OfflineModeChange) => void;
 };
 
 export type ConnectivityStoreHandle = {
@@ -116,6 +139,13 @@ export type ConnectivityStoreHandle = {
   confirmBackendAvailability: () => Promise<boolean>;
   setAppActive: (active: boolean) => void;
   setOfflineMode: (enabled: boolean, source: OfflineModeSource) => void;
+  /**
+   * Adopt a persisted/echoed value WITHOUT re-persisting it or filing a toggle
+   * event. This is how the stored setting reaches the store at launch, and how
+   * a write from anywhere else gets mirrored — including the echo of our own
+   * write, which lands back here and no-ops because the value already matches.
+   */
+  seedOfflineMode: (enabled: boolean) => void;
   setDetectionEnabled: (enabled: boolean) => void;
   setDevForcedUnreachable: (forced: boolean) => void;
   dispose: () => void;
@@ -573,11 +603,9 @@ export function createConnectivityStore(deps: ConnectivityStoreDeps): Connectivi
     }
   }
 
-  // `_source` is carried by the type (not used here) so the toggle's telemetry
-  // and PR-B's persistence both read it off ONE call, rather than every caller
-  // remembering to emit its own event.
-  function setOfflineMode(enabled: boolean, _source: OfflineModeSource): void {
-    if (disposed || state.offlineMode === enabled) return;
+  /** The state machine half of the toggle. Answers whether anything moved. */
+  function applyOfflineMode(enabled: boolean): boolean {
+    if (disposed || state.offlineMode === enabled) return false;
     state.offlineMode = enabled;
     if (!enabled) {
       // Leaving offline mode: nothing we believed about the server while nobody
@@ -592,11 +620,30 @@ export function createConnectivityStore(deps: ConnectivityStoreDeps): Connectivi
     publish();
     if (enabled) {
       cancelProbeTimer();
-      return;
+      return true;
     }
     // Guarded like the ladder itself: with no uplink, or with detection killed,
     // there is nothing a probe could tell us.
     if (state.device !== 'offline' && state.detectionEnabled) void runProbe('offline_mode_off');
+    return true;
+  }
+
+  // `source` is carried on the change event rather than used here, so the
+  // toggle's persistence and its telemetry both read it off ONE call instead of
+  // every caller remembering to write the setting and emit its own event.
+  function setOfflineMode(enabled: boolean, source: OfflineModeSource): void {
+    // Captured BEFORE the flip: `reason` becomes `offline_mode` the moment the
+    // switch goes on, so read after the fact it would say the same thing on
+    // every event and could never distinguish the outage escape hatch.
+    const reasonBefore = currentSnapshot.reason;
+    if (!applyOfflineMode(enabled)) return;
+    try {
+      deps.onOfflineModeChange?.({ enabled, source, reasonBefore });
+    } catch (error) {
+      // The state already moved and the UI already re-rendered. A binding that
+      // failed to persist or to file the event must not undo that.
+      if (__DEV__) console.warn('[connectivity] offline-mode sink threw', error);
+    }
   }
 
   function setDetectionEnabled(enabled: boolean): void {
@@ -655,6 +702,9 @@ export function createConnectivityStore(deps: ConnectivityStoreDeps): Connectivi
     confirmBackendAvailability,
     setAppActive,
     setOfflineMode,
+    seedOfflineMode: (enabled: boolean) => {
+      applyOfflineMode(enabled);
+    },
     setDetectionEnabled,
     setDevForcedUnreachable,
     dispose: () => {
@@ -716,6 +766,7 @@ const lateBoundDeps: ConnectivityStoreDeps = {
   onOnlineChange: (online) =>
     bindings.onOnlineChange ? bindings.onOnlineChange(online) : defaultOnOnlineChange(online),
   onTransition: (event) => bindings.onTransition?.(event),
+  onOfflineModeChange: (change) => bindings.onOfflineModeChange?.(change),
 };
 
 function store(): ConnectivityStoreHandle {
@@ -775,10 +826,28 @@ export function setDevForcedUnreachable(forced: boolean): void {
   store().setDevForcedUnreachable(forced);
 }
 
-/** In-memory for PR-A; PR-B persists it. Inert on Expo web, which has no toggle. */
+/**
+ * The deliberate toggle, from all three surfaces (More, the banner, sign-out).
+ * Persistence and the `Offline Mode Toggled` event ride the binding's
+ * `onOfflineModeChange`, so no caller has to remember either. Inert on Expo web,
+ * which has no toggle and no native store behind one.
+ */
 export function setOfflineMode(enabled: boolean, source: OfflineModeSource): void {
   if (bindings.offlineModeSupported === false) return;
   store().setOfflineMode(enabled, source);
+}
+
+/**
+ * Whether this build has an offline-mode switch at all, so a surface can decide
+ * not to draw one rather than draw a dead one. False only on Expo web, where
+ * `setOfflineMode` is inert and nothing persists the choice. Unbound reads as
+ * supported, matching `setOfflineMode`: a consumer that runs before the app root
+ * started the store is on native.
+ *
+ * A launch constant, not reactive — nothing flips it after `bindConnectivityStore`.
+ */
+export function isOfflineModeSupported(): boolean {
+  return bindings.offlineModeSupported !== false;
 }
 
 export function __resetConnectivityStoreForTests(): void {

--- a/packages/mobile/src/lib/connectivity/start-connectivity.ts
+++ b/packages/mobile/src/lib/connectivity/start-connectivity.ts
@@ -3,7 +3,7 @@ import NetInfo, { type NetInfoState } from '@react-native-community/netinfo';
 import { onlineManager } from '@tanstack/react-query';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../analytics';
-import { addErrorBreadcrumb } from '../error-reporting';
+import { addErrorBreadcrumb, reportHandledError } from '../error-reporting';
 import { getSetting, setSetting, subscribeSettings } from '../../settings/hooks';
 import {
   bindConnectivityStore,
@@ -124,7 +124,16 @@ function reportBackendReachabilityTransition(event: ConnectivityTransitionEvent)
  * matches, so the loop closes after one comparison.
  */
 function persistAndReportOfflineMode(change: OfflineModeChange): void {
-  setSetting('offlineMode', change.enabled);
+  try {
+    setSetting('offlineMode', change.enabled);
+  } catch (error) {
+    // MMKV is a native module and can genuinely fail — a full disk, a corrupt
+    // store. Swallowing that would be the worst of both: the switch moves, the
+    // banner says offline mode is on, and the next launch quietly comes back
+    // online with no record of why. Report it and keep going: the in-memory flip
+    // is what the climber asked for, and it is honest for THIS launch.
+    reportHandledError(error, { tags: { source: 'connectivity', kind: 'offline-mode-persist' } });
+  }
   track(SHARED_EVENTS.OfflineModeToggled, {
     enabled: change.enabled,
     source: change.source,

--- a/packages/mobile/src/lib/connectivity/start-connectivity.ts
+++ b/packages/mobile/src/lib/connectivity/start-connectivity.ts
@@ -4,6 +4,7 @@ import { onlineManager } from '@tanstack/react-query';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../analytics';
 import { addErrorBreadcrumb } from '../error-reporting';
+import { getSetting, setSetting, subscribeSettings } from '../../settings/hooks';
 import {
   bindConnectivityStore,
   getConnectivitySnapshot,
@@ -12,6 +13,7 @@ import {
   type ConnectivityTransitionEvent,
   type DeviceReachability,
   type DeviceState,
+  type OfflineModeChange,
 } from './connectivity-store';
 
 /**
@@ -27,10 +29,15 @@ import {
 
 let started = false;
 let handle: ConnectivityStoreHandle | null = null;
-// Process-lifetime subscriptions. Held only so `__resetStartConnectivityForTests`
-// can tear them down between suites; the app never unsubscribes.
+
+// Every long-lived subscription this module opens, so the test reset can close
+// them. In the app they live for the launch and are never torn down; in a suite
+// that starts and resets repeatedly, a discarded unsubscribe is a listener still
+// holding a disposed handle and still being called on every NetInfo push,
+// AppState change or settings write.
 let unsubscribeNetInfo: (() => void) | null = null;
-let appStateSubscription: { remove(): void } | null = null;
+let unsubscribeSettings: (() => void) | null = null;
+let appStateSubscription: { remove: () => void } | null = null;
 
 type DeviceReading = { device: DeviceState; deviceReachability: DeviceReachability };
 
@@ -105,17 +112,58 @@ function reportBackendReachabilityTransition(event: ConnectivityTransitionEvent)
   });
 }
 
+/**
+ * Offline mode is a real device preference, not a session flag: a climber who
+ * switches it on in the gym expects it to still be on tomorrow morning. The
+ * store itself is pure TypeScript with no storage, so persistence lands here,
+ * on the same callback that files the event — which is why the toggle's three
+ * call sites (More, the banner, sign-out) each need to do neither.
+ *
+ * The write echoes straight back through `subscribeSettings` below. That is
+ * harmless by construction: `seedOfflineMode` no-ops when the value already
+ * matches, so the loop closes after one comparison.
+ */
+function persistAndReportOfflineMode(change: OfflineModeChange): void {
+  setSetting('offlineMode', change.enabled);
+  track(SHARED_EVENTS.OfflineModeToggled, {
+    enabled: change.enabled,
+    source: change.source,
+    reasonBefore: change.reasonBefore,
+  });
+}
+
 export function startConnectivityStore(): void {
   if (started) return;
   started = true;
 
-  handle = bindConnectivityStore({
+  // Expo web has no offline-mode surface (and no native storage to persist one),
+  // so the toggle — and everything below that keeps it in step with the stored
+  // setting — is inert there.
+  const offlineModeSupported = Platform.OS !== 'web';
+
+  const boundStore = bindConnectivityStore({
     readDeviceState: readDeviceStateFromNetInfo,
     onTransition: reportBackendReachabilityTransition,
-    // Expo web has no offline-mode surface (and no native storage to persist
-    // one), so the toggle is inert there.
-    offlineModeSupported: Platform.OS !== 'web',
+    onOfflineModeChange: offlineModeSupported ? persistAndReportOfflineMode : undefined,
+    offlineModeSupported,
   });
+  handle = boundStore;
+
+  if (offlineModeSupported) {
+    // Before anything else asks whether we are online. MMKV reads synchronously,
+    // so a phone that was left in offline mode never gets the window where the
+    // first screen of the launch fires the requests the climber switched off.
+    boundStore.seedOfflineMode(getSetting('offlineMode'));
+    // One listener for the whole settings store (there is no per-key registry),
+    // so this re-reads one key on every settings write and compares. That covers
+    // a write from outside the store — a reset-all, a future debug screen — and
+    // absorbs the echo of our own `persistAndReportOfflineMode`. It lives for the
+    // launch like the NetInfo listener below; the unsubscribe is kept only so the
+    // test reset can close it.
+    unsubscribeSettings = subscribeSettings(() => {
+      boundStore.seedOfflineMode(getSetting('offlineMode'));
+    });
+  }
 
   // Seed before the first change event: the store starts at `unknown`, which
   // reads as online, and a genuinely offline cold start would otherwise fire a
@@ -153,10 +201,17 @@ export function startConnectivityStore(): void {
   });
 }
 
-/** Test-only: re-arm the once-per-launch guard. */
+/**
+ * Test-only: re-arm the once-per-launch guard, and close every subscription the
+ * previous start opened. Dropping the unsubscribes instead would leave each
+ * suite's listeners stacked on the platform modules, all pointing at handles the
+ * next reset disposed.
+ */
 export function __resetStartConnectivityForTests(): void {
   unsubscribeNetInfo?.();
   unsubscribeNetInfo = null;
+  unsubscribeSettings?.();
+  unsubscribeSettings = null;
   appStateSubscription?.remove();
   appStateSubscription = null;
   started = false;

--- a/packages/mobile/src/lib/connectivity/use-connectivity.ts
+++ b/packages/mobile/src/lib/connectivity/use-connectivity.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import { getConnectivitySnapshot, subscribeConnectivity, type ConnectivitySnapshot } from './connectivity-store';
 
 /**
@@ -29,7 +29,10 @@ export function useConnectivity(): ConnectivitySnapshot {
  * to module scope so its identity is stable too.
  */
 export function useConnectivityField<Field>(select: (snapshot: ConnectivitySnapshot) => Field): Field {
-  const readSelectedField = () => select(getConnectivitySnapshot());
+  // Stable per selector: `useSyncExternalStore` re-subscribes when its snapshot
+  // reader changes identity, so a fresh closure every render would churn the
+  // subscription on each commit even though the selector never moved.
+  const readSelectedField = useCallback(() => select(getConnectivitySnapshot()), [select]);
   return useSyncExternalStore(subscribeConnectivity, readSelectedField, readSelectedField);
 }
 

--- a/packages/mobile/src/lib/connectivity/use-connectivity.ts
+++ b/packages/mobile/src/lib/connectivity/use-connectivity.ts
@@ -27,6 +27,11 @@ export function useConnectivity(): ConnectivitySnapshot {
  * selector that builds a fresh object every call reads as "changed on every
  * commit" and loops until React's update-depth guard fires. Hoist the selector
  * to module scope so its identity is stable too.
+ *
+ * @param select - MUST be a stable, module-scoped reference (e.g. the hoisted
+ *   `selectOfflineMode` below), never an inline arrow: the reader is memoized
+ *   on it, so a new identity each render re-registers the subscription on
+ *   every commit.
  */
 export function useConnectivityField<Field>(select: (snapshot: ConnectivitySnapshot) => Field): Field {
   // Stable per selector: `useSyncExternalStore` re-subscribes when its snapshot

--- a/packages/mobile/src/lib/connectivity/use-connectivity.ts
+++ b/packages/mobile/src/lib/connectivity/use-connectivity.ts
@@ -14,3 +14,26 @@ import { getConnectivitySnapshot, subscribeConnectivity, type ConnectivitySnapsh
 export function useConnectivity(): ConnectivitySnapshot {
   return useSyncExternalStore(subscribeConnectivity, getConnectivitySnapshot, getConnectivitySnapshot);
 }
+
+/**
+ * One field of the same machine. `useConnectivity()` re-renders on EVERY
+ * snapshot change — `probing` alone flips twice per rung of the backoff ladder
+ * — so a component that only cares whether offline mode is on would re-render
+ * through a whole outage for nothing. This narrows the subscription to what the
+ * caller reads.
+ *
+ * `select` must return a primitive, or a reference that is stable while the
+ * value is unchanged: `useSyncExternalStore` compares with `Object.is`, and a
+ * selector that builds a fresh object every call reads as "changed on every
+ * commit" and loops until React's update-depth guard fires. Hoist the selector
+ * to module scope so its identity is stable too.
+ */
+export function useConnectivityField<Field>(select: (snapshot: ConnectivitySnapshot) => Field): Field {
+  const readSelectedField = () => select(getConnectivitySnapshot());
+  return useSyncExternalStore(subscribeConnectivity, readSelectedField, readSelectedField);
+}
+
+/** Hoisted for `useConnectivityField`: the deliberate offline-mode switch only. */
+export function selectOfflineMode(snapshot: ConnectivitySnapshot): boolean {
+  return snapshot.offlineMode;
+}

--- a/packages/mobile/src/lib/graphql/__tests__/ws-client-offline-mode.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/ws-client-offline-mode.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Client, CreateGraphQLClientOptions, ExtendedClient } from '@boardsesh/graphql-client';
+import { BACKEND_UNAVAILABLE_ERROR_NAME } from '@boardsesh/offline-sync/error-classification';
+
+// The WebSocket half of offline mode (issue #4862). `getWsClient()` is the ONE
+// place a socket can be created, and plenty of callers reach it with no
+// connectivity gate of their own — the drawer host restoring a stored active
+// board on a cold launch, a BLE auto-connect bind, a party-queue mutation. This
+// suite pins the factory gate that catches all of them.
+
+const disposeSpy = vi.hoisted(() => vi.fn());
+const realClient = vi.hoisted(() => ({ dispose: disposeSpy }) as unknown as ExtendedClient);
+const createGraphQLClient = vi.hoisted(() => vi.fn());
+
+// Only the client factory is replaced: `execute` and `subscribe` stay REAL, so
+// the assertions below run the same code path a mutation does in the app.
+vi.mock('@boardsesh/graphql-client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/graphql-client')>()),
+  createGraphQLClient: (options: CreateGraphQLClientOptions) => createGraphQLClient(options),
+}));
+
+vi.mock('../../error-reporting', () => ({ reportHandledError: vi.fn() }));
+vi.mock('../../env', () => ({ BACKEND_URL: 'https://api.test' }));
+
+import { execute, subscribe } from '@boardsesh/graphql-client';
+import { createWsClientModule } from '../ws-client-core';
+
+const createSocket = vi.fn(() => ({}) as unknown as WebSocket);
+const offlineMode = { on: false };
+
+function createModule() {
+  return createWsClientModule({
+    createSocket,
+    captureAuthCredentialGeneration: () => 1,
+    getAuthToken: () => Promise.resolve('jwt-token'),
+    isAuthCredentialGenerationCurrent: () => true,
+    ensureFreshToken: () => Promise.resolve(true),
+    recoverAuthRejection: () => Promise.resolve('refreshed' as const),
+    isOfflineModeOn: () => offlineMode.on,
+  });
+}
+
+/** What `subscribe()` handed the sink, if anything. */
+function captureSubscriptionError(client: Client): { error: unknown; unsubscribe: () => void } {
+  let captured: unknown;
+  const unsubscribe = subscribe<Record<string, unknown>>(
+    client,
+    { query: 'subscription Feed { feed { id } }' },
+    {
+      next: () => {},
+      error: (error) => {
+        captured = error;
+      },
+      complete: () => {},
+    },
+  );
+  return { error: captured, unsubscribe };
+}
+
+describe('ws-client — offline mode gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    offlineMode.on = false;
+    createGraphQLClient.mockReturnValue(realClient);
+  });
+
+  it('builds no client at all while offline mode is on', () => {
+    offlineMode.on = true;
+    const { getWsClient } = createModule();
+
+    getWsClient();
+    getWsClient();
+
+    // Not "a client that fails to connect" — no client, and so no socket.
+    expect(createGraphQLClient).not.toHaveBeenCalled();
+    expect(createSocket).not.toHaveBeenCalled();
+  });
+
+  it('hands the real client back when the switch is off', () => {
+    const { getWsClient } = createModule();
+
+    expect(getWsClient()).toBe(realClient);
+    expect(createGraphQLClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses the one real client across calls', () => {
+    const { getWsClient } = createModule();
+
+    getWsClient();
+    getWsClient();
+
+    expect(createGraphQLClient).toHaveBeenCalledTimes(1);
+  });
+
+  // The whole point of the gate: a subscription started while the mode is on
+  // fails locally instead of dialling. `BackendUnavailableError` is what PR-A's
+  // HTTP chokepoint already throws — the shared classifier reads it as a
+  // transport stop (no `retry_count` strike), `reportHandledError` drops it, and
+  // React Query refuses to retry it.
+  it('fails a subscription synchronously, with the offline-mode reason', () => {
+    offlineMode.on = true;
+    const { getWsClient } = createModule();
+
+    const { error, unsubscribe } = captureSubscriptionError(getWsClient());
+
+    expect(error).toMatchObject({ name: BACKEND_UNAVAILABLE_ERROR_NAME, reason: 'offline_mode' });
+    expect(() => unsubscribe()).not.toThrow();
+  });
+
+  // graphql-ws models a mutation as a one-shot subscription, so this is every
+  // imperative write in the app: the presence provider's board bind, a party
+  // queue mutation, the drawer host's active-board restore.
+  it('rejects a mutation immediately rather than waiting out its timeout', async () => {
+    offlineMode.on = true;
+    const { getWsClient } = createModule();
+
+    await expect(execute(getWsClient(), { query: 'mutation Bind { bindBoard { id } }' })).rejects.toMatchObject({
+      name: BACKEND_UNAVAILABLE_ERROR_NAME,
+      reason: 'offline_mode',
+    });
+    expect(createGraphQLClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects the pull-based iterate() the same way', async () => {
+    offlineMode.on = true;
+    const { getWsClient } = createModule();
+
+    const iterator = getWsClient().iterate({ query: 'subscription Feed { feed { id } }' });
+
+    await expect(iterator.next()).rejects.toMatchObject({ name: BACKEND_UNAVAILABLE_ERROR_NAME });
+  });
+
+  it('gives each rejection its own error object, so stacks are not shared', () => {
+    offlineMode.on = true;
+    const { getWsClient } = createModule();
+    const client = getWsClient();
+
+    const first = captureSubscriptionError(client).error;
+    const second = captureSubscriptionError(client).error;
+
+    expect(first).not.toBe(second);
+  });
+
+  it('leaves the lifecycle methods inert instead of throwing', () => {
+    offlineMode.on = true;
+    const { getWsClient } = createModule();
+    const client = getWsClient();
+
+    expect(() => client.on('connected', () => {})()).not.toThrow();
+    expect(() => client.terminate()).not.toThrow();
+    expect(() => void client.dispose()).not.toThrow();
+  });
+
+  // The stub is never cached as "the client". Caching it would leave a phone
+  // that turned offline mode back off holding a dead transport for the rest of
+  // the launch — the exact trap #4862 is about.
+  it('builds a real client on the first call after the switch goes off', () => {
+    offlineMode.on = true;
+    const { getWsClient } = createModule();
+    expect(getWsClient()).not.toBe(realClient);
+
+    offlineMode.on = false;
+
+    expect(getWsClient()).toBe(realClient);
+    expect(createGraphQLClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('goes inert again when the switch comes back on, without rebuilding later', () => {
+    const { getWsClient } = createModule();
+    expect(getWsClient()).toBe(realClient);
+
+    offlineMode.on = true;
+    expect(getWsClient()).not.toBe(realClient);
+
+    offlineMode.on = false;
+    expect(getWsClient()).toBe(realClient);
+    expect(createGraphQLClient).toHaveBeenCalledTimes(1);
+  });
+
+  // `disposeWsClient` still owns the real client's teardown; the gate only
+  // decides which client `getWsClient()` hands out.
+  it('still disposes the real client when one was built', () => {
+    const { getWsClient, disposeWsClient } = createModule();
+    getWsClient();
+
+    disposeWsClient();
+
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/lib/graphql/ws-client-core.ts
+++ b/packages/mobile/src/lib/graphql/ws-client-core.ts
@@ -1,8 +1,57 @@
 import { createGraphQLClient, type Client } from '@boardsesh/graphql-client';
 import { reportHandledError } from '../error-reporting';
 import { BACKEND_URL } from '../env';
+import { BackendUnavailableError } from '../connectivity/backend-unavailable-error';
 import type { AuthRejectionResult } from '../auth-rejection-result';
 import { AUTH_REFRESH_RETRY_CLOSE_CODE, AUTH_REJECTED_CLOSE_CODE } from './ws-close-codes';
+
+/**
+ * An async iterator that rejects on the first pull. `iterate()` is the pull-based
+ * twin of `subscribe()`, and the inert client has to answer both the same way.
+ * Written as a plain object rather than an `async function*` so it needs no
+ * unreachable `yield` to satisfy the linter.
+ */
+function createOfflineModeIterator(): AsyncIterableIterator<never> {
+  const iterator: AsyncIterableIterator<never> = {
+    [Symbol.asyncIterator]: () => iterator,
+    next: () => Promise.reject(new BackendUnavailableError('offline_mode')),
+  };
+  return iterator;
+}
+
+/**
+ * The client `getWsClient()` hands out while the climber's offline-mode switch
+ * is on (issue #4862) — a `Client`-shaped object that opens no socket and holds
+ * no state.
+ *
+ * This is what makes "offline mode talks to no server" true for the WebSocket
+ * half. `ConnectivityBridge`'s `disposeWsClient()` is a CUT: it drops the cached
+ * client, but the next `getWsClient()` would build a fresh one, and plenty of
+ * callers reach the socket without a connectivity gate of their own — the
+ * drawer host restoring a stored active board on a cold launch, the BLE
+ * auto-connect bind, a party-queue mutation. Gating the FACTORY catches all of
+ * them at once, so no caller has to remember.
+ *
+ * Every operation fails the way PR-A's HTTP chokepoint already does: a fresh
+ * `BackendUnavailableError('offline_mode')`, which the shared classifier reads
+ * as a transport-class stop (drainer-safe: no `retry_count` strike), which
+ * `reportHandledError` drops, and which React Query refuses to retry. Fresh per
+ * call so each rejection carries its own stack.
+ *
+ * Stateless, so ONE instance is enough — and it is deliberately never assigned
+ * to `wsClient`, or turning offline mode back off would hand out a dead client
+ * for the rest of the launch.
+ */
+const OFFLINE_MODE_CLIENT: Client = {
+  on: () => () => {},
+  subscribe: (_payload, sink) => {
+    sink.error(new BackendUnavailableError('offline_mode'));
+    return () => {};
+  },
+  iterate: () => createOfflineModeIterator(),
+  terminate: () => {},
+  dispose: () => {},
+};
 
 /**
  * Platform seam for the GraphQL-WS transport. Native and web differ only in how
@@ -20,6 +69,20 @@ export type WsClientDeps = {
   isAuthCredentialGenerationCurrent: (generation: number) => boolean;
   ensureFreshToken: () => Promise<boolean>;
   recoverAuthRejection: () => Promise<AuthRejectionResult>;
+  /**
+   * Is the climber's deliberate offline-mode switch on? Read per call, never
+   * captured, so the answer follows the store rather than the launch.
+   *
+   * `offlineMode` ONLY — not `effectiveOffline`. A tunnel or a backend blip must
+   * keep graphql-ws's own retry ladder, which recovers a live subscription
+   * without anyone re-subscribing; swapping in the inert client there would kill
+   * the party session on every lift. Offline mode is deliberate and sticky, and
+   * the climber asked for exactly this.
+   *
+   * Native reads the connectivity store; Expo web has no offline-mode surface
+   * and passes `() => false`.
+   */
+  isOfflineModeOn: () => boolean;
 };
 
 export type WsClientModule = {
@@ -35,6 +98,7 @@ export function createWsClientModule(deps: WsClientDeps): WsClientModule {
     isAuthCredentialGenerationCurrent,
     ensureFreshToken,
     recoverAuthRejection,
+    isOfflineModeOn,
   } = deps;
 
   function getWsUrl(): string {
@@ -183,6 +247,11 @@ export function createWsClientModule(deps: WsClientDeps): WsClientModule {
   let wsClient: Client | null = null;
 
   function getWsClient(): Client {
+    // The one chokepoint. Handing back the inert client — rather than building
+    // or reusing the real one — is what stops a socket being opened by a caller
+    // that has no offline gate of its own. Checked on every call and never
+    // cached, so the first call after the switch goes off gets a real client.
+    if (isOfflineModeOn()) return OFFLINE_MODE_CLIENT;
     if (!wsClient) {
       wsClient = createGraphQLClient({
         url: getWsUrl(),

--- a/packages/mobile/src/lib/graphql/ws-client.ts
+++ b/packages/mobile/src/lib/graphql/ws-client.ts
@@ -1,5 +1,6 @@
 import { captureAuthCredentialGeneration, getAuthToken, isAuthCredentialGenerationCurrent } from '../auth-store';
 import { ensureFreshToken, recoverAuthRejection } from '../auth-interceptor';
+import { getConnectivitySnapshot } from '../connectivity/connectivity-store';
 import { createWsClientModule } from './ws-client-core';
 
 // React Native's WebSocket derives an `Origin` header from the JS bundle
@@ -27,6 +28,9 @@ const { getWsClient, disposeWsClient } = createWsClientModule({
   isAuthCredentialGenerationCurrent,
   ensureFreshToken,
   recoverAuthRejection,
+  // The store is pure TypeScript with no react-native in its graph, so reading
+  // it here costs this module nothing it did not already carry.
+  isOfflineModeOn: () => getConnectivitySnapshot().offlineMode,
 });
 
 export { getWsClient, disposeWsClient };

--- a/packages/mobile/src/lib/graphql/ws-client.web.ts
+++ b/packages/mobile/src/lib/graphql/ws-client.web.ts
@@ -11,6 +11,9 @@ const { getWsClient, disposeWsClient } = createWsClientModule({
   isAuthCredentialGenerationCurrent,
   ensureFreshToken,
   recoverAuthRejection,
+  // Expo web draws no offline-mode row and persists no setting behind one, so
+  // there is nothing here for the gate to read.
+  isOfflineModeOn: () => false,
 });
 
 export { getWsClient, disposeWsClient };

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -1815,6 +1815,10 @@ describe('AuthProvider.checkAuth signed-out cleanup', () => {
     // Same cleanup as the explicit signOut tests, minus authSignOut() — the
     // expiry path skips re-revoking an already-invalid token.
     expect(authSignOutMock).not.toHaveBeenCalled();
+    // The FORCED path (a server-rejected refresh, no confirm dialog, no drain)
+    // must reset offline mode too: a phone left signed out with the switch on
+    // would show a login screen whose own sign-in request is gated (#4862).
+    expect(setOfflineModeMock).toHaveBeenCalledWith(false, 'sign_out');
     expect(clearStoredSessionIdMock).toHaveBeenCalledTimes(1);
     expect(clearStoredActiveBoardMock).toHaveBeenCalledTimes(1);
     expect(resetHttpClientMock).toHaveBeenCalledTimes(1);

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -262,6 +262,16 @@ vi.mock('../../lib/graphql/ws-client', () => ({
   disposeWsClient: () => disposeWsClientMock(),
 }));
 
+const setOfflineModeMock = vi.fn();
+// Spread the real module: the auth interceptor and auth-session read
+// `getConnectivitySnapshot` from it, and a mock that only knows
+// `setOfflineMode` would turn every checkAuth into a TypeError before the
+// cleanup under test ever ran.
+vi.mock('../../lib/connectivity/connectivity-store', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/connectivity/connectivity-store')>()),
+  setOfflineMode: (enabled: boolean, source: string) => setOfflineModeMock(enabled, source),
+}));
+
 vi.mock('../../lib/graphql/use-active-board', () => ({
   ACTIVE_BOARD_QUERY_KEY: ['activeBoard'] as const,
   clearStoredActiveBoardCoordinated: (...args: unknown[]) => clearStoredActiveBoardMock(...args),
@@ -408,6 +418,7 @@ describe('AuthProvider.signOut', () => {
     clearStoredActiveBoardMock.mockReset();
     resetHttpClientMock.mockReset();
     disposeWsClientMock.mockReset();
+    setOfflineModeMock.mockReset();
     reportErrorMock.mockReset();
     redirectMock.mockReset();
     setSettingMock.mockReset();
@@ -488,6 +499,10 @@ describe('AuthProvider.signOut', () => {
     expect(clearSessionCommentDraftMock).not.toHaveBeenCalled();
     expect(resetHttpClientMock).toHaveBeenCalledTimes(1);
     expect(disposeWsClientMock).toHaveBeenCalledTimes(1);
+    // Offline mode gates the backend, so a phone left signed out with the switch
+    // still on would show a login screen whose own sign-in request is blocked —
+    // locked out by a setting that is no longer reachable (#4862).
+    expect(setOfflineModeMock).toHaveBeenCalledWith(false, 'sign_out');
     // Shared-device privacy: the per-user offline selection AND the board snapshots
     // the offline picker replays (which carry board NAMES) must not survive into the
     // next account. Asserted, not left to code review.
@@ -1013,6 +1028,7 @@ describe('AuthProvider.signOut mutation-queue drain gating', () => {
     getDatabaseHandleMock.mockReset();
     drainMutationQueueMock.mockReset();
     getOutboxSummaryMock.mockReset();
+    setOfflineModeMock.mockReset();
     getAuthTokenMock.mockResolvedValue('jwt-token');
     isTokenExpiringSoonMock.mockResolvedValue(false);
     authSignOutMock.mockResolvedValue(true);
@@ -1049,6 +1065,23 @@ describe('AuthProvider.signOut mutation-queue drain gating', () => {
     await signOutWithQueueState(3);
     expect(getOutboxSummaryMock).toHaveBeenCalled();
     expect(drainMutationQueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  // #4862. Offline mode holds `onlineManager` false, and the drainer returns on
+  // its first `isOnline()` check — so a flip that only happened later, in
+  // runSignedOutCleanup, would let `purgeLocalDataForSignOut` delete exactly the
+  // writes the confirmation dialog promised to try and send. Ordering IS the fix.
+  it('leaves offline mode before the drain runs, not after it', async () => {
+    await signOutWithQueueState(3);
+
+    expect(setOfflineModeMock).toHaveBeenCalledWith(false, 'sign_out');
+    expect(drainMutationQueueMock).toHaveBeenCalledTimes(1);
+    expect(setOfflineModeMock.mock.invocationCallOrder[0]!).toBeLessThan(
+      getOutboxSummaryMock.mock.invocationCallOrder[0]!,
+    );
+    expect(setOfflineModeMock.mock.invocationCallOrder[0]!).toBeLessThan(
+      drainMutationQueueMock.mock.invocationCallOrder[0]!,
+    );
   });
 
   it('skips the drain entirely when the outbox is empty', async () => {

--- a/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/board-presence-provider.test.tsx
@@ -23,8 +23,13 @@ const transport = vi.hoisted(() => ({
 }));
 const sharedProvider = vi.hoisted(() => ({
   lastBoardId: undefined as number | null | undefined,
+  lastClient: undefined as unknown,
   lastOnCatchUp: undefined as ((info: { reason: string; recoveredThroughSeqDelta: number }) => void) | undefined,
 }));
+// The offline-mode switch, read through the same narrowed selector the provider
+// uses. Presence is the one realtime consumer whose transport opens a socket on
+// demand, so this is what stops it re-dialling (issue #4862).
+const connectivity = vi.hoisted(() => ({ offlineMode: false }));
 // The refresh action exposed by the (mocked) shared actions context, and a track
 // spy — so we can assert the foreground sync and catch-up telemetry wiring.
 const refreshMock = vi.hoisted(() => vi.fn());
@@ -78,6 +83,12 @@ vi.mock('../../lib/board-presence/board-presence-client', () => ({
 
 vi.mock('../../lib/graphql/ws-client', () => ({ getWsClient: () => ({}) }));
 
+vi.mock('../../lib/connectivity/use-connectivity', () => ({
+  selectOfflineMode: (snapshot: { offlineMode: boolean }) => snapshot.offlineMode,
+  useConnectivityField: (select: (snapshot: { offlineMode: boolean }) => boolean) =>
+    select({ offlineMode: connectivity.offlineMode }),
+}));
+
 // Keep react-native host components (the disambiguation Modal) out of this
 // jsdom suite — it asserts provider logic, not the picker UI.
 vi.mock('../../components/board-discovery/BoardDisambiguationSheet', () => ({
@@ -92,14 +103,17 @@ vi.mock('../../components/board-discovery/BoardDisambiguationSheet', () => ({
 vi.mock('@boardsesh/board-presence-react', () => ({
   BoardPresenceProvider: ({
     boardId,
+    client,
     onCatchUp,
     children,
   }: {
     boardId: number | null;
+    client: unknown;
     onCatchUp?: (info: { reason: string; recoveredThroughSeqDelta: number }) => void;
     children: ReactNode;
   }) => {
     sharedProvider.lastBoardId = boardId;
+    sharedProvider.lastClient = client;
     sharedProvider.lastOnCatchUp = onCatchUp;
     return createElement('div', { 'data-board-id': String(boardId) }, children);
   },
@@ -156,7 +170,9 @@ describe('MobileBoardPresenceProvider', () => {
     transport.reportClimb.mockClear();
     transport.reportClimb.mockResolvedValue(true);
     sharedProvider.lastBoardId = undefined;
+    sharedProvider.lastClient = undefined;
     sharedProvider.lastOnCatchUp = undefined;
+    connectivity.offlineMode = false;
     refreshMock.mockClear();
     trackMock.mockClear();
     appState.addEventListener.mockClear();
@@ -798,5 +814,34 @@ describe('MobileBoardPresenceProvider', () => {
     act(() => sharedProvider.lastOnCatchUp?.({ reason: 'foreground', recoveredThroughSeqDelta: 0 }));
 
     expect(trackMock).not.toHaveBeenCalledWith(SHARED_EVENTS.BoardHistoryCatchUp, expect.anything());
+  });
+
+  // Issue #4862. Every presence transport call — the subscription, each catch-up
+  // fetch, the foreground refresh — goes through `getWsClient()`, which OPENS a
+  // socket on demand, so the client the ConnectivityBridge disposes would come
+  // straight back. A null client is the shared hook's inert state.
+  it('hands the presence hook no transport while offline mode is on', () => {
+    connectivity.offlineMode = true;
+
+    renderProvider();
+
+    expect(sharedProvider.lastClient).toBeNull();
+  });
+
+  it('keeps the transport attached when offline mode is off', () => {
+    renderProvider();
+
+    expect(sharedProvider.lastClient).not.toBeNull();
+  });
+
+  it('re-attaches the transport on the store edge back to online', () => {
+    connectivity.offlineMode = true;
+    const { rerender } = renderProvider();
+    expect(sharedProvider.lastClient).toBeNull();
+
+    connectivity.offlineMode = false;
+    rerender(createElement(MobileBoardPresenceProvider, null, createElement(Probe)));
+
+    expect(sharedProvider.lastClient).not.toBeNull();
   });
 });

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -27,6 +27,7 @@ import { reportError, reportHandledError } from '../lib/error-reporting';
 import { setOnForcedSignOut } from '../lib/auth-interceptor';
 import { getHttpClient, resetHttpClient } from '../lib/graphql/client';
 import { disposeWsClient } from '../lib/graphql/ws-client';
+import { setOfflineMode } from '../lib/connectivity/connectivity-store';
 import { clearStoredSessionId } from '../lib/session-store';
 import { clearStoredQueueSnapshot } from '../lib/queue-snapshot-store';
 import { clearAllCreateClimbDrafts } from '../lib/create-climb-draft-store';
@@ -324,6 +325,16 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       // their `Offline Board Download Started`. Production showed exactly that:
       // every `Offline Data Wiped On Sign Out` sat on a different person_id from
       // the `Logout` half a second earlier.
+      //
+      // Before the analytics reset, for the same reason as everything above it:
+      // `Offline Mode Toggled { source: 'sign_out' }` has to land on the account
+      // that is leaving, not on a fresh anonymous distinct_id.
+      //
+      // The reset itself is the point (issue #4862). Offline mode gates the
+      // backend, so a phone left signed out with the switch still on would show
+      // a login screen whose own sign-in request is blocked — the climber would
+      // be locked out of the app by a setting they cannot reach from there.
+      setOfflineMode(false, 'sign_out');
       resetAnalytics();
       if (!isAuthTransitionCurrent(transitionEpoch)) return false;
       // Reset the per-user "downloaded boards" list so the next account on a shared
@@ -815,6 +826,15 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       const transitionEpoch = beginAuthTransition();
       updateNativeSessionDegraded(false);
       track(SHARED_EVENTS.Logout, { method });
+      // BEFORE the drain, not just in `runSignedOutCleanup` further down. The
+      // store holds `onlineManager` false while offline mode is on, so the
+      // drainer's `if (!options.isOnline()) return;` would bail in microseconds
+      // and `purgeLocalDataForSignOut` would then delete the very
+      // pending_mutations the confirm dialog promised to try and send. The
+      // cleanup call stays where it is for the forced-401 and expiry paths,
+      // which never reach this function; a second call is idempotent, so it
+      // neither writes the setting nor files a second event.
+      setOfflineMode(false, 'sign_out');
       await drainLocalMutationQueueBestEffort();
 
       // A login in this or another tab supersedes the old account's intent. Do

--- a/packages/mobile/src/providers/board-presence-provider.tsx
+++ b/packages/mobile/src/providers/board-presence-provider.tsx
@@ -163,6 +163,13 @@ type BoardPresenceControlsValue = {
 
 const BoardPresenceControlsContext = createContext<BoardPresenceControlsValue | null>(null);
 
+// Screenshot builds swap in a seed client that serves canned real climbs (no
+// graphql-ws), so the kiosk lights up in the simulator; the branch dead-strips
+// in normal builds. `EXPO_PUBLIC_SCREENSHOT_MODE` is inlined at build time, so
+// this is a launch constant — which is also why the offline gate below can
+// treat "seed transport" as a fixed fact rather than a render input.
+const USES_SEED_TRANSPORT = process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1';
+
 export function MobileBoardPresenceProvider({ children }: { children: ReactNode }) {
   // Always-on: presence shipped GA, so the provider is never inert. `enabled` is
   // kept (constant true here) so consumers and the outside-provider fallback can
@@ -185,17 +192,10 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
     candidates: BoardCandidate[];
   } | null>(null);
 
-  // Screenshot builds swap in a seed client that serves canned real climbs (no
-  // graphql-ws), so the kiosk lights up in the simulator; the branch dead-strips
-  // in normal builds. Read once here so the offline gate below can tell a
-  // network transport from a purely local one.
-  const usesSeedTransport = process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1';
-
-  // The injected transport, built once.
+  // The injected transport, built once. `USES_SEED_TRANSPORT` is a module
+  // constant, so the empty dep list is exact rather than a lint exception.
   const client = useMemo<MobileBoardPresenceClient | null>(
-    () => (usesSeedTransport ? createScreenshotBoardPresenceClient() : createMobileBoardPresenceClient(getWsClient)),
-    // `EXPO_PUBLIC_SCREENSHOT_MODE` is inlined at build time, so the transport
-    // choice is a launch constant: the client is created exactly once.
+    () => (USES_SEED_TRANSPORT ? createScreenshotBoardPresenceClient() : createMobileBoardPresenceClient(getWsClient)),
     [],
   );
   const clientRef = useRef(client);
@@ -224,7 +224,7 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
   // binding a board, or reporting a lit climb, is one-shot and user-initiated, so
   // it fails visibly instead of redialling in the background.
   const offlineMode = useConnectivityField(selectOfflineMode);
-  const liveClient = offlineMode && !usesSeedTransport ? null : client;
+  const liveClient = offlineMode && !USES_SEED_TRANSPORT ? null : client;
 
   // A bound identity is cached by the exact resolver key. A same-key reconnect
   // can reuse it; a different serial/config/UUID must resolve independently.

--- a/packages/mobile/src/providers/board-presence-provider.tsx
+++ b/packages/mobile/src/providers/board-presence-provider.tsx
@@ -38,6 +38,7 @@ import {
   SCREENSHOT_SEED_BOARD_ID,
 } from '../lib/board-presence/screenshot-wall-seed';
 import { getWsClient } from '../lib/graphql/ws-client';
+import { selectOfflineMode, useConnectivityField } from '../lib/connectivity/use-connectivity';
 import { track } from '../lib/analytics';
 import { BoardDisambiguationSheet } from '../components/board-discovery/BoardDisambiguationSheet';
 
@@ -184,19 +185,44 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
     candidates: BoardCandidate[];
   } | null>(null);
 
-  // The injected transport, built once. Presence is always-on, so the shared
-  // hook always has a client to attach its subscription to. Screenshot builds
-  // swap in a seed client that serves canned real climbs (no graphql-ws), so the
-  // kiosk lights up in the simulator; the branch dead-strips in normal builds.
+  // Screenshot builds swap in a seed client that serves canned real climbs (no
+  // graphql-ws), so the kiosk lights up in the simulator; the branch dead-strips
+  // in normal builds. Read once here so the offline gate below can tell a
+  // network transport from a purely local one.
+  const usesSeedTransport = process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1';
+
+  // The injected transport, built once.
   const client = useMemo<MobileBoardPresenceClient | null>(
-    () =>
-      process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1'
-        ? createScreenshotBoardPresenceClient()
-        : createMobileBoardPresenceClient(getWsClient),
-    [],
+    () => (usesSeedTransport ? createScreenshotBoardPresenceClient() : createMobileBoardPresenceClient(getWsClient)),
+    [usesSeedTransport],
   );
   const clientRef = useRef(client);
   clientRef.current = client;
+
+  // Offline mode has to reach the wall feed too (issue #4862). The shared
+  // presence hook subscribes whenever it holds a board AND a client, and every
+  // one of its transport calls — the subscription, each catch-up fetch, the
+  // foreground refresh — goes through `getWsClient()`, which OPENS a socket on
+  // demand. So the socket `ConnectivityBridge` disposes would come straight back
+  // the next time a board binds or the app is foregrounded.
+  //
+  // Handing the hook `null` is its documented inert state: it resets, subscribes
+  // to nothing, and `refresh()` becomes a no-op. Passing the real client back on
+  // the store's edge re-subscribes and catches up from the durable history in one
+  // go — the same defer-and-resume shape as `use-session-realtime`, expressed
+  // through the prop the hook already understands.
+  //
+  // Gated on `offlineMode` alone, NOT `effectiveOffline`. A dropped signal or a
+  // backend blip already has an answer here: graphql-ws retries, the feed stays
+  // on screen and goes not-live. Widening the gate would blank the wall's history
+  // on every tunnel. Offline mode is a deliberate, sticky choice, and clearing a
+  // live feed nobody is allowed to fetch is what the climber asked for.
+  //
+  // The imperative controls below keep the ungated `clientRef`: resolving and
+  // binding a board, or reporting a lit climb, is one-shot and user-initiated, so
+  // it fails visibly instead of redialling in the background.
+  const offlineMode = useConnectivityField(selectOfflineMode);
+  const liveClient = offlineMode && !usesSeedTransport ? null : client;
 
   // A bound identity is cached by the exact resolver key. A same-key reconnect
   // can reuse it; a different serial/config/UUID must resolve independently.
@@ -502,7 +528,7 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
 
   return (
     <BoardPresenceControlsContext.Provider value={controls}>
-      <BoardPresenceProvider boardId={boardId} client={client} onCatchUp={handleCatchUp}>
+      <BoardPresenceProvider boardId={boardId} client={liveClient} onCatchUp={handleCatchUp}>
         <BoardPresenceForegroundSync />
         {children}
       </BoardPresenceProvider>

--- a/packages/mobile/src/providers/board-presence-provider.tsx
+++ b/packages/mobile/src/providers/board-presence-provider.tsx
@@ -194,7 +194,9 @@ export function MobileBoardPresenceProvider({ children }: { children: ReactNode 
   // The injected transport, built once.
   const client = useMemo<MobileBoardPresenceClient | null>(
     () => (usesSeedTransport ? createScreenshotBoardPresenceClient() : createMobileBoardPresenceClient(getWsClient)),
-    [usesSeedTransport],
+    // `EXPO_PUBLIC_SCREENSHOT_MODE` is inlined at build time, so the transport
+    // choice is a launch constant: the client is created exactly once.
+    [],
   );
   const clientRef = useRef(client);
   clientRef.current = client;

--- a/packages/mobile/src/settings/__tests__/hooks.test.ts
+++ b/packages/mobile/src/settings/__tests__/hooks.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mockStorage = new Map<string, string>();
 
@@ -20,7 +20,7 @@ vi.mock('react-native-mmkv', () => {
   return { createMMKV: vi.fn(() => createMockInstance()) };
 });
 
-import { getSetting, setSetting, getAllSettings, resetAllSettings } from '../hooks';
+import { getSetting, setSetting, getAllSettings, resetAllSettings, subscribeSettings } from '../hooks';
 import { DEFAULT_SETTINGS } from '../defaults';
 
 describe('settings', () => {
@@ -213,6 +213,55 @@ describe('settings', () => {
       expect(getSetting('defaultBoardUuid')).toBe('some-uuid');
       setSetting('defaultBoardUuid', null);
       expect(getSetting('defaultBoardUuid')).toBeNull();
+    });
+  });
+
+  // The non-React read of the same change signal `useSetting` rides. The
+  // connectivity store's binding lives on it: a module-level singleton cannot
+  // see a hook, and offline mode has to notice a write from anywhere.
+  describe('subscribeSettings', () => {
+    // The listener set is module-level and outlives each test, so a subscription
+    // left open would still be called by the NEXT test's writes.
+    const openSubscriptions: Array<() => void> = [];
+    function subscribeForThisTest(listener: () => void): () => void {
+      const unsubscribe = subscribeSettings(listener);
+      openSubscriptions.push(unsubscribe);
+      return unsubscribe;
+    }
+
+    afterEach(() => {
+      for (const unsubscribe of openSubscriptions.splice(0)) unsubscribe();
+    });
+
+    it('notifies after a write', () => {
+      const listener = vi.fn();
+      subscribeForThisTest(listener);
+
+      setSetting('offlineMode', true);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(getSetting('offlineMode')).toBe(true);
+    });
+
+    it('notifies after a reset-all, which is a change to every key at once', () => {
+      setSetting('offlineMode', true);
+      const listener = vi.fn();
+      subscribeForThisTest(listener);
+
+      resetAllSettings();
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(getSetting('offlineMode')).toBe(false);
+    });
+
+    it('stops on unsubscribe', () => {
+      const listener = vi.fn();
+      const unsubscribe = subscribeForThisTest(listener);
+      unsubscribe();
+
+      setSetting('offlineMode', true);
+
+      expect(listener).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/mobile/src/settings/defaults.ts
+++ b/packages/mobile/src/settings/defaults.ts
@@ -7,6 +7,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   offlineDownloadTriggers: {},
   offlineDownloadAllTapPending: false,
   autoOfflineBoards: false,
+  offlineMode: false,
   autoConnectBle: true,
   autoDisconnectBle: false,
   autoDisconnectTimeoutSeconds: 30,

--- a/packages/mobile/src/settings/hooks.ts
+++ b/packages/mobile/src/settings/hooks.ts
@@ -28,6 +28,20 @@ function subscribe(callback: () => void): () => void {
   return () => listeners.delete(callback);
 }
 
+/**
+ * The same change signal `useSetting` rides, for code that is not a React
+ * component — the connectivity store's binding, which has to notice an offline
+ * mode written from anywhere and cannot see a hook.
+ *
+ * Fires after every `setSetting` and after `resetAllSettings`, with NO argument:
+ * one listener set covers every key, so a subscriber re-reads the key it cares
+ * about and compares. That is deliberate — the alternative is a per-key registry
+ * for a store whose writes are a handful per session.
+ */
+export function subscribeSettings(listener: () => void): () => void {
+  return subscribe(listener);
+}
+
 function readSetting<K extends SettingsKey>(key: K): AppSettings[K] {
   const raw = storage.getString(key);
   if (raw === undefined) return DEFAULT_SETTINGS[key];

--- a/packages/mobile/src/settings/index.ts
+++ b/packages/mobile/src/settings/index.ts
@@ -1,6 +1,14 @@
 export type { AppSettings, SettingsKey } from './types';
 export { DEFAULT_SETTINGS } from './defaults';
-export { getSetting, setSetting, getAllSettings, resetAllSettings, useSetting, useSettings } from './hooks';
+export {
+  getSetting,
+  setSetting,
+  getAllSettings,
+  resetAllSettings,
+  subscribeSettings,
+  useSetting,
+  useSettings,
+} from './hooks';
 export {
   offlineBoardKey,
   offlineBoardKeyForBoard,

--- a/packages/mobile/src/settings/types.ts
+++ b/packages/mobile/src/settings/types.ts
@@ -30,6 +30,22 @@ export type AppSettings = {
   offlineDownloadAllTapPending: boolean;
   /** Keep every board the user follows/uses available offline by default. */
   autoOfflineBoards: boolean;
+  /**
+   * The climber's deliberate "use only what's on this phone" switch (issue
+   * #4862). Distinct from having no signal: nothing is wrong, the climber asked
+   * for it, and it survives a relaunch — which is why it is a persisted setting
+   * rather than the in-memory flag PR-A shipped.
+   *
+   * What it gates: the backend GraphQL/WS traffic and the sync engine. What it
+   * does NOT touch: analytics, Sentry, OTA updates, the board-snapshot CDN and
+   * sign-in — those are either tiny, already batched, or the one thing a
+   * climber cannot recover from being cut off.
+   *
+   * Native only (Expo web has no toggle and no native storage behind it), and
+   * reset on sign-out: a signed-out phone that stayed in offline mode would
+   * show a login screen whose own requests are gated.
+   */
+  offlineMode: boolean;
   autoConnectBle: boolean;
   autoDisconnectBle: boolean;
   autoDisconnectTimeoutSeconds: number;

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -930,10 +930,17 @@ export const SHARED_EVENTS = {
   // than it is.
   ConnectivityRecovered: 'Connectivity Recovered',
   // The offline-mode switch was flipped, either way. Props: { enabled, source:
-  // 'more' | 'banner' | 'sign_out', pendingCount, reasonBefore }. `source`
-  // separates the deliberate More-tab choice from the one-tap escape the banner
-  // offers during an outage — different intents, and only the second is evidence
-  // the degraded state needed an escape hatch at all.
+  // 'more' | 'banner' | 'sign_out', reasonBefore }. `source` separates the
+  // deliberate More-tab choice from the one-tap escape the banner offers during
+  // an outage — different intents, and only the second is evidence the degraded
+  // state needed an escape hatch at all. `reasonBefore` is the connectivity
+  // reason from BEFORE the flip, for the same cut: after it, every "on" event
+  // would read `offline_mode`.
+  //
+  // No pending-write count: the outbox lives in SQLite, and the connectivity
+  // store that fires this owns no database handle, so filling it in would mean
+  // a query on the toggle tap. The queue depth is already on the drain and
+  // offline-read events.
   OfflineModeToggled: 'Offline Mode Toggled',
 } as const;
 

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -335,6 +335,8 @@
       },
       "offline": {
         "title": "Offline",
+        "offlineMode": "Offline-Modus",
+        "offlineModeDescription": "Stoppt jede Anfrage, bis du ihn wieder ausschaltest. Heruntergeladene Boards funktionieren weiter und deine Begehungen warten auf deinem Handy.",
         "autoDownload": "Boards offline halten",
         "autoDownloadDescription": "Lade jedes Board herunter, das du nutzt, damit du ohne Empfang stöbern und Begehungen eintragen kannst. Neue Boards laden automatisch.",
         "downloadingAll_one": "1 Board wird für offline geladen",

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -336,7 +336,7 @@
       "offline": {
         "title": "Offline",
         "offlineMode": "Offline-Modus",
-        "offlineModeDescription": "Stoppt jede Anfrage, bis du ihn wieder ausschaltest. Heruntergeladene Boards funktionieren weiter und deine Begehungen warten auf deinem Handy.",
+        "offlineModeDescription": "Stoppt den Kontakt zum Boardsesh-Server, bis du ihn wieder ausschaltest. Heruntergeladene Boards funktionieren weiter und deine Begehungen warten auf deinem Handy.",
         "autoDownload": "Boards offline halten",
         "autoDownloadDescription": "Lade jedes Board herunter, das du nutzt, damit du ohne Empfang stöbern und Begehungen eintragen kannst. Neue Boards laden automatisch.",
         "downloadingAll_one": "1 Board wird für offline geladen",
@@ -529,7 +529,7 @@
       },
       "offlineMode": {
         "title": "Offline-Modus ist an",
-        "body": "Bis du ihn ausschaltest, verlässt nichts dein Handy. Heruntergeladene Boards funktionieren weiter.",
+        "body": "Kein Kontakt zum Boardsesh-Server, bis du den Offline-Modus wieder ausschaltest. Heruntergeladene Boards funktionieren weiter.",
         "pill": "Offline-Modus",
         "goOnline": "Online gehen"
       },

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -336,7 +336,7 @@
       "offline": {
         "title": "Offline",
         "offlineMode": "Offline mode",
-        "offlineModeDescription": "Stop every request until you turn this off. Downloaded boards keep working and sends queue up on your phone.",
+        "offlineModeDescription": "Stop talking to the Boardsesh server until you turn this off. Downloaded boards keep working and sends queue up on your phone.",
         "autoDownload": "Keep boards offline",
         "autoDownloadDescription": "Download every board you use so you can browse and log sends with no signal. New boards download automatically.",
         "downloadingAll_one": "Downloading 1 board for offline",
@@ -529,7 +529,7 @@
       },
       "offlineMode": {
         "title": "Offline mode is on",
-        "body": "Nothing leaves your phone until you turn it off. Downloaded boards keep working.",
+        "body": "No more talking to the Boardsesh server until you turn it off. Downloaded boards keep working.",
         "pill": "Offline mode",
         "goOnline": "Go online"
       },

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -335,6 +335,8 @@
       },
       "offline": {
         "title": "Offline",
+        "offlineMode": "Offline mode",
+        "offlineModeDescription": "Stop every request until you turn this off. Downloaded boards keep working and sends queue up on your phone.",
         "autoDownload": "Keep boards offline",
         "autoDownloadDescription": "Download every board you use so you can browse and log sends with no signal. New boards download automatically.",
         "downloadingAll_one": "Downloading 1 board for offline",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -592,7 +592,7 @@
       "offline": {
         "title": "Sin conexión",
         "offlineMode": "Modo sin conexión",
-        "offlineModeDescription": "Detiene todas las peticiones hasta que lo desactives. Los plafones descargados siguen funcionando y tus encadenes quedan en cola en el móvil.",
+        "offlineModeDescription": "Deja de hablar con el servidor de Boardsesh hasta que lo desactives. Los plafones descargados siguen funcionando y tus encadenes quedan en cola en el móvil.",
         "autoDownload": "Mantener los plafones sin conexión",
         "autoDownloadDescription": "Descarga todos los plafones que usas para explorarlos y registrar tus ascensos sin conexión. Los plafones nuevos se descargan automáticamente.",
         "downloadingAll_one": "Descargando 1 plafón para usarlo sin conexión",
@@ -785,7 +785,7 @@
       },
       "offlineMode": {
         "title": "El modo sin conexión está activado",
-        "body": "No sale nada del móvil hasta que lo desactives. Los plafones descargados siguen funcionando.",
+        "body": "No se habla con el servidor de Boardsesh hasta que lo desactives. Los plafones descargados siguen funcionando.",
         "pill": "Modo sin conexión",
         "goOnline": "Conectarte"
       },

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -591,6 +591,8 @@
       },
       "offline": {
         "title": "Sin conexión",
+        "offlineMode": "Modo sin conexión",
+        "offlineModeDescription": "Detiene todas las peticiones hasta que lo desactives. Los plafones descargados siguen funcionando y tus encadenes quedan en cola en el móvil.",
         "autoDownload": "Mantener los plafones sin conexión",
         "autoDownloadDescription": "Descarga todos los plafones que usas para explorarlos y registrar tus ascensos sin conexión. Los plafones nuevos se descargan automáticamente.",
         "downloadingAll_one": "Descargando 1 plafón para usarlo sin conexión",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -335,6 +335,8 @@
       },
       "offline": {
         "title": "Hors ligne",
+        "offlineMode": "Mode hors ligne",
+        "offlineModeDescription": "Coupe toutes les requêtes jusqu'à ce que tu le désactives. Les boards téléchargées continuent de fonctionner et tes croix attendent sur ton téléphone.",
         "autoDownload": "Garder les boards hors ligne",
         "autoDownloadDescription": "Télécharge toutes les boards que tu utilises pour les parcourir et enregistrer tes croix hors ligne. Les nouvelles boards se téléchargent automatiquement.",
         "downloadingAll_one": "Téléchargement d'1 board pour le hors ligne",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -336,7 +336,7 @@
       "offline": {
         "title": "Hors ligne",
         "offlineMode": "Mode hors ligne",
-        "offlineModeDescription": "Coupe toutes les requêtes jusqu'à ce que tu le désactives. Les boards téléchargées continuent de fonctionner et tes croix attendent sur ton téléphone.",
+        "offlineModeDescription": "Coupe les échanges avec le serveur Boardsesh jusqu'à ce que tu le désactives. Les boards téléchargées continuent de fonctionner et tes croix attendent sur ton téléphone.",
         "autoDownload": "Garder les boards hors ligne",
         "autoDownloadDescription": "Télécharge toutes les boards que tu utilises pour les parcourir et enregistrer tes croix hors ligne. Les nouvelles boards se téléchargent automatiquement.",
         "downloadingAll_one": "Téléchargement d'1 board pour le hors ligne",
@@ -529,7 +529,7 @@
       },
       "offlineMode": {
         "title": "Le mode hors ligne est activé",
-        "body": "Rien ne quitte ton téléphone tant que tu ne le désactives pas. Les boards téléchargées continuent de marcher.",
+        "body": "Plus d'échanges avec le serveur Boardsesh tant que tu ne le désactives pas. Les boards téléchargées continuent de marcher.",
         "pill": "Mode hors ligne",
         "goOnline": "Repasser en ligne"
       },


### PR DESCRIPTION
## Summary

Stacked on #5215 (merge that first). Second half of #4862: a climber can now put the app into **Offline mode** on purpose.

- **One switch, More → Offline, first row.** Persisted (MMKV `offlineMode`), on until the climber turns it off, reset on sign-out so a shared device never lands on a login screen whose requests are gated. No confirmation dialog: the banner appearing is the feedback.
- **What it gates:** GraphQL over HTTP and WebSocket to `BACKEND_URL`, and the sync engine (drain + pull). The party socket is disposed on enable and the deferred join resubscribes on the way back. What it does **not** gate: analytics, Sentry, OTA updates, the snapshot CDN, and sign-in.
- **What the climber sees:** the "Offline mode is on" banner (never hidden, collapses to a pill), placards that say Offline mode rather than "No signal", the boards picker's downloaded-only list, the climbs tab's "This filter needs you online", and the pending-changes count. "Stay offline" on the server-trouble banner flips it on; "Go online" flips it off and runs the usual "Syncing N changes…" → "All synced" recovery.
- `Offline Mode Toggled { enabled, source: more | banner | sign_out, reasonBefore }` fires once per flip from the store binding.

Author-side verification: `vp run typecheck:mobile`, `vp run test:mobile`, the `i18n` vitest project, `vp check` on the changed files and `vp run check:mobile-bundle`. Paired reviewer findings folded in.

## Release Notes

- Going somewhere with bad wifi? Flip on Offline mode in More → Offline and the app stops waiting on the server: downloaded boards, search and logging keep working, and your sends sync the moment you turn it off.

## Test plan

1. Signed in, one board downloaded. More → Offline → Offline mode on → banner shows
2. Log a tick → banner reads "1 change waiting"
3. Kill and reopen the app → banner still shows, toggle still on
4. Banner → Go online → "Syncing 1 change…" then "All synced"
5. Toggle on again, sign out, sign back in → toggle is off

## Risk

Risk: 3/5 — persisted setting that gates all backend traffic; kill path is the same switch, plus the PR-A flag
