### PR TITLE
feat(mobile): show where you stand on a climb in the rich list row

### DIFF
--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -18,24 +18,14 @@ import { useTheme } from '../providers/theme-provider';
 import { Icon } from './Icon';
 import { ClimbAttributeIcons } from './ClimbAttributeIcons';
 import { ClimbPlaylistChips } from './ClimbPlaylistChips';
+import { ClimbProgressLine } from './ClimbProgressLine';
+import { ASCENT_STATUS_ICON } from './ascent-status-icon';
 import { isClimbResolved } from '../lib/queue-climb-resolution';
 import { useIsClimbFavorited } from '../hooks/use-is-climb-favorited';
-import type { IconName } from './icon-map';
-import type { AscentStatusValue } from '../lib/ascent-status-utils';
 
-// Scan-line status marker. Status is carried by glyph SHAPE in a single neutral
-// grey — not a colour — so it can't be mistaken for the colour-coded grade right
-// beside it, and so it stays readable for colour-blind users. ⚡ flashed,
-// ✓ sent, ✗ attempted.
 // Hoisted so the compact tier hands `ClimbListThumbnail` a referentially stable
 // `size` — a fresh object per render would break its `React.memo` on every row.
 const COMPACT_THUMBNAIL_SIZE = thumbnailSizeForDensity('compact');
-
-const ASCENT_STATUS_ICON: Record<AscentStatusValue, IconName> = {
-  flash: 'flash',
-  send: 'tick.outline',
-  attempt: 'ascent.attempt',
-};
 
 /**
  * Minimal structural climb shape this visual needs. Kept permissive so BOTH the
@@ -395,6 +385,13 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
             isNoMatch={climb.is_no_match}
           />
         </View>
+        {/* Line 2 of the rich tier: what YOU have done on this climb, above the
+            crowd line. Its own memo boundary (and the ONLY new logbook
+            subscriber) so a tick merge re-renders one text line, never the
+            thumbnail — see the comment on `AscentStatusGlyph`. Renders null for
+            a climb you have no history with, so a compact/default row and every
+            signed-out rich row stay byte-for-byte what they were. */}
+        {isRich ? <ClimbProgressLine climbUuid={climb.uuid} angle={angle} /> : null}
         {/* Compact drops the whole subtitle line — and with it `LiveClimbSubtitle`'s
             per-row `useEffectiveClimbStats` subscription, so a compact row costs
             strictly less than a default one rather than just looking smaller. */}

