### PR TITLE
docs: specify Kilter live activity and plan bidirectional integration

### DIFF
--- a/docs/KILTER_HTTP_API_SPEC.md
+++ b/docs/KILTER_HTTP_API_SPEC.md
@@ -1,7 +1,7 @@
 # Kilter HTTP API Specification
 
 **Covered version**: Kilter Board mobile app, current as of 2026-05-23
-**Sibling docs**: [KILTER_POWERSYNC_SPEC.md](KILTER_POWERSYNC_SPEC.md), [AURORA_BLUETOOTH_PROTOCOL_SPEC.md](AURORA_BLUETOOTH_PROTOCOL_SPEC.md)
+**Sibling docs**: [KILTER_POWERSYNC_SPEC.md](KILTER_POWERSYNC_SPEC.md), [AURORA_BLUETOOTH_PROTOCOL_SPEC.md](AURORA_BLUETOOTH_PROTOCOL_SPEC.md), [KILTER_LIVE_SPEC.md](KILTER_LIVE_SPEC.md)
 
 > Kilter Grips runs their own backend, separate from the Aurora Climbing backend that other Aurora-family boards share. The wire-level Bluetooth protocol used to drive the LED hardware is shared with Aurora and is documented in [`AURORA_BLUETOOTH_PROTOCOL_SPEC.md`](AURORA_BLUETOOTH_PROTOCOL_SPEC.md). **This document only covers the HTTP and realtime-sync APIs.**
 >

--- a/docs/KILTER_LIVE_SPEC.md
+++ b/docs/KILTER_LIVE_SPEC.md
@@ -154,6 +154,32 @@ The following is the live-relevant subset of that parser, **not** a complete res
 
 **Confidence: LOW.** There is no established upstream disconnect/clear operation, guaranteed one-entry-per-climb behavior across installations, or acknowledged retry protocol. A changed or disconnected Boardsesh session cannot be translated into a fabricated upstream leave event.
 
