### PR TITLE
fix(mobile): tell the truth about board-account linking

### DIFF
--- a/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
+++ b/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
@@ -15,6 +15,7 @@ import * as Clipboard from 'expo-clipboard';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
+import { boardTypeLabel } from '@boardsesh/board-constants';
 import { DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR } from '@boardsesh/shared-schema/sync-error-codes';
 import {
   AURORA_BOARDS,
@@ -36,7 +37,7 @@ import { useToast } from '../../providers/toast-provider';
 import { useConfirm } from '../../providers/dialog-provider';
 import { useFeatureFlag } from '../../providers/feature-flags-provider';
 import { borderRadius, spacing } from '../../theme/tokens';
-import { iosSystemColors } from '../../theme/ios-colors';
+import { iosDarkColors } from '../../theme/ios-colors';
 import {
   BoardAccountError,
   deleteAuroraCredential,
@@ -101,8 +102,13 @@ const AURORA_UNSYNCED_QUERY_KEY = ['auroraCredentials', 'unsynced'] as const;
 // MoonBoard isn't an Aurora board, so it has no credential/sync flow.
 const MOONBOARD_SUPPORT_EMAIL = 'moonboardsupport@moonclimbing.com';
 
+// Brand names, not a capitalised slug: `charAt(0).toUpperCase()` renders `soill`
+// as "Soill", which shipped a mangled trademark on the So iLL card and into every
+// `{{boardName}}` interpolation on this screen. `boardTypeLabel` is the canonical
+// map (`@boardsesh/board-constants`), which its own header comment asks call sites
+// to migrate to as they're touched.
 function boardDisplayName(boardType: AuroraBoardName): string {
-  return boardType.charAt(0).toUpperCase() + boardType.slice(1);
+  return boardTypeLabel(boardType);
 }
 
 function getCredential(credentials: AuroraCredentialStatus[] | undefined, boardType: AuroraBoardName) {
@@ -490,9 +496,16 @@ export function BoardAccountsSection() {
     })();
   }, [importBoard, importData, queryClient, showToast, t]);
 
-  const inputBackground = colorScheme === 'dark' ? iosSystemColors.white : '#FFFFFF';
-  const inputBorder = colorScheme === 'dark' ? 'rgba(60, 60, 67, 0.36)' : 'rgba(60, 60, 67, 0.18)';
-  const inputStyle = [styles.input, { backgroundColor: inputBackground, borderColor: inputBorder, color: '#000000' }];
+  // Both branches used to resolve to white with hardcoded black text, so the link
+  // dialog punched two glaring white fields into an otherwise dark screen. The
+  // field sits on the modal card (`secondaryBackground`), so it takes the next
+  // surface up and the theme's own label colour in both schemes.
+  const inputBackground = systemColors.tertiaryBackground;
+  const inputBorder = colorScheme === 'dark' ? iosDarkColors.separator : 'rgba(60, 60, 67, 0.18)';
+  const inputStyle = [
+    styles.input,
+    { backgroundColor: inputBackground, borderColor: inputBorder, color: systemColors.label },
+  ];
 
   const credentials = credentialsQuery.data?.credentials;
   const hasKilterCredential = getCredential(credentials ?? [], 'kilter') !== null;