--- a/packages/mobile/src/components/ClimbProgressLine.tsx
+++ b/packages/mobile/src/components/ClimbProgressLine.tsx
@@ -79,6 +79,12 @@ export const ClimbProgressLine = React.memo(function ClimbProgressLine({
 
     let recency: string | null = null;
     if (progress.latestClimbedAtMs !== null) {
+      // The clock is read inside the memo and is deliberately NOT a dependency:
+      // a row left mounted across midnight keeps yesterday's wording until it
+      // next re-renders (a scroll, a recycle, or a tick merge). The alternative
+      // is a per-row clock, and `LogbookDayDivider` already spells out why that
+      // is the wrong trade — it owns its own `useFocusEffect` clock precisely so
+      // the climb rows beside it do not pay for one.
       const bucket = describeClimbProgressRecency(progress.latestClimbedAtMs, Date.now());
       recency =
         bucket.kind === 'today'
@@ -92,6 +98,9 @@ export const ClimbProgressLine = React.memo(function ClimbProgressLine({
     return tokens.slice(0, climbProgressTokenBudget(fontScale)).join(' · ');
   }, [progress, fontScale, t, i18n.language]);
 
+  // `label` is non-null whenever `progress` is, so the second half is unreachable
+  // at runtime — but it is what narrows `label` to `string` for the
+  // `accessibilityLabel` below, which takes no null.
   if (!progress || label === null) return null;
 
   return (

--- a/packages/mobile/src/components/ClimbProgressLine.tsx
+++ b/packages/mobile/src/components/ClimbProgressLine.tsx
@@ -1,0 +1,127 @@
+import React, { useMemo } from 'react';
+import { View, StyleSheet, useWindowDimensions } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Text } from './Text';
+import { Icon } from './Icon';
+import { ASCENT_STATUS_ICON } from './ascent-status-icon';
+import { useTheme } from '../providers/theme-provider';
+import { useClimbProgress } from '../hooks/use-climb-progress';
+import { climbProgressTokenBudget, describeClimbProgressRecency, PROGRESS_MAX_FONT_SCALE } from '../lib/climb-progress';
+
+/**
+ * Leading glyph size. Smaller than the trailing 16pt status marker on purpose —
+ * it sits on a footnote line, and matches the 13pt `people` glyph the grade
+ * column already uses for its inline marker.
+ */
+const GLYPH_SIZE = 13;
+
+/**
+ * Line 2 of the rich tier's centre column: what YOU have done on this climb.
+ *
+ * The row's widest slot has always belonged to the crowd (`66k sends · 3.2★ ·
+ * jwebxl`), with everything personal squeezed into 16pt glyphs at the edge — so
+ * the row could not answer "where am I on this climb?" (#4796). This line answers
+ * it in up to three tokens: what you did, which way round (#4801's climbs-list
+ * half), and how long ago.
+ *
+ * It outranks the crowd line by COLOUR and WEIGHT, never by size: `label` at 600
+ * against the crowd line's dimmed `footnote`. Size tiering would be a no-op on
+ * Android, where `caption1` and `caption2` are byte-identical in the M3 scale
+ * (11/16, weight 500).
+ *
+ * Its own `React.memo` boundary over primitive props, for the same reason as
+ * `AscentStatusGlyph` and `ClimbPlaylistChips`: this and the status glyph are the
+ * ONLY parts of the row subscribed to the logbook, so a tick write re-renders one
+ * text line rather than the thumbnail, the name and the grade. Hoisting
+ * `useClimbProgress` into `ClimbListItemContent` would re-render every visible
+ * row's artwork on every logbook merge — the regression the climbs-search
+ * redesign shipped once already.
+ *
+ * Renders null when the climber has no history with the climb, which is the
+ * majority case and every signed-out row.
+ */
+export const ClimbProgressLine = React.memo(function ClimbProgressLine({
+  climbUuid,
+  angle,
+}: {
+  climbUuid: string;
+  angle: number;
+}) {
+  const { t, i18n } = useTranslation('climbs');
+  const { systemColors } = useTheme();
+  // Dynamic Type governs how many tokens fit on one line. `fontScale` is a real
+  // Dynamic Type multiplier on both platforms (iOS reads it off
+  // RCTAccessibilityManager.multiplier), and it changes about as often as the
+  // user visits Settings, so the subscription costs a mounted row nothing.
+  const { fontScale } = useWindowDimensions();
+  const progress = useClimbProgress(climbUuid, angle);
+
+  const label = useMemo(() => {
+    if (!progress) return null;
+
+    const outcome =
+      progress.outcome.kind === 'flash'
+        ? t('mobile.climbRow.progress.flashed')
+        : progress.outcome.kind === 'send'
+          ? progress.outcome.sendCount > 1
+            ? t('mobile.climbRow.progress.sentTimes', { count: progress.outcome.sendCount })
+            : t('mobile.climbRow.progress.sent')
+          : t('mobile.climbRow.progress.tries', { count: progress.outcome.tries });
+
+    // `original` is deliberately absent: it is the default orientation, so a
+    // token on nearly every row would carry no information at all.
+    const mirror =
+      progress.mirror === 'both'
+        ? t('mobile.climbRow.progress.bothWays')
+        : progress.mirror === 'mirror'
+          ? t('mobile.climbRow.progress.mirror')
+          : null;
+
+    let recency: string | null = null;
+    if (progress.latestClimbedAtMs !== null) {
+      const bucket = describeClimbProgressRecency(progress.latestClimbedAtMs, Date.now());
+      recency =
+        bucket.kind === 'today'
+          ? t('mobile.climbRow.progress.today')
+          : bucket.kind === 'days'
+            ? t('mobile.climbRow.progress.daysAgo', { count: bucket.count })
+            : new Date(bucket.ms).toLocaleDateString(i18n.language, { month: 'short', day: 'numeric' });
+    }
+
+    const tokens = [outcome, mirror, recency].filter((token): token is string => token != null);
+    return tokens.slice(0, climbProgressTokenBudget(fontScale)).join(' · ');
+  }, [progress, fontScale, t, i18n.language]);
+
+  if (!progress || label === null) return null;
+
+  return (
+    // One grouped utterance, so screen readers speak "Flashed · mirror · today"
+    // rather than announcing the glyph and the text as two separate elements.
+    <View style={styles.row} accessible accessibilityRole="text" accessibilityLabel={label}>
+      <Icon name={ASCENT_STATUS_ICON[progress.status]} size={GLYPH_SIZE} color={systemColors.label} />
+      <Text
+        variant="footnote"
+        numberOfLines={1}
+        maxFontSizeMultiplier={PROGRESS_MAX_FONT_SCALE}
+        style={[styles.text, { color: systemColors.label }]}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    minWidth: 0,
+  },
+  text: {
+    // Weight, not size, is what puts this line above the crowd line — see the
+    // component comment for why size tiering would be a no-op on Android.
+    fontWeight: '600',
+    flexShrink: 1,
+  },
+});

--- a/packages/mobile/src/components/__tests__/climb-list-density.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-list-density.test.tsx
@@ -20,6 +20,10 @@ vi.mock('@boardsesh/board-react', () => ({
     qualityAverage: base.qualityAverage ?? null,
     difficulty: base.difficulty ?? null,
   }),
+  // The rich tier's `ClimbProgressLine` reads the logbook index; this file is
+  // about layout, so it renders outside a provider (and therefore renders null).
+  logbookClimbAngleKey: (climbUuid: string, angle: number) => `${climbUuid}:${angle}`,
+  useOptionalBoardLogbook: () => null,
 }));
 
 // View keeps its style on the DOM node so the thumbnail cell's width/height are
@@ -30,10 +34,13 @@ vi.mock('react-native', () => ({
     const flattened = Array.isArray(style) ? Object.assign({}, ...style.filter(Boolean)) : (style ?? {});
     return createElement('div', { 'data-style': JSON.stringify(flattened) }, children);
   },
+  // The rich tier mounts `ClimbProgressLine`, which reads the Dynamic Type
+  // multiplier to decide how many tokens fit on its line.
+  useWindowDimensions: () => ({ width: 390, height: 844, scale: 3, fontScale: 1 }),
 }));
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en-US' } }),
 }));
 
 vi.mock('../../hooks/use-display-grade', () => ({

--- a/packages/mobile/src/components/__tests__/climb-list-item-content-progress.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-list-item-content-progress.test.tsx
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { LogbookEntry } from '@boardsesh/board-react';
+
+/**
+ * The rich tier's personal line, and the memo boundary that keeps it cheap.
+ *
+ * The load-bearing test here is the last one: a logbook merge must re-render the
+ * progress line and NOTHING else. `ClimbListItemContent.tsx`'s own comments
+ * record the climbs-search redesign inlining `useAscentStatus` into the row and
+ * re-rendering every visible thumbnail on every tick write; this asserts the new
+ * line did not reintroduce that.
+ */
+
+// A REAL context stands in for `BoardLogbookContext` (module-private in
+// board-provider). That matters: a plain `vi.fn()` returning a value could not
+// model context propagation, which is exactly the mechanism under test — a new
+// provider value must reach the line's consumer while `ClimbListItemContent`
+// itself bails out on memo.
+const logbookContextRef = vi.hoisted(() => ({
+  current: null as null | React.Context<{ logbookByClimbAngle: Map<string, LogbookEntry[]> } | null>,
+}));
+
+const thumbnailRenders = vi.hoisted(() => ({ count: 0 }));
+const fontScale = vi.hoisted(() => ({ current: 1 }));
+
+vi.mock('@boardsesh/board-react', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  const context = React.createContext<{ logbookByClimbAngle: Map<string, LogbookEntry[]> } | null>(null);
+  logbookContextRef.current = context;
+  return {
+    logbookClimbAngleKey: (climbUuid: string, angle: number) => `${climbUuid}:${angle}`,
+    useOptionalBoardLogbook: () => React.useContext(context),
+    useEffectiveClimbStats: (
+      _boardName: string,
+      _layoutId: number,
+      _climbUuid: string,
+      _angle: number,
+      base: { ascensionistCount?: number; qualityAverage?: string; difficulty?: string },
+    ) => ({
+      ascensionistCount: base.ascensionistCount ?? 0,
+      qualityAverage: base.qualityAverage ?? null,
+      difficulty: base.difficulty ?? null,
+    }),
+  };
+});
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: ({ children }: { children?: ReactNode }) => createElement('div', {}, children),
+  useWindowDimensions: () => ({ width: 390, height: 844, scale: 3, fontScale: fontScale.current }),
+}));
+
+// Echo the key, and the count when one is interpolated, so a test can name the
+// exact token it expects without depending on English copy.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number }) => (options?.count == null ? key : `${key}:${options.count}`),
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+vi.mock('../../hooks/use-display-grade', () => ({
+  useDisplayGrade: () => ({ boardseshActive: false, resolveGrade: () => ({ label: 'V5', color: '#abcdef' }) }),
+}));
+
+vi.mock('../../hooks/use-is-climb-favorited', () => ({ useIsClimbFavorited: () => false }));
+
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { label: '#000000', secondaryLabel: '#8E8E93' } }),
+}));
+
+vi.mock('../../lib/format-climb-stats', () => ({ formatSends: () => 'sends', formatQuality: () => '4.5' }));
+
+vi.mock('../Text', () => ({
+  Text: ({ children, variant }: { children?: ReactNode; variant?: string }) =>
+    createElement('span', { 'data-variant': variant }, children),
+}));
+
+vi.mock('../ClimbListThumbnail', () => ({
+  ClimbListThumbnail: () => {
+    thumbnailRenders.count += 1;
+    return null;
+  },
+  THUMBNAIL_WIDTH: 76,
+  THUMBNAIL_HEIGHT: 96,
+}));
+
+vi.mock('../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }),
+}));
+vi.mock('../ClimbAttributeIcons', () => ({ ClimbAttributeIcons: () => null }));
+vi.mock('../ClimbPlaylistChips', () => ({ ClimbPlaylistChips: () => null }));
+
+import { ClimbListItemContent } from '../ClimbListItemContent';
+
+const climb = {
+  uuid: 'c1',
+  name: 'Test Climb',
+  frames: 'p1r1',
+  difficulty: '6b/V4',
+  quality_average: '4.5',
+  ascensionist_count: 10,
+};
+
+const entry = (overrides: Partial<LogbookEntry> = {}): LogbookEntry =>
+  ({
+    uuid: 't1',
+    climb_uuid: 'c1',
+    angle: 40,
+    is_mirror: false,
+    tries: 1,
+    quality: null,
+    difficulty: null,
+    comment: '',
+    climbed_at: new Date().toISOString().replace('Z', ''),
+    is_ascent: true,
+    status: 'send',
+    upvotes: 0,
+    downvotes: 0,
+    commentCount: 0,
+    ...overrides,
+  }) as LogbookEntry;
+
+function logbook(entries: LogbookEntry[]) {
+  const logbookByClimbAngle = new Map<string, LogbookEntry[]>();
+  if (entries.length > 0) logbookByClimbAngle.set('c1:40', entries);
+  return { logbookByClimbAngle };
+}
+
+function renderRow(density: 'compact' | 'default' | 'rich', entries: LogbookEntry[]) {
+  const context = logbookContextRef.current;
+  if (context === null) throw new Error('board-react mock did not create the logbook context');
+  const row = (
+    <ClimbListItemContent
+      climb={climb}
+      boardName="kilter"
+      layoutId={1}
+      sizeId={1}
+      setIds="1"
+      angle={40}
+      density={density}
+    />
+  );
+  const result = render(<context.Provider value={logbook(entries)}>{row}</context.Provider>);
+  return {
+    ...result,
+    merge: (next: LogbookEntry[]) => result.rerender(<context.Provider value={logbook(next)}>{row}</context.Provider>),
+  };
+}
+
+const progressText = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll('[data-variant="footnote"]'))
+    .map((node) => node.textContent ?? '')
+    .find((text) => text.startsWith('mobile.climbRow.progress.')) ?? null;
+
+beforeEach(() => {
+  thumbnailRenders.count = 0;
+  fontScale.current = 1;
+});
+
+describe('rich-tier progress line', () => {
+  it('renders nothing for a climb the climber has no history with', () => {
+    const { container } = renderRow('rich', []);
+    expect(progressText(container)).toBeNull();
+  });
+
+  it('renders nothing in the compact and default tiers, history or not', () => {
+    expect(progressText(renderRow('compact', [entry()]).container)).toBeNull();
+    expect(progressText(renderRow('default', [entry()]).container)).toBeNull();
+  });
+
+  it('leads with the outcome and closes with recency', () => {
+    const { container } = renderRow('rich', [entry()]);
+    expect(progressText(container)).toBe('mobile.climbRow.progress.sent · mobile.climbRow.progress.today');
+  });
+
+  it('names the mirror state when both orientations are sent (#4801)', () => {
+    const { container } = renderRow('rich', [entry(), entry({ uuid: 't2', is_mirror: true })]);
+    expect(progressText(container)).toBe(
+      'mobile.climbRow.progress.sentTimes:2 · mobile.climbRow.progress.bothWays · mobile.climbRow.progress.today',
+    );
+  });
+
+  it('omits the mirror token for an original-only send, since that is the default', () => {
+    const { container } = renderRow('rich', [entry()]);
+    expect(progressText(container)).not.toContain('mirror');
+    expect(progressText(container)).not.toContain('bothWays');
+  });
+
+  it('carries the matching status glyph', () => {
+    const { container } = renderRow('rich', [entry({ status: 'flash' })]);
+    expect(container.querySelectorAll('[data-icon="flash"]').length).toBeGreaterThan(0);
+  });
+
+  it('drops tokens from the right as Dynamic Type grows', () => {
+    fontScale.current = 1.15;
+    expect(progressText(renderRow('rich', [entry(), entry({ uuid: 't2', is_mirror: true })]).container)).toBe(
+      'mobile.climbRow.progress.sentTimes:2 · mobile.climbRow.progress.bothWays',
+    );
+
+    fontScale.current = 1.3;
+    expect(progressText(renderRow('rich', [entry(), entry({ uuid: 't2', is_mirror: true })]).container)).toBe(
+      'mobile.climbRow.progress.sentTimes:2',
+    );
+  });
+});
+
+describe('rich-tier progress line memo boundary', () => {
+  it('does not re-render the thumbnail when a logbook merge lands', () => {
+    const { container, merge } = renderRow('rich', []);
+    expect(thumbnailRenders.count).toBe(1);
+    expect(progressText(container)).toBeNull();
+
+    merge([entry()]);
+
+    // The line updated...
+    expect(progressText(container)).toBe('mobile.climbRow.progress.sent · mobile.climbRow.progress.today');
+    // ...and the board artwork did not re-render. This is the regression bar.
+    expect(thumbnailRenders.count).toBe(1);
+  });
+
+  it('does not re-render the thumbnail on a merge that misses this climb', () => {
+    const { merge } = renderRow('rich', [entry()]);
+    expect(thumbnailRenders.count).toBe(1);
+    merge([entry(), entry({ uuid: 't2', climb_uuid: 'other' })]);
+    expect(thumbnailRenders.count).toBe(1);
+  });
+});

