### PR TITLE
feat(mobile): measure the board-account link funnel

### DIFF
--- a/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
+++ b/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
@@ -16,6 +16,12 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { boardTypeLabel } from '@boardsesh/board-constants';
+import {
+  trackLinkFailed,
+  trackLinkStarted,
+  trackLinkSucceeded,
+  type BoardLinkFailureReason,
+} from '../../lib/integrations/board-link-analytics';
 import { DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR } from '@boardsesh/shared-schema/sync-error-codes';
 import {
   AURORA_BOARDS,
@@ -101,6 +107,12 @@ const AURORA_UNSYNCED_QUERY_KEY = ['auroraCredentials', 'unsynced'] as const;
 
 // MoonBoard isn't an Aurora board, so it has no credential/sync flow.
 const MOONBOARD_SUPPORT_EMAIL = 'moonboardsupport@moonclimbing.com';
+
+// This screen is the one surface that offers linking today, so its funnel `source`
+// is fixed. Later surfaces (the empty logbook, onboarding) report their own, which
+// is the whole point of splitting the funnel by source — a climber who came here
+// deliberately is not comparable to one we interrupted.
+const LINK_SOURCE = 'integrations' as const;
 
 // Brand names, not a capitalised slug: `charAt(0).toUpperCase()` renders `soill`
 // as "Soill", which shipped a mangled trademark on the So iLL card and into every
@@ -249,6 +261,13 @@ async function saveBoardCredential(input: { boardType: AuroraBoardName; username
   return saveAuroraCredential(input);
 }
 
+// The funnel's `reason`. A non-`BoardAccountError` is a thrown network/parse
+// failure rather than a code the server sent, so it reports as `request_failed` —
+// the same bucket its user-facing copy falls into below.
+function failureReasonFor(error: unknown): BoardLinkFailureReason {
+  return error instanceof BoardAccountError ? error.code : 'request_failed';
+}
+
 function errorMessageFor(error: unknown, t: TFunction<'settings'>): string {
   if (error instanceof BoardAccountError) {
     switch (error.code) {
@@ -301,6 +320,7 @@ export function BoardAccountsSection() {
   const saveCredentialMutation = useMutation({
     mutationFn: saveBoardCredential,
     onSuccess: async (_credential, variables) => {
+      trackLinkSucceeded({ boardType: variables.boardType, source: LINK_SOURCE });
       const boardName = boardDisplayName(variables.boardType);
       showToast(t('aurora.mobile.linkSuccess', { boardName }), 'success');
       setLinkBoard(null);
@@ -311,7 +331,10 @@ export function BoardAccountsSection() {
         queryClient.invalidateQueries({ queryKey: AURORA_UNSYNCED_QUERY_KEY }),
       ]);
     },
-    onError: (error) => {
+    // `variables` is taken here, not just `error`, so the failure lands on the same
+    // board as its Started — a funnel split by boardType is useless otherwise.
+    onError: (error, variables) => {
+      trackLinkFailed({ boardType: variables.boardType, source: LINK_SOURCE }, failureReasonFor(error));
       showToast(errorMessageFor(error, t), 'error');
     },
   });
@@ -364,6 +387,10 @@ export function BoardAccountsSection() {
 
   const handleSubmitLink = useCallback(() => {
     if (!linkBoard) return;
+    // Started fires on the attempt, not on opening the dialog: a climber who opens
+    // it and closes it never tried, and counting that as a start would understate
+    // the success rate of the people who did.
+    trackLinkStarted({ boardType: linkBoard, source: LINK_SOURCE });
     saveCredentialMutation.mutate({
       boardType: linkBoard,
       username: username.trim(),

--- a/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
+++ b/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
@@ -23,6 +23,17 @@ const mocks = vi.hoisted(() => ({
   refetch: vi.fn(() => Promise.resolve()),
   flags: {} as Record<string, boolean | undefined>,
   credentials: [] as AuroraCredentialStatus[],
+  linkStarted: vi.fn(),
+  linkSucceeded: vi.fn(),
+  linkFailed: vi.fn(),
+}));
+
+// Mocked at the analytics seam rather than at `track`, so the assertions read as
+// "what does this screen report about the funnel" and no test drags in posthog.
+vi.mock('../../../lib/integrations/board-link-analytics', () => ({
+  trackLinkStarted: mocks.linkStarted,
+  trackLinkSucceeded: mocks.linkSucceeded,
+  trackLinkFailed: mocks.linkFailed,
 }));
 
 vi.mock('../../../lib/aurora-credentials', () => ({
@@ -50,7 +61,7 @@ vi.mock('@boardsesh/shared-schema', () => ({
 type MutationOptions = {
   mutationFn: (vars: unknown) => unknown;
   onSuccess?: (result: unknown, vars: unknown) => unknown;
-  onError?: (error: unknown) => unknown;
+  onError?: (error: unknown, variables: unknown) => unknown;
 };
 
 vi.mock('@tanstack/react-query', () => ({
@@ -70,7 +81,10 @@ vi.mock('@tanstack/react-query', () => ({
     mutate: (vars: unknown) => {
       void Promise.resolve(opts.mutationFn(vars))
         .then((result) => opts.onSuccess?.(result, vars))
-        .catch((error) => opts.onError?.(error));
+        // Real React Query passes `(error, variables)` — verified against the
+        // installed @tanstack/query-core 5.101.4 type. The stub used to drop the
+        // second argument, which hid whether a caller could read it.
+        .catch((error) => opts.onError?.(error, vars));
     },
     isPending: false,
     variables: undefined,
@@ -148,7 +162,10 @@ vi.mock('../../../theme/tokens', () => ({
   spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24, 8: 32 },
   borderRadius: { md: 8, lg: 12, full: 999 },
 }));
-vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { white: '#fff' } }));
+// `iosDarkColors` is what the section actually imports. The mock used to export only
+// `iosSystemColors`, which passed by luck: the dark branch is inside a ternary that
+// never evaluates while `colorScheme` is 'light'.
+vi.mock('../../../theme/ios-colors', () => ({ iosDarkColors: { separator: '#38383A' } }));
 
 type TextProps = { children?: ReactNode };
 vi.mock('../../Text', () => ({
@@ -247,6 +264,63 @@ describe('BoardAccountsSection — Kilter password card', () => {
       expect(mocks.saveKilterViaPassword).toHaveBeenCalledWith({ username: 'climber', password: 'secret' });
     });
     expect(mocks.saveAurora).not.toHaveBeenCalled();
+  });
+});
+
+// The funnel these guard did not exist before: nothing emitted an event, a person
+// property or a log line when a climber linked a board account. The invariant worth
+// protecting is that every Started resolves to exactly one Linked or Failed, and
+// that both carry the board the attempt was actually for.
+describe('BoardAccountsSection — link funnel', () => {
+  beforeEach(() => {
+    mocks.saveAurora.mockReset().mockResolvedValue(null);
+    mocks.showToast.mockReset();
+    mocks.invalidate.mockClear();
+    mocks.linkStarted.mockReset();
+    mocks.linkSucceeded.mockReset();
+    mocks.linkFailed.mockReset();
+    mocks.flags = {};
+    mocks.credentials = [];
+  });
+
+  const submitTensionLink = (container: HTMLElement) => {
+    fireEvent.click(button(container, 'aurora.card.link')!);
+    fireEvent.change(input(container, 'aurora.linkDialog.usernamePlaceholder')!, {
+      target: { value: 'climber' },
+    });
+    fireEvent.change(input(container, 'aurora.linkDialog.passwordPlaceholder')!, {
+      target: { value: 'secret' },
+    });
+    fireEvent.click(button(container, 'aurora.linkDialog.submit')!);
+  };
+
+  it('reports a start and a success, tagged with the board and the surface', async () => {
+    const { container } = render(<BoardAccountsSection />);
+    submitTensionLink(container);
+
+    await waitFor(() => expect(mocks.linkSucceeded).toHaveBeenCalledTimes(1));
+    expect(mocks.linkStarted).toHaveBeenCalledWith({ boardType: 'tension', source: 'integrations' });
+    expect(mocks.linkSucceeded).toHaveBeenCalledWith({ boardType: 'tension', source: 'integrations' });
+    expect(mocks.linkFailed).not.toHaveBeenCalled();
+  });
+
+  it('reports a failure with its reason, on the board the attempt was for', async () => {
+    // A plain Error, not a BoardAccountError: a thrown network/parse failure is the
+    // case that would otherwise report no reason at all.
+    mocks.saveAurora.mockRejectedValue(new Error('offline'));
+    const { container } = render(<BoardAccountsSection />);
+    submitTensionLink(container);
+
+    await waitFor(() => expect(mocks.linkFailed).toHaveBeenCalledTimes(1));
+    expect(mocks.linkFailed).toHaveBeenCalledWith({ boardType: 'tension', source: 'integrations' }, 'request_failed');
+    expect(mocks.linkStarted).toHaveBeenCalledTimes(1);
+    expect(mocks.linkSucceeded).not.toHaveBeenCalled();
+  });
+
+  it('does not report a start when the dialog is opened but never submitted', () => {
+    const { container } = render(<BoardAccountsSection />);
+    fireEvent.click(button(container, 'aurora.card.link')!);
+    expect(mocks.linkStarted).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/mobile/src/lib/integrations/board-link-analytics.ts
+++ b/packages/mobile/src/lib/integrations/board-link-analytics.ts
@@ -1,0 +1,47 @@
+// Thin wrappers around the board-account linking events, so the surfaces that
+// offer linking stay free of property-key bookkeeping. Mirrors the shape of
+// `src/lib/onboarding/onboarding-analytics.ts`.
+//
+// The funnel this feeds did not exist before: nothing anywhere emitted an event,
+// a person property or even a log line when a climber linked a board account, so
+// "how many people link, and how many try and fail?" was unanswerable. Every
+// surface that can start a link reports through here with its own `source`, which
+// is what makes the surfaces comparable.
+//
+// The invariant, mirrored from the event catalogue: **every Started resolves to
+// exactly one Linked or Failed.** Nothing here enforces that — callers must fire a
+// terminal event on every path, including the ones that abandon. The onboarding
+// tour learned this the hard way (see the `trackTourDismissed` note): ~a third of
+// its Starts used to resolve to nothing at all, which quietly deflated Completed.
+
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import type { AuroraBoardName } from '@boardsesh/shared-schema';
+import { track } from '../analytics';
+import type { BoardAccountErrorCode } from '../aurora-credentials';
+
+/**
+ * Which surface offered the link. Not cosmetic: the whole point of the funnel is
+ * to compare Settings (where a climber has already gone looking) against the
+ * places we interrupt them, so pooling these would answer nothing.
+ */
+export type BoardLinkSource = 'integrations' | 'onboarding' | 'progress_empty' | 'logbook_empty';
+
+/**
+ * A dismissed browser sheet is a decision, not a fault, so it is kept out of the
+ * error codes rather than collapsed into `request_failed`.
+ */
+export type BoardLinkFailureReason = BoardAccountErrorCode | 'cancelled';
+
+type LinkContext = { boardType: AuroraBoardName; source: BoardLinkSource };
+
+export function trackLinkStarted({ boardType, source }: LinkContext): void {
+  track(SHARED_EVENTS.BoardAccountLinkStarted, { boardType, source });
+}
+
+export function trackLinkSucceeded({ boardType, source }: LinkContext): void {
+  track(SHARED_EVENTS.BoardAccountLinked, { boardType, source });
+}
+
+export function trackLinkFailed({ boardType, source }: LinkContext, reason: BoardLinkFailureReason): void {
+  track(SHARED_EVENTS.BoardAccountLinkFailed, { boardType, source, reason });
+}

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -369,6 +369,26 @@ export const SHARED_EVENTS = {
   // { boardId?, pageSize: number, returnedCount: number }. `returnedCount <
   // pageSize` means that page was the last one.
   BoardHistoryPageLoaded: 'Board History Page Loaded',
+  // Board-account linking — the Kilter/Tension/Aurora credential funnel. These are
+  // deliberately NOT the Integration* events below: those mean an external platform
+  // (Apple Health, Strava) and they feed the `integrations_connected_count` person
+  // property, so folding board accounts in would silently change what that number
+  // means. A board account is the climber's login WITH THE BOARD MAKER, which is what
+  // brings their existing sends across.
+  //
+  // Invariant: every Started resolves to exactly one BoardAccountLinked or
+  // BoardAccountLinkFailed. `cancelled` is a Failed `reason`, not a separate event,
+  // but it is kept distinct from the error codes so a dismissed browser sheet never
+  // inflates the real failure rate.
+  //
+  // Props on all three: { boardType, source: 'integrations' | 'onboarding' |
+  //   'progress_empty' | 'logbook_empty' }. Failed adds { reason }, one of the
+  //   BoardAccountError codes ('invalid_credentials' | 'account_already_linked' |
+  //   'rate_limited' | 'not_allowed' | 'unauthorized' | 'request_failed') or
+  //   'cancelled'.
+  BoardAccountLinkStarted: 'Board Account Link Started',
+  BoardAccountLinked: 'Board Account Linked',
+  BoardAccountLinkFailed: 'Board Account Link Failed',
   // External platform integrations (Apple Health, Strava). Props:
   // { integration: 'apple_health' | 'strava', trigger?: 'auto' | 'manual',
   //   enabled?: boolean }


### PR DESCRIPTION
## Summary

Stacked on #5231.

Nothing in the product emitted an event, a person property, or even a log line when a
climber linked a board account. So "how many people link their Kilter or Tension
account, and how many try and fail?" was unanswerable — which is awkward, because that
is exactly the question behind the Discord report that started this work.

Adds three events to `@boardsesh/analytics` and wires them from the Connected apps
screen:

- `Board Account Link Started` — on submit, not on opening the dialog. Someone who
  opens the form and closes it never tried, and counting that as a start would
  understate the success rate of the people who did.
- `Board Account Linked`
- `Board Account Link Failed` — carries a `reason`, mapped straight from the existing
  `BoardAccountError` codes.

All three carry `boardType` and `source`. The `source` split is the point: a climber who
navigated to Settings on purpose is not comparable to one we interrupted, and the later
surfaces in this stack (the empty logbook, onboarding) report their own.

**These are deliberately not the existing `Integration Connected` event.** That one means
an external platform — Apple Health, Strava — and it feeds the
`integrations_connected_count` person property. Folding board accounts into it would
silently change what that number means.

### Two things worth a look

**`onError` now takes `variables`.** Without it the failure event couldn't say which
board the attempt was for, which makes a funnel split by `boardType` useless. The test
harness's `useMutation` stub was dropping that second argument, so it was invisible —
the stub now matches the real signature, verified against the installed
`@tanstack/query-core` 5.101.4 type rather than assumed.

**No person property in this PR.** The plan called for a `board_accounts_linked_count`
alongside the events. Wiring it into `party-profile-provider` would add a REST call to
every cold start for every user just to populate an analytics field, and setting it
opportunistically from the Connected apps screen would only ever cover people who
visited that screen — biased in exactly the direction that makes it useless. The events
answer the funnel questions; sizing the already-linked population is a database
question, better asked directly. Flagging rather than quietly dropping it.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — analytics only. No user-visible change and no behaviour change.