@@ -599,7 +612,7 @@ export function BoardAccountsSection() {
               value={username}
               onChangeText={setUsername}
               placeholder={t('aurora.linkDialog.usernamePlaceholder')}
-              placeholderTextColor="rgba(60, 60, 67, 0.6)"
+              placeholderTextColor={systemColors.tertiaryLabel}
               autoCapitalize="none"
               autoCorrect={false}
               style={inputStyle}
@@ -608,7 +621,7 @@ export function BoardAccountsSection() {
               value={password}
               onChangeText={setPassword}
               placeholder={t('aurora.linkDialog.passwordPlaceholder')}
-              placeholderTextColor="rgba(60, 60, 67, 0.6)"
+              placeholderTextColor={systemColors.tertiaryLabel}
               autoCapitalize="none"
               autoCorrect={false}
               secureTextEntry

--- a/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
+++ b/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
@@ -37,7 +37,9 @@ vi.mock('../../../lib/aurora-credentials', () => ({
 }));
 
 vi.mock('@boardsesh/shared-schema', () => ({
-  AURORA_BOARDS: ['kilter', 'tension'],
+  // `soill` is here for the trademark regression below — it is the one board whose
+  // brand name a naive capitalise gets wrong.
+  AURORA_BOARDS: ['kilter', 'tension', 'soill'],
   parseAuroraExportJson: vi.fn(() => ({
     data: { user: { username: 'aurora' }, ascents: [], attempts: [], circuits: [], climbs: [] },
     preview: { username: 'aurora', ascents: 0, attempts: 0, circuits: 0, climbs: 0 },
@@ -179,6 +181,16 @@ describe('BoardAccountsSection — Kilter password card', () => {
     mocks.invalidate.mockClear();
     mocks.flags = {};
     mocks.credentials = [];
+  });
+
+  // Regression: the card title used to run `charAt(0).toUpperCase() + slice(1)` over
+  // the board type, which renders `soill` as "Soill" — a mangled trademark shipped on
+  // the card and into every `{{boardName}}` interpolation on this screen. It now goes
+  // through `boardTypeLabel`, the canonical brand map.
+  it('renders board brand names, not capitalised slugs', () => {
+    const { container } = render(<BoardAccountsSection />);
+    expect(container.textContent).toContain('So iLL');
+    expect(container.textContent).not.toContain('Soill');
   });
 
   it('shows the Kilter (new) sign-in card when the flag is on', () => {

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -605,7 +605,7 @@
     "statistics": "Statistiken",
     "sessions": "Sessions",
     "createdClimbs": "Gebaute Boulder",
-    "auroraMigration": "Aurora-Migration",
+    "auroraMigration": "Routenbuch mitnehmen",
     "startClimbing": "Loslegen",
     "signIn": "Anmelden",
     "nav": {
@@ -867,7 +867,7 @@
       "help": "Hilfe",
       "docs": "Doku",
       "playlists": "Playlists",
-      "auroraMigration": "Aurora-Migration",
+      "auroraMigration": "Routenbuch mitnehmen",
       "legal": "Impressum",
       "privacy": "Datenschutz",
       "gymsKilter": "Hallen mit einem Kilter Board",

--- a/packages/shared/i18n/locales/de/settings.json
+++ b/packages/shared/i18n/locales/de/settings.json
@@ -149,7 +149,7 @@
       "kilterNewCopy": "Melde dich mit deinem Kilter-Benutzernamen und -Passwort an und hol deine Begehungen, Versuche, Bewertungen und Circuits nach Boardsesh.",
       "kilterSignIn": "Bei Kilter anmelden",
       "reconnect": "Neu verbinden",
-      "notConnected": "Nicht verbunden. Verknüpf dein {{boardName}}-Konto, um deine Aurora-Daten zu holen, oder importier eine JSON-Exportdatei.",
+      "notConnected": "Nicht verbunden. Verknüpf dein {{boardName}}-Konto, um deine Begehungen zu holen, oder importier eine JSON-Exportdatei.",
       "link": "Verknüpfen",
       "import": "Importieren",
       "requestData": "Daten anfordern",
@@ -177,7 +177,7 @@
     },
     "linkDialog": {
       "title": "{{boardName}}-Konto verknüpfen",
-      "description": "Gib Benutzernamen und Passwort für dein {{boardName}} Board ein, um deine Aurora-Daten zu holen. Deine Zugangsdaten werden verschlüsselt und sicher gespeichert. Die Sync läuft alle 12 Stunden.",
+      "description": "Melde dich so an, wie du dich bei {{boardName}} anmeldest: mit deinem {{boardName}}-Benutzernamen, nicht deiner E-Mail. Deine Zugangsdaten werden vor dem Speichern verschlüsselt.",
       "usernameLabel": "Benutzername",
       "usernamePlaceholder": "Gib deinen Benutzernamen ein",
       "passwordLabel": "Passwort",
@@ -185,12 +185,12 @@
       "submit": "Konto verknüpfen",
       "submitting": "Wird verknüpft...",
       "linkError": "Konto konnte nicht verknüpft werden",
-      "linkSuccess": "{{boardName}}-Konto verknüpft. Deine Daten sind innerhalb von 12 Stunden da.",
+      "linkSuccess": "{{boardName}}-Konto verknüpft. Deine Begehungen sind unterwegs — die meisten sind in ein paar Minuten da.",
       "accountAlreadyLinked": "Ein anderes Boardsesh-Mitglied hat dieses Konto schon verknüpft. Wenn es deins ist, trenn es dort zuerst und versuch es dann nochmal."
     },
     "kilterLinkDialog": {
       "title": "Bei Kilter anmelden",
-      "description": "Gib deinen Kilter-Benutzernamen und dein Passwort ein. Dein Passwort wird gegen ein sicheres Token getauscht und nie gespeichert. Deine Begehungen sind in ein paar Stunden da.",
+      "description": "Gib deinen Kilter-Benutzernamen und dein Passwort ein. Dein Passwort wird gegen ein sicheres Token getauscht und nie gespeichert. Deine Begehungen sind in ein paar Minuten da.",
       "passwordHelp": "Funktioniert mit deinem bestehenden Kilter-Login. Konten mit Zwei-Faktor oder reinem Social-Login kommen hier nicht rein – nutz stattdessen den Import."
     },
     "unlinkError": "Konto konnte nicht getrennt werden",
@@ -314,7 +314,7 @@
       "connected": "Verbunden",
       "notConnected": "Nicht verbunden",
       "kilterNotAllowed": "Die Kilter-Sync ist für dieses Konto noch nicht freigeschaltet.",
-      "linkSuccess": "{{boardName}} verknüpft",
+      "linkSuccess": "{{boardName}} verknüpft — deine Begehungen sind unterwegs.",
       "unlinkSuccess": "{{boardName}} getrennt",
       "unlinkPartial": "{{boardName}} ist hier weg, beim Anbieter läuft die Sitzung aber vielleicht noch.",
       "invalidCredentials": "Benutzername oder Passwort hat nicht gepasst.",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -605,7 +605,7 @@
     "statistics": "Statistics",
     "sessions": "Sessions",
     "createdClimbs": "Created Climbs",
-    "auroraMigration": "Aurora Migration",
+    "auroraMigration": "Bring your logbook",
     "startClimbing": "Start climbing",
     "signIn": "Sign in",
     "nav": {
@@ -867,7 +867,7 @@
       "help": "Help",
       "docs": "Developer docs",
       "playlists": "Playlists",
-      "auroraMigration": "Aurora migration",
+      "auroraMigration": "Bring your logbook",
       "legal": "Legal",
       "privacy": "Privacy",
       "gymsKilter": "Gyms with a Kilter board",

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -149,7 +149,7 @@
       "kilterNewCopy": "Sign in with your Kilter username and password to pull your sends, attempts, ratings and circuits into Boardsesh.",
       "kilterSignIn": "Sign in to Kilter",
       "reconnect": "Reconnect",
-      "notConnected": "Not connected. Link your {{boardName}} account to import your Aurora data, or import from a JSON export file.",
+      "notConnected": "Not connected. Link your {{boardName}} account to bring your sends across, or import from a JSON export file.",
       "link": "Link",
       "import": "Import",
       "requestData": "Request your data",
@@ -177,7 +177,7 @@
     },
     "linkDialog": {
       "title": "Link {{boardName}} Account",
-      "description": "Enter your {{boardName}} Board username and password to import your Aurora data. Your credentials are encrypted and securely stored. Data syncs every 12 hours.",
+      "description": "Sign in the way you'd sign in to {{boardName}} itself — your {{boardName}} username, not your email. Your credentials are encrypted before they're stored.",
       "usernameLabel": "Username",
       "usernamePlaceholder": "Enter your username",
       "passwordLabel": "Password",
@@ -185,12 +185,12 @@
       "submit": "Link Account",
       "submitting": "Linking...",
       "linkError": "Failed to link account",
-      "linkSuccess": "{{boardName}} account linked. Your data will show up within 12 hours.",
+      "linkSuccess": "{{boardName}} linked. Your sends are on their way — most land within a few minutes.",
       "accountAlreadyLinked": "Another Boardsesh member already has this account linked. If it's yours, unlink it from their account first, then try again."
     },
     "kilterLinkDialog": {
       "title": "Sign in to Kilter",
-      "description": "Enter your Kilter username and password. Your password is exchanged for a secure token and never stored. Your sends sync within a few hours.",
+      "description": "Enter your Kilter username and password. Your password is exchanged for a secure token and never stored. Your sends start arriving within minutes.",
       "passwordHelp": "Works with your existing Kilter login. Two-factor or social-login-only accounts can't sign in this way — use Import instead."
     },
     "unlinkError": "Failed to unlink account",
@@ -314,7 +314,7 @@
       "connected": "Connected",
       "notConnected": "Not connected",
       "kilterNotAllowed": "Kilter sync is not enabled for this account yet.",
-      "linkSuccess": "{{boardName}} linked",
+      "linkSuccess": "{{boardName}} linked — your sends are on their way.",
       "unlinkSuccess": "{{boardName}} unlinked",
       "unlinkPartial": "{{boardName}} was removed here, but the provider session may still be live.",
       "invalidCredentials": "That username or password didn't work.",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -37,7 +37,7 @@
     "statistics": "Estadísticas",
     "sessions": "Sesiones",
     "createdClimbs": "Bloques creados",
-    "auroraMigration": "Migración de Aurora",
+    "auroraMigration": "Trae tu historial",
     "startClimbing": "Empieza a escalar",
     "signIn": "Iniciar sesión",
     "nav": {
@@ -867,7 +867,7 @@
       "help": "Ayuda",
       "docs": "Documentación",
       "playlists": "Listas",
-      "auroraMigration": "Migración desde Aurora",
+      "auroraMigration": "Trae tu historial",
       "legal": "Aviso legal",
       "privacy": "Privacidad",
       "gymsKilter": "Rocódromos con un plafón Kilter",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -149,7 +149,7 @@
       "kilterNewCopy": "Inicia sesión con tu usuario y contraseña de Kilter para traer tus encadenamientos, intentos, valoraciones y circuitos a Boardsesh.",
       "kilterSignIn": "Iniciar sesión en Kilter",
       "reconnect": "Volver a conectar",
-      "notConnected": "No vinculado. Vincula tu cuenta de {{boardName}} para importar tus datos de Aurora, o impórtalos desde un archivo JSON.",
+      "notConnected": "No vinculado. Vincula tu cuenta de {{boardName}} para traer tus encadenamientos, o impórtalos desde un archivo JSON.",
       "link": "Vincular",
       "import": "Importar",
       "requestData": "Pedir tus datos",
@@ -177,7 +177,7 @@
     },
     "linkDialog": {
       "title": "Vincular cuenta de {{boardName}}",
-      "description": "Introduce el usuario y la contraseña de tu cuenta de {{boardName}} para importar tus datos de Aurora. Tus credenciales se cifran y se guardan de forma segura. Los datos se sincronizan cada 12 horas.",
+      "description": "Inicia sesión igual que lo harías en {{boardName}}: con tu usuario de {{boardName}}, no con tu correo. Tus credenciales se cifran antes de guardarse.",
       "usernameLabel": "Usuario",
       "usernamePlaceholder": "Escribe tu usuario",
       "passwordLabel": "Contraseña",
@@ -185,12 +185,12 @@
       "submit": "Vincular cuenta",
       "submitting": "Vinculando...",
       "linkError": "No se pudo vincular la cuenta",
-      "linkSuccess": "Cuenta de {{boardName}} vinculada. Tus datos aparecerán en menos de 12 horas.",
+      "linkSuccess": "Cuenta de {{boardName}} vinculada. Tus encadenamientos vienen en camino: la mayoría llegan en unos minutos.",
       "accountAlreadyLinked": "Otro miembro de Boardsesh ya tiene esta cuenta vinculada. Si es tuya, desvincúlala primero de su cuenta y vuelve a intentarlo."
     },
     "kilterLinkDialog": {
       "title": "Iniciar sesión en Kilter",
-      "description": "Introduce tu usuario y contraseña de Kilter. Tu contraseña se canjea por un token seguro y nunca se guarda. Tus encadenamientos se sincronizan en unas horas.",
+      "description": "Introduce tu usuario y contraseña de Kilter. Tu contraseña se canjea por un token seguro y nunca se guarda. Tus encadenamientos empiezan a llegar en unos minutos.",
       "passwordHelp": "Funciona con tu acceso habitual de Kilter. Las cuentas con verificación en dos pasos o solo con inicio de sesión social no pueden entrar por aquí: usa Importar."
     },
     "unlinkError": "No se pudo desvincular la cuenta",
@@ -201,7 +201,7 @@
       "connected": "Conectado",
       "notConnected": "No conectado",
       "kilterNotAllowed": "La sincronización con Kilter aún no está habilitada para esta cuenta.",
-      "linkSuccess": "{{boardName}} vinculado",
+      "linkSuccess": "{{boardName}} vinculado: tus encadenamientos vienen en camino.",
       "unlinkSuccess": "{{boardName}} desvinculado",
       "unlinkPartial": "{{boardName}} se eliminó aquí, pero la sesión del proveedor puede seguir activa.",
       "invalidCredentials": "Ese usuario o contraseña no funcionó.",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -605,7 +605,7 @@
     "statistics": "Statistiques",
     "sessions": "Sessions",
     "createdClimbs": "Blocs créés",
-    "auroraMigration": "Migration Aurora",
+    "auroraMigration": "Importer votre carnet",
     "startClimbing": "Commencer à grimper",
     "signIn": "Se connecter",
     "nav": {
@@ -867,7 +867,7 @@
       "help": "Aide",
       "docs": "Doc développeur",
       "playlists": "Playlists",
-      "auroraMigration": "Migration Aurora",
+      "auroraMigration": "Importer votre carnet",
       "legal": "Mentions légales",
       "privacy": "Confidentialité",
       "gymsKilter": "Salles avec une board Kilter",

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -149,7 +149,7 @@
       "kilterNewCopy": "Connectez-vous avec votre identifiant et mot de passe Kilter pour rapatrier vos croix, essais, notes et circuits dans Boardsesh.",
       "kilterSignIn": "Se connecter à Kilter",
       "reconnect": "Reconnecter",
-      "notConnected": "Non lié. Liez votre compte {{boardName}} pour importer vos données Aurora, ou importez depuis un fichier d'export JSON.",
+      "notConnected": "Non lié. Liez votre compte {{boardName}} pour récupérer vos croix, ou importez depuis un fichier d'export JSON.",
       "link": "Lier",
       "import": "Importer",
       "requestData": "Demander vos données",
@@ -177,7 +177,7 @@
     },
     "linkDialog": {
       "title": "Lier le compte {{boardName}}",
-      "description": "Saisissez l'identifiant et le mot de passe de votre compte {{boardName}} Board pour importer vos données Aurora. Vos identifiants sont chiffrés et stockés en sécurité. Les données se synchronisent toutes les 12 heures.",
+      "description": "Connectez-vous comme vous le feriez sur {{boardName}} : avec votre identifiant {{boardName}}, pas votre e-mail. Vos identifiants sont chiffrés avant d'être stockés.",
       "usernameLabel": "Identifiant",
       "usernamePlaceholder": "Votre identifiant",
       "passwordLabel": "Mot de passe",
@@ -185,12 +185,12 @@
       "submit": "Lier le compte",
       "submitting": "Liaison...",
       "linkError": "Liaison du compte impossible",
-      "linkSuccess": "Compte {{boardName}} lié. Vos données arriveront sous 12 heures.",
+      "linkSuccess": "Compte {{boardName}} lié. Vos croix sont en route — la plupart arrivent en quelques minutes.",
       "accountAlreadyLinked": "Un autre membre de Boardsesh a déjà lié ce compte. S'il est à toi, délie-le d'abord de son compte, puis réessaie."
     },
     "kilterLinkDialog": {
       "title": "Se connecter à Kilter",
-      "description": "Saisissez votre identifiant et mot de passe Kilter. Votre mot de passe est échangé contre un jeton sécurisé et n'est jamais stocké. Vos croix se synchronisent sous quelques heures.",
+      "description": "Saisissez votre identifiant et mot de passe Kilter. Votre mot de passe est échangé contre un jeton sécurisé et n'est jamais stocké. Vos croix commencent à arriver en quelques minutes.",
       "passwordHelp": "Fonctionne avec votre connexion Kilter habituelle. Les comptes avec double authentification ou connexion sociale uniquement ne peuvent pas se connecter ainsi — utilisez Importer."
     },
     "unlinkError": "Déliaison du compte impossible",
@@ -201,7 +201,7 @@
       "connected": "Connecté",
       "notConnected": "Non connecté",
       "kilterNotAllowed": "La synchronisation Kilter n'est pas encore activée pour ce compte.",
-      "linkSuccess": "{{boardName}} lié",
+      "linkSuccess": "{{boardName}} lié — vos croix sont en route.",
       "unlinkSuccess": "{{boardName}} délié",
       "unlinkPartial": "{{boardName}} a été retiré ici, mais la session du fournisseur peut rester active.",
       "invalidCredentials": "Cet identifiant ou ce mot de passe n'a pas fonctionné.",

--- a/packages/web/app/components/board-entity/__tests__/board-import-prompt.test.tsx
+++ b/packages/web/app/components/board-entity/__tests__/board-import-prompt.test.tsx
@@ -178,7 +178,7 @@ describe('BoardImportPrompt', () => {
 
       await waitFor(() => {
         expect(mockShowMessage).toHaveBeenCalledWith(
-          'Tension account linked. Your data will show up within 12 hours.',
+          'Tension linked. Your sends are on their way — most land within a few minutes.',
           'success',
         );
       });

--- a/packages/web/app/components/site-chrome/__tests__/marketing-header.test.tsx
+++ b/packages/web/app/components/site-chrome/__tests__/marketing-header.test.tsx
@@ -376,7 +376,7 @@ describe('MarketingHeader', () => {
       mockPathname = '/aurora-migration';
       render(<MarketingHeader />);
 
-      expect(screen.getByText('Aurora Migration')).toBeTruthy();
+      expect(screen.getByText('Bring your logbook')).toBeTruthy();
       expect(screen.getByTestId('back-button').getAttribute('data-fallback')).toBe('/');
     });
   });


### PR DESCRIPTION
## Summary

Three things on the board-account linking screen were telling users something untrue.

**The sync latency was invented.** The link dialog said "Data syncs every 12 hours" and
the success toast said "your data will show up within 12 hours". Nothing in the code
runs on a 12-hour schedule. A freshly-linked credential jumps the queue —
`ORDER BY last_sync_attempt_at ASC NULLS FIRST` in `claim-credential.ts` — and lands in
1–15 minutes, unless it's made inside the nightly pause (22:00–07:00 Australia/Sydney),
which costs up to ~7 hours. Meanwhile the *recurring* interval for an established link
is `fleet_size × cycle_length`, which can be far worse than 12 hours. So the number was
wrong in both directions at once.

The dialog now makes no timing promise at all — at that point the user may still fail to
sign in, so any number there is noise — and the promise moved to the success message,
where it's true.

**A mangled trademark.** `BoardAccountsSection` rolled its own
`charAt(0).toUpperCase() + slice(1)`, which renders `soill` as **"Soill"**. That shipped
on the So iLL card title and into every `{{boardName}}` interpolation on the screen —
nine call sites. It now uses `boardTypeLabel` from `@boardsesh/board-constants`, the
canonical brand map, whose own header comment asks call sites to migrate to it as
they're touched. Covered by a regression test.

**White fields in dark mode.** The link dialog's two text inputs resolved to white in
*both* schemes (`colorScheme === 'dark' ? iosSystemColors.white : '#FFFFFF'`) with
hardcoded black text and a hardcoded placeholder colour, punching two glaring white
boxes into an otherwise dark screen. They now take `tertiaryBackground` (the surface
above the modal card they sit on) and the theme's own label colour.

Also drops "Aurora" from the copy a climber reads. Aurora Climbing builds the software
behind Kilter and Tension, but climbers don't transact with them by name — the term
survives only where it's load-bearing: the data-request email to Aurora, and the JSON
import, where the file genuinely is an Aurora export. The website's "Aurora migration"
nav item becomes "Bring your logbook"; the `/aurora-migration` URL is unchanged, so
there's no SEO impact.

All four locales move together, following the Spanish/French/German glossaries
(`encadenamientos`, `croix`, `Begehungen`).

## Release Notes

Linking your Kilter or Tension account now tells you the truth about when your sends
show up — usually a few minutes, not the twelve hours we used to claim. The So iLL card
spells So iLL properly, and the sign-in fields are no longer blinding white in dark mode.

## Test plan

1. Profile → More → Connected apps. Cards read So iLL, not Soill.
2. Tap Link on Tension. Fields match the dark theme.
3. Read the dialog text. No mention of 12 hours.
4. Switch the app to Spanish. Same screen, no English left.

## Risk

Risk: 1/5 — copy, a colour token, and a brand-name lookup. No behaviour change.