--- a/packages/mobile/src/components/__tests__/climb-row-vertical-budget.test.ts
+++ b/packages/mobile/src/components/__tests__/climb-row-vertical-budget.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// The type scales are plain data, but `theme/typography` imports react-native for
+// its `TextStyle` type and the runtime import survives transform. Nothing here
+// touches a host component, so an empty module is enough.
+vi.mock('react-native', () => ({}));
+
+import { textStyles, materialTextStyles } from '../../theme/typography';
+import { THUMBNAIL_HEIGHT } from '../climb-list-thumbnail-metrics';
+import { PROGRESS_MAX_FONT_SCALE } from '../../lib/climb-progress';
+
+/**
+ * The rich row's vertical budget, done as arithmetic rather than eyeballed.
+ *
+ * The 76×96 thumbnail pins the row: as long as the centre column's stacked lines
+ * come in under `THUMBNAIL_HEIGHT`, adding a line costs zero row height. Past it
+ * the row grows and the list's rhythm breaks. Gaps and paddings do NOT scale with
+ * Dynamic Type; line heights do (React Native scales `lineHeight` with `fontSize`
+ * whenever `allowFontScaling` is on), which is what makes this worth computing.
+ *
+ * Line heights come from the REAL type scales, so a change to either variant's
+ * scale fails here instead of silently overflowing on a device.
+ */
+
+/** `styles.centerColumn.gap` in ClimbListItemContent. */
+const CENTER_COLUMN_GAP = 2;
+
+/** `ClimbPlaylistChips`: `styles.row.marginTop`, `styles.chip` padding + minHeight, CHIP_MAX_FONT_SCALE. */
+const CHIP_ROW_MARGIN_TOP = 4; // spacing[1]
+const CHIP_VERTICAL_PADDING = 2 * 2;
+const CHIP_MIN_HEIGHT = 20;
+const CHIP_MAX_FONT_SCALE = 1.3;
+
+type Variant = 'liquidGlass' | 'material';
+
+const scaleFor = (variant: Variant) => (variant === 'material' ? materialTextStyles : textStyles);
+
+function lineHeight(variant: Variant, key: 'body' | 'footnote' | 'caption1', fontScale: number, cap: number): number {
+  return scaleFor(variant)[key].lineHeight * Math.min(fontScale, cap);
+}
+
+/**
+ * Height of the rich tier's centre column. `hasProgressLine` is the line this PR
+ * adds; `hasPlaylistChips` is the base branch's tag strip, which only renders for
+ * a climb that is actually in a playlist.
+ */
+function centreColumnHeight({
+  variant,
+  fontScale,
+  hasProgressLine,
+  hasPlaylistChips,
+}: {
+  variant: Variant;
+  fontScale: number;
+  hasProgressLine: boolean;
+  hasPlaylistChips: boolean;
+}): number {
+  // `Text` itself caps every variant at 1.5 (maxFontSizeMultiplier).
+  const nameHeight = lineHeight(variant, 'body', fontScale, 1.5);
+  const subtitleHeight = lineHeight(variant, 'footnote', fontScale, 1.5);
+  const progressHeight = hasProgressLine ? lineHeight(variant, 'footnote', fontScale, PROGRESS_MAX_FONT_SCALE) : 0;
+  const chipHeight = hasPlaylistChips
+    ? CHIP_ROW_MARGIN_TOP +
+      Math.max(CHIP_MIN_HEIGHT, CHIP_VERTICAL_PADDING + lineHeight(variant, 'caption1', fontScale, CHIP_MAX_FONT_SCALE))
+    : 0;
+
+  const lines = 2 + (hasProgressLine ? 1 : 0) + (hasPlaylistChips ? 1 : 0);
+  const gaps = (lines - 1) * CENTER_COLUMN_GAP;
+  return nameHeight + progressHeight + subtitleHeight + gaps + chipHeight;
+}
+
+const round = (value: number) => Math.round(value * 10) / 10;
+
+const VARIANTS: Variant[] = ['liquidGlass', 'material'];
+const TIERS = [1, 1.15, 1.3, 1.5];
+
+describe('rich row vertical budget', () => {
+  it('pins the budget to the thumbnail', () => {
+    expect(THUMBNAIL_HEIGHT).toBe(96);
+  });
+
+  it('fits name + progress + crowd line at every Dynamic Type tier', () => {
+    for (const variant of VARIANTS) {
+      for (const fontScale of TIERS) {
+        const height = centreColumnHeight({ variant, fontScale, hasProgressLine: true, hasPlaylistChips: false });
+        expect(
+          height,
+          `${variant} @ ${fontScale}× measures ${round(height)}pt against a ${THUMBNAIL_HEIGHT}pt budget`,
+        ).toBeLessThanOrEqual(THUMBNAIL_HEIGHT);
+      }
+    }
+  });
+
+  it('measures the three-line rich row exactly', () => {
+    const measure = (variant: Variant, fontScale: number) =>
+      round(centreColumnHeight({ variant, fontScale, hasProgressLine: true, hasPlaylistChips: false }));
+    // Liquid Glass (HIG): body 22 · footnote 18 · gap 2.
+    expect(measure('liquidGlass', 1)).toBe(62);
+    expect(measure('liquidGlass', 1.15)).toBe(70.7);
+    expect(measure('liquidGlass', 1.3)).toBe(79.4);
+    expect(measure('liquidGlass', 1.5)).toBe(87.4);
+    // Material (M3): body 24 · footnote 16 · gap 2.
+    expect(measure('material', 1)).toBe(60);
+    expect(measure('material', 1.15)).toBe(68.4);
+    expect(measure('material', 1.3)).toBe(76.8);
+    expect(measure('material', 1.5)).toBe(84.8);
+  });
+
+  it('still fits with playlist tags at the default text size', () => {
+    for (const variant of VARIANTS) {
+      const height = centreColumnHeight({ variant, fontScale: 1, hasProgressLine: true, hasPlaylistChips: true });
+      expect(height).toBeLessThanOrEqual(THUMBNAIL_HEIGHT);
+    }
+  });
+
+  it('records that FOUR lines cannot fit above ~1.08×, tags included', () => {
+    // Documented, not hidden: a climb that is BOTH in a playlist AND has personal
+    // history stacks four lines, and four lines exceed the thumbnail once text
+    // scales past ~1.08× (Liquid Glass) / ~1.11× (Material). Shedding the tag strip there would have to live in
+    // ClimbPlaylistChips (the row cannot know whether the progress line rendered
+    // without subscribing to the logbook itself, which is the whole point of the
+    // memo boundary), so it is deliberately out of scope for this PR.
+    const height = centreColumnHeight({
+      variant: 'liquidGlass',
+      fontScale: 1.15,
+      hasProgressLine: true,
+      hasPlaylistChips: true,
+    });
+    expect(round(height)).toBe(99.1);
+    expect(height).toBeGreaterThan(THUMBNAIL_HEIGHT);
+  });
+
+  it('leaves the base branch (no progress line) untouched and inside budget', () => {
+    for (const variant of VARIANTS) {
+      for (const fontScale of TIERS) {
+        const height = centreColumnHeight({ variant, fontScale, hasProgressLine: false, hasPlaylistChips: true });
+        expect(height).toBeLessThanOrEqual(THUMBNAIL_HEIGHT);
+      }
+    }
+  });
+});

