### PR TITLE
feat(mobile): mark routes with a frame count and calm the attribute badges

### DIFF
--- a/packages/mobile/src/components/ClimbAttributeIcons.tsx
+++ b/packages/mobile/src/components/ClimbAttributeIcons.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import {
@@ -11,6 +11,7 @@ import {
   isNoMatch,
 } from '@boardsesh/shared-schema';
 import { Icon } from './Icon';
+import { Text } from './Text';
 import { useTheme } from '../providers/theme-provider';
 
 type ClimbAttributeIconsProps = {
@@ -26,7 +27,12 @@ type ClimbAttributeIconsProps = {
    * (e.g. session-tick rows). Ignored when `characteristics` is provided.
    */
   isNoMatch?: boolean | null;
-  /** Glyph size; defaults to 14 to sit beside body-sized climb names. */
+  /**
+   * Glyph size; defaults to 14 to sit beside body-sized climb names. Applies to
+   * the ICONS only — the text badges ride the shared `caption1` type scale so they
+   * follow the per-UI-variant scale and Dynamic Type, rather than a fixed size
+   * derived from this (#4883).
+   */
   size?: number;
 };
 
@@ -104,10 +110,12 @@ export const ClimbAttributeIcons = memo(function ClimbAttributeIcons({
         </View>
       ) : null}
       {method ? (
-        <Text style={[styles.method, { fontSize: size - 2, color: theme.systemColors.secondaryLabel }]}>{method}</Text>
+        <Text variant="caption1" color={theme.systemColors.secondaryLabel} style={styles.method}>
+          {method}
+        </Text>
       ) : null}
       {extraLabels.length > 0 ? (
-        <Text style={[styles.method, { fontSize: size - 2, color: theme.systemColors.secondaryLabel }]}>
+        <Text variant="caption1" color={theme.systemColors.secondaryLabel} style={styles.method}>
           {extraLabels.join(' · ')}
         </Text>
       ) : null}
@@ -120,11 +128,15 @@ const styles = StyleSheet.create({
     marginLeft: 4,
     flexShrink: 0,
   },
+  // No `textTransform: 'uppercase'` and no tracking: #4883 is about this cluster
+  // shouting FOOTLESS / NO KB / CAMPUS beside a quietly-set no-match glyph. Sentence
+  // case at the shared caption weight puts the two on the same footing, and the
+  // catalog strings stay ABBREVIATED on purpose — see the PR body's width budget:
+  // spelling "No KB" out in full costs the German row roughly three times the
+  // badge width at Dynamic Type 1.5×, all of it taken from the climb's name.
   method: {
     marginLeft: 6,
     flexShrink: 0,
     fontWeight: '600',
-    textTransform: 'uppercase',
-    letterSpacing: 0.3,
   },
 });

--- a/packages/mobile/src/components/ClimbFramesBadge.tsx
+++ b/packages/mobile/src/components/ClimbFramesBadge.tsx
@@ -1,0 +1,129 @@
+import { memo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Text } from './Text';
+import { Icon } from './Icon';
+import { borderRadius } from '../theme/tokens';
+
+/**
+ * Ink, scrim and edge of the frames chip. Fixed values, NOT theme colours: the
+ * chip sits on board art, not on an app surface, so it has to be legible against
+ * a photo rather than against `systemColors.background` — and the photo doesn't
+ * change with the colour scheme.
+ *
+ * Why a scrim AND an edge, rather than one or the other:
+ *
+ * - White ink on the 72%-black scrim clears WCAG AA on both extremes of our board
+ *   art. Over a near-black Kilter wall (~#101010, relative luminance ≈ 0.006) the
+ *   composited chip lands at L ≈ 0.28·0.006 ≈ 0.002, so white reads at
+ *   (1.0 + 0.05) / (0.002 + 0.05) ≈ 20:1. Over a bright Tension plywood wall
+ *   (~#C8B48C, L ≈ 0.47) it lands at L ≈ 0.28·0.47 ≈ 0.13, so white still reads
+ *   at (1.05) / (0.18) ≈ 5.8:1. Both are above the 4.5:1 floor.
+ * - The scrim alone disappears INTO the near-black Kilter art — 20:1 on the text
+ *   is useless if you can't see where the chip is. The 45%-white hairline is what
+ *   separates the chip from a dark wall; against the bright wall the scrim itself
+ *   already does that job.
+ *
+ * Contrast figures above are computed, not measured on a device — see the PR's
+ * test plan for the device pass that still owes us the visual confirmation.
+ */
+const BADGE_INK = '#FFFFFF';
+const BADGE_SCRIM = 'rgba(0, 0, 0, 0.72)';
+const BADGE_EDGE = 'rgba(255, 255, 255, 0.45)';
+
+/** Stack-glyph point size per density tier. The compact cell is 56×72, not 76×96. */
+const GLYPH_SIZE = 11;
+const COMPACT_GLYPH_SIZE = 9;
+
+/**
+ * Whether a climb is a multi-frame route rather than a single-frame boulder.
+ *
+ * Exported so the row can gate MOUNTING the badge on it: `ClimbFramesBadge` calls
+ * `useTranslation`, and a hook can't be skipped from inside the component, so a
+ * badge mounted on every row would add an i18n listener to every row in the list
+ * for the sake of the handful that are routes (docs/react-native-performance.md —
+ * no per-row subscriptions). The badge keeps its own guard as well, so mounting it
+ * unconditionally is merely wasteful, never wrong.
+ *
+ * Boards whose `multiFrameClimbs` capability is false (Woods) can never produce a
+ * count above 1, so this is false for every climb on such a board.
+ */
+export function isMultiFrameClimb(framesCount: number | null | undefined): boolean {
+  return typeof framesCount === 'number' && framesCount > 1;
+}
+
+type ClimbFramesBadgeProps = {
+  /** Number of frames on the climb. Below 2 the badge renders nothing. */
+  framesCount: number;
+  /** True on the compact density tier, whose thumbnail cell is 56×72. */
+  compact?: boolean;
+};
+
+/**
+ * Frame-count pip drawn over a climb thumbnail, marking a multi-frame route in a
+ * list that mixes routes and boulders (#4635). Two jobs at once: it says "this is
+ * a route, not a boulder" while filters allow both, and it explains why the
+ * thumbnail looks sparse — the artwork is only the FIRST frame, so a good route
+ * can read as an undesirable climb until you open it.
+ *
+ * A `View` with a `Text` in it, deliberately: board art is the app's largest
+ * memory consumer (docs/react-native-performance.md §7 — foreground OOM kills on
+ * 4 GB iPhones), so the pip adds no image layer and does not touch the
+ * thumbnail's render width.
+ *
+ * Monochrome by the same rule as the row's ascent-status and favourite glyphs:
+ * colour in a climb row means GRADE and nothing else, so a colour-blind climber
+ * loses no signal here.
+ */
+export const ClimbFramesBadge = memo(function ClimbFramesBadge({
+  framesCount,
+  compact = false,
+}: ClimbFramesBadgeProps) {
+  const { t } = useTranslation('climbs');
+
+  if (!isMultiFrameClimb(framesCount)) return null;
+
+  return (
+    <View
+      accessibilityRole="image"
+      accessibilityLabel={t('mobile.climbRow.frameCount', { count: framesCount })}
+      style={[styles.badge, compact ? styles.badgeCompact : null]}
+    >
+      <Icon name="frames" size={compact ? COMPACT_GLYPH_SIZE : GLYPH_SIZE} color={BADGE_INK} />
+      <Text variant="caption2" color={BADGE_INK} style={styles.count}>
+        {String(framesCount)}
+      </Text>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  // Bottom-right of the thumbnail cell: the top of a board photo is where the
+  // finish holds sit, and covering those is what would actually mislead someone
+  // scanning the list.
+  badge: {
+    position: 'absolute',
+    right: 3,
+    bottom: 3,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 2,
+    paddingHorizontal: 4,
+    paddingVertical: 1,
+    borderRadius: borderRadius.sm,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: BADGE_EDGE,
+    backgroundColor: BADGE_SCRIM,
+  },
+  // The compact cell is 20pt narrower and 24pt shorter, so the chip pulls in to
+  // the very corner and loses its horizontal breathing room.
+  badgeCompact: {
+    right: 2,
+    bottom: 2,
+    gap: 1,
+    paddingHorizontal: 3,
+  },
+  count: {
+    fontWeight: '700',
+  },
+});

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -17,6 +17,7 @@ import { useAscentStatus } from '../hooks/use-ascent-status';
 import { useTheme } from '../providers/theme-provider';
 import { Icon } from './Icon';
 import { ClimbAttributeIcons } from './ClimbAttributeIcons';
+import { ClimbFramesBadge, isMultiFrameClimb } from './ClimbFramesBadge';
 import { ClimbPlaylistChips } from './ClimbPlaylistChips';
 import { isClimbResolved } from '../lib/queue-climb-resolution';
 import { useIsClimbFavorited } from '../hooks/use-is-climb-favorited';
@@ -57,6 +58,19 @@ export type ClimbListItemClimb = {
   is_no_match?: boolean | null;
   benchmark_difficulty?: string | null;
   characteristics?: string[] | null;
+  /**
+   * How many frames the climb has. Above 1 the climb is a ROUTE, and the row marks
+   * it with a pip over the thumbnail — both because a mixed boulders + routes
+   * filter otherwise gives you no way to tell them apart, and because the artwork
+   * only ever draws the FIRST frame, which makes a good route look sparse (#4635).
+   *
+   * Optional + permissive for the same reason as the Boardsesh grade fields below:
+   * both the web-schema `Climb` and the `@boardsesh/queue` `Climb` declare it as
+   * `number | null`, and this shape has to accept both without a cast. Absent on
+   * the tick-sourced rows that build a climb from a logbook entry, which simply
+   * show no pip.
+   */
+  framesCount?: number | null;
   // Boardsesh grade (data-science difficulty + confidence), carried on every climb
   // from PR #3554. Optional + permissive so both the web-schema `Climb` and the
   // `@boardsesh/queue` `Climb` satisfy this shape; `resolveGrade` renders the
@@ -381,6 +395,14 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
           mirrored={climb.mirrored ?? false}
           size={thumbnailSize}
         />
+        {/* Absolutely-positioned child of the (already `position: 'relative'`)
+            thumbnail cell, so the pip costs the row no extra layout box. Mounted
+            only for a route: the badge calls `useTranslation`, and a hook can't be
+            skipped from inside, so mounting it on every row would put an i18n
+            listener on every row in the list. */}
+        {isMultiFrameClimb(climb.framesCount) ? (
+          <ClimbFramesBadge framesCount={climb.framesCount ?? 0} compact={isCompact} />
+        ) : null}
       </View>
 
       {/* Center: name (+ intrinsic-attribute glyphs) + subtitle */}

--- a/packages/mobile/src/components/__tests__/ClimbAttributeIcons.test.tsx
+++ b/packages/mobile/src/components/__tests__/ClimbAttributeIcons.test.tsx
@@ -3,13 +3,35 @@ import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
-// react-native View → a div that surfaces the a11y label; Text → a plain span
-// (the method / extra-characteristic text badges); StyleSheet passthrough.
+// react-native View → a div that surfaces the a11y label; StyleSheet passthrough.
 vi.mock('react-native', () => ({
   StyleSheet: { create: (styles: unknown) => styles },
   View: ({ children, accessibilityLabel }: { children?: ReactNode; accessibilityLabel?: string }) =>
     createElement('div', { 'data-a11y': accessibilityLabel }, children),
-  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+// The shared Text primitive (the method / extra-characteristic badges) → a span
+// carrying its variant and flattened style, so the type scale it rides and the
+// absence of the old shouty uppercase transform are both assertable.
+vi.mock('../Text', () => ({
+  Text: ({
+    children,
+    variant,
+    color,
+    style,
+  }: {
+    children?: ReactNode;
+    variant?: string;
+    color?: string;
+    style?: unknown;
+  }) => {
+    const flattened = Array.isArray(style) ? Object.assign({}, ...style.filter(Boolean)) : (style ?? {});
+    return createElement(
+      'span',
+      { 'data-variant': variant, 'data-color': color, 'data-style': JSON.stringify(flattened) },
+      children,
+    );
+  },
 }));
 
 // Icon → a span exposing the glyph name + size + colour so we can assert which
@@ -117,6 +139,36 @@ describe('ClimbAttributeIcons', () => {
   it('joins both badges with " · " when both characteristics are present', () => {
     const { container } = render(<ClimbAttributeIcons characteristics={['no_kickboard', 'campus']} />);
     expect(badgeTexts(container)).toEqual(['mobile.climbRow.campus · mobile.climbRow.noKickboard']);
+  });
+
+  it('renders the badges on the shared caption1 scale, not a hardcoded font size', () => {
+    const { container } = render(<ClimbAttributeIcons characteristics={['campus']} />);
+    const badge = container.querySelector('span:not([data-icon])');
+    expect(badge?.getAttribute('data-variant')).toBe('caption1');
+    const style = JSON.parse(badge?.getAttribute('data-style') ?? '{}') as Record<string, unknown>;
+    expect(style.fontSize).toBeUndefined();
+  });
+
+  it('no longer shouts the badges in uppercase with extra tracking (#4883)', () => {
+    const { container } = render(<ClimbAttributeIcons characteristics={['campus', 'no_kickboard']} />);
+    const style = JSON.parse(
+      container.querySelector('span:not([data-icon])')?.getAttribute('data-style') ?? '{}',
+    ) as Record<string, unknown>;
+    expect(style.textTransform).toBeUndefined();
+    expect(style.letterSpacing).toBeUndefined();
+  });
+
+  it('keeps the badges monochrome — colour in a climb row means grade and nothing else', () => {
+    const { container } = render(<ClimbAttributeIcons characteristics={['campus']} />);
+    expect(container.querySelector('span:not([data-icon])')?.getAttribute('data-color')).toBe('#8E8E93');
+  });
+
+  it('does not resize the badge text when a caller changes the glyph size', () => {
+    const small = render(<ClimbAttributeIcons characteristics={['campus']} size={10} />).container;
+    const large = render(<ClimbAttributeIcons characteristics={['campus']} size={20} />).container;
+    const variantOf = (container: HTMLElement) =>
+      container.querySelector('span:not([data-icon])')?.getAttribute('data-variant');
+    expect(variantOf(small)).toBe(variantOf(large));
   });
 
   it('coexists with no-match and benchmark when all three apply at once', () => {

--- a/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
+++ b/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
@@ -32,7 +32,11 @@ vi.mock('@boardsesh/board-react', () => ({
 }));
 
 vi.mock('react-native', () => ({
-  StyleSheet: { create: (styles: unknown) => styles },
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 0.5 },
+  // theme/tokens (via the frames pip) reaches theme/colors, which branches on
+  // `Platform.OS` and only calls `PlatformColor` on iOS.
+  Platform: { OS: 'android', select: (choices: Record<string, unknown>) => choices.android ?? choices.default },
+  PlatformColor: (name: string) => name,
   View: ({ children }: { children?: ReactNode }) => createElement('div', {}, children),
 }));
 

--- a/packages/mobile/src/components/__tests__/climb-frames-badge.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-frames-badge.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// View keeps its flattened style on the node so the scrim chip's colours and the
+// absolute placement inside the thumbnail cell are assertable.
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 0.5 },
+  // theme/tokens reaches theme/colors, which branches on `Platform.OS` and only
+  // calls `PlatformColor` on iOS.
+  Platform: { OS: 'android', select: (choices: Record<string, unknown>) => choices.android ?? choices.default },
+  PlatformColor: (name: string) => name,
+  View: ({
+    children,
+    style,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    style?: unknown;
+    accessibilityLabel?: string;
+  }) => {
+    const flattened = Array.isArray(style) ? Object.assign({}, ...style.filter(Boolean)) : (style ?? {});
+    return createElement('div', { 'data-style': JSON.stringify(flattened), 'data-a11y': accessibilityLabel }, children);
+  },
+}));
+
+vi.mock('../Icon', () => ({
+  Icon: ({ name, size, color }: { name: string; size?: number; color?: string }) =>
+    createElement('i', { 'data-icon': name, 'data-size': String(size), 'data-color': color }),
+}));
+
+vi.mock('../Text', () => ({
+  Text: ({ children, variant, color }: { children?: ReactNode; variant?: string; color?: string }) =>
+    createElement('span', { 'data-variant': variant, 'data-color': color }, children),
+}));
+
+// t() returns "key:count" so the plural call is assertable without a real catalog.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, options?: { count?: number }) => `${key}:${options?.count}` }),
+}));
+
+import { ClimbFramesBadge, isMultiFrameClimb } from '../ClimbFramesBadge';
+
+const chip = (container: HTMLElement) => container.querySelector('div[data-style]');
+const chipStyle = (container: HTMLElement) =>
+  JSON.parse(chip(container)?.getAttribute('data-style') ?? '{}') as Record<string, unknown>;
+
+describe('isMultiFrameClimb', () => {
+  it('is true only for a frame count above one', () => {
+    expect(isMultiFrameClimb(2)).toBe(true);
+    expect(isMultiFrameClimb(12)).toBe(true);
+  });
+
+  it('is false for a single-frame boulder, a missing count, or a nonsense count', () => {
+    expect(isMultiFrameClimb(1)).toBe(false);
+    expect(isMultiFrameClimb(0)).toBe(false);
+    expect(isMultiFrameClimb(null)).toBe(false);
+    expect(isMultiFrameClimb(undefined)).toBe(false);
+    expect(isMultiFrameClimb(Number.NaN)).toBe(false);
+  });
+});
+
+describe('ClimbFramesBadge', () => {
+  it('renders the stack glyph and the raw count for a multi-frame route', () => {
+    const { container } = render(<ClimbFramesBadge framesCount={4} />);
+    expect(container.querySelector('[data-icon]')?.getAttribute('data-icon')).toBe('frames');
+    expect(container.querySelector('span')?.textContent).toBe('4');
+  });
+
+  it('renders nothing for a single-frame boulder even if it is mounted anyway', () => {
+    const { container } = render(<ClimbFramesBadge framesCount={1} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('labels itself with the pluralised frame count for screen readers', () => {
+    const { container } = render(<ClimbFramesBadge framesCount={3} />);
+    expect(chip(container)?.getAttribute('data-a11y')).toBe('mobile.climbRow.frameCount:3');
+  });
+
+  it('paints an opaque dark scrim with a light hairline edge, so it reads on both bright and near-black board art', () => {
+    const { container } = render(<ClimbFramesBadge framesCount={3} />);
+    const style = chipStyle(container);
+    expect(style.backgroundColor).toBe('rgba(0, 0, 0, 0.72)');
+    expect(style.borderColor).toBe('rgba(255, 255, 255, 0.45)');
+    expect(style.position).toBe('absolute');
+  });
+
+  it('inks the glyph and the count in the same fixed white — the chip is dark in both colour schemes', () => {
+    const { container } = render(<ClimbFramesBadge framesCount={3} />);
+    expect(container.querySelector('[data-icon]')?.getAttribute('data-color')).toBe('#FFFFFF');
+    expect(container.querySelector('span')?.getAttribute('data-color')).toBe('#FFFFFF');
+  });
+
+  it('shrinks the glyph on the compact tier, whose cell is 56x72 rather than 76x96', () => {
+    const standard = render(<ClimbFramesBadge framesCount={3} />).container;
+    const compact = render(<ClimbFramesBadge framesCount={3} compact />).container;
+    const standardSize = Number(standard.querySelector('[data-icon]')?.getAttribute('data-size'));
+    const compactSize = Number(compact.querySelector('[data-icon]')?.getAttribute('data-size'));
+    expect(compactSize).toBeLessThan(standardSize);
+  });
+
+  it('keeps the count on the shared caption type scale rather than a hardcoded size', () => {
+    const { container } = render(<ClimbFramesBadge framesCount={3} />);
+    expect(container.querySelector('span')?.getAttribute('data-variant')).toBe('caption2');
+  });
+});

--- a/packages/mobile/src/components/__tests__/climb-list-density.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-list-density.test.tsx
@@ -25,7 +25,11 @@ vi.mock('@boardsesh/board-react', () => ({
 // View keeps its style on the DOM node so the thumbnail cell's width/height are
 // assertable — the whole point of the compact tier.
 vi.mock('react-native', () => ({
-  StyleSheet: { create: (styles: unknown) => styles },
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 0.5 },
+  // theme/tokens (via the frames pip) reaches theme/colors, which branches on
+  // `Platform.OS` and only calls `PlatformColor` on iOS.
+  Platform: { OS: 'android', select: (choices: Record<string, unknown>) => choices.android ?? choices.default },
+  PlatformColor: (name: string) => name,
   View: ({ children, style }: { children?: ReactNode; style?: unknown }) => {
     const flattened = Array.isArray(style) ? Object.assign({}, ...style.filter(Boolean)) : (style ?? {});
     return createElement('div', { 'data-style': JSON.stringify(flattened) }, children);
@@ -69,7 +73,8 @@ vi.mock('../ClimbListThumbnail', () => ({
 }));
 
 vi.mock('../Icon', () => ({
-  Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }),
+  Icon: ({ name, size }: { name: string; size?: number }) =>
+    createElement('i', { 'data-icon': name, 'data-size': String(size) }),
 }));
 vi.mock('../ClimbAttributeIcons', () => ({
   ClimbAttributeIcons: () => createElement('i', { 'data-icon': 'attributes' }),
@@ -168,6 +173,40 @@ describe('climb list density — rich tier', () => {
     const { container } = renderRow({ density: 'rich' });
     expect(subtitle(container)).not.toBeNull();
     expect(chips(container)?.getAttribute('data-chips')).toBe('forced');
+  });
+});
+
+describe('climb list density — frames pip', () => {
+  const pip = (container: HTMLElement) => container.querySelector('[data-icon="frames"]');
+  const route = { ...climb, framesCount: 3 };
+
+  it('marks a multi-frame route on every tier, so a mixed boulders + routes filter stays readable', () => {
+    for (const density of ['compact', 'default', 'rich'] as const) {
+      const { container } = renderRow({ climb: route, density });
+      expect(pip(container)).not.toBeNull();
+      expect(container.textContent).toContain('3');
+    }
+  });
+
+  it('shrinks its glyph on the compact tier, whose cell is 56x72 rather than 76x96', () => {
+    const compactGlyph = Number(
+      pip(renderRow({ climb: route, density: 'compact' }).container)?.getAttribute('data-size'),
+    );
+    const defaultGlyph = Number(
+      pip(renderRow({ climb: route, density: 'default' }).container)?.getAttribute('data-size'),
+    );
+    expect(compactGlyph).toBeLessThan(defaultGlyph);
+  });
+
+  it('shows nothing for a single-frame boulder, or a climb whose count never arrived', () => {
+    expect(pip(renderRow({ climb: { ...climb, framesCount: 1 } }).container)).toBeNull();
+    expect(pip(renderRow({ climb: { ...climb, framesCount: null } }).container)).toBeNull();
+    expect(pip(renderRow().container)).toBeNull();
+  });
+
+  it('leaves the thumbnail cell exactly as it was — a pip is a View, not another image layer', () => {
+    expect(thumbnailCellStyle(renderRow({ climb: route }).container)).toMatchObject({ width: 76, height: 96 });
+    expect(thumbnailSizeAttr(renderRow({ climb: route }).container)).toBe('default');
   });
 });
 

--- a/packages/mobile/src/components/__tests__/icon-map.test.ts
+++ b/packages/mobile/src/components/__tests__/icon-map.test.ts
@@ -37,7 +37,7 @@ describe('iconMap', () => {
     expect(uniqueKeys.size).toBe(keys.length);
   });
 
-  it.each(['boards', 'search', 'queue', 'profile', 'more', 'favorite', 'bluetooth', 'tick'] as const)(
+  it.each(['boards', 'search', 'queue', 'profile', 'more', 'favorite', 'bluetooth', 'tick', 'frames'] as const)(
     'contains critical icon "%s"',
     (iconName) => {
       expect(iconMap[iconName]).toBeDefined();
@@ -65,6 +65,16 @@ describe('iconMap', () => {
     expect(iconMap.share).toBeDefined();
     expect(iconMap.delete).toBeDefined();
     expect(iconMap.edit).toBeDefined();
+  });
+
+  // `Icon` renders `SymbolView` with no fallback, so an SF Symbol that does not
+  // exist on the running iOS version draws NOTHING — no error, no exception, no
+  // Sentry event. The frames pip is a bare glyph plus a number over board art, so a
+  // silent blank there is indistinguishable from a rendering bug; pinning the name
+  // keeps the choice on an SF Symbols 1.0 (iOS 13.0+) glyph.
+  it('marks multi-frame routes with a long-available stack glyph on both platforms', () => {
+    expect(iconMap.frames.ios).toBe('rectangle.stack');
+    expect(iconMap.frames.android).toBe('card-multiple-outline');
   });
 
   it('contains status icons', () => {

--- a/packages/mobile/src/components/icon-map.ts
+++ b/packages/mobile/src/components/icon-map.ts
@@ -112,6 +112,13 @@ export const iconMap = {
   // Remove-one-frame in the create-climb route editor — a circled X, distinct
   // from the trash-can `delete` glyph the Clear-all-holds action already uses.
   'frame.remove': { ios: 'xmark.circle', android: 'close-circle-outline' },
+  // Multi-frame route marker on a climb thumbnail (the frames pip). `Icon` renders
+  // `SymbolView` with NO fallback, so an SF Symbol missing on the running iOS
+  // version is a silent blank — no error, no exception, no Sentry event.
+  // `rectangle.stack` is an SF Symbols 1.0 glyph (iOS 13.0+), a decade below any
+  // OS this app runs on, so it cannot be that blank. Android's
+  // `card-multiple-outline` is the same idea: one card in front of a stack.
+  frames: { ios: 'rectangle.stack', android: 'card-multiple-outline' },
   // Intrinsic climb-attribute glyphs shown after the name (web parity:
   // climb-card/climb-icons.tsx © benchmark + ⊘ no-match).
   'no.match': { ios: 'hand.raised.slash', android: 'hand-back-right-off-outline' },

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -480,6 +480,8 @@
       "anyFeet": "Freie Füße",
       "noKickboard": "Ohne FL",
       "benchmark": "Benchmark",
+      "frameCount_one": "{{count}} Bild",
+      "frameCount_other": "{{count}} Bilder",
       "method": {
         "footless": "Ohne Füße",
         "footlessKickboard": "Ohne Füße + KB",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -480,6 +480,8 @@
       "anyFeet": "Any feet",
       "noKickboard": "No KB",
       "benchmark": "Benchmark",
+      "frameCount_one": "{{count}} frame",
+      "frameCount_other": "{{count}} frames",
       "method": {
         "footless": "Footless",
         "footlessKickboard": "Footless + KB",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -480,6 +480,8 @@
       "anyFeet": "Pies libres",
       "noKickboard": "Sin repisa",
       "benchmark": "Benchmark",
+      "frameCount_one": "{{count}} cuadro",
+      "frameCount_other": "{{count}} cuadros",
       "method": {
         "footless": "Sin pies",
         "footlessKickboard": "Sin pies + KB",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -480,6 +480,8 @@
       "anyFeet": "Pieds libres",
       "noKickboard": "Sans KB",
       "benchmark": "Benchmark",
+      "frameCount_one": "{{count}} image",
+      "frameCount_other": "{{count}} images",
       "method": {
         "footless": "Sans pieds",
         "footlessKickboard": "Sans pieds + KB",


### PR DESCRIPTION
Stacks on `feat/climb-list-density` — review that branch first; this PR's base is `feat/climb-list-density`, not `main`.

Closes #4635. Addresses the icon half of #4883.

## Summary

Two pieces of user feedback about the same climb row.

**#4635 — a frames pip on the artwork.** With boulders and routes both in the list there is nothing to tell them apart, and a route's thumbnail draws only its *first* frame, so a good route reads as a sparse, undesirable climb until you open it. `ClimbFramesBadge` puts a small chip over the bottom-right of the thumbnail with the frame count, rendered only when `framesCount > 1`.

- `framesCount` was already in `CLIMB_SEARCH_FIELDS` (verified) and on both the web-schema `Climb` and `@boardsesh/queue`'s `Climb`. It was **not** on `ClimbListItemClimb`, so it is added there as `framesCount?: number | null`; `vp run typecheck:mobile` confirms both `Climb` types still satisfy the shape without a cast.
- The pip is an absolutely-positioned child of the already-`position: 'relative'` thumbnail cell. The row is not restructured, the thumbnail's render width is untouched, and no image layer is added — it is a `View` with a `Text` in it. Board art is the app's largest memory consumer (`docs/react-native-performance.md` §7).
- It is not mounted on single-frame rows. `ClimbFramesBadge` calls `useTranslation`, and a hook cannot be skipped from inside the component, so the row gates mounting on the exported `isMultiFrameClimb()` predicate. No per-row subscription, no inline closure in `renderItem`, primitive props, `React.memo`.
- **Woods sets `multiFrameClimbs: false`**, so a Woods climb can never carry a count above 1 and the pip can never appear on that board. That is correct, not a bug.

**#4883 — calmer attribute badges.** `ClimbAttributeIcons` rendered `benchmark` and `no-match` as quiet 14pt grey glyphs and then shouted the rest — FOOTLESS / NO KB / CAMPUS / ANY FEET — through a raw `RNText` with `textTransform: 'uppercase'`, `letterSpacing: 0.3` and a hardcoded `fontSize: size - 2`. The badges now use the shared `Text` primitive at `variant="caption1"`: no uppercase, no tracking, no hardcoded size. They follow the per-UI-variant type scale (HIG on Liquid Glass, M3 on Material) and Dynamic Type, and they now inherit `Text`'s `maxFontSizeMultiplier={1.5}` cap, which the raw `RNText` did not have — today they grow without bound at accessibility text sizes. Still monochrome `secondaryLabel`: colour in this row means grade and nothing else.

### Badge copy: the abbreviations stay, and the width arithmetic for why

The catalog values are already abbreviated (`mobile.climbRow.noKickboard` is "No KB" / "Ohne FL" / "Sans KB" / "Sin repisa"), so dropping the transform gives "No KB", not "No kickboard". I kept them. The budget, on a 375pt-wide phone, worst-case row (grade + ascent glyph + favourite heart in the trailing rail):

```
centre column = 375 − 8 − 8 (row padding) − 76 (thumbnail)
                    − 12 − 12 (two column gaps) − 84 (trailing rail)
              = 175pt        (219pt when the rail is grade-only)
```

German "Ohne FL" (7 chars), mixed case at caption1 12pt, advance ≈ 0.50em:

| | today (uppercase 12pt + 0.3 tracking) | this PR (caption1, mixed case) |
|---|---|---|
| 1.0× | 7 × 12 × 0.62 + 2.1 ≈ **54pt** | 7 × 12 × 0.50 = **42pt** |
| 1.5× | 7 × 18 × 0.62 + 2.1 ≈ **80pt** | 7 × 18 × 0.50 = **63pt** |
| above 1.5× | unbounded | capped at 63pt |

So the change *buys* 12–17pt of name back at every size, and puts a ceiling where there wasn't one.

Spelling it out ("Ohne Fußleiste", 14 chars) costs 14 × 18 × 0.50 = **126pt** at 1.5×. Plus the 6pt margin that is 132 of the 175pt column, leaving 43pt for the climb name — at body 17pt × 1.5 ≈ 25.5pt that is about three characters and an ellipsis. The two-badge German case is worse: "Campus · Ohne Fußleiste" (23 chars) is 207pt, wider than the whole centre column, against 144pt for "Campus · Ohne FL". Three characters of climb name is not shippable, so the abbreviations stay.

### The label-on-tap half of #4883 is NOT in this PR

#4883 also asks for the words on demand. The row's press is taken (it opens the climb) and the row is a single `accessible` node, so there is no per-badge tap target to hang them on. I checked the honest alternative: `ClimbPreviewCard` (the row at the top of the actions / add-to-playlist sheets) just re-renders `ClimbListItemContent`, so it repeats the same abbreviations rather than spelling anything out. `explicitClimbRules` / `resolveClimbRuleLabels` does say both rules in full, but only in `PlayDrawerHeader` and only for Woods. Putting the full wording in the preview card for every board is a product decision about that sheet, not a mechanical follow-on from this change, so it needs its own issue. **This PR does the icon half only.**

### The pip's contrast is computed, not seen

The chip is white ink on a 72%-black scrim with a 45%-white hairline edge. Against a near-black Kilter wall (~#101010) the composited chip lands at L ≈ 0.002 and white reads at ≈ 20:1; against a bright Tension plywood wall (~#C8B48C, L ≈ 0.47) it lands at L ≈ 0.13 and white reads at ≈ 5.8:1. Both clear the 4.5:1 floor. The hairline edge exists because the scrim alone vanishes *into* the near-black Kilter art — 20:1 on the text is useless if you cannot see where the chip is.

**Those are computed figures. I could not capture a screenshot on the build machine, so nobody has looked at this on a real wall yet** — the test plan below is the device pass, and it is the one thing in this PR I am not asserting from evidence.

### Icon

One new `icon-map.ts` entry: `frames` → iOS `rectangle.stack`, Android `card-multiple-outline`. `Icon` renders `SymbolView` with no fallback, so an SF Symbol missing on the running iOS version is a silent blank — no error, no exception, no Sentry event. `rectangle.stack` is in the **SF Symbols 1.0** set (iOS 13.0+), a decade below any OS this app runs on, confirmed against the `sf-symbols-typescript` version blocks that back `expo-symbols`' name union. `icon-map.test.ts` now pins both platform names and adds `frames` to its critical-icon list.

### Density tiers

The pip renders in all three tiers. `compact`'s cell is 56×72 rather than 76×96, so the glyph drops 11pt → 9pt and the chip pulls into the corner (3pt inset → 2pt, 4pt horizontal padding → 3pt). At Dynamic Type 1.5× the chip measures roughly 3 + 9 + 1 + 9 (one digit at caption2 11pt × 1.5) + 6 padding ≈ 29pt wide and ≈ 21pt tall inside a 56×72 cell, so it still fits with room to spare. Covered by `climb-list-density.test.tsx`.

### Out of scope, deliberately

The centre column's text lines, the trailing rail (grade, ⋮, heart, ascent glyph — the heart stays where it is), and the density tiers themselves all belong to other PRs and are untouched.

## Validation

`vp run typecheck:mobile`, the scoped mobile tests (6 files, 71 tests), `vp check`, `vp run check:i18n`, `vp run check:i18n:orphans`, and the `i18n` catalog-parity project (101 tests) all pass. Every new test was confirmed red before the change. JS only — no native change, OTA-compatible.

## Release Notes

Routes now wear a small frame count on their thumbnail, so you can tell a route from a boulder at a glance instead of tapping in to find out — and you know the sparse-looking preview is just frame one. The little rule tags next to a climb's name (Campus, No KB, Any feet) stopped SHOUTING IN CAPS and now scale with your text size like the rest of the app.

## Test plan

1. Filter to boulders and routes → routes show a count pip.
2. Open a Kilter list, then a Tension one → pip readable on both.
3. More → Climb list → Compact → pip still fits the smaller thumbnail.
4. Settings → text size to largest → tags scale, name still readable.
5. Switch to German → tags read Ohne FL, not shouted caps.

## Risk

Risk: 2/5 — a presentational pip and a type-scale swap on an existing badge; no data, no native, no new query. The contrast call over board art is computed, not seen, which is what step 2 is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELkpe6R3CCsHmmvNShY9Ta