+### 4.4 Where the serial comes from
+
+**Confidence: HIGH.** The Bluetooth scan callback constructs a `Candidate` using the device's name from FlutterBluePlus's platform-name cache. `_connectToBoardByName` passes that candidate name to `_serialNumberFromBoardName`, then passes the result into `BluetoothProvider.connectToDevice`. The provider stores it as the connection-associated serial subsequently read by the live publisher. This value is name-derived; it is not the selected wall's saved `serial_number` or the Bluetooth device address.
+
+**Confidence: HIGH.** The parser implements these rules:
+
+1. Split the name on `#`; return null if there is no second segment.
+2. Split that second segment on `@`; return null if there is no second segment.
+3. Trim the text before that `@`; return it if nonempty, otherwise null.
+
+The following examples are consequences of the parser, not captured controller advertisements:
+
+| Device name | Result |
+| --- | --- |
+| `Kilter Board#abc123@3` | `abc123` |
+| `Kilter Board#abc123@2` | `abc123` |
+| `Kilter Board#abc123` | null — this parser requires `@` too |
+| `Kilter Board@2` | null |
+| `Kilter Board` | null |
+
+**Confidence: HIGH.** The parser does not validate a numeric API version or restrict the serial to alphanumeric characters. This is a different parsing rule from the older Aurora regex described in [Bluetooth §4](AURORA_BLUETOOTH_PROTOCOL_SPEC.md#4-device-name-format), although both recognize the familiar `Name#serial@version` format.
+
+**Confidence: HIGH for the inspected paths.** No serial characteristic read or manufacturer-data decoder supplies this connection value. The provider's notification callback prints the received bytes and notifies listeners; it does not decode a serial or replace the stored serial. A separate device-label path matches a name-derived serial against saved wall serials to find a wall name; it does not supply a missing serial to the connection path.
+
+**Confidence: MEDIUM.** Continued compatibility with controllers using the existing name suffix is sufficient to explain the live request's serial field. The serial-less gym publication branch (§4.2) explicitly accommodates a null result. **Confidence: LOW / unresolved** that newer Kilter-built controllers have resumed emitting serials: the client provides no such evidence. Establishing a hardware or firmware change requires an advertisement/GATT capture from an identified controller revision or a firmware specification; a nullable REST field cannot establish that change.
+
 ## 5. Moderation
 
 **Confidence: HIGH.** The live screen's `_confirmAndReport` flow calls `reportRecentlyDisplayedClimb`, which sends bearer authorization and JSON:
@@ -217,6 +243,7 @@ All items below are **LOW confidence / unresolved**, unless an explicit client o
 6. Idempotency, duplicate submission handling, response bodies, timeout ambiguity, quotas, and account/IP/client rate-limit scope.
 7. Report scope, moderation outcomes, deletion/clear support, and behavior after disconnect.
 8. The named stream carrying `app_configs`, current timing values, and protocol changes across Android/iOS releases.
+9. Whether any newer Kilter-built controller revision emits a serial; the observed client only establishes name-suffix compatibility and a serial-less fallback.
 
 ## 9. Verification anchors
 
@@ -236,3 +263,7 @@ All items below are **LOW confidence / unresolved**, unless an explicit client o
 | `screen/live/live_at_board.dart` | `_preloadLiveAtBoardClimbs` `0x79ee3c`; `_pollRecentlyDisplayedClimbs` `0x79fbf8` | Read auth and refresh lifecycle |
 | `provider/app.dart` | `_applyAppConfigRows` `0x8a7d8c`; query `0x8a804c`; schema table object `0x9e9941` | Timing configuration and defaults |
 | `provider/login.dart` | `setUserUuid` `0x860760` | Account identifier from JWT `sub` |
+| `screen/components/bluetooth_device_dialog.dart` | Scan callback `0x839a38`; parser call `0x8379b4`; `_serialNumberFromBoardName` `0x83cc00` | Connection serial from the scanned candidate's platform name |
+| `domain/candidate.dart` | Constructor `0x839fb0` | Retains the device and platform name used at connection |
+| `provider/bluetooth_provider.dart` | `connectToDevice` `0x83a270`, serial store `0x83a330`; notification callback `0x83cb80` | Connection serial storage; notifications do not decode serials |
+| `screen/components/bluetooth_device_dialog.dart` | Label closure `0x83d264`; wall predicate `0x83d6a4` | Name-derived serial used to look up a saved wall's display name |

--- a/docs/KILTER_LIVE_SPEC.md
+++ b/docs/KILTER_LIVE_SPEC.md
@@ -1,0 +1,238 @@
+# Kilter Live Board Activity Specification
+
+**Covered version**: Kilter Board Android 2.10.1, versionCode 65 (`com.kiltergrips.kilter_board_app`)
+**Re-verified**: 2026-09-07 against the Google Play APK installed on the connected Android phone, using readable Dart AOT strings and call-path analysis of `libapp.so` (SHA-256 `f5191fdbf466cf2082a9ae5e076c43cf69d13e6b5ca9aeca3eebb79f9222eeed`; 30,922 strings at minimum length 5).
+**Sibling docs**: [HTTP API](KILTER_HTTP_API_SPEC.md), [PowerSync](KILTER_POWERSYNC_SPEC.md), [Bluetooth](AURORA_BLUETOOTH_PROTOCOL_SPEC.md), [Kilter sync](kilter-sync.md), [integration plan](kilter-live-integration-plan.md)
+
+> The live feature reads recently displayed climbs through authenticated REST polling and publishes display events through a separate REST endpoint. Its observed contract is a wall-scoped recent-climb feed. A feed entry does not establish that a climber is still present or that a climb is still lit.
+>
+> Confidence markers apply to client behavior: **HIGH** means a literal, serializer, or call path establishes the claim; **MEDIUM** means the client supports an interpretation whose server semantics remain unverified; **LOW** means unresolved. No authenticated live responses or production writes were exercised. Android and iOS version numbers are independent; this document makes no claim of iOS protocol parity.
+
+---
+
+## Table of Contents
+
+1. [Transport and new surface](#1-transport-and-new-surface)
+2. [Identity and event semantics](#2-identity-and-event-semantics)
+3. [Read: recently displayed climbs](#3-read-recently-displayed-climbs)
+4. [Write: publish a displayed climb](#4-write-publish-a-displayed-climb)
+5. [Moderation](#5-moderation)
+6. [Configuration and timing](#6-configuration-and-timing)
+7. [Authentication, attribution, and privacy](#7-authentication-attribution-and-privacy)
+8. [Open questions](#8-open-questions)
+9. [Verification anchors](#9-verification-anchors)
+
+---
+
+## 1. Transport and new surface
+
+**Confidence: HIGH.** These paths extend the inventory in [KILTER_HTTP_API_SPEC.md](KILTER_HTTP_API_SPEC.md). All three call `package:http`'s `post`; the read operation is also a POST.
+
+| Method | Host and path | Role |
+| --- | --- | --- |
+| POST | `https://portal.kiltergrips.com/api/recently-displayed-climbs/climbs` | Read recent climbs for a wall selection |
+| POST | `https://portal.kiltergrips.com/api/recently-displayed-climbs/add` | Publish a displayed climb |
+| POST | `https://portal.kiltergrips.com/api/recently-displayed-climbs/report` | Report an existing feed entry |
+
+**Confidence: HIGH.** The traced activity paths use the existing portal host and Keycloak bearer token. They do not call PowerSync CRUD upload, a live-specific stream subscription, WebSocket, or SSE. PowerSync's client schema additionally contains `app_configs`, which supplies timing settings (§6). No new activity hostname or activity stream-subscription name is established by these paths. Existing identity and reference-sync hosts remain documented in the sibling specs.
+
+**Confidence: MEDIUM.** “Live” describes periodically refreshed recent display history. There is no session lease, heartbeat, occupancy count, or disconnect event in the observed request schemas. This does not exclude an undiscovered server facility.
+
+## 2. Identity and event semantics
+
+**Confidence: HIGH** for keys and their client uses; server matching rules are **LOW** confidence.
+
+| Identifier | Observed role | Boundary |
+| --- | --- | --- |
+| `gymUuid` | Read selector; gym scope on normal-wall writes | Custom-wall writes use the signed-in token's `sub` in this field (§4) |
+| `productLayoutUuid` | Read selector and published layout | A layout describes a configuration, not a unique physical installation |
+| `wallUuid` | Read selector and published wall reference | Obtained from the selected wall; not a Bluetooth address |
+| `serialNumber` | Optional published controller serial | Absent from the read body; serial-less gym writes have a local proximity gate |
+| `climbUuid` | Published climb identifier; returned climb identity | Identifies the climb, not a particular display event |
+| `recentlyDisplayedClimbId` | Returned numeric event identifier; moderation target | Distinct from `climbUuid` |
+| JWT `sub` | Signed-in account identifier in the client | Separate from Boardsesh user and participant IDs |
+| `liveBoardUsername` | Nullable read-side identity label specific to this feature | Not a stable account-join key; anonymity semantics unverified |
+
+**Confidence: HIGH.** Publication includes an integer angle, but no Boardsesh-style session ID, queue-item ID, participant ID, duration, or client event ID. The ordinary climb-detail parser also reads `userUuid` and `username`; these must not be assumed to identify the person who displayed the climb simply because they occur in a live response. The live-specific field is `liveBoardUsername`.
+
+## 3. Read: recently displayed climbs
+
+### 3.1 Request
+
+**Confidence: HIGH.** `ClimbService.fetchRecentlyDisplayedClimbs` sends the following schema. Placeholder strings below illustrate field positions, not a tested request:
+
+```http
+POST /api/recently-displayed-climbs/climbs
+Host: portal.kiltergrips.com
+Authorization: Bearer <access_token>
+Content-Type: application/json
+Accept-Encoding: gzip
+```
+
+```json
+{
+  "gymUuid": "<kilter-gym-id>",
+  "productLayoutUuid": "<kilter-layout-id>",
+  "wallUuid": "<kilter-wall-id>"
+}
+```
+
+**Confidence: HIGH.** The map permits nullable strings and serializes all three keys. It includes no serial, angle, timestamp cursor, page size, or user ID. Nullable client types do not establish that omitting a selector or sending null returns a broader/public feed.
+
+### 3.2 Response
+
+**Confidence: HIGH.** The client accepts status **200**, decodes the body as UTF-8 JSON, and expects a top-level iterable of climb-detail objects (a JSON array), rather than a `{data: ...}` envelope. It filters entries with `isDeleted == true` and uses `Climb.climbDetailFromJson` for the remaining entries.
+
+The following is the live-relevant subset of that parser, **not** a complete response fixture:
+
+| Field | Client interpretation | Confidence |
+| --- | --- | --- |
+| `climbUuid` | String climb identifier | HIGH |
+| `angle` | Nullable number converted to an integer | HIGH |
+| `derivativeAngle` | Nullable number converted to an integer; preferred over `angle` for feed deduplication | HIGH |
+| `recentlyDisplayedAt` | Nullable string passed to `DateTime.tryParse`; invalid date becomes null | HIGH |
+| `recentlyDisplayedClimbId` | Nullable number converted to an integer | HIGH |
+| `recentlyDisplayedReported` | Nullable Boolean, default false | HIGH |
+| `liveBoardUsername` | Nullable string | HIGH |
+
+**Confidence: HIGH.** The client deduplicates by `climbUuid` plus `(derivativeAngle ?? angle ?? 0)`, keeps the entry with the newer `recentlyDisplayedAt`, and sorts descending by that timestamp with null timestamps last. The visible list therefore need not represent every individual display or every climber.
+
+**Confidence: LOW.** Retention window, maximum response size, timestamp timezone/clock source, server ordering, and whether the returned angle always equals the submitted display angle remain unverified. Ordinary climb `createdAt` is distinct from `recentlyDisplayedAt`.
+
+### 3.3 Refresh and failures
+
+**Confidence: HIGH.** The live screen preloads the list, then uses a one-shot timer which reloads and schedules another timer after completion. The default delay is 30 seconds (§6); request duration adds to that delay. Disposal cancels the screen's timer.
+
+**Confidence: HIGH.** A non-200 response in the service returns its prior in-memory list, or an empty list if there is no cached result. This is not evidence of an empty wall or fresh data. The memory key uses gym, layout, and a third caller-supplied selector; the separately supplied `wallUuid` and bearer token are not incorporated by that key function. A new integration should scope caches explicitly to both account and complete wall selection.
+
+**Confidence: LOW.** No live-endpoint quota, `Retry-After` contract, or documented error response schema is established. The inspected service does not provide an HTTP-level freshness guarantee.
+
+## 4. Write: publish a displayed climb
+
+### 4.1 Request and result
+
+**Confidence: HIGH.** `ClimbService.addRecentlyDisplayedClimb` sends bearer authorization and JSON to `/api/recently-displayed-climbs/add`. `RecentlyDisplayedClimb.toJson` emits exactly these eight keys:
+
+```json
+{
+  "gymUuid": "<kilter-gym-id>",
+  "productLayoutUuid": "<kilter-layout-id>",
+  "serialNumber": "<controller-serial>",
+  "userUuid": null,
+  "climbUuid": "<kilter-climb-id>",
+  "angle": 40,
+  "createdAt": null,
+  "wallUuid": "<kilter-wall-id>"
+}
+```
+
+**Confidence: HIGH.** In the traced publisher, `serialNumber` is the trimmed connection-associated serial or JSON null. `userUuid` is left unset and serializes as null; `createdAt` is explicitly serialized as null. The example angle is illustrative. No coordinates are transmitted in this body.
+
+**Confidence: HIGH.** The method returns whether the status is exactly 200. It does not decode an assigned event ID or a per-item acknowledgement. The caller awaits this Boolean without using it and catches failures. No persistent outbox, client reference, or idempotency key is present in this path.
+
+**Confidence: MEDIUM.** Null identity and creation time suggest that the server supplies attribution and event time. The binary cannot establish that the server binds attribution to the token, rejects alternate `userUuid` values, or deduplicates retries.
+
+### 4.2 Publication eligibility
+
+**Confidence: HIGH.** `_writePendingClimbFrames` awaits the Bluetooth provider's `writeData` before calling `_queueRecentlyDisplayedClimb`. This is a client write-completion path, not hardware acknowledgement that the holds are visibly correct.
+
+**Confidence: HIGH.** Scheduling requires a nonempty access token and account `sub`, a connected Bluetooth device with a nonempty device identifier, and a nonempty selected wall reference. The wall reference comes from the climb-detail selection or the active-board provider. The event captures the climb and angle and uses the wall's layout, falling back to the captured layout if the wall layout is empty.
+
+| Wall path | Client eligibility and body scope | Confidence |
+| --- | --- | --- |
+| Normal gym wall, serial available | Requires nonempty gym and layout; sends wall's gym ID and trimmed serial | HIGH |
+| Normal gym wall, no serial | Requires location and gym coordinates; distance must be at most **200 metres**; sends wall's gym ID and `serialNumber: null` | HIGH |
+| Custom-wall path | Requires a nonempty serial; sends the current account's JWT `sub` as **`gymUuid`**, with selected `wallUuid` and layout | HIGH |
+
+**Confidence: HIGH.** The proximity check happens locally through `Geolocator.distanceBetween`; coordinates are not added to the published model. The custom-wall screen sets the branch flag responsible for the serial requirement and account-scoped `gymUuid`. Its downstream server lookup and privacy rules are **LOW** confidence. A custom wall must not be treated as a normal public gym solely because this field is named `gymUuid`.
+
+### 4.3 Debounce and cancellation
+
+**Confidence: HIGH.** A shared `RecentlyDisplayedDebounceService` holds one pending timer. The publisher supplies a key composed of wall reference, captured layout, climb UUID, angle, and serial-or-empty, plus the configurable delay (default 45 seconds). Matching pending work is suppressed; replacement work cancels the earlier timer. Timer expiry clears pending state and evaluates an eligibility predicate before invoking the publisher.
+
+**Confidence: HIGH.** The predicate requires the same connected Bluetooth device, a nonempty token, and the same account `sub`. The async publisher checks the connection/device and token again after its wall/gym/location work. The observed checks are client eligibility rules, not server-verifiable proof of location or board ownership.
+
+**Confidence: LOW.** There is no established upstream disconnect/clear operation, guaranteed one-entry-per-climb behavior across installations, or acknowledged retry protocol. A changed or disconnected Boardsesh session cannot be translated into a fabricated upstream leave event.
+
+## 5. Moderation
+
+**Confidence: HIGH.** The live screen's `_confirmAndReport` flow calls `reportRecentlyDisplayedClimb`, which sends bearer authorization and JSON:
+
+```http
+POST /api/recently-displayed-climbs/report
+Host: portal.kiltergrips.com
+Content-Type: application/json
+Authorization: Bearer <access_token>
+```
+
+```json
+{ "recentlyDisplayedClimbId": 123 }
+```
+
+**Confidence: HIGH.** The numeric value is an illustrative event ID. The client treats status 200 as success. This endpoint reports an existing entry; it does not contribute activity. The response parser's `recentlyDisplayedReported` flag is not an opt-out setting.
+
+**Confidence: LOW.** Whether reporting hides an entry for one viewer, hides it globally, or sends it for review is unverified. Deletion, report reversal, and moderation thresholds are also unverified.
+
+## 6. Configuration and timing
+
+**Confidence: HIGH.** The PowerSync client `Schema` contains an `app_configs` table with these integer columns. `AppProvider` watches the first row using the query below and applies positive-integer defaults:
+
+```sql
+SELECT live_climbs_pool_interval, live_climbs_append_debounce
+FROM app_configs
+LIMIT 1
+```
+
+| Column | Meaning in client | Default |
+| --- | --- | --- |
+| `live_climbs_pool_interval` | Delay in seconds between completed live loads and the next poll | 30 |
+| `live_climbs_append_debounce` | Delay in seconds before pending publication | 45 |
+
+**Confidence: HIGH.** `pool` is the literal spelling of the first key. The table carries configuration, while the traced feed carries activity through REST. **Confidence: LOW** for which named server stream delivers `app_configs` and its current production values. Do not invent a `live`, `presence`, or `recently_displayed_climbs` stream from the feature name.
+
+## 7. Authentication, attribution, and privacy
+
+| Question | Observed answer | Confidence |
+| --- | --- | --- |
+| Does the official read path sign in? | It requires a non-null access token and sends it as a bearer token | HIGH |
+| Do publish and report send auth? | Both use bearer authorization; publication also checks account `sub` | HIGH |
+| Is any live endpoint public? | No unauthenticated live path is established; server behavior without a token is unknown | LOW |
+| Who is announced? | Write body carries null `userUuid`; read parser has nullable `liveBoardUsername` | HIGH |
+| Does the token determine the announced user? | Likely, but server attribution/enforcement is unverified | MEDIUM |
+| Can users hide their identity or opt out? | No live-specific privacy field or preference check was found in the traced publication path or inspected user-settings model | HIGH for that observation; LOW for availability elsewhere |
+| Does a null username mean anonymous participation? | The parser permits null; its cause and meaning are unverified | LOW |
+| Are sessions or other climbers announced together? | No such fields occur in the observed publish serializer | HIGH |
+
+**Confidence: LOW.** Account linkage, visibility to strangers, custom-wall access restrictions, retention of identities, and deletion rights cannot be established from this client alone. A recent username must not be equated with a currently present person or mapped automatically onto a Boardsesh account.
+
+## 8. Open questions
+
+All items below are **LOW confidence / unresolved**, unless an explicit client observation above narrows the question:
+
+1. Server validation and selector precedence for gym, layout, wall, serial, and null selectors; wall visibility and account ownership checks.
+2. Whether custom-wall account-scoped gym IDs and wall references are stable across devices and visible only to their owner.
+3. Accepted write shapes in practice, serial-less write acceptance, and whether the server applies additional physical-presence checks.
+4. Attribution to token `sub`, generation of `liveBoardUsername`, anonymity/opt-out controls, and identity retention.
+5. Full response examples, event retention, limits, timezones, and display-angle semantics.
+6. Idempotency, duplicate submission handling, response bodies, timeout ambiguity, quotas, and account/IP/client rate-limit scope.
+7. Report scope, moderation outcomes, deletion/clear support, and behavior after disconnect.
+8. The named stream carrying `app_configs`, current timing values, and protocol changes across Android/iOS releases.
+
+## 9. Verification anchors
+
+**Confidence: HIGH.** These method/constant addresses identify the client evidence for future re-verification. Addresses are specific to the covered ARM64 snapshot; they are not wire identifiers. No application binary or disassembly is included in this repository.
+
+| Component | Anchor | Contract area |
+| --- | --- | --- |
+| `services/climb_service.dart` | `fetchRecentlyDisplayedClimbs` `0x79f0dc` | Read URL, headers, body, response and cache |
+| `services/climb_service.dart` | `_recentlyDisplayedKey` `0x79f710`; closures `0x79f7a0`, `0x79f83c`, `0x79f88c` | Cache key, sort, parser, deletion filter |
+| `domain/climb.dart` | `Climb.climbDetailFromJson` `0x484028` | Response fields and nullable types |
+| `services/climb_service.dart` | `addRecentlyDisplayedClimb` `0x7ddc74` | Publish POST and status handling |
+| `domain/recently_displayed_climb.dart` | `toJson` `0x7ddda4` | Eight-key publish body |
+| `screen/climbs/detail/climb_detail.dart` | `_writePendingClimbFrames` `0x7dccdc`; `_queueRecentlyDisplayedClimb` `0x7dcff8`; callbacks `0x7dd81c`, `0x7deaa4` | Publish trigger, null attribution, wall lookup, proximity, connection guards |
+| `screen/custom_walls/custom_wall_details.dart` | Climb-detail construction `0x7c54f0`–`0x7c5534` | Custom-wall branch selection |
+| `services/recently_displayed_debounce_service.dart` | `schedule` `0x7dd5b0`; callback `0x7dd74c` | Pending-event timer |
+| `services/climb_service.dart` | `reportRecentlyDisplayedClimb` `0x7d23e4` | Moderation POST |
+| `screen/live/live_at_board.dart` | `_preloadLiveAtBoardClimbs` `0x79ee3c`; `_pollRecentlyDisplayedClimbs` `0x79fbf8` | Read auth and refresh lifecycle |
+| `provider/app.dart` | `_applyAppConfigRows` `0x8a7d8c`; query `0x8a804c`; schema table object `0x9e9941` | Timing configuration and defaults |
+| `provider/login.dart` | `setUserUuid` `0x860760` | Account identifier from JWT `sub` |

--- a/docs/KILTER_POWERSYNC_SPEC.md
+++ b/docs/KILTER_POWERSYNC_SPEC.md
@@ -2,7 +2,7 @@
 
 **Covered version**: Kilter Board mobile app, current as of 2026-05-23
 **Re-verified**: 2026-06-01 against the decompiled APK (`libapp.so` / `libpowersync.so` string dumps)
-**Sibling docs**: [KILTER_HTTP_API_SPEC.md](KILTER_HTTP_API_SPEC.md), [AURORA_BLUETOOTH_PROTOCOL_SPEC.md](AURORA_BLUETOOTH_PROTOCOL_SPEC.md), [aurora-sync.md](aurora-sync.md)
+**Sibling docs**: [KILTER_HTTP_API_SPEC.md](KILTER_HTTP_API_SPEC.md), [AURORA_BLUETOOTH_PROTOCOL_SPEC.md](AURORA_BLUETOOTH_PROTOCOL_SPEC.md), [aurora-sync.md](aurora-sync.md), [KILTER_LIVE_SPEC.md](KILTER_LIVE_SPEC.md)
 
 > Kilter mirrors part of its Postgres database into the client over [PowerSync](https://www.powersync.com), an open-source sync layer. To consume Kilter user data from Boardsesh — the analogue of what `@boardsesh/aurora-sync` does for Tension/Decoy/So-iLL — Boardsesh acts as a **PowerSync client** against `sync1.kiltergrips.com`. This document describes Kilter's PowerSync setup.
 >

--- a/docs/kilter-live-integration-plan.md
+++ b/docs/kilter-live-integration-plan.md
@@ -1,0 +1,158 @@
+# Kilter Live Activity Integration Plan
+
+**Status**: Proposed; read and contribution are separate deliverables, both disabled until their verification gates pass.
+**Protocol baseline**: [KILTER_LIVE_SPEC.md](KILTER_LIVE_SPEC.md), Android 2.10.1 / build 65.
+**Related docs**: [Kilter sync](kilter-sync.md), [HTTP API](KILTER_HTTP_API_SPEC.md), [PowerSync](KILTER_POWERSYNC_SPEC.md), [Bluetooth](AURORA_BLUETOOTH_PROTOCOL_SPEC.md), [board merges](board-merge-tombstones.md).
+
+This plan adds viewing through a consenting user's own Kilter account and contribution of eligible climbs displayed during Boardsesh sessions. It does not equate recent activity with current occupancy. No feature implementation, account linking, or upstream activity write is part of this documentation change.
+
+Protocol and repository observations use **HIGH / MEDIUM / LOW** confidence as in the spec. Proposed behavior and budgets are design decisions, not claims about Kilter's server. Unknown server behavior remains a release condition.
+
+## Table of Contents
+
+1. [Existing integration and risk baseline](#1-existing-integration-and-risk-baseline)
+2. [Resolve physical board identity](#2-resolve-physical-board-identity)
+3. [Read through the user's account](#3-read-through-the-users-account)
+4. [Contribute displayed climbs](#4-contribute-displayed-climbs)
+5. [Capacity, attribution, and account risk](#5-capacity-attribution-and-account-risk)
+6. [Implementation sequence and acceptance gates](#6-implementation-sequence-and-acceptance-gates)
+
+## 1. Existing integration and risk baseline
+
+**Confidence: HIGH — repository.** `packages/kilter-sync` already contains Keycloak authentication, PowerSync snapshot ingestion, REST catalog pulls, encrypted credentials, reference mappings, and the push-back design. Reuse those responsibilities and the existing account-link model; do not introduce a second login system.
+
+There is a material distinction in the current checkout: [`src/sync/push-back.ts`](../packages/kilter-sync/src/sync/push-back.ts) is gated by `KILTER_SYNC_PUSH_ENABLED` and its tick, rating, and circuit paths call `pushNotWired()` before any HTTP request. [`src/api/kilter-rest.ts`](../packages/kilter-sync/src/api/kilter-rest.ts) supplies typed scaffolding and transport helpers. Thus the baseline is an established account-scoped write architecture, but this checkout does **not** demonstrate operational upstream write traffic, accepted payloads, quotas, or account safety.
+
+**Confidence: HIGH — repository.** Push-back selects user-owned rows, resolves Kilter climb aliases, and plans successful-result backfills so batches can recover from partial completion. Live `/add` has neither an observed client reference nor a decoded event acknowledgement. Its timeout ambiguity requires a different retry policy from durable logbook synchronization.
+
+**Confidence: HIGH — protocol.** The live read plane is REST polling, while PowerSync provides reference data and has an `app_configs` table. [`powersync-client.ts`](../packages/kilter-sync/src/api/powersync-client.ts) intentionally stops at `checkpoint_complete`. Keep that snapshot behavior; do not convert the existing sync daemon into an unbounded live-feed subscriber or invent an activity stream.
+
+## 2. Resolve physical board identity
+
+### Available keys
+
+**Confidence: HIGH — repository**, except the stated coverage estimate.
+
+| Side | Keys available | What they can establish |
+| --- | --- | --- |
+| Kilter references | Wall `wallUuid`/`id`, `gymUuid`, `productLayoutUuid`, product name, serial, hold-set mask, angle/configuration, name and listing state | Source wall and compatible configuration |
+| Boardsesh board | `user_boards.uuid` and numeric ID; board type, layout, size, sets, gym, nullable serial, `mergedIntoBoardUuid` | Boardsesh identity and canonical survivor |
+| Imported location | Source key `kilter:<gymUuid>:<wallUuid-or-id>`; deterministic board UUID from that key | Exact source-wall candidate without a serial |
+| Gym source mapping | `location_sync_gym_sources.source_key = kilter:<gymUuid>` | External gym association; not a unique wall within it |
+| Per-user serial memory | `user_board_serials`: user, board name, serial, configuration and optional `boardUuid` | User's previous disambiguation of a controller |
+| Current session/report | Session ID, stable participant ID, confirmed climb, board record, optional connection serial | Session state and emitting actor; not an external wall ID |
+
+The user-provided estimate is that roughly **79% of board rows lack a serial**; it was not remeasured for this work. Serial matching cannot be the default join.
+
+**Confidence: HIGH — repository.** [`locations-sync.ts`](../packages/kilter-sync/src/sync/locations-sync.ts) builds the Kilter source key; [`boardUuidForSource`](../packages/location-sync/src/ids.ts) hashes it deterministically. The wall source key is not stored verbatim on `user_boards`, so reconstruct it from reference enumeration and compare the resulting UUID. Use the shared function rather than reproducing its hash formatting. Kilter layout aliases can be many-to-one and may contain small-integer strings despite the `Uuid` field name; preserve source IDs as opaque strings.
+
+### Join options and checkable conditions
+
+Each option has a client condition checkable against the binary and a separate server gate. A client passing a selector does not prove the server's interpretation of it.
+
+| Option | What must be true in the protocol | Evidence/status | Proposed use |
+| --- | --- | --- | --- |
+| Reconstruct imported identity | Feed requests carry the same wall/gym/layout identifiers exposed by wall references; reads do not require serial | HIGH: read body has those selectors and no serial. LOW: exact server matching still needs verification | Preferred candidate: enumerate source walls, derive board UUID, follow merge chain, compare current configuration |
+| User confirms a Kilter wall | A selected reference `wallUuid` can be sent with its gym/layout without requiring a proprietary hardware lookup first | HIGH: official read path does this. LOW: account visibility and mismatched-selector behavior | For manually created boards, offer compatible walls at the associated gym; persist an explicit user binding |
+| Serial corroborates a candidate | Connection serial can be associated with a wall; `/add` accepts that serial alongside wall/gym/layout | HIGH: publisher includes serial. LOW: serial uniqueness and server validation | Normalize for comparison and require board type/config plus user disambiguation; never auto-merge solely on serial |
+| Serial-less gym contribution | Publisher has a branch using `serialNumber: null`, known wall/gym/layout, and local location eligibility | HIGH: observed 200 m branch. LOW: server acceptance | Enable only after controlled verification; require consent to location and current eligibility |
+| Custom/home-wall binding | Account-specific wall ID/layout and serial can be used; custom `gymUuid` is the token's `sub` | HIGH: custom client branch. LOW: server visibility and stability | Separate account-scoped binding; defer initial contribution until custom-wall behavior is verified |
+| Infer wall from configuration or proximity alone | Protocol would need a unique physical-wall resolver from layout/sets/angle or location | LOW: no such resolver established | Suggestions only; never commit a binding or publish from this inference |
+
+### Binding storage and merge behavior
+
+Propose a dedicated binding relation in `packages/db`, exposed through backend GraphQL. Store canonical Boardsesh board UUID, Kilter wall/gym/layout IDs, scope (`gym` or `custom`), linked Kilter account for private/manual bindings, evidence kind (`import` / `user-confirmed` / `serial-corroborated`), source board UUID, confirmation actor/time, and mapping revision. Store read enablement and contribution consent separately from mapping evidence. Do not write a Kilter wall ID into Boardsesh's serial field.
+
+Use at most one active binding per account and canonical board. Imported public candidates may be shared as reference metadata; custom-wall bindings and manual confirmations remain account scoped. Revalidate the linked account, source visibility, configuration and mapping revision whenever enabling contribution. Never combine multiple upstream wall feeds silently because duplicate Boardsesh rows merged.
+
+**Confidence: HIGH — repository.** [`followBoardMergeChain`](../packages/backend/src/graphql/resolvers/board-presence/shared.ts) follows at most three links; a plain deletion, dangling target, or excessive chain does not resolve. Its callers enforce access to the survivor. Apply the same canonicalization and access checks before reading a binding, storing it, or publishing. Preserve source provenance across merges; conflicting upstream IDs disable contribution and require a new wall confirmation. A changed board configuration or gym also invalidates prior write eligibility.
+
+**Confidence: HIGH — repository.** [`user_board_serials`](../packages/db/src/schema/app/board-serials.ts) is unique per `(userId, boardName, serialNumber)`, not globally. Existing resolution trims and uppercases serials and considers board/configuration preferences. Keep original connection serial separately for the outgoing protocol representation; do not assume backend normalization is Kilter's normalization. Multiple candidates require explicit selection.
+
+## 3. Read through the user's account
+
+Proposed ownership:
+
+- `packages/kilter-sync`: a small live REST client using existing host/auth/error conventions, with strict response parsing and explicit freshness/error results.
+- `packages/backend`: GraphQL queries/subscriptions, account and board authorization, binding resolution, poll ownership, limits, and credential access.
+- `packages/shared/kilter-live`: pure event types, selector normalization, response projection, freshness rules and publish eligibility shared by platforms. Inject time and platform I/O; no duplicated web/mobile business logic.
+- `packages/mobile`: the activity view and separate consent controls, using shared logic. Any later browser surface uses the same backend and shared package.
+
+Read flow:
+
+1. The signed-in Boardsesh user enables viewing for their own linked Kilter account and confirms a wall binding when no exact imported binding is available.
+2. Backend resolves the canonical board, checks user access and binding scope, and obtains credentials through the existing encrypted account store. Coordinate refresh-token rotation with the sync daemon using a per-account lease and persisted replacement tokens; concurrent workers must not race rotating credentials.
+3. Backend calls `/climbs` with the three verified selectors. Share an in-flight request only within the same account and complete selector tuple. Do not serve one user's authenticated response to unrelated users.
+4. While a foreground viewer exists, schedule at the configured interval, with **30 seconds as the initial minimum** and jitter that only lengthens it. Stop when the last authorized viewer disconnects; recheck consent on reconnect. Add `app_configs` ingestion only after identifying its existing stream; no global wall crawl for activity.
+5. Return recent entries, `fetchedAt`, `lastSuccessfulFetchAt`, source label, and an explicit stale/error state. Use the upstream event ID when present and preserve repeated display semantics; a UI projection may follow Kilter's climb-plus-angle deduplication. Keep data ephemeral and account scoped; invalidate on unlink, consent withdrawal, or binding change.
+
+Show “Recently displayed” and its timestamp. Never replace Boardsesh's confirmed on-wall state, declare a wall empty from a failed read, infer occupants, auto-join a session, or light a climb merely because a feed entry arrived. Do not link `liveBoardUsername` to a Boardsesh profile by name. Treat normal climb setter metadata and the live actor label as distinct fields.
+
+**Release conditions:** verify one authorized response including null/malformed optional fields, confirm wall scoping with two distinct wall selections, establish visibility restrictions, and resolve read-use terms with Kilter. Public or account-independent caching remains disabled unless an explicit public contract is established. New activity/session routes default to `noindex, follow`; no public SEO route is needed for the initial feature.
+
+## 4. Contribute displayed climbs
+
+### Trigger and actor
+
+**Confidence: HIGH — repository.** [`confirmClimbOnWall`](../packages/backend/src/graphql/resolvers/sessions/mutations.ts) validates stable participant membership and recent queue history, then records the session confirmation. It is not an external wall identity or proof of physical display. [`reportBoardClimb`](../packages/backend/src/graphql/resolvers/board-presence/mutations.ts) already accepts display reports, resolves the emitting actor, checks board membership and catalog compatibility, and tracks current writer, deduplication and durable activity. Its membership check accepts a selected board, so it is not physical attestation either.
+
+Use the successful device-write report behind `reportBoardClimb` as the contribution candidate, and require an authenticated actor with their own Kilter link and explicit contribution consent. Add a current connection lease/proof record to the candidate contract if the existing report cannot distinguish actual device writes from selection-only clients. A session host's account must never announce all participants' activity. Anonymous emitters, accountless controllers, kiosk browsing, queue selection, failed device writes and imported live-feed events are ineligible.
+
+### Proposed contribution lifecycle
+
+1. Capture canonical board and binding revision, actor/account ID, actual controller/device context, Kilter climb ID, integer angle, display sequence, successful-write time, and eligibility evidence. Resolve Kilter climb aliases in one batch, as push-back does; require proven Kilter catalog membership when no alias exists. Skip Boardsesh-only climbs instead of guessing that a canonical UUID is accepted upstream.
+2. Maintain one pending candidate per active controller/actor. Use the configured append delay with **45 seconds as the initial minimum**, replacing pending work when the displayed climb or angle changes. Require the display sequence, controller lease, account, consent, binding revision and current writer to remain valid at dispatch. Disconnect, logout, unlink, handoff and mapping changes cancel pending work.
+3. For a gym wall, require the connection serial or a recent, consented location check within 200 m of the mapped gym, following the observed client alternatives. Validate that location evidence is fresh and belongs to the emitting device; keep it short-lived and out of logs. A backend request alone cannot prove physical proximity. Do not fabricate serials or coordinates to pass this gate.
+4. Serialize the verified eight fields, including `userUuid: null` and `createdAt: null`, and use the actor's token. The server must first be verified to attribute this correctly. Do not add arbitrary session IDs, spoof another username, or append a Boardsesh brand suffix to a real account's identity.
+5. Persist local delivery state (`pending`, `sending`, `accepted`, `unknown`, `cancelled`, `failed`) with a unique local display-event key, short expiry and worker lease. Status 200 means the observed client success condition, not proven exactly-once delivery. A timeout after send becomes `unknown`; do not automatically replay ambiguous POSTs until upstream idempotency is established. Expired/offline activity must not be backfilled as if current.
+
+The local deduplication key includes account, canonical wall binding/revision, controller lease and display sequence. Reconnects must retain the same logical event identifier; a new genuine display can publish later. This prevents Boardsesh worker retries and duplicate device reports, but cannot suppress a simultaneous event from Kilter's app without upstream support.
+
+Contribute only display events supported by this protocol. Ending a Boardsesh session stops future contributions and cancels pending work; it does not call `/report`, manufacture a leave event, or promise removal of an already accepted entry. Read and write flags remain independently switchable.
+
+**Release conditions:** controlled observation of accepted serial and serial-less events, identity and timestamp attribution, duplicate/timeout behavior, and agreed account-risk controls. Custom-wall contributions additionally require verification of token-sub-as-gym semantics and private visibility. Any implementation touching BLE code receives the required Fable/Astra review before merge.
+
+## 5. Capacity, attribution, and account risk
+
+### Sizing
+
+These are proposed capacity estimates, **not Kilter quotas**. Let `R` be active account/selector pollers after same-account coalescing and `W` active contributing controllers. With the observed defaults, steady read traffic is approximately `R / 30` requests/second; a sustained scenario where each controller produces an eligible event every 45 seconds is `W / 45` writes/second. Actual request durations reduce polling frequency; initial loads, reconnects and retries add traffic.
+
+| Active read pollers / contributing controllers | Read requests/second | Sustained write scenario/second |
+| --- | --- | --- |
+| 100 / 100 | 3.3 | 2.2 |
+| 1,000 / 1,000 | 33.3 | 22.2 |
+| 10,000 / 10,000 | 333.3 | 222.2 |
+
+One continuously active viewer at 30 seconds is about 120 reads/hour. One controller publishing every 45 seconds is about 80 writes/hour. This is substantially different from sporadic logbook changes, even with the same user token. Do not apply Boardsesh's existing `reportBoardClimb` allowance (60/minute per signed-in user) as an upstream quota.
+
+Propose an allowlisted pilot of **at most five accounts**, one selected wall per account, read cap **1 request/second globally**, write cap **1 request/5 seconds globally**, and per-account minimum intervals of 30/45 seconds. Apply global limits across backend instances using Redis; count initial loads, refresh attempts and retries. Expire pending work rather than draining a stale queue. These are conservative starting budgets requiring Kilter agreement, not a claim they are safe production limits. Increase only against explicit quotas and measured traffic.
+
+Use bounded timeouts, single-flight reads, positive jitter, and exponential backoff for safe reads. Respect `Retry-After` when supplied; on 429 pause the affected scope and reduce the global budget if scope is unknown. A 401 allows one coordinated refresh; repeated 401, any unexplained 403, or changed response schema pauses the account. Ambiguous writes are not blindly retried. Track counts, status, latency, backoff, mapping confidence and local delivery state without logging tokens, raw coordinates or response usernames.
+
+### Attribution, terms, and account flags
+
+**Confidence: HIGH — published terms; LOW — application/enforcement to this integration.** Kilter's terms, last updated March 9, 2026, restrict alternate interfaces, automated copying and non-personal/commercial use (§1), make account holders responsible for account activity (§2), restrict reverse engineering subject to stated exceptions (§5), and permit suspension and changing service limits (§§1, 6). Those provisions create concrete exposure for this integration and its users; consent to link an account does not itself resolve that exposure. Applicability and any interoperability exceptions need assessment, not an assumption of permission. [Kilter Terms of Use](https://app.kiltergrips.com/terms).
+
+Propose discussing both read access and contribution with Kilter before production rollout, using the protocol spec with its provenance intact. Obtain an agreed client identity, quota scopes, supported attribution, visibility/opt-out rules, idempotency behavior, and an escalation contact for account flags. This plan does not send that outreach.
+
+Explain contribution separately from read consent: eligible climbs may appear under the user's Kilter identity, with the mapped wall, angle and time; upstream visibility and deletion must be confirmed before making promises. Let users stop future contribution without disabling reading or existing account sync. Technical compatibility must never imply endorsement by Kilter or Aurora.
+
+**Confidence: LOW — risk probability.** The likelihood of flags is unknown. Centralized server egress, many account tokens, publication bursts, wrong wall attribution, and duplicate events are plausible flagging or moderation triggers, not observed detection rules. Monitor account failures and reports during the pilot; stop the affected scope and offer relinking only after diagnosis. Do not rotate accounts/IPs, spoof the official client, or retry through a restriction. Existing push-back scaffolding provides no measured reassurance about this risk.
+
+## 6. Implementation sequence and acceptance gates
+
+| Phase | Deliverable | Exit evidence |
+| --- | --- | --- |
+| 0. Protocol agreement and fixtures | Resolve prioritized open questions with Kilter; obtain minimal consented read/write observations | Confirm wall scoping, actor identity, timestamps, serial-less acceptance, quotas and permitted use; retain redacted fixtures |
+| 1. Mapping and shared contract | Pure types/parsers/eligibility in `packages/shared/kilter-live`; binding schema generated through Drizzle; backend binding resolvers | Imported serial-less join; manual ambiguity; opaque/many-to-one layout aliases; serial collisions; merge and private-survivor tests |
+| 2. Read pilot | Live REST reader, coordinated credentials, backend poll ownership, mobile activity view and read consent | Two-wall separation, account-cache isolation, expiry/stale UI, refresh rotation race, disconnect cleanup, and rate-limit tests |
+| 3. Contribution preparation | Separate opt-in, real-device-write candidate, debounce/cancellation, delivery ledger and global budget | Dry-run shows correct wall, actor, alias and angle; no network publication; reconnect/handoff/merge/offline cases pass |
+| 4. Contribution pilot | Enable serial-equipped gym writes, then verified serial-less branch, each behind separate allowlists | Controlled upstream result matches physical display and intended account; no duplicates, stale replay, or account restrictions; emergency disable exercised |
+| 5. Broader compatibility | Expand only within agreed budgets; consider custom walls after their additional gates | Measured load within quotas; privacy, reporting and operational support agreed |
+
+Implementation QA must cover two phones sharing a session, one user's multiple devices, a controller without a linked account, no-serial boards, denied/stale location, two identical configurations at one gym, a merged/deleted/private board, wrong climb aliases, and disconnect or consent withdrawal during the debounce. Assert that feed reads never trigger contribution and that failed reads never alter confirmed on-wall state.
+
+Use `vp check` and `vp run typecheck` for each implementation PR, plus meaningful package tests. Mobile changes also follow the repo's mobile test/bundle/simulator sequence. This documentation PR needs the canonical checks and documentation review; no behavior-mirroring tests are added for Markdown.
+
+The first implementation decision is the mapping/read contract. Contribution remains a planned deliverable with explicit upstream gates; it must not disappear from scope or be enabled merely because reading works.

--- a/docs/kilter-live-integration-plan.md
+++ b/docs/kilter-live-integration-plan.md
@@ -69,6 +69,8 @@ Use at most one active binding per account and canonical board. Imported public 
 
 **Confidence: HIGH — repository.** [`user_board_serials`](../packages/db/src/schema/app/board-serials.ts) is unique per `(userId, boardName, serialNumber)`, not globally. Existing resolution trims and uppercases serials and considers board/configuration preferences. Keep original connection serial separately for the outgoing protocol representation; do not assume backend normalization is Kilter's normalization. Multiple candidates require explicit selection.
 
+**Confidence: HIGH — protocol.** Kilter's live publisher takes its connection serial from the Bluetooth candidate's `Name#serial@version` suffix, with both delimiters required; it does not fill a missing serial from the selected wall's saved metadata. See [serial acquisition](KILTER_LIVE_SPEC.md#44-where-the-serial-comes-from). A bare-name Kilter controller therefore follows the serial-less gym branch even if a board record contains a manually entered serial. Preserve that distinction in eligibility evidence. Whether newer Kilter-built hardware has resumed serial advertising remains **LOW confidence / unresolved**; do not base coverage estimates or custom-wall support on that assumption.
+
 ## 3. Read through the user's account
 
 Proposed ownership:


### PR DESCRIPTION
## Summary

Documents the live board activity contract from the installed Google Play Android 2.10.1 / build 65: authenticated REST reads, debounced display publication, and the separate moderation endpoint. The spec retains one provenance line, confidence markers, binary anchors, and explicit server-side unknowns.

Plans both viewing through each user's own Kilter account and contribution of eligible Boardsesh display events. Covers serial-less imported wall identity, explicit bindings, board merges, actor attribution, consent, traffic budgets, ambiguous writes, and terms/account risks. Records that the existing push-back architecture currently stops at `pushNotWired()` before HTTP calls.

Validation: `vp check` passed with zero errors; `vp run typecheck` passed; local Markdown links and diff whitespace checked. No application binaries are committed and no upstream live activity was written.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — Documentation only; implementation and production rollout remain gated by protocol verification.