--- a/packages/mobile/src/components/ascent-status-icon.ts
+++ b/packages/mobile/src/components/ascent-status-icon.ts
@@ -1,0 +1,19 @@
+import type { IconName } from './icon-map';
+import type { AscentStatusValue } from '../lib/ascent-status-utils';
+
+/**
+ * Scan-line status marker. Status is carried by glyph SHAPE in a single neutral
+ * colour — not a hue — so it can't be mistaken for the colour-coded grade beside
+ * it, and so it stays readable for colour-blind users. ⚡ flashed, ✓ sent,
+ * ✗ attempted.
+ *
+ * Lives in its own module because two components now draw it — the trailing
+ * `AscentStatusGlyph` and the rich tier's leading `ClimbProgressLine` glyph — and
+ * `ClimbListItemContent` imports the latter, so keeping the map there would make
+ * the pair a cycle.
+ */
+export const ASCENT_STATUS_ICON: Record<AscentStatusValue, IconName> = {
+  flash: 'flash',
+  send: 'tick.outline',
+  attempt: 'ascent.attempt',
+};

--- a/packages/mobile/src/hooks/use-climb-progress.ts
+++ b/packages/mobile/src/hooks/use-climb-progress.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import { logbookClimbAngleKey, useOptionalBoardLogbook } from '@boardsesh/board-react';
+import { tickTimeMs } from '@boardsesh/profile-stats';
+import { deriveClimbProgress, type ClimbProgress } from '../lib/climb-progress';
+
+/**
+ * What the climber has done on this climb at this angle — outcome, mirror state
+ * and recency — or null when they have no history with it (and outside a
+ * BoardProvider). Drives `ClimbProgressLine`, the rich tier's personal line.
+ *
+ * Reads the same pre-grouped `logbookByClimbAngle` index `useAscentStatus` does:
+ * ONE `Map.get` over that climb's handful of ticks, never a scan or filter over
+ * the whole logbook (docs/react-native-performance.md §4). The `useMemo` keys on
+ * the bucket identity, which only changes when a merge actually touches this
+ * climb's ticks.
+ */
+export function useClimbProgress(climbUuid: string, angle: number): ClimbProgress | null {
+  const logbook = useOptionalBoardLogbook();
+  const entries = logbook?.logbookByClimbAngle.get(logbookClimbAngleKey(climbUuid, angle));
+  return useMemo(() => deriveClimbProgress(entries, tickTimeMs), [entries]);
+}

