### PR TITLE
feat(mobile): let climbers pick how much rides in each climbs-list row

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -90,6 +90,7 @@ import {
 } from '../../../src/lib/onboarding/onboarding-storage';
 import { ONBOARDING_TIP_QUICKACTIONS_KEY } from '@boardsesh/key-value-storage';
 import { useClimbQuickActionsButton } from '../../../src/lib/climb-quick-actions-button-preference';
+import { useClimbListDensity } from '../../../src/lib/climb-list-density-preference';
 import { useAuth } from '../../../src/providers/auth-provider';
 import { ensureBackgroundsCached } from '../../../src/lib/background-image-cache';
 import {
@@ -210,6 +211,10 @@ function ClimbListInner() {
   // The ⋮ quick-actions button is a user setting that defaults on (More → Display
   // lets climbers turn it off).
   const { enabled: quickActionsButtonEnabled } = useClimbQuickActionsButton();
+  // Row density is a user setting too (More → Climb list), and ONLY this list reads
+  // it — the other four surfaces that render a ClimbListRow keep the default shape.
+  // A primitive, so it drops straight into renderClimbItem's deps below.
+  const { density: rowDensity } = useClimbListDensity();
   const { addToQueue } = useQueueActions();
   const {
     filters,
@@ -1378,6 +1383,17 @@ function ClimbListInner() {
     [useNativeSearch, t, handleNativeSearchChange, handleSearchFocus, handleSearchBlur, handleNativeSearchCancel],
   );
 
+  // A density change relayouts every row, and FlashList v2 needs nothing extra for
+  // it. `rowDensity` in these deps gives `renderItem` a new identity, which is one
+  // of the props ViewHolder's memo compares (ViewHolder.tsx), so every mounted cell
+  // re-renders; its `onLayout` reports the new height (nothing sets
+  // `enforcedHeight` for a vertical list — LinearLayoutManager only enforces
+  // width), and the layout manager recomputes from the lowest changed index. There
+  // is no `estimatedItemSize` in v2 to keep in sync, and `getItemType` would be
+  // actively wrong here: the tier is global, so every item shares one type at any
+  // instant and a density-keyed type would add no estimate accuracy while throwing
+  // away the whole recycling pool on each switch — fresh mounts of every visible
+  // row on the app's largest memory consumer.
   const renderClimbItem = useCallback(
     ({ item: climb }: { item: Climb }) => (
       <ActiveAwareClimbListRow
@@ -1395,6 +1411,7 @@ function ClimbListInner() {
         showFavorite
         showMoreButton={quickActionsButtonEnabled}
         surface="climbs_list"
+        density={rowDensity}
       />
     ),
     [
@@ -1408,6 +1425,7 @@ function ClimbListInner() {
       openAddToPlaylist,
       handleAddToQueue,
       quickActionsButtonEnabled,
+      rowDensity,
     ],
   );
 

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -750,7 +750,15 @@ function ClimbListInner() {
   // third-row playlist tags can render (gated inside the hook on the user
   // setting + auth). Memoize the uuid list so the fetch effect's dep is stable.
   const visibleClimbUuids = useMemo(() => visibleClimbs.map((climb) => climb.uuid), [visibleClimbs]);
-  useClimbListPlaylistMemberships({ boardName, layoutId, climbUuids: visibleClimbUuids });
+  // `force` on rich: that tier renders the tag line whatever the setting says, so
+  // the store has to be filled or the line paints empty for everyone who left the
+  // setting off — which is its default.
+  useClimbListPlaylistMemberships({
+    boardName,
+    layoutId,
+    climbUuids: visibleClimbUuids,
+    force: rowDensity === 'rich',
+  });
 
   // Same batched shape for the favourite hearts: fetch the visible UUIDs' state
   // once per board+angle and write it into `favoritesStore`, which each row's

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -51,6 +51,8 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { useShowPlaylistTagsPreference } from '../../../src/lib/show-playlist-tags-preference';
 import { useBoardseshGradesPreference } from '../../../src/lib/boardsesh-grades-preference';
 import { useClimbQuickActionsButton } from '../../../src/lib/climb-quick-actions-button-preference';
+import { useClimbListDensity } from '../../../src/lib/climb-list-density-preference';
+import type { ClimbListDensity } from '../../../src/components/climb-list-thumbnail-metrics';
 import { useToast } from '../../../src/providers/toast-provider';
 import {
   useFeatureFlag,
@@ -95,6 +97,7 @@ export default function MoreScreen() {
   const { enabled: showPlaylistTags, setEnabled: setShowPlaylistTags } = useShowPlaylistTagsPreference();
   const { enabled: showBoardseshGrades, setEnabled: setShowBoardseshGrades } = useBoardseshGradesPreference();
   const { enabled: showQuickActionsButton, setEnabled: setShowQuickActionsButton } = useClimbQuickActionsButton();
+  const { density: climbListDensity, setDensity: setClimbListDensity } = useClimbListDensity();
   const boardseshGradeFlagEnabled = useBoardseshGradeEnabled();
   const { showToast } = useToast();
   const stravaEnabled = useFeatureFlag('strava-integration') === true;
@@ -278,6 +281,12 @@ export default function MoreScreen() {
     { key: 'system', label: t('mobile.more.appearance.system') },
     { key: 'light', label: t('mobile.more.appearance.light') },
     { key: 'dark', label: t('mobile.more.appearance.dark') },
+  ];
+
+  const climbListDensityOptions: { key: ClimbListDensity; label: string }[] = [
+    { key: 'compact', label: t('mobile.more.climbListDensity.compact') },
+    { key: 'default', label: t('mobile.more.climbListDensity.standard') },
+    { key: 'rich', label: t('mobile.more.climbListDensity.rich') },
   ];
 
   const gradeFormatOptions: { key: GradeDisplayFormat; label: string }[] = [
@@ -489,6 +498,34 @@ export default function MoreScreen() {
           if (next) {
             hapticSelection();
             setGradeFormat(next.key);
+          }
+        },
+      },
+    ],
+  });
+
+  // Climb list density (segmented) — description as the section footer, the same
+  // shape as Grade Format above. Its own section on purpose: a segmented row shows
+  // no visible label of its own (the SECTION HEADER is the label — see
+  // MoreForm.ios), so folding it into "Display" below would leave three unexplained
+  // segments under a header that says nothing about row size.
+  sections.push({
+    key: 'climbListDensity',
+    title: t('mobile.more.climbListDensity.title'),
+    footer: t('mobile.more.climbListDensity.description'),
+    rows: [
+      {
+        kind: 'segmented',
+        key: 'climbListDensity',
+        label: t('mobile.more.climbListDensity.title'),
+        options: climbListDensityOptions,
+        selectedKey: climbListDensity,
+        onSelect: (key) => {
+          const next = climbListDensityOptions.find((option) => option.key === key);
+          if (next) {
+            hapticSelection();
+            track(SHARED_EVENTS.ClimbListDensityChanged, { density: next.key });
+            setClimbListDensity(next.key);
           }
         },
       },

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -4,6 +4,12 @@ import { useTranslation } from 'react-i18next';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { Text } from './Text';
 import { ClimbListThumbnail, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT } from './ClimbListThumbnail';
+import {
+  COMPACT_THUMBNAIL_HEIGHT,
+  COMPACT_THUMBNAIL_WIDTH,
+  thumbnailSizeForDensity,
+  type ClimbListDensity,
+} from './climb-list-thumbnail-metrics';
 import { formatSends, formatQuality } from '../lib/format-climb-stats';
 import { useEffectiveClimbStats } from '@boardsesh/board-react';
 import { useDisplayGrade } from '../hooks/use-display-grade';
@@ -21,6 +27,10 @@ import type { AscentStatusValue } from '../lib/ascent-status-utils';
 // grey — not a colour — so it can't be mistaken for the colour-coded grade right
 // beside it, and so it stays readable for colour-blind users. ⚡ flashed,
 // ✓ sent, ✗ attempted.
+// Hoisted so the compact tier hands `ClimbListThumbnail` a referentially stable
+// `size` — a fresh object per render would break its `React.memo` on every row.
+const COMPACT_THUMBNAIL_SIZE = thumbnailSizeForDensity('compact');
+
 const ASCENT_STATUS_ICON: Record<AscentStatusValue, IconName> = {
   flash: 'flash',
   send: 'tick.outline',
@@ -118,6 +128,18 @@ type ClimbListItemContentProps = {
    * scroll past and nothing on the rest.
    */
   showFavorite?: boolean;
+  /**
+   * How much of the climb this row shows — the climbs list's user-selectable
+   * density (More → Climb list). Defaults to `'default'`, which is today's row
+   * byte-for-byte, so every OTHER surface that renders this visual (queue,
+   * session, logbook, playlist detail, profile climbs, board-presence, the
+   * actions-sheet preview card) is untouched by simply not passing it.
+   *
+   * - `compact` — 56×72 thumbnail, no subtitle, no playlist tags.
+   * - `default` — unchanged.
+   * - `rich` — the playlist tags always show, whatever `showPlaylistChips` says.
+   */
+  density?: ClimbListDensity;
 };
 
 /**
@@ -303,8 +325,22 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
   gradeIsConsensus = false,
   showPlaylistChips = false,
   showFavorite = false,
+  density = 'default',
 }: ClimbListItemContentProps) {
   const { t: tSession } = useTranslation('session');
+
+  const isCompact = density === 'compact';
+  // Two StyleSheet entries picked by a ternary, not an inline object: an inline
+  // style would allocate a new object on every row render and defeat the memo
+  // boundaries below it.
+  const thumbnailContainerStyle = isCompact ? styles.compactThumbnailContainer : styles.thumbnailContainer;
+  // `size` is omitted (not computed) for the 76×96 tiers so the default row hands
+  // `ClimbListThumbnail` exactly the props it got before this prop existed.
+  const thumbnailSize = isCompact ? COMPACT_THUMBNAIL_SIZE : undefined;
+  // The rich tier IS the opt-in to the tag line, so it shows the tags whatever the
+  // "Show playlist tags" toggle says; that toggle still governs the default tier.
+  const isRich = density === 'rich';
+  const showChips = !isCompact && (isRich || showPlaylistChips);
 
   const subtitleDetailText = useMemo(() => {
     const parts = subtitleDetailParts?.filter((part) => part.length > 0) ?? [];
@@ -321,7 +357,7 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
   if (!climb || !isClimbResolved(climb)) {
     return (
       <>
-        <View style={styles.thumbnailContainer} />
+        <View style={thumbnailContainerStyle} />
         <View style={styles.centerColumn}>
           <Text variant="body" numberOfLines={1} style={styles.climbName}>
             {tSession('mobile.queue.unknownClimb')}
@@ -335,7 +371,7 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
   return (
     <>
       {/* Left: portrait thumbnail with ascent badge */}
-      <View style={styles.thumbnailContainer}>
+      <View style={thumbnailContainerStyle}>
         <ClimbListThumbnail
           frames={climb.frames}
           boardName={boardName}
@@ -343,6 +379,7 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
           sizeId={sizeId}
           setIds={setIds}
           mirrored={climb.mirrored ?? false}
+          size={thumbnailSize}
         />
       </View>
 
@@ -358,7 +395,10 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
             isNoMatch={climb.is_no_match}
           />
         </View>
-        {primarySubtitleOverride === undefined ? (
+        {/* Compact drops the whole subtitle line — and with it `LiveClimbSubtitle`'s
+            per-row `useEffectiveClimbStats` subscription, so a compact row costs
+            strictly less than a default one rather than just looking smaller. */}
+        {isCompact ? null : primarySubtitleOverride === undefined ? (
           <LiveClimbSubtitle
             boardName={boardName}
             layoutId={layoutId}
@@ -374,12 +414,12 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
             {primarySubtitleOverride}
           </Text>
         ) : null}
-        {subtitleDetailText ? (
+        {subtitleDetailText && !isCompact ? (
           <Text variant="caption1" numberOfLines={1} style={styles.subtitle}>
             {subtitleDetailText}
           </Text>
         ) : null}
-        {showPlaylistChips ? <ClimbPlaylistChips climbUuid={climb.uuid} /> : null}
+        {showChips ? <ClimbPlaylistChips climbUuid={climb.uuid} forceVisible={isRich} /> : null}
       </View>
 
       {/* Right: favourite heart + ascent-status glyph + colorized grade */}
@@ -405,6 +445,15 @@ const styles = StyleSheet.create({
   thumbnailContainer: {
     width: THUMBNAIL_WIDTH,
     height: THUMBNAIL_HEIGHT,
+    flexShrink: 0,
+    position: 'relative',
+  },
+  // The compact tier's cell. This is what actually shrinks the row: 72 + 8 + 8 of
+  // padding = an 88pt row, against the default's 96 + 16 = 112pt. Dropping text
+  // lines alone would save nothing, because the thumbnail is the tallest child.
+  compactThumbnailContainer: {
+    width: COMPACT_THUMBNAIL_WIDTH,
+    height: COMPACT_THUMBNAIL_HEIGHT,
     flexShrink: 0,
     position: 'relative',
   },

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -24,6 +24,7 @@ import { Icon } from './Icon';
 import { track } from '../lib/analytics';
 import { ClimbListItemContent } from './ClimbListItemContent';
 import { climbListRowStyles } from './climb-list-row-styles';
+import type { ClimbListDensity } from './climb-list-thumbnail-metrics';
 import { hapticLight, hapticMedium, hapticSuccess } from '../lib/haptics';
 import { useTheme } from '../providers/theme-provider';
 import { iosSystemColors } from '../theme/ios-colors';
@@ -222,6 +223,18 @@ type ClimbListRowProps = {
    * exists to close. A new surface extends `ClimbRowSurface` rather than opting out.
    */
   surface: ClimbRowSurface;
+  /**
+   * Row density — how much of the climb the default content layout shows, and how
+   * tall the row is (compact ~88pt, default/rich 112pt). Defaults to `'default'`,
+   * today's row byte-for-byte.
+   *
+   * DELIBERATELY per-surface, not global: five surfaces render a `ClimbListRow`
+   * and only the climbs list reads the user's density setting. Playlist detail,
+   * profile climbs and the two board-presence lists keep today's shape by not
+   * passing this. Ignored when `renderContent` supplies a custom layout — the
+   * separator inset still follows the tier, since that's the host row's job.
+   */
+  density?: ClimbListDensity;
 };
 
 /** The lists that render a `ClimbListRow`; the value of the events' `surface` prop. */
@@ -249,6 +262,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
   showFavorite = false,
   showMoreButton = false,
   surface,
+  density = 'default',
 }: ClimbListRowProps) {
   const { t } = useTranslation('climbs');
   const { systemColors, brandColors: brand } = useTheme();
@@ -522,6 +536,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
       angle={angle}
       showPlaylistChips={showPlaylistChips}
       showFavorite={showFavorite}
+      density={density}
     />
   );
 
@@ -607,9 +622,16 @@ const ClimbListRow = React.memo(function ClimbListRow({
         </GestureDetector>
       </ReanimatedSwipeable>
 
-      {/* Separator — inset to start at the text column (after the thumbnail) */}
+      {/* Separator — inset to start at the text column (after the thumbnail), so
+          the compact tier follows its own narrower cell rather than the 76pt one. */}
       {showSeparator ? (
-        <View style={[climbListRowStyles.separator, { backgroundColor: systemColors.separator }, separatorStyle]} />
+        <View
+          style={[
+            density === 'compact' ? climbListRowStyles.compactSeparator : climbListRowStyles.separator,
+            { backgroundColor: systemColors.separator },
+            separatorStyle,
+          ]}
+        />
       ) : null}
     </View>
   );

--- a/packages/mobile/src/components/ClimbPlaylistChips.tsx
+++ b/packages/mobile/src/components/ClimbPlaylistChips.tsx
@@ -35,8 +35,22 @@ type ResolvedChip = { key: string; name: string; dotColor: string; emoji: string
  * so the whole row stays one clean target (membership management lives in the
  * actions sheet).
  */
-export const ClimbPlaylistChips = React.memo(function ClimbPlaylistChips({ climbUuid }: { climbUuid: string }) {
-  const { enabled } = useShowPlaylistTagsPreference();
+export const ClimbPlaylistChips = React.memo(function ClimbPlaylistChips({
+  climbUuid,
+  forceVisible = false,
+}: {
+  climbUuid: string;
+  /**
+   * Show the tags even with the "Show playlist tags" setting off. Set only by the
+   * climbs list's `rich` density tier, where the tag line is what the tier IS —
+   * picking it in More → Climb list is the opt-in, so re-checking the (default-off)
+   * toggle would leave the tier doing nothing for most climbers. Every other caller
+   * leaves this alone and the toggle stays in charge.
+   */
+  forceVisible?: boolean;
+}) {
+  const { enabled: tagSettingEnabled } = useShowPlaylistTagsPreference();
+  const enabled = forceVisible || tagSettingEnabled;
   const membership = useClimbPlaylistMemberships(climbUuid);
   const playlistsContext = usePlaylistsContextOptional();
   const { variant, systemColors, m3 } = useTheme();

--- a/packages/mobile/src/components/__tests__/climb-list-density.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-list-density.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ComponentProps, type ReactNode } from 'react';
+
+// Geometry-only test: what each density tier renders, and what it hands the
+// thumbnail. Everything the row reaches for at runtime (live stats, grade
+// resolution, logbook, theme) is stubbed — the assertions are about SIZE and
+// which lines exist, nothing else.
+
+vi.mock('@boardsesh/board-react', () => ({
+  useEffectiveClimbStats: (
+    _boardName: string,
+    _layoutId: number,
+    _climbUuid: string,
+    _angle: number,
+    base: { ascensionistCount?: number; qualityAverage?: string; difficulty?: string },
+  ) => ({
+    ascensionistCount: base.ascensionistCount ?? 0,
+    qualityAverage: base.qualityAverage ?? null,
+    difficulty: base.difficulty ?? null,
+  }),
+}));
+
+// View keeps its style on the DOM node so the thumbnail cell's width/height are
+// assertable — the whole point of the compact tier.
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: ({ children, style }: { children?: ReactNode; style?: unknown }) => {
+    const flattened = Array.isArray(style) ? Object.assign({}, ...style.filter(Boolean)) : (style ?? {});
+    return createElement('div', { 'data-style': JSON.stringify(flattened) }, children);
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../hooks/use-display-grade', () => ({
+  useDisplayGrade: () => ({
+    boardseshActive: false,
+    resolveGrade: () => ({ label: 'V4', color: '#111111', isBoardsesh: false }),
+  }),
+}));
+
+vi.mock('../../hooks/use-ascent-status', () => ({ useAscentStatus: () => null }));
+
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { secondaryLabel: '#8E8E93' }, actionColors: { favorite: '#FF3B30' } }),
+}));
+
+vi.mock('../../lib/format-climb-stats', () => ({
+  formatSends: () => '10 sends',
+  formatQuality: () => '4.5',
+}));
+
+vi.mock('../Text', () => ({
+  Text: ({ children, variant }: { children?: ReactNode; variant?: string }) =>
+    createElement('span', { 'data-variant': variant }, children),
+}));
+
+// Records the size handed to the thumbnail. `undefined` is meaningful: it means the
+// row asked for the untouched default cell.
+vi.mock('../ClimbListThumbnail', () => ({
+  ClimbListThumbnail: ({ size }: { size?: { width: number; height: number } }) =>
+    createElement('img', { 'data-size': size ? `${size.width}x${size.height}` : 'default' }),
+  THUMBNAIL_WIDTH: 76,
+  THUMBNAIL_HEIGHT: 96,
+}));
+
+vi.mock('../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }),
+}));
+vi.mock('../ClimbAttributeIcons', () => ({
+  ClimbAttributeIcons: () => createElement('i', { 'data-icon': 'attributes' }),
+}));
+vi.mock('../ClimbPlaylistChips', () => ({
+  ClimbPlaylistChips: ({ forceVisible }: { forceVisible?: boolean }) =>
+    createElement('div', { 'data-chips': forceVisible ? 'forced' : 'gated' }),
+}));
+
+import { ClimbListItemContent } from '../ClimbListItemContent';
+import {
+  COMPACT_THUMBNAIL_HEIGHT,
+  COMPACT_THUMBNAIL_WIDTH,
+  THUMBNAIL_WIDTH,
+  separatorInsetForDensity,
+  thumbnailSizeForDensity,
+} from '../climb-list-thumbnail-metrics';
+
+const climb = {
+  uuid: 'c1',
+  name: 'Golden Boy',
+  frames: 'p1r1',
+  difficulty: '6b/V4',
+  quality_average: '4.5',
+  ascensionist_count: 10,
+  setter_username: 'setter',
+};
+
+function renderRow(props: Partial<ComponentProps<typeof ClimbListItemContent>> = {}) {
+  return render(
+    <ClimbListItemContent climb={climb} boardName="kilter" layoutId={1} sizeId={1} setIds="1" angle={40} {...props} />,
+  );
+}
+
+const thumbnailSizeAttr = (container: HTMLElement) => container.querySelector('img')?.getAttribute('data-size');
+const subtitle = (container: HTMLElement) => container.querySelector('[data-variant="footnote"]');
+const chips = (container: HTMLElement) => container.querySelector('[data-chips]');
+const thumbnailCellStyle = (container: HTMLElement) =>
+  JSON.parse(container.querySelector('div[data-style]')?.getAttribute('data-style') ?? '{}') as {
+    width?: number;
+    height?: number;
+  };
+
+describe('climb list density — default tier', () => {
+  it('renders today shape: 76x96 cell, the sends/quality/setter subtitle, and no size override', () => {
+    const { container } = renderRow();
+    expect(thumbnailCellStyle(container)).toMatchObject({ width: 76, height: 96 });
+    expect(thumbnailSizeAttr(container)).toBe('default');
+    expect(subtitle(container)).not.toBeNull();
+  });
+
+  it('is what a row with no density prop at all renders — the two are the same tree', () => {
+    const withoutProp = renderRow().container.innerHTML;
+    const withDefault = renderRow({ density: 'default' }).container.innerHTML;
+    expect(withDefault).toBe(withoutProp);
+  });
+
+  it('keeps the playlist tags gated on the user setting', () => {
+    const { container } = renderRow({ density: 'default', showPlaylistChips: true });
+    expect(chips(container)?.getAttribute('data-chips')).toBe('gated');
+  });
+});
+
+describe('climb list density — compact tier', () => {
+  it('shrinks the thumbnail cell to 56x72, which is what actually shortens the row', () => {
+    const { container } = renderRow({ density: 'compact' });
+    expect(thumbnailCellStyle(container)).toMatchObject({
+      width: COMPACT_THUMBNAIL_WIDTH,
+      height: COMPACT_THUMBNAIL_HEIGHT,
+    });
+    expect(thumbnailSizeAttr(container)).toBe('56x72');
+  });
+
+  it('drops the subtitle but keeps the name, the attribute glyphs and the grade', () => {
+    const { container } = renderRow({ density: 'compact' });
+    expect(subtitle(container)).toBeNull();
+    expect(container.textContent).toContain('Golden Boy');
+    expect(container.querySelector('[data-icon="attributes"]')).not.toBeNull();
+    expect(container.querySelector('[data-variant="title3"]')?.textContent).toBe('V4');
+  });
+
+  it('shows no playlist tags even when the surface opts in', () => {
+    const { container } = renderRow({ density: 'compact', showPlaylistChips: true });
+    expect(chips(container)).toBeNull();
+  });
+});
+
+describe('climb list density — rich tier', () => {
+  it('keeps the default 76x96 cell — a richer tier adds lines, never pixels', () => {
+    const { container } = renderRow({ density: 'rich' });
+    expect(thumbnailCellStyle(container)).toMatchObject({ width: 76, height: 96 });
+    expect(thumbnailSizeAttr(container)).toBe('default');
+  });
+
+  it('promotes the playlist tags under the subtitle, whatever the tags setting says', () => {
+    const { container } = renderRow({ density: 'rich' });
+    expect(subtitle(container)).not.toBeNull();
+    expect(chips(container)?.getAttribute('data-chips')).toBe('forced');
+  });
+});
+
+describe('climb list density metrics', () => {
+  it('never hands the thumbnail a cell wider than the default 76pt', () => {
+    for (const density of ['compact', 'default', 'rich'] as const) {
+      expect(thumbnailSizeForDensity(density).width).toBeLessThanOrEqual(THUMBNAIL_WIDTH);
+    }
+  });
+
+  it('derives every separator inset from the tier own thumbnail width, not a second magic number', () => {
+    expect(separatorInsetForDensity('default')).toBe(76 + 8 + 12);
+    expect(separatorInsetForDensity('rich')).toBe(76 + 8 + 12);
+    expect(separatorInsetForDensity('compact')).toBe(COMPACT_THUMBNAIL_WIDTH + 8 + 12);
+  });
+});

--- a/packages/mobile/src/components/climb-list-row-styles.ts
+++ b/packages/mobile/src/components/climb-list-row-styles.ts
@@ -1,5 +1,6 @@
 import { StyleSheet } from 'react-native';
 import { THUMBNAIL_WIDTH } from './ClimbListThumbnail';
+import { separatorInsetForDensity } from './climb-list-thumbnail-metrics';
 import { spacing } from '../theme/tokens';
 
 /**
@@ -8,6 +9,12 @@ import { spacing } from '../theme/tokens';
  * (`ClimbPreviewCard`), so the preview renders byte-for-byte like a list row.
  * Colours (row background, separator) are applied inline by each consumer from
  * scheme-aware `systemColors` — only the layout lives here.
+ *
+ * The EXISTING values are frozen: the preview card's whole reason to import this
+ * is that it matches a `default`-density list row exactly. The climbs-list density
+ * tiers therefore add styles ALONGSIDE (`compactSeparator`) rather than changing
+ * anything here. `contentRow` itself needs no tier variant — every tier keeps the
+ * same 8pt padding and 12pt gap, and only the thumbnail's height moves the row.
  */
 export const climbListRowStyles = StyleSheet.create({
   contentRow: {
@@ -21,5 +28,12 @@ export const climbListRowStyles = StyleSheet.create({
   separator: {
     height: StyleSheet.hairlineWidth,
     marginLeft: THUMBNAIL_WIDTH + spacing[2] + spacing[3],
+  },
+  // Same separator against the compact tier's narrower thumbnail. Derived from the
+  // metrics module, not a second hardcoded number, so the inset can't drift from
+  // the cell it's supposed to line up with.
+  compactSeparator: {
+    height: StyleSheet.hairlineWidth,
+    marginLeft: separatorInsetForDensity('compact'),
   },
 });

--- a/packages/mobile/src/components/climb-list-thumbnail-metrics.ts
+++ b/packages/mobile/src/components/climb-list-thumbnail-metrics.ts
@@ -1,8 +1,60 @@
 /**
- * Portrait dimensions of the shared climb-list thumbnail cell.
+ * Portrait dimensions of the shared climb-list thumbnail cell, and the geometry
+ * of the selectable climbs-list density tiers.
  *
  * Kept separate from `ClimbListThumbnail` so list-adjacent components can align
  * placeholders and separators without importing the native image renderer.
  */
 export const THUMBNAIL_WIDTH = 76;
 export const THUMBNAIL_HEIGHT = 96;
+
+/**
+ * How much of a climb the climbs list shows per row. A user setting
+ * (More → Climb list), read ONLY by the climbs list — every other surface that
+ * renders a `ClimbListRow` (playlist detail, profile climbs, the two board-presence
+ * lists) stays on `default`.
+ *
+ * - `compact` — 56×72 thumbnail, name + attribute glyphs + grade. No subtitle, no
+ *   playlist tags. ~88pt row.
+ * - `default` — today's row, byte-for-byte: 76×96 thumbnail, name row + the
+ *   `sends · ★ · setter` subtitle. 112pt row.
+ * - `rich` — `default` plus the playlist tags under the subtitle. Still 112pt.
+ */
+export type ClimbListDensity = 'compact' | 'default' | 'rich';
+
+/**
+ * Compact thumbnail cell. SMALLER than the default on purpose, and no tier in the
+ * app renders one LARGER.
+ *
+ * The thumbnail pins the row height (76×96 plus 8pt of vertical padding IS the
+ * 112pt row), so a compact tier that only drops text lines would save nothing — it
+ * has to shrink the cell. Shrinking is free: `ClimbListThumbnail` renders at
+ * `Math.max(400, cellWidth * 5)`, so a 56pt cell resolves to the SAME 400px render
+ * as the 76pt cell — byte-identical, no new cache generation. Growing it is not
+ * free: a 132pt cell would ask for 660px and mint a second generation in both the
+ * native render cache and expo-image's disk cache, on the app's largest memory
+ * consumer (docs/react-native-performance.md §7 — foreground OOM kills on 4 GB
+ * iPhones, #3479). So a richer tier adds LINES, never pixels.
+ */
+export const COMPACT_THUMBNAIL_WIDTH = 56;
+export const COMPACT_THUMBNAIL_HEIGHT = 72;
+
+/** Row padding + thumbnail-to-text gap, mirroring `climbListRowStyles.contentRow`. */
+const ROW_HORIZONTAL_PADDING = 8;
+const ROW_COLUMN_GAP = 12;
+
+/** The thumbnail cell for a density tier. `default` and `rich` share the 76×96 cell. */
+export function thumbnailSizeForDensity(density: ClimbListDensity): { width: number; height: number } {
+  return density === 'compact'
+    ? { width: COMPACT_THUMBNAIL_WIDTH, height: COMPACT_THUMBNAIL_HEIGHT }
+    : { width: THUMBNAIL_WIDTH, height: THUMBNAIL_HEIGHT };
+}
+
+/**
+ * Left inset of the row separator, so it starts at the text column rather than the
+ * screen edge. Derived from the tier's own thumbnail width — the compact row must
+ * not carry a second hardcoded inset that silently drifts from its cell.
+ */
+export function separatorInsetForDensity(density: ClimbListDensity): number {
+  return thumbnailSizeForDensity(density).width + ROW_HORIZONTAL_PADDING + ROW_COLUMN_GAP;
+}

--- a/packages/mobile/src/hooks/__tests__/use-climb-list-playlist-memberships.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-climb-list-playlist-memberships.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// Run scheduled interaction callbacks immediately — the deferral is covered by the
+// shared `runAfterInteractions` contract, not by these tests.
+const { runAfterInteractions, request, isAuthenticated, tagsSetting } = vi.hoisted(() => ({
+  runAfterInteractions: vi.fn((callback: () => void) => {
+    callback();
+    return { cancel: vi.fn() };
+  }),
+  request: vi.fn(),
+  isAuthenticated: { value: true },
+  tagsSetting: { enabled: false },
+}));
+
+vi.mock('react-native', () => ({ InteractionManager: { runAfterInteractions } }));
+vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request }) }));
+vi.mock('../../providers/auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: isAuthenticated.value }),
+}));
+vi.mock('../../lib/show-playlist-tags-preference', () => ({
+  useShowPlaylistTagsPreference: () => ({ enabled: tagsSetting.enabled }),
+}));
+
+import { useClimbListPlaylistMemberships } from '../use-climb-list-playlist-memberships';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('useClimbListPlaylistMemberships', () => {
+  beforeEach(() => {
+    request.mockReset();
+    request.mockResolvedValue({ playlistsForClimbs: [] });
+    runAfterInteractions.mockClear();
+    isAuthenticated.value = true;
+    tagsSetting.enabled = false;
+  });
+
+  it('asks for nothing while the tags setting is off', async () => {
+    renderHook(() => useClimbListPlaylistMemberships({ boardName: 'kilter', layoutId: 1, climbUuids: ['a'] }));
+    await flush();
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  // The rich density tier draws the tag line whatever the setting says, so the
+  // store has to be filled or that line paints empty for every climber who left
+  // the setting off — which is its default, i.e. almost everyone. Without
+  // `force` the tier's headline feature ships dead.
+  it('fetches for the rich tier even with the tags setting off', async () => {
+    renderHook(() =>
+      useClimbListPlaylistMemberships({ boardName: 'kilter', layoutId: 1, climbUuids: ['a'], force: true }),
+    );
+    await flush();
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(expect.anything(), {
+      input: { boardType: 'kilter', layoutId: 1, climbUuids: ['a'] },
+    });
+  });
+
+  it('still fetches when the setting is on and nothing forces it', async () => {
+    tagsSetting.enabled = true;
+
+    renderHook(() => useClimbListPlaylistMemberships({ boardName: 'kilter', layoutId: 1, climbUuids: ['a'] }));
+    await flush();
+
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it('asks for nothing when signed out, however it was forced', async () => {
+    isAuthenticated.value = false;
+
+    renderHook(() =>
+      useClimbListPlaylistMemberships({ boardName: 'kilter', layoutId: 1, climbUuids: ['a'], force: true }),
+    );
+    await flush();
+
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/hooks/use-climb-list-playlist-memberships.ts
+++ b/packages/mobile/src/hooks/use-climb-list-playlist-memberships.ts
@@ -18,6 +18,14 @@ type UseClimbListPlaylistMembershipsArgs = {
   // Must be a referentially-stable array (memoize at the call site) — the effect
   // depends on it, so a fresh array every render would refetch every render.
   climbUuids: readonly string[];
+  /**
+   * Fetch even when the "Show playlist tags" setting is off. The rich density
+   * tier renders the tag line unconditionally — the tags ARE what that tier
+   * adds — so without this the rows would ask for tags the store was never
+   * filled with and render an empty line for anyone who left the setting off,
+   * which is its default.
+   */
+  force?: boolean;
 };
 
 /**
@@ -27,7 +35,8 @@ type UseClimbListPlaylistMembershipsArgs = {
  * to the established "fetch the visible UUIDs, write into the external store"
  * pattern (see the favorites note in `use-mobile-climb-actions-data.ts`).
  *
- * No-op unless the user enabled the setting AND is signed in. Dedupes via a ref
+ * No-op unless the user enabled the setting (or a caller passes `force`) AND is
+ * signed in. Dedupes via a ref
  * so each climb is requested once; resets the ref and clears the store whenever
  * the board/layout/auth/enabled context flips, so a previous board's memberships
  * can't paint the new board's rows. Deferred past the active fling via
@@ -37,8 +46,10 @@ export function useClimbListPlaylistMemberships({
   boardName,
   layoutId,
   climbUuids,
+  force = false,
 }: UseClimbListPlaylistMembershipsArgs): void {
-  const { enabled } = useShowPlaylistTagsPreference();
+  const { enabled: settingEnabled } = useShowPlaylistTagsPreference();
+  const enabled = force || settingEnabled;
   const { isAuthenticated } = useAuth();
 
   const fetchedRef = useRef<Set<string>>(new Set());

--- a/packages/mobile/src/lib/__tests__/climb-list-density-preference.test.ts
+++ b/packages/mobile/src/lib/__tests__/climb-list-density-preference.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@react-native-async-storage/async-storage', () => {
+  let storage: Record<string, string> = {};
+  return {
+    default: {
+      getItem: vi.fn(async (key: string) => storage[key] ?? null),
+      setItem: vi.fn(async (key: string, value: string) => {
+        storage[key] = value;
+      }),
+      removeItem: vi.fn(async (key: string) => {
+        delete storage[key];
+      }),
+      __reset: () => {
+        storage = {};
+      },
+      __setRaw: (key: string, value: string) => {
+        storage[key] = value;
+      },
+    },
+  };
+});
+
+async function asyncStorageMock() {
+  return (await import('@react-native-async-storage/async-storage')).default as unknown as {
+    __reset: () => void;
+    __setRaw: (key: string, value: string) => void;
+    getItem: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('climb-list-density-preference', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    (await asyncStorageMock()).__reset();
+  });
+
+  it('leaves the choice unset when nothing is stored, so the default tier wins', async () => {
+    const { loadClimbListDensityChoice } = await import('../climb-list-density-preference');
+    await expect(loadClimbListDensityChoice()).resolves.toBeUndefined();
+  });
+
+  it('honours an explicit compact choice persisted from a previous session', async () => {
+    (await asyncStorageMock()).__setRaw('climbListDensity', JSON.stringify('compact'));
+
+    const { loadClimbListDensityChoice } = await import('../climb-list-density-preference');
+    await expect(loadClimbListDensityChoice()).resolves.toBe('compact');
+  });
+
+  it('honours an explicit rich choice persisted from a previous session', async () => {
+    (await asyncStorageMock()).__setRaw('climbListDensity', JSON.stringify('rich'));
+
+    const { loadClimbListDensityChoice } = await import('../climb-list-density-preference');
+    await expect(loadClimbListDensityChoice()).resolves.toBe('rich');
+  });
+
+  it('keeps an explicit default choice, rather than collapsing it back to "unset"', async () => {
+    (await asyncStorageMock()).__setRaw('climbListDensity', JSON.stringify('default'));
+
+    const { loadClimbListDensityChoice } = await import('../climb-list-density-preference');
+    await expect(loadClimbListDensityChoice()).resolves.toBe('default');
+  });
+
+  it('ignores a stored value that is not a density tier', async () => {
+    (await asyncStorageMock()).__setRaw('climbListDensity', JSON.stringify('enormous'));
+
+    const { loadClimbListDensityChoice } = await import('../climb-list-density-preference');
+    await expect(loadClimbListDensityChoice()).resolves.toBeUndefined();
+  });
+
+  it('persists the climber choice', async () => {
+    const { loadClimbListDensityChoice, setClimbListDensityPreference } =
+      await import('../climb-list-density-preference');
+    await setClimbListDensityPreference('compact');
+    await expect(loadClimbListDensityChoice()).resolves.toBe('compact');
+  });
+
+  it('lets a set() that races in during the initial load win over the (now stale) persisted value', async () => {
+    const asyncStorage = await asyncStorageMock();
+    // Persisted value is `rich`, but gate the read so it resolves only after the
+    // user's explicit choice has already landed.
+    asyncStorage.__setRaw('climbListDensity', JSON.stringify('rich'));
+    let releaseRead: () => void = () => {};
+    const readGate = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    asyncStorage.getItem.mockImplementationOnce(async () => {
+      await readGate;
+      return JSON.stringify('rich');
+    });
+
+    const { loadClimbListDensityChoice, setClimbListDensityPreference } =
+      await import('../climb-list-density-preference');
+
+    const loadPromise = loadClimbListDensityChoice();
+    // The climber's explicit compact choice lands while the (slow) disk read is
+    // still in flight.
+    await setClimbListDensityPreference('compact');
+    releaseRead();
+
+    await expect(loadPromise).resolves.toBe('compact');
+  });
+
+  it('leaves the store unloaded when the storage read rejects, so a later read retries', async () => {
+    const asyncStorage = await asyncStorageMock();
+    asyncStorage.getItem.mockRejectedValueOnce(new Error('locked before first unlock'));
+
+    const { loadClimbListDensityChoice } = await import('../climb-list-density-preference');
+    await expect(loadClimbListDensityChoice()).rejects.toThrow('locked before first unlock');
+
+    asyncStorage.__setRaw('climbListDensity', JSON.stringify('compact'));
+    await expect(loadClimbListDensityChoice()).resolves.toBe('compact');
+  });
+});

--- a/packages/mobile/src/lib/climb-list-density-preference.ts
+++ b/packages/mobile/src/lib/climb-list-density-preference.ts
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { getPreference, setPreference } from './preference-store';
+import type { ClimbListDensity } from '../components/climb-list-thumbnail-metrics';
+
+// How much of a climb the climbs list packs into a row — compact / default / rich.
+// A user setting (More → Climb list) that defaults to `default`, which is today's
+// row byte-for-byte: a climber who never opens the setting sees no change at all.
+//
+// The store is TRI-STATE — `choice` is `undefined` until the climber makes an
+// explicit choice, at which point their value wins over the default; so a choice
+// made in an earlier session always survives a change to `DEFAULT_DENSITY`.
+//
+// Structure mirrors `climb-quick-actions-button-preference.ts`: a module-level
+// store read via `useSyncExternalStore` with a referentially-stable cached
+// snapshot (rebuilt only inside `notify()`), plus a promise-singleton one-time
+// load so any number of mounted consumers trigger the AsyncStorage read once.
+const STORAGE_KEY = 'climbListDensity';
+
+// Default when the climber hasn't chosen — today's row, unchanged.
+const DEFAULT_DENSITY: ClimbListDensity = 'default';
+
+const DENSITIES: readonly ClimbListDensity[] = ['compact', 'default', 'rich'];
+
+/** Storage is untyped JSON, so a stale/corrupt value must not become a density. */
+function isClimbListDensity(value: unknown): value is ClimbListDensity {
+  return typeof value === 'string' && (DENSITIES as readonly string[]).includes(value);
+}
+
+type ChoiceSnapshot = { choice: ClimbListDensity | undefined; loaded: boolean };
+
+let current: ClimbListDensity | undefined;
+let hasLoaded = false;
+let snapshot: ChoiceSnapshot = { choice: current, loaded: hasLoaded };
+const listeners = new Set<() => void>();
+
+const SERVER_SNAPSHOT: ChoiceSnapshot = { choice: undefined, loaded: false };
+
+function notify(): void {
+  snapshot = { choice: current, loaded: hasLoaded };
+  for (const listener of listeners) listener();
+}
+
+export async function loadClimbListDensityChoice(): Promise<ClimbListDensity | undefined> {
+  if (hasLoaded) return current;
+  const stored = await getPreference<unknown>(STORAGE_KEY);
+  // A `setClimbListDensityPreference` may have raced in while we awaited storage;
+  // honour the user's choice over the (now stale) persisted value.
+  if (hasLoaded) return current;
+  // An explicit stored tier wins; anything else stays `undefined` so the hook
+  // falls back to the default.
+  current = isClimbListDensity(stored) ? stored : undefined;
+  hasLoaded = true;
+  notify();
+  return current;
+}
+
+export async function setClimbListDensityPreference(density: ClimbListDensity): Promise<void> {
+  current = density;
+  hasLoaded = true;
+  notify();
+  await setPreference(STORAGE_KEY, density);
+}
+
+let loadPromise: Promise<ClimbListDensity | undefined> | null = null;
+function ensureLoaded(): Promise<ClimbListDensity | undefined> {
+  if (!loadPromise) {
+    loadPromise = loadClimbListDensityChoice().catch((error: unknown) => {
+      // A failed read must not leave a rejected promise cached — clear the
+      // singleton so the next mount retries instead of staying stuck until the
+      // app restarts.
+      loadPromise = null;
+      throw error;
+    });
+  }
+  return loadPromise;
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+function getSnapshot(): ChoiceSnapshot {
+  return snapshot;
+}
+
+function getServerSnapshot(): ChoiceSnapshot {
+  return SERVER_SNAPSHOT;
+}
+
+/**
+ * The effective climbs-list density: the climber's explicit choice if they've made
+ * one, otherwise `default`. Backs both the climbs list and the More → Climb list
+ * segmented control.
+ *
+ * `density` is a PRIMITIVE on purpose — consumers subscribe to the value itself and
+ * drop it straight into a `renderItem` dependency array, never into a context object.
+ */
+export function useClimbListDensity(): {
+  density: ClimbListDensity;
+  loaded: boolean;
+  setDensity: (density: ClimbListDensity) => void;
+} {
+  const { choice, loaded } = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  useEffect(() => {
+    // Swallow read failures here — the load already clears its cached promise so a
+    // later mount retries; nothing to do at this call site.
+    ensureLoaded().catch(() => {});
+  }, []);
+
+  const setDensity = useCallback((next: ClimbListDensity) => {
+    void setClimbListDensityPreference(next);
+  }, []);
+
+  return { density: choice ?? DEFAULT_DENSITY, loaded, setDensity };
+}

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -109,6 +109,12 @@ export const SHARED_EVENTS = {
   // Fired when the climber toggles the "Show quick-actions button" setting, with an
   // `enabled` prop — measures opt-in (control) vs opt-out (treatment) against the flag.
   ClimbQuickActionsSettingChanged: 'Climb Quick Actions Setting Changed',
+  // Fired when the climber picks a climbs-list density in More → Climb list, with a
+  // `density` prop ('compact' | 'default' | 'rich'). Only an explicit choice fires
+  // it — never a load — so it measures how many people want a shape other than the
+  // shipped one, and which way they lean. Pair with `Climb List Paginated` to see
+  // whether compact actually makes people scan deeper.
+  ClimbListDensityChanged: 'Climb List Density Changed',
   FavoriteToggle: 'Favorite Toggle',
   MirrorClimb: 'Mirror Climb',
   ClimbShared: 'Climb Shared',

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -320,6 +320,13 @@
         "font": "Französisch",
         "both": "Beide"
       },
+      "climbListDensity": {
+        "title": "Boulder-Liste",
+        "description": "Kompakt zeigt mehr Boulder auf einmal. Ausführlich blendet unter jedem Boulder die Playlist-Tags ein.",
+        "compact": "Kompakt",
+        "standard": "Standard",
+        "rich": "Ausführlich"
+      },
       "displayOptions": {
         "title": "Anzeige",
         "playlistTags": "Playlist-Tags anzeigen",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -320,6 +320,13 @@
         "font": "French",
         "both": "Both"
       },
+      "climbListDensity": {
+        "title": "Climb list",
+        "description": "Compact fits more climbs on screen. Rich adds playlist tags under each climb.",
+        "compact": "Compact",
+        "standard": "Standard",
+        "rich": "Rich"
+      },
       "displayOptions": {
         "title": "Display",
         "playlistTags": "Show playlist tags",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -583,6 +583,13 @@
         "font": "Francés",
         "both": "Ambos"
       },
+      "climbListDensity": {
+        "title": "Lista de bloques",
+        "description": "Compacta muestra más bloques en pantalla. Ampliada añade las etiquetas de playlist bajo cada bloque.",
+        "compact": "Compacta",
+        "standard": "Estándar",
+        "rich": "Ampliada"
+      },
       "displayOptions": {
         "title": "Visualización",
         "playlistTags": "Mostrar etiquetas de playlist",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -320,6 +320,13 @@
         "font": "Français",
         "both": "Les deux"
       },
+      "climbListDensity": {
+        "title": "Liste des blocs",
+        "description": "Compacte affiche plus de blocs à l'écran. Détaillée ajoute les étiquettes de playlist sous chaque bloc.",
+        "compact": "Compacte",
+        "standard": "Standard",
+        "rich": "Détaillée"
+      },
       "displayOptions": {
         "title": "Affichage",
         "playlistTags": "Afficher les étiquettes de playlist",


### PR DESCRIPTION
Stacked on `feat/climb-row-a11y-telemetry` — review that one first; this PR's base is that branch, not `main`.

Ships the selectable climbs-list density asked for in #4838 (bring the medium view back) as one control instead of three competing row requests (#4635, #4801, #4533). Set once in More → Climb list; the Climbs tab is the only surface that reads it.

| Tier | Thumbnail | Content | Measured row pitch |
| --- | --- | --- | --- |
| Compact | 56×72 | name + attribute glyphs + grade | **88pt** (72 + 8 + 8) |
| Standard | 76×96 | today exactly | **112pt** (96 + 8 + 8), unchanged |
| Rich | 76×96 | standard + playlist tags under the subtitle | **112pt** |

Plus a hairline separator on every tier, so the on-screen pitch is 88.33 / 112.33pt at 3× DPR.

### No tier renders a thumbnail wider than 76pt

`ClimbListThumbnail` renders at `Math.max(400, cellWidth * 5)`, so the compact 56pt cell resolves to the **same 400px render** as today's 76pt cell — byte-identical, no new cache generation. A larger cell would not be free: 132pt asks for 660px and mints a second generation in both the native render cache and expo-image's disk cache, on the app's largest memory consumer (`docs/react-native-performance.md` §7 — foreground OOM kills on 4 GB iPhones, #3479). **So the rich tier adds a line, not pixels.** That rule is written into `climb-list-thumbnail-metrics.ts` and asserted by a test that walks every tier.

It also means compact had to shrink the cell: the thumbnail is the tallest child in the row, so a tier that only dropped text lines would have saved nothing.

### Measurements, and what the right-hand rail does

The rail is `flexDirection: 'row'` — the grade sits *beside* the ⋮, not stacked under it — so the rail's height is `max(44pt ⋮, grade)`. The grade is `title3`: 25pt line height on the Liquid Glass scale, 28pt on Material. 44 < 72, so the **thumbnail still drives the compact row** and the pitch is a real 88pt, not the taller number a stacked rail would have forced. That holds to Dynamic Type 1.5× too (title3 → 37.5/42pt, ⋮ fixed at 44pt, name → 33pt — all under 72). No hitSlop or negative margin was needed; the ⋮ keeps its full 44pt target.

### FlashList: nothing needed, and here is why

Checked against `@shopify/flash-list@2.3.2` in `node_modules`, not from memory:

- There is **no `estimatedItemSize`** in v2's `FlashListProps.ts` at all — nothing to keep in sync.
- `ViewHolder.tsx` gives every cell `onLayout → onSizeChanged(index, layout)`, and sets an explicit `height` only when `layout.enforcedHeight`. `LinearLayoutManager.ts:88` sets only `enforcedWidth` for a vertical list, so row height stays content-driven and re-measures on any re-render.
- `LayoutManager.ts` (`computeEstimatesAndMinMaxChangedLayout`) compares each reported height against the stored layout and recomputes from the lowest changed index — exactly the relayout a tier switch needs.
- `ViewHolder`'s memo comparator includes `prevProps.renderItem === nextProps.renderItem`, and `density` is in `renderClimbItem`'s deps, so every mounted cell re-renders and re-measures on a switch.
- `getItemType` would be actively **wrong** here. It only partitions the running height-average window (`getEstimatedHeight → heightAverageWindow.getCurrentValue(getItemType(index))`); the tier is global, so every item shares one type at any instant and a density-keyed type buys no estimate accuracy — while throwing away the whole recycling pool on each switch, forcing fresh mounts of every visible row on the app's largest memory consumer. Same reason no `key` on the list (it would also dump scroll position).

### Choices worth a second pair of eyes

- **`climb-list-row-styles.ts` values are untouched.** Its docblock says it exists so `ClimbPreviewCard` renders byte-for-byte like a list row, so the tiers add a style *alongside* (`compactSeparator`) rather than overriding. No style-override prop was needed: `contentRow` is identical across all three tiers (same 8pt padding, same 12pt gap) — only the thumbnail's height moves the row, and only the separator's inset moves sideways. Both separator insets are derived from `separatorInsetForDensity()` in the metrics module, so the compact row carries no second magic number.
- **Rich shows the playlist tags whatever the "Show playlist tags" toggle says.** That toggle defaults OFF, so without this the rich tier would have been a no-op for most climbers — picking rich in More → Climb list *is* the opt-in, and the section footer says so. The toggle still governs the standard tier. Shout if you'd rather rich deferred to it.
- **The control is its own section, not a row inside "Display".** A segmented row publishes no visible label of its own — `MoreForm.ios.tsx` says the section header *is* the label — so folding it under a header reading "Display" would have left three unexplained segments. It sits directly above Display, following the Grade Format pattern (segmented row, description as the section footer).
- Compact also drops `LiveClimbSubtitle`, and with it a per-row `useEffectiveClimbStats` subscription, so a compact row genuinely costs less rather than just looking smaller.
- The initial-load skeleton (`ClimbListRowSkeleton`) still draws at 112pt in every tier. Left alone to keep the diff on the row itself; a compact user sees one settle on first load.

Seams for the follow-ups are left open and empty: no placeholder props for the personal-progress line or the artwork pips.

## Release Notes

The Climbs tab now fits your eyes. Pick Compact for a tighter list that gets you deeper into the results in one scroll, Standard for the row you already know, or Rich to see which playlists a climb is in without opening it. One setting, in More → Climb list.

## Test plan

1. More → Climb list → tap Compact. Rows shrink, subtitles go.
2. Scroll the Climbs tab. Smaller wall images, still sharp.
3. Tap Rich. Rows grow back, playlist tags appear.
4. Tap Standard. Rows look exactly as before.
5. Force-quit, reopen Climbs. Your pick survived.

## Risk

Risk: 2/5 — JS-only row geometry behind a new setting that defaults to today's exact row; no native change, no migration, no BLE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELkpe6R3CCsHmmvNShY9Ta
