### PR TITLE
fix(mobile): reach the climb actions menu with a screen reader, and measure the list

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -757,9 +757,19 @@ function ClimbListInner() {
     void refetch();
   }, [refetch]);
 
+  // Read through a ref so the tracking below can name the page being fetched without
+  // putting a `.length` in this callback's deps — that would rebuild `renderItem`'s
+  // sibling handlers on every page and re-render every mounted row (perf checklist §3).
+  const loadedPageCountRef = useRef(0);
+  loadedPageCountRef.current = searchPages?.pages.length ?? 0;
+
   const handleEndReached = useCallback(() => {
     if (hasNextPage && !isClimbsLoading && !isFetchingNextPage && !isRefetching && !isLoadingMoreRef.current) {
       isLoadingMoreRef.current = true;
+      // List scroll depth, which was previously unmeasurable: this handler tracked
+      // nothing, so no row-density or scan-speed change could be evaluated against
+      // how far people actually scroll. 0-based, matching the search pages.
+      track(SHARED_EVENTS.ClimbListPaginated, { page: loadedPageCountRef.current });
       void fetchNextPage().finally(() => {
         isLoadingMoreRef.current = false;
       });
@@ -1384,6 +1394,7 @@ function ClimbListInner() {
         showPlaylistChips
         showFavorite
         showMoreButton={quickActionsButtonEnabled}
+        surface="climbs_list"
       />
     ),
     [

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -216,8 +216,12 @@ type ClimbListRowProps = {
    * `Climb Row Tapped`. Only the climbs list passes `showMoreButton`, so without
    * this every other surface can emit `long_press` and nothing else — and a
    * `source` breakdown silently pools four screens against one.
+   *
+   * REQUIRED on purpose: an optional one would let a new list ship rows whose
+   * events land in an unattributable bucket, which is the exact hole this prop
+   * exists to close. A new surface extends `ClimbRowSurface` rather than opting out.
    */
-  surface?: ClimbRowSurface;
+  surface: ClimbRowSurface;
 };
 
 /** The lists that render a `ClimbListRow`; the value of the events' `surface` prop. */

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -211,7 +211,17 @@ type ClimbListRowProps = {
    * long-press only. No-op without `onOpenActions`.
    */
   showMoreButton?: boolean;
+  /**
+   * Which list this row is in, carried on `Climb Actions Opened` and
+   * `Climb Row Tapped`. Only the climbs list passes `showMoreButton`, so without
+   * this every other surface can emit `long_press` and nothing else — and a
+   * `source` breakdown silently pools four screens against one.
+   */
+  surface?: ClimbRowSurface;
 };
+
+/** The lists that render a `ClimbListRow`; the value of the events' `surface` prop. */
+export type ClimbRowSurface = 'climbs_list' | 'playlist' | 'profile' | 'board_sheet';
 
 const ClimbListRow = React.memo(function ClimbListRow({
   climb,
@@ -234,6 +244,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
   showPlaylistChips = false,
   showFavorite = false,
   showMoreButton = false,
+  surface,
 }: ClimbListRowProps) {
   const { t } = useTranslation('climbs');
   const { systemColors, brandColors: brand } = useTheme();
@@ -278,15 +289,16 @@ const ClimbListRow = React.memo(function ClimbListRow({
   unsupportedRef.current = unsupported;
   // Board metadata for analytics, read through a ref so the dep-free handlers below
   // never capture a stale value when the list's board config changes.
-  const boardMetaRef = useRef({ boardName, layoutId });
-  boardMetaRef.current = { boardName, layoutId };
+  const boardMetaRef = useRef({ boardName, layoutId, surface });
+  boardMetaRef.current = { boardName, layoutId, surface };
 
   // One place that opens the reaction menu + records how it was reached, so the
   // ⋮-button experiment can compare open rates + entry point between cohorts.
-  const openActions = useCallback((source: 'long_press' | 'more_button') => {
+  const openActions = useCallback((source: 'long_press' | 'more_button' | 'accessibility_action') => {
     if (unsupportedRef.current) return;
     track(SHARED_EVENTS.ClimbActionsOpened, {
       source,
+      surface: boardMetaRef.current.surface,
       climbUuid: climbRef.current.uuid,
       boardName: boardMetaRef.current.boardName,
       layoutId: boardMetaRef.current.layoutId,
@@ -298,6 +310,14 @@ const ClimbListRow = React.memo(function ClimbListRow({
     if (unsupportedRef.current) return;
     const press = onPressRef.current;
     if (!press) return;
+    // The denominator for `Climb Actions Opened`: how many rows people open at all.
+    // Fired before the press so a handler that navigates away can't lose the event.
+    track(SHARED_EVENTS.ClimbRowTapped, {
+      surface: boardMetaRef.current.surface,
+      climbUuid: climbRef.current.uuid,
+      boardName: boardMetaRef.current.boardName,
+      layoutId: boardMetaRef.current.layoutId,
+    });
     hapticLight();
     press(climbRef.current);
   }, []);
@@ -316,13 +336,18 @@ const ClimbListRow = React.memo(function ClimbListRow({
 
   // Screen-reader activate → the same handlers the RNGH taps call. Branch on the
   // action name so a future custom action on these rows can't turn every action
-  // into a row press / menu open.
+  // into a row press / menu open. The menu route reports its own `source`: this
+  // action is published whether or not the ⋮ is on screen, so counting it as
+  // `more_button` would credit a button the climber may not even have.
   const handleRowAccessibilityAction = useCallback(
     (event: AccessibilityActionEvent) => {
       if (event.nativeEvent.actionName === 'activate') handleRowPress();
-      if (event.nativeEvent.actionName === MORE_ACTIONS_ACTION_NAME) handleOpenActions();
+      if (event.nativeEvent.actionName === MORE_ACTIONS_ACTION_NAME) {
+        hapticMedium();
+        openActions('accessibility_action');
+      }
     },
-    [handleRowPress, handleOpenActions],
+    [handleRowPress, openActions],
   );
 
   const handleMoreButtonAccessibilityAction = useCallback(
@@ -337,12 +362,18 @@ const ClimbListRow = React.memo(function ClimbListRow({
   // `t` identity on plenty of renders, which would rebuild this array every time
   // and churn the row element's props.
   const moreActionsLabel = t('mobile.climbRow.moreActions');
+  // Published whenever the row can open the menu AT ALL — not only when the ⋮ is
+  // visible. RNGH gestures never register with the accessibility bridge, so the
+  // long-press is unperformable by VoiceOver/TalkBack; gating this on the button
+  // meant that with "Show quick-actions button" off, queue / tick / favourite /
+  // playlist were unreachable to a screen reader entirely.
+  const canOpenActions = !!onOpenActions;
   const rowAccessibilityActions = useMemo(
     () =>
-      hasMoreButton
+      canOpenActions
         ? rowAccessibilityActionsWith({ name: MORE_ACTIONS_ACTION_NAME, label: moreActionsLabel })
         : ACTIVATE_ACCESSIBILITY_ACTIONS,
-    [hasMoreButton, moreActionsLabel],
+    [canOpenActions, moreActionsLabel],
   );
 
   // Commit-on-release: fired from onSwipeableWillOpen the instant the user
@@ -517,13 +548,18 @@ const ClimbListRow = React.memo(function ClimbListRow({
             style={[climbListRowStyles.contentRow, { backgroundColor: systemColors.background }, contentRowStyle]}
             accessible
             accessibilityRole="button"
-            accessibilityLabel={climb.name}
+            // NO explicit label. An `accessible` container with one overrides its
+            // children, and this row's children already publish exactly the labels
+            // a climber needs — the attribute glyphs, the favourite heart, the
+            // ascent status, the subtitle and the grade all carry their own. Setting
+            // the name here silenced every one of them: VoiceOver and TalkBack read
+            // "Golden Boy" and nothing else. Letting RN compose gives the visual
+            // order, because the children are already in it.
             accessibilityState={{ selected: !!selected }}
             onAccessibilityTap={handleRowPress}
-            // Carries the ⋮ menu as a labelled custom action when that button is
-            // shown. When `showMoreButton` is false the reaction menu is reachable
-            // by long-press alone, which a screen reader can't perform — surfacing
-            // it there needs its own product copy, so it stays a follow-up.
+            // Carries the ⋮ menu as a labelled custom action whenever the row can
+            // open it — the button's visibility is a user setting, the menu's
+            // reachability must not be.
             accessibilityActions={rowAccessibilityActions}
             onAccessibilityAction={handleRowAccessibilityAction}
           >
@@ -545,6 +581,12 @@ const ClimbListRow = React.memo(function ClimbListRow({
                   accessible
                   accessibilityRole="button"
                   accessibilityLabel={t('mobile.climbRow.moreActions')}
+                  // iOS only: UIKit treats the row as a leaf, so this button is never
+                  // focusable there — but its label WOULD join the row's composed
+                  // string, appending "More actions" to every row VoiceOver reads.
+                  // The row publishes it as a custom action instead. TalkBack does
+                  // focus inside the row, so Android keeps the button as it is.
+                  accessibilityElementsHidden={Platform.OS === 'ios'}
                   onAccessibilityTap={handleOpenActions}
                   accessibilityActions={ACTIVATE_ACCESSIBILITY_ACTIONS}
                   onAccessibilityAction={handleMoreButtonAccessibilityAction}

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -361,7 +361,6 @@ const ClimbListRow = React.memo(function ClimbListRow({
     [handleOpenActions],
   );
 
-  const hasMoreButton = !!(showMoreButton && onOpenActions);
   // Keyed on the resolved label string, not on `t` — react-i18next hands back a new
   // `t` identity on plenty of renders, which would rebuild this array every time
   // and churn the row element's props.

--- a/packages/mobile/src/components/__tests__/climb-list-row-accessibility.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-list-row-accessibility.test.tsx
@@ -15,6 +15,7 @@ import type { Climb } from '@boardsesh/shared-schema';
 // the fix leaves them undefined and fails.
 type AccessibilityCapture = {
   onAccessibilityTap?: () => void;
+  accessibilityLabel?: string;
   accessibilityActions?: { name: string; label?: string }[];
   onAccessibilityAction?: (event: { nativeEvent: { actionName: string } }) => void;
 };
@@ -32,6 +33,7 @@ const platform = vi.hoisted(() => ({ OS: 'ios' as 'ios' | 'android' }));
 vi.mock('react-native', () => {
   const capture = (props: AccessibilityCapture): AccessibilityCapture => ({
     onAccessibilityTap: props.onAccessibilityTap,
+    accessibilityLabel: props.accessibilityLabel,
     accessibilityActions: props.accessibilityActions,
     onAccessibilityAction: props.onAccessibilityAction,
   });
@@ -224,6 +226,38 @@ describe('ClimbListRow screen-reader activation', () => {
     expect(onOpenActions).toHaveBeenCalledTimes(1);
     expect(onOpenActions).toHaveBeenCalledWith(climb);
     expect(onPress).not.toHaveBeenCalled();
+  });
+
+  // The regression this PR exists for: the ⋮ is a user setting, and while it was
+  // off the custom action was never published — so with no button to tap and a
+  // long-press RNGH gestures never expose to the a11y bridge, queue / tick /
+  // favourite / playlist were unreachable to VoiceOver and TalkBack entirely.
+  it('publishes the menu action even with the ⋮ button hidden', () => {
+    const onOpenActions = vi.fn();
+    render(<ClimbListRow climb={climb} {...boardProps} onPress={vi.fn()} onOpenActions={onOpenActions} />);
+
+    expect(a11y.moreButton).toBeNull();
+    expect(a11y.row?.accessibilityActions).toEqual([{ name: 'moreActions', label: 'mobile.climbRow.moreActions' }]);
+
+    a11y.row?.onAccessibilityAction?.({ nativeEvent: { actionName: 'moreActions' } });
+    expect(onOpenActions).toHaveBeenCalledTimes(1);
+    expect(onOpenActions).toHaveBeenCalledWith(climb);
+  });
+
+  // A row that cannot open the menu must not advertise it.
+  it('omits the menu action when the row has no actions handler', () => {
+    render(<ClimbListRow climb={climb} {...boardProps} onPress={vi.fn()} />);
+
+    expect(a11y.row?.accessibilityActions).toBeUndefined();
+  });
+
+  // An `accessible` container with an explicit label overrides its children, so the
+  // name here silenced the attribute glyphs, the favourite heart, the ascent status
+  // and the grade — every one of which already publishes its own label.
+  it('leaves the row label to its children', () => {
+    render(<ClimbListRow climb={climb} {...boardProps} onPress={vi.fn()} />);
+
+    expect(a11y.row?.accessibilityLabel).toBeUndefined();
   });
 
   it('keeps one accessibilityActions array across rerenders', () => {

--- a/packages/mobile/src/components/__tests__/climb-list-row-accessibility.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-list-row-accessibility.test.tsx
@@ -95,7 +95,8 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
+const analytics = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock('../../lib/analytics', () => ({ track: analytics.track }));
 
 vi.mock('../../lib/haptics', () => ({
   hapticLight: vi.fn(),
@@ -139,6 +140,7 @@ const boardProps = {
   sizeId: 10,
   setIds: '1,2',
   angle: 40,
+  surface: 'climbs_list' as const,
 };
 
 describe('ClimbListRow screen-reader activation', () => {
@@ -258,6 +260,46 @@ describe('ClimbListRow screen-reader activation', () => {
     render(<ClimbListRow climb={climb} {...boardProps} onPress={vi.fn()} />);
 
     expect(a11y.row?.accessibilityLabel).toBeUndefined();
+  });
+
+  // The events are the reason the row's entry points can be argued about at all,
+  // so they are asserted rather than merely mocked: a `source` or `surface` that
+  // silently went missing would leave every assertion above green.
+  it('reports a screen-reader menu open as its own source, with the surface', () => {
+    render(<ClimbListRow climb={climb} {...boardProps} onPress={vi.fn()} onOpenActions={vi.fn()} />);
+
+    a11y.row?.onAccessibilityAction?.({ nativeEvent: { actionName: 'moreActions' } });
+
+    // Not 'more_button': this action is published whether or not the ⋮ is on screen,
+    // so counting it as a button tap would credit a control the climber may not have.
+    expect(analytics.track).toHaveBeenCalledWith('Climb Actions Opened', {
+      source: 'accessibility_action',
+      surface: 'climbs_list',
+      climbUuid: 'climb-1',
+      boardName: 'kilter',
+      layoutId: 1,
+    });
+  });
+
+  it('reports a row tap with the surface', () => {
+    render(<ClimbListRow climb={climb} {...boardProps} onPress={vi.fn()} surface="playlist" />);
+
+    a11y.row?.onAccessibilityTap?.();
+
+    expect(analytics.track).toHaveBeenCalledWith('Climb Row Tapped', {
+      surface: 'playlist',
+      climbUuid: 'climb-1',
+      boardName: 'kilter',
+      layoutId: 1,
+    });
+  });
+
+  it('records nothing for a tap on an unsupported row', () => {
+    render(<ClimbListRow climb={climb} {...boardProps} onPress={vi.fn()} unsupported />);
+
+    a11y.row?.onAccessibilityTap?.();
+
+    expect(analytics.track).not.toHaveBeenCalled();
   });
 
   it('keeps one accessibilityActions array across rerenders', () => {

--- a/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
+++ b/packages/mobile/src/components/board-presence/NowOnTheWallPanel.tsx
@@ -987,6 +987,7 @@ const InteractiveHeroRow = memo(function InteractiveHeroRowInner({
       contentRowStyle={contentRowStyle}
       showSeparator={false}
       renderContent={renderContent}
+      surface="board_sheet"
     />
   );
 });
@@ -1169,6 +1170,7 @@ const InteractiveHistoryRow = memo(function InteractiveHistoryRowInner({
       contentRowStyle={styles.historyInteractiveRow}
       showSeparator={false}
       renderContent={renderContent}
+      surface="board_sheet"
     />
   );
 });

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -359,6 +359,7 @@ export function PlaylistDetailView({
           onPress={handleActivate}
           onOpenActions={handleOpenActions}
           unsupported={resolvedRow.incompatible}
+          surface="playlist"
         />
       );
     },

--- a/packages/mobile/src/components/you/ProfileClimbsTab.tsx
+++ b/packages/mobile/src/components/you/ProfileClimbsTab.tsx
@@ -103,6 +103,7 @@ export function ProfileClimbsTab({ userId, topInset = 0 }: ProfileClimbsTabProps
           angle={item.angle}
           onPress={handlePress}
           onOpenActions={handleOpenActions}
+          surface="profile"
         />
       );
     },

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -89,9 +89,23 @@ export const SHARED_EVENTS = {
   QueueSeedFullSyncGuarded: 'Queue Seed FullSync Guarded',
   // Climb actions
   // Fired when the climb reaction/actions menu is opened, with a `source` prop
-  // ('long_press' | 'more_button'). Powers the ⋮-button discoverability experiment:
-  // compare open rates + entry point between the flag's control/treatment cohorts.
+  // ('long_press' | 'more_button') and a `surface` prop naming the list the row was
+  // in ('climbs_list' | 'playlist' | 'profile' | 'board_sheet'). Powers the
+  // ⋮-button discoverability experiment: compare open rates + entry point.
+  //
+  // `surface` matters more than it looks: only the Climbs list passes
+  // `showMoreButton`, so every other surface can emit `long_press` and nothing else.
+  // Without it a `source` breakdown pools four screens against one and reads as a
+  // like-for-like comparison it is not.
   ClimbActionsOpened: 'Climb Actions Opened',
+  // Fired when a climb row is tapped to open the climb, with the same `surface`
+  // prop. The denominator `Climb Actions Opened` never had: it tells us how many
+  // rows people engage with before reaching for the menu at all.
+  ClimbRowTapped: 'Climb Row Tapped',
+  // Fired once per page fetched by the climbs list's end-reach, with the resulting
+  // page index. List scroll depth was previously invisible — `handleEndReached`
+  // tracked nothing — so no row-density or scan-speed change could be evaluated.
+  ClimbListPaginated: 'Climb List Paginated',
   // Fired when the climber toggles the "Show quick-actions button" setting, with an
   // `enabled` prop — measures opt-in (control) vs opt-out (treatment) against the flag.
   ClimbQuickActionsSettingChanged: 'Climb Quick Actions Setting Changed',


### PR DESCRIPTION
## Summary

Groundwork for the climb-list IA work. No pixels move. Two accessibility dead ends and three measurement holes, all found while working out whether the row's ⋮ button earns its place.

**The ⋮ is a user setting. The menu's reachability was riding on it.** `rowAccessibilityActions` published the `moreActions` custom action only when the button was visible. RNGH gestures never register with the accessibility bridge (the reasoning is already written down in `lib/row-accessibility-actions.ts`), so the long-press is unperformable by VoiceOver and TalkBack — which means with "Show quick-actions button" off, queue, tick, favourite and playlist were unreachable to a screen reader entirely. The action is now published whenever the row can open the menu at all. The code comment deferring this for "product copy" was stale: `mobile.climbRow.moreActions` already exists and the button already uses it.

**The row read out its name and nothing else.** The container is `accessible` with `accessibilityLabel={climb.name}`, and an explicit label on an `accessible` container overrides its children — so the benchmark and no-match glyphs, the favourite heart, the ascent status, the subtitle and the grade were all silent, every one of which already publishes its own label. Dropping the label lets RN compose them, and the children are already in visual order. The ⋮ gets `accessibilityElementsHidden` on iOS so its own label does not tack "More actions" onto every row VoiceOver reads; TalkBack focuses inside the row, so Android keeps the button as it is.

**A screen-reader menu open no longer claims to be a button tap.** The row's custom action is published whether or not the ⋮ is on screen, so it reports `source: 'accessibility_action'` rather than crediting a button the climber may not have.

### The measurement half

Three events, because the ellipsis question could not actually be answered from what we collect:

- **`surface` on `Climb Actions Opened`** (`climbs_list` | `playlist` | `profile` | `board_sheet`). Only the climbs list passes `showMoreButton`, so every other surface can emit `long_press` and nothing else. Today's 154-⋮-users vs 86-long-press-users split therefore pools four screens against one and reads as a like-for-like comparison it is not.
- **`Climb Row Tapped`** — the denominator. We know how many people open the menu; we have never known how many rows they open first, so "the menu is a minor path" has been unfalsifiable in both directions.
- **`Climb List Paginated`** — `handleEndReached` tracked nothing, so list scroll depth is invisible. Any future row-density or scan-speed change is unevaluable without it. The page index is read through a ref so the callback's deps stay free of a `.length`, which would rebuild `renderItem`'s siblings on every page and re-render every mounted row.

Both new a11y tests were confirmed to fail against the unfixed component (`2 failed | 7 passed`), then pass with it (`9 passed`).

**Worth a reviewer's eye:** the composed label is the part no unit test can prove. The RN mock makes `View` a bare div, so the tests pin that the row no longer *sets* a label — not what VoiceOver and TalkBack actually speak. That needs the device pass in the test plan, on both platforms.

## Release Notes

- VoiceOver and TalkBack can now open a climb's quick-actions menu from the climb list, even with the ⋮ button turned off — before, the menu was unreachable without it
- Screen readers now read a climb row in full: its grade, whether you have sent it, whether you have favourited it, and its badges — not just the name

## Test plan

1. More → Display → turn the ⋮ button off.
2. Turn on VoiceOver (or TalkBack), open Climbs.
3. Swipe to a climb row → it reads name, grade, status.
4. Use the rotor (iOS) or actions menu → "More actions" opens the menu.
5. Turn the ⋮ back on → row still reads once, not twice.

## Risk

Risk: 2/5 — no layout changes and no new user-facing surface; it removes one accessibility prop and adds three analytics events. The exposure is what screen readers speak on every climb row, which unit tests cannot cover, so it carries a real device pass on both platforms.