--- a/packages/mobile/src/lib/__tests__/climb-progress.test.ts
+++ b/packages/mobile/src/lib/__tests__/climb-progress.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import {
+  climbProgressTokenBudget,
+  deriveClimbProgress,
+  describeClimbProgressRecency,
+  type ClimbProgressEntry,
+} from '../climb-progress';
+
+// The real parser lives in @boardsesh/profile-stats (naive-UTC aware); these
+// fixtures already carry a Z, so Date.parse is an exact stand-in here.
+const parseMs = (climbedAt: string) => Date.parse(climbedAt);
+
+const tick = (overrides: Partial<ClimbProgressEntry> = {}): ClimbProgressEntry => ({
+  is_mirror: false,
+  tries: 1,
+  climbed_at: '2026-09-01T12:00:00Z',
+  status: 'send',
+  is_ascent: true,
+  ...overrides,
+});
+
+describe('deriveClimbProgress', () => {
+  it('returns null for a climb with no history (the majority row)', () => {
+    expect(deriveClimbProgress(undefined, parseMs)).toBeNull();
+    expect(deriveClimbProgress([], parseMs)).toBeNull();
+  });
+
+  it('reads a single flash as flashed', () => {
+    const progress = deriveClimbProgress([tick({ status: 'flash' })], parseMs);
+    expect(progress?.status).toBe('flash');
+    expect(progress?.outcome).toEqual({ kind: 'flash' });
+  });
+
+  it('counts repeat sends', () => {
+    const progress = deriveClimbProgress([tick(), tick({ climbed_at: '2026-09-03T12:00:00Z' })], parseMs);
+    expect(progress?.outcome).toEqual({ kind: 'send', sendCount: 2 });
+  });
+
+  it('sums tries across attempts when nothing is topped yet', () => {
+    const progress = deriveClimbProgress(
+      [
+        tick({ status: 'attempt', is_ascent: false, tries: 4 }),
+        tick({ status: 'attempt', is_ascent: false, tries: 3, climbed_at: '2026-09-02T12:00:00Z' }),
+      ],
+      parseMs,
+    );
+    expect(progress?.status).toBe('attempt');
+    expect(progress?.outcome).toEqual({ kind: 'attempt', tries: 7 });
+  });
+
+  it('counts a tick with no try count as one go', () => {
+    const progress = deriveClimbProgress([tick({ status: 'attempt', is_ascent: false, tries: null })], parseMs);
+    expect(progress?.outcome).toEqual({ kind: 'attempt', tries: 1 });
+  });
+
+  it('prefers a flash over a later plain send for the glyph', () => {
+    const progress = deriveClimbProgress(
+      [tick({ status: 'send' }), tick({ status: 'flash', climbed_at: '2026-09-05T12:00:00Z' })],
+      parseMs,
+    );
+    expect(progress?.status).toBe('flash');
+  });
+});
+
+describe('deriveClimbProgress mirror state (#4801)', () => {
+  it('reports original-only, which the line then omits', () => {
+    expect(deriveClimbProgress([tick({ is_mirror: false })], parseMs)?.mirror).toBe('original');
+  });
+
+  it('reports mirror when every send is mirrored', () => {
+    expect(deriveClimbProgress([tick({ is_mirror: true })], parseMs)?.mirror).toBe('mirror');
+  });
+
+  it('reports both when the two orientations are both sent', () => {
+    const progress = deriveClimbProgress(
+      [tick({ is_mirror: true }), tick({ is_mirror: false, climbed_at: '2026-09-04T12:00:00Z' })],
+      parseMs,
+    );
+    expect(progress?.mirror).toBe('both');
+  });
+
+  it('ignores a mirrored ATTEMPT once the original is sent', () => {
+    const progress = deriveClimbProgress(
+      [tick({ is_mirror: false }), tick({ is_mirror: true, status: 'attempt', is_ascent: false, tries: 2 })],
+      parseMs,
+    );
+    expect(progress?.mirror).toBe('original');
+  });
+
+  it('falls back to the attempts when nothing is sent', () => {
+    const progress = deriveClimbProgress(
+      [tick({ is_mirror: true, status: 'attempt', is_ascent: false, tries: 2 })],
+      parseMs,
+    );
+    expect(progress?.mirror).toBe('mirror');
+  });
+});
+
+describe('deriveClimbProgress recency', () => {
+  it('keeps the most recent tick', () => {
+    const progress = deriveClimbProgress(
+      [tick({ climbed_at: '2026-09-01T12:00:00Z' }), tick({ climbed_at: '2026-09-04T09:00:00Z' })],
+      parseMs,
+    );
+    expect(progress?.latestClimbedAtMs).toBe(Date.parse('2026-09-04T09:00:00Z'));
+  });
+
+  it('survives ticks with no timestamp', () => {
+    const progress = deriveClimbProgress([tick({ climbed_at: null })], parseMs);
+    expect(progress?.latestClimbedAtMs).toBeNull();
+  });
+});
+
+describe('describeClimbProgressRecency', () => {
+  const at = (year: number, month: number, day: number, hour = 12, minute = 0) =>
+    new Date(year, month - 1, day, hour, minute).getTime();
+
+  it('calls the same local day today, even at 23:00', () => {
+    expect(describeClimbProgressRecency(at(2026, 9, 6, 23), at(2026, 9, 6, 23, 59))).toEqual({ kind: 'today' });
+  });
+
+  it('counts whole local days, never a 0d', () => {
+    expect(describeClimbProgressRecency(at(2026, 9, 5, 23), at(2026, 9, 6, 1))).toEqual({ kind: 'days', count: 1 });
+    expect(describeClimbProgressRecency(at(2026, 9, 3), at(2026, 9, 6))).toEqual({ kind: 'days', count: 3 });
+  });
+
+  it('switches to a date once a week has passed', () => {
+    const ms = at(2026, 8, 12);
+    expect(describeClimbProgressRecency(ms, at(2026, 9, 6))).toEqual({ kind: 'date', ms });
+  });
+
+  it('clamps a future tick (clock skew) to today', () => {
+    expect(describeClimbProgressRecency(at(2026, 9, 8), at(2026, 9, 6))).toEqual({ kind: 'today' });
+  });
+});
+
+describe('climbProgressTokenBudget', () => {
+  it('shows all three tokens at the default text size', () => {
+    expect(climbProgressTokenBudget(1)).toBe(3);
+    expect(climbProgressTokenBudget(1.14)).toBe(3);
+  });
+
+  it('drops recency first, then mirror, as Dynamic Type grows', () => {
+    expect(climbProgressTokenBudget(1.15)).toBe(2);
+    expect(climbProgressTokenBudget(1.29)).toBe(2);
+    expect(climbProgressTokenBudget(1.3)).toBe(1);
+    expect(climbProgressTokenBudget(1.5)).toBe(1);
+  });
+
+  it('falls back to the full line for a nonsense scale', () => {
+    expect(climbProgressTokenBudget(Number.NaN)).toBe(3);
+  });
+});

--- a/packages/mobile/src/lib/climb-progress.ts
+++ b/packages/mobile/src/lib/climb-progress.ts
@@ -1,0 +1,170 @@
+import { normalizeAscentStatus, pickHighestAscentStatus, type AscentStatusValue } from './ascent-status-utils';
+
+/**
+ * What the climber has done on ONE climb at ONE angle — the personal half of a
+ * climbs-list row (#4796), plus the mirror state that #4801 asks for.
+ *
+ * Pure and clock-injected: the hook feeds it the handful of logbook entries the
+ * `logbookByClimbAngle` index already holds for that key, so a row never scans
+ * the whole logbook (docs/react-native-performance.md §4).
+ */
+
+/** A logbook tick narrowed to the fields the progress line reads. */
+export type ClimbProgressEntry = {
+  is_mirror?: boolean | null;
+  tries?: number | null;
+  climbed_at?: string | null;
+  status?: AscentStatusValue | null;
+  is_ascent?: boolean | null;
+};
+
+/**
+ * The outcome token. `flash` and `send` carry no try count on purpose — once
+ * you have topped it, how many goes it took is logbook detail, not scan-line
+ * information. `attempt` is the one case where the count IS the story.
+ */
+export type ClimbProgressOutcome =
+  | { kind: 'flash' }
+  | { kind: 'send'; sendCount: number }
+  | { kind: 'attempt'; tries: number };
+
+/**
+ * Which orientations the climber has ticks in. `original` is the DEFAULT and is
+ * never rendered — a token that appears on nearly every row says nothing.
+ */
+export type ClimbProgressMirror = 'original' | 'mirror' | 'both';
+
+export type ClimbProgress = {
+  /** Highest status across every orientation — drives the leading glyph. */
+  status: AscentStatusValue;
+  outcome: ClimbProgressOutcome;
+  mirror: ClimbProgressMirror;
+  /** Most recent tick, as an absolute epoch ms; null when no tick parsed. */
+  latestClimbedAtMs: number | null;
+};
+
+/** Recency bucket. `date` hands the caller a timestamp to format in-locale. */
+export type ClimbProgressRecency = { kind: 'today' } | { kind: 'days'; count: number } | { kind: 'date'; ms: number };
+
+/** Past this many days a relative "{{n}}d" stops being easier to read than a date. */
+const RELATIVE_DAY_LIMIT = 7;
+
+const MS_PER_DAY = 86_400_000;
+
+function statusOf(entry: ClimbProgressEntry): AscentStatusValue {
+  return normalizeAscentStatus({ status: entry.status, isAscent: entry.is_ascent, tries: entry.tries });
+}
+
+function isTopped(status: AscentStatusValue): boolean {
+  return status === 'flash' || status === 'send';
+}
+
+/**
+ * Fold a climb's ticks at one angle into the row's personal summary, or null
+ * when the climber has no history with it — the majority case and every
+ * signed-out row, where the line must not render at all.
+ *
+ * `parseClimbedAtMs` is injected so this module stays free of the dayjs/UTC
+ * parsing rules that live in `@boardsesh/profile-stats` (the `climbed_at`
+ * strings are naive UTC and must not be parsed as local).
+ */
+export function deriveClimbProgress(
+  entries: readonly ClimbProgressEntry[] | undefined,
+  parseClimbedAtMs: (climbedAt: string) => number,
+): ClimbProgress | null {
+  if (!entries || entries.length === 0) return null;
+
+  const statuses: AscentStatusValue[] = [];
+  let sendCount = 0;
+  let attemptTries = 0;
+  let latestClimbedAtMs: number | null = null;
+
+  // Mirror state is read off the SENDS when there are any — "mirror" should mean
+  // "you have only ever topped it mirrored", not "you once poked at the mirror".
+  // With no sends it falls back to the attempts, which are then all you have.
+  let sentMirrored = false;
+  let sentOriginal = false;
+  let triedMirrored = false;
+  let triedOriginal = false;
+
+  for (const entry of entries) {
+    const status = statusOf(entry);
+    statuses.push(status);
+    const mirrored = entry.is_mirror === true;
+
+    if (isTopped(status)) {
+      sendCount += 1;
+      if (mirrored) sentMirrored = true;
+      else sentOriginal = true;
+    } else {
+      // `tries` is the tick's attemptCount; a null/0 count still means one go.
+      attemptTries += Math.max(1, entry.tries ?? 1);
+      if (mirrored) triedMirrored = true;
+      else triedOriginal = true;
+    }
+
+    if (entry.climbed_at) {
+      const ms = parseClimbedAtMs(entry.climbed_at);
+      if (Number.isFinite(ms) && (latestClimbedAtMs === null || ms > latestClimbedAtMs)) {
+        latestClimbedAtMs = ms;
+      }
+    }
+  }
+
+  const status = pickHighestAscentStatus(statuses);
+  if (status === null) return null;
+
+  const hasMirrored = sendCount > 0 ? sentMirrored : triedMirrored;
+  const hasOriginal = sendCount > 0 ? sentOriginal : triedOriginal;
+  const mirror: ClimbProgressMirror =
+    hasMirrored && hasOriginal ? 'both' : hasMirrored ? 'mirror' : ('original' as const);
+
+  const outcome: ClimbProgressOutcome =
+    status === 'flash'
+      ? { kind: 'flash' }
+      : status === 'send'
+        ? { kind: 'send', sendCount }
+        : { kind: 'attempt', tries: attemptTries };
+
+  return { status, outcome, mirror, latestClimbedAtMs };
+}
+
+/**
+ * Bucket a tick timestamp for the recency token: "today", "3d", or a date.
+ * Both sides are cut to LOCAL midnight first, so a 23:00 tick is "today" until
+ * midnight and "1d" the moment after — never "0d" for something 20 hours old.
+ */
+export function describeClimbProgressRecency(ms: number, nowMs: number): ClimbProgressRecency {
+  const tickDay = startOfLocalDay(ms);
+  const today = startOfLocalDay(nowMs);
+  const dayDiff = Math.round((today - tickDay) / MS_PER_DAY);
+  if (dayDiff <= 0) return { kind: 'today' };
+  if (dayDiff < RELATIVE_DAY_LIMIT) return { kind: 'days', count: dayDiff };
+  return { kind: 'date', ms };
+}
+
+function startOfLocalDay(ms: number): number {
+  const date = new Date(ms);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+}
+
+/**
+ * The progress line stops growing before the rest of the row does — same cap and
+ * same reason as the playlist chips below it: the row's height is pinned by the
+ * 96pt thumbnail, and a fourth text line scaling all the way to 1.5 would push
+ * the centre column past it. See `climb-row-vertical-budget.test.ts`.
+ */
+export const PROGRESS_MAX_FONT_SCALE = 1.3;
+
+/**
+ * How many of the three tokens (outcome · mirror · recency) fit on one line at
+ * a given Dynamic Type scale. They drop from the RIGHT — recency first, then
+ * mirror — because the outcome is the only one a climber cannot infer from the
+ * rest of the row.
+ */
+export function climbProgressTokenBudget(fontScale: number): number {
+  if (!Number.isFinite(fontScale) || fontScale < 1.15) return 3;
+  if (fontScale < 1.3) return 2;
+  return 1;
+}

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -475,6 +475,17 @@
         "send": "Getoppt",
         "attempt": "Versucht"
       },
+      "progress": {
+        "flashed": "Geflasht",
+        "sent": "Getoppt",
+        "sentTimes": "Getoppt ×{{count}}",
+        "tries_one": "{{count}} Versuch",
+        "tries_other": "{{count}} Versuche",
+        "mirror": "gespiegelt",
+        "bothWays": "beide Seiten",
+        "today": "heute",
+        "daysAgo": "{{count}} Tg."
+      },
       "noMatch": "Kein Matchen",
       "campus": "Campus",
       "anyFeet": "Freie Füße",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -475,6 +475,17 @@
         "send": "Sent",
         "attempt": "Tried"
       },
+      "progress": {
+        "flashed": "Flashed",
+        "sent": "Sent",
+        "sentTimes": "Sent ×{{count}}",
+        "tries_one": "{{count}} try",
+        "tries_other": "{{count}} tries",
+        "mirror": "mirror",
+        "bothWays": "both ways",
+        "today": "today",
+        "daysAgo": "{{count}}d"
+      },
       "noMatch": "No matching",
       "campus": "Campus",
       "anyFeet": "Any feet",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -475,6 +475,17 @@
         "send": "Encadenado",
         "attempt": "Intentado"
       },
+      "progress": {
+        "flashed": "Flasheado",
+        "sent": "Encadenado",
+        "sentTimes": "Encadenado ×{{count}}",
+        "tries_one": "{{count}} intento",
+        "tries_other": "{{count}} intentos",
+        "mirror": "espejo",
+        "bothWays": "normal y espejo",
+        "today": "hoy",
+        "daysAgo": "{{count}} d"
+      },
       "noMatch": "Sin igualar",
       "campus": "Campus",
       "anyFeet": "Pies libres",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -475,6 +475,17 @@
         "send": "Enchaîné",
         "attempt": "Essayé"
       },
+      "progress": {
+        "flashed": "Flashé",
+        "sent": "Enchaîné",
+        "sentTimes": "Enchaîné ×{{count}}",
+        "tries_one": "{{count}} essai",
+        "tries_other": "{{count}} essais",
+        "mirror": "miroir",
+        "bothWays": "les deux sens",
+        "today": "aujourd’hui",
+        "daysAgo": "{{count}} j"
+      },
       "noMatch": "Une main par prise",
       "campus": "Campus",
       "anyFeet": "Pieds libres",


### PR DESCRIPTION
Stacks on `feat/climb-list-density` (#5222) — that branch added the `rich` density tier; this one gives it content. Review/merge that first.

## Summary

The climbs-list row spends its widest slot on the crowd — `66k sends · 3.2★ · jwebxl` — and compresses everything personal into two 16pt grey glyphs at the trailing edge: one binary tick/flash/attempt marker and one heart. So the row cannot answer the question a returning climber actually has: *where am I on this climb?* (#4796)

The `rich` tier now carries a **personal line** as line 2 of the centre column, directly under the name and above the crowd line. Up to three tokens, joined `·`:

1. **outcome** — Flashed / Sent / Sent ×3 / 7 tries
2. **mirror** — `mirror` when every send is mirrored, `both ways` when both orientations exist. Original-only is omitted, because it is the default and a token on every row says nothing.
3. **recency** — today / 3d / 12 Aug

It outranks the crowd line by **colour and weight** (`label` at 600 vs the crowd line's dimmed `footnote`), never by size — on the Material scale `caption1` and `caption2` are byte-identical (11/16, weight 500), so size tiering is a no-op on Android.

### On #4801

This addresses the **climbs-list half** of #4801, not the whole issue. `mirrored` is not in `CLIMB_SEARCH_FIELDS`, so the list never renders a mirrored climb as its own row — but the mirror *state of your ticks* comes from each logbook entry's `is_mirror`, which is available, so the row can now say `both ways` / `mirror`. Leaving #4801 open.

### Performance

`ClimbProgressLine` is its own `React.memo` boundary over primitive props, and it is the only new logbook subscriber. It reads the same pre-grouped `logbookByClimbAngle` index `useAscentStatus` does — one `Map.get` over that climb's handful of ticks, never a scan (docs/react-native-performance.md §4). Hoisting the subscription into `ClimbListItemContent` would re-render every visible thumbnail and name on every tick merge, which is the regression the file's boundary comments already record from the climbs-search redesign. `climb-list-item-content-progress.test.tsx` pushes a logbook merge through a real context and asserts the thumbnail render count does not move.

It renders `null` when you have no history with the climb — the majority case and every signed-out row — so those rows and the whole `compact` / `default` tiers stay byte-identical to the base branch.

### Vertical budget (measured, not estimated)

The 76×96 thumbnail pins the row, so the centre column has 96pt. Gaps do not scale with Dynamic Type; line heights do. Measured in `climb-row-vertical-budget.test.ts` off the real type scales:

| Dynamic Type | Liquid Glass (HIG) | Material (M3) | Tokens shown |
| --- | --- | --- | --- |
| 1.0× | 62.0pt | 60.0pt | outcome · mirror · recency |
| 1.15× | 70.7pt | 68.4pt | outcome · mirror |
| 1.3× | 79.4pt | 76.8pt | outcome |
| 1.5× | 87.4pt | 84.8pt | outcome |

Recency drops at 1.15×, mirror at 1.3× — from the right, so the outcome (the one thing you cannot infer from the rest of the row) always survives. The line itself is capped at `maxFontSizeMultiplier` 1.3, same cap and same reason as the playlist chips below it.

**One honest caveat, asserted in the test rather than hidden:** a climb that is *both* in a playlist *and* has personal history stacks four lines, and four lines exceed 96pt past ~1.08× (99.1pt at 1.15×). Token dropping cannot fix that — tokens are horizontal. The fix is to shed the (lowest-priority) tag strip, and that has to live in `ClimbPlaylistChips`: the row cannot know whether the progress line rendered without subscribing to the logbook itself, which is exactly what the memo boundary exists to prevent. Deliberately out of scope here.

### Copy

| key | en-US | es | fr | de |
| --- | --- | --- | --- | --- |
| flashed | Flashed | Flasheado | Flashé | Geflasht |
| sent | Sent | Encadenado | Enchaîné | Getoppt |
| sentTimes | Sent ×{{count}} | Encadenado ×{{count}} | Enchaîné ×{{count}} | Getoppt ×{{count}} |
| tries_one | {{count}} try | {{count}} intento | {{count}} essai | {{count}} Versuch |
| tries_other | {{count}} tries | {{count}} intentos | {{count}} essais | {{count}} Versuche |
| mirror | mirror | espejo | miroir | gespiegelt |
| bothWays | both ways | normal y espejo | les deux sens | beide Seiten |
| today | today | hoy | aujourd’hui | heute |
| daysAgo | {{count}}d | {{count}} d | {{count}} j | {{count}} Tg. |

Per the glossaries: French uses *enchaîné* / *essais* (never *envoyer*, never *tentatives*), German uses *Getoppt* / *Versuche* (never *senden*), Spanish matches the existing *Encadenado* / *intentos*. `daysAgo` mirrors the `litAgoDays` wording each locale already ships. Absolute dates go through `toLocaleDateString(i18n.language, …)`, so "12 Aug" localises itself.

## Release Notes

The climbs list can now tell you where *you* stand on a climb, not just what the crowd did. Pick the rich row in More → Climb list and every climb you've touched gets its own line: flashed it, sent it twice, seven tries deep — plus whether you did it mirrored, both ways, or just the original, and how long ago. Mirror ticks finally show up while you're browsing, so you know which way round you still owe yourself.

## Test plan

1. More → Climb list → pick the rich row.
2. Browse climbs. Sent ones show a line like "Sent · today".
3. Log a mirrored tick on a climb you've already sent.
4. Return to the list. That row now reads "both ways".
5. Sign out. Rows show no personal line.

## Risk

Risk: 2/5 — one extra memoized text line, only in the opt-in rich density tier, JS-only and OTA-compatible. Renders nothing for a climb with no logbook history, so the compact and default tiers and every signed-out row are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELkpe6R3CCsHmmvNShY9Ta
