### PR TITLE
feat(mobile): offer the board-account link during first-run

### DIFF
--- a/packages/mobile/app/onboarding.tsx
+++ b/packages/mobile/app/onboarding.tsx
@@ -4,6 +4,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { useTheme as usePaperTheme } from 'react-native-paper';
 import { OnboardingPrompt } from '../src/components/onboarding/OnboardingPrompt';
 import { OnboardingBoardRoute } from '../src/components/onboarding/OnboardingBoardRoute';
+import { OnboardingLinkRoute } from '../src/components/onboarding/OnboardingLinkRoute';
 import { BoardLookStep } from '../src/components/board-look/BoardLookStep';
 import { useTheme } from '../src/providers/theme-provider';
 import { useVariantValue } from '../src/theme/variants';
@@ -67,6 +68,17 @@ export default function OnboardingScreen() {
 
   if (step === 'board-look') {
     return <BoardLookRoute accentColor={accentColor} bodyColor={bodyColor} backgroundColor={backgroundColor} />;
+  }
+
+  if (step === 'link') {
+    return (
+      <OnboardingLinkRoute
+        accentColor={accentColor}
+        iconColor={iconColor}
+        bodyColor={bodyColor}
+        backgroundColor={backgroundColor}
+      />
+    );
   }
 
   if (step === 'board') {

--- a/packages/mobile/src/components/onboarding/OnboardingBoardRoute.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingBoardRoute.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { router } from 'expo-router';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { OnboardingBoardStep } from './OnboardingBoardStep';
@@ -14,6 +14,10 @@ import { useBoardOfflineState } from '../board-discovery/use-board-offline-state
 import { trackNudgeAccepted, trackNudgeDismissed, trackNudgeShown } from '../../lib/offline-nudges/nudge-analytics';
 import type { NudgeEventContext } from '../../lib/offline-nudges/nudge-analytics';
 import { offlineBoardKeyForBoard } from '../../settings';
+import { shouldOfferLink } from '../../lib/onboarding/should-offer-link';
+import { hasAnsweredLinkStep } from '../../lib/onboarding/link-step-answered';
+import { useBoardAccountCredentials } from '../../lib/integrations/use-board-account-credentials';
+import { useFeatureFlag } from '../../providers/feature-flags-provider';
 
 // Module-level so an absent board list keeps a stable identity — a fresh `[]`
 // per render would rebuild the carousel's items on every commit.
@@ -51,6 +55,23 @@ export function OnboardingBoardRoute({
   const { confirmAndDownload } = useConfirmBoardDownload();
   const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
   const boardOfflineState = useBoardOfflineState();
+
+  // Inputs for the link offer, read while the picker is on screen so the decision
+  // is ready the moment a board is bound. A positive rollout flag: unresolved
+  // reads false, so the extra step simply does not appear.
+  const linkStepEnabled = useFeatureFlag('board-link-onboarding-step') === true;
+  const { data: credentials } = useBoardAccountCredentials(linkStepEnabled && isAuthenticated);
+  const [linkStepAnswered, setLinkStepAnswered] = useState<boolean | undefined>(undefined);
+  useEffect(() => {
+    if (!linkStepEnabled) return;
+    let cancelled = false;
+    void hasAnsweredLinkStep().then((answered) => {
+      if (!cancelled) setLinkStepAnswered(answered);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [linkStepEnabled]);
 
   const nudgeContextFor = useCallback(
     (board: UserBoard, surface: NudgeEventContext['surface']): NudgeEventContext => ({
@@ -96,14 +117,63 @@ export function OnboardingBoardRoute({
     router.replace('/(tabs)/climbs');
   }, []);
 
+  // Where the board step hands off. Normally Climbs, as before; when the link
+  // offer applies to the board they just picked, the link card sits in between.
+  //
+  // It goes BEFORE the board-look step rather than after, and that ordering is
+  // forced rather than chosen: `app/onboarding.tsx` forbids chaining past
+  // `BoardLookStepGate` (the gate's refusal to run without a synced climb and a
+  // renderer probe is what makes a no-exit step safe), and board-look may never
+  // run at all. Sitting here also means the board type is warm — the card can name
+  // the wall they picked ninety seconds ago.
+  //
+  // The offline-download dialog is awaited inside `onBound`, so this fires after
+  // it resolves; the two interruptions never overlap.
+  //
+  // Anything other than `show` — including `wait`, if a read somehow hasn't landed
+  // by the time a board is bound — goes to Climbs. That is deliberate: this is a
+  // one-shot moment with no second chance to ask, and stalling first-run on a
+  // storage read would be a worse trade than skipping an optional card. The
+  // climber is not lost either way, because the empty-logbook prompt catches
+  // exactly this case. Both reads start when the picker mounts, well before any
+  // board is bound, so in practice they have resolved.
+  const boardRef = useRef<UserBoard | null>(null);
+  const leaveAfterBind = useCallback(() => {
+    const board = boardRef.current;
+    if (
+      board &&
+      shouldOfferLink({
+        enabled: linkStepEnabled,
+        boardType: board.boardType,
+        isOffline,
+        answered: linkStepAnswered,
+        // Tri-state: `undefined` while the read is in flight, never collapsed to
+        // false, or a climber who linked months ago gets a first-run card.
+        hasLinkedAccount: credentials === undefined ? undefined : credentials.length > 0,
+      }) === 'show'
+    ) {
+      router.replace({ pathname: '/onboarding', params: { step: 'link', boardType: board.boardType } });
+      return;
+    }
+    leaveToClimbs();
+  }, [credentials, isOffline, linkStepAnswered, linkStepEnabled, leaveToClimbs]);
+
   const activateBoard = useActivateBoard({
     source: 'onboarding',
     returnTo: '/(tabs)/climbs',
-    navigate: leaveToClimbs,
+    navigate: leaveAfterBind,
     onBound: offerDownload,
   });
 
-  const onSelect = useCallback((board: UserBoard) => void activateBoard(board), [activateBoard]);
+  // Captured before the bind so it is set by the time `navigate()` runs after
+  // `onBound`.
+  const onSelect = useCallback(
+    (board: UserBoard) => {
+      boardRef.current = board;
+      void activateBoard(board);
+    },
+    [activateBoard],
+  );
 
   /**
    * The card glyph: download a board WITHOUT binding it.

--- a/packages/mobile/src/components/onboarding/OnboardingLinkRoute.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingLinkRoute.tsx
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useState } from 'react';
+import { BackHandler, View } from 'react-native';
+import { router, useIsFocused, useLocalSearchParams } from 'expo-router';
+import type { AuroraBoardName } from '@boardsesh/shared-schema';
+import { OnboardingLinkStep } from './OnboardingLinkStep';
+import { isLinkableBoard } from '../../lib/integrations/board-link-eligibility';
+import { markLinkStepAnswered } from '../../lib/onboarding/link-step-answered';
+import { reportError } from '../../lib/error-reporting';
+
+/**
+ * The link step's data and exits.
+ *
+ * Its own component, like `BoardLookRoute`, so nothing it needs is mounted while a
+ * different step is on screen.
+ *
+ * The board comes from the route param rather than a query: the previous step
+ * bound it moments ago and passed it along, so there is nothing to look up and no
+ * loading state to render. A deep link straight to `?step=link` without a usable
+ * board type leaves rather than showing a card about no board in particular.
+ */
+export function OnboardingLinkRoute({
+  accentColor,
+  iconColor,
+  bodyColor,
+  backgroundColor,
+}: {
+  accentColor: string;
+  iconColor: string;
+  bodyColor: string;
+  backgroundColor: string;
+}) {
+  const { boardType } = useLocalSearchParams<{ boardType?: string }>();
+  const isFocused = useIsFocused();
+  const [leaving, setLeaving] = useState(false);
+
+  const leave = useCallback(() => {
+    setLeaving(true);
+    // `replace`, not `dismissTo`: onboarding is a full-screen cover with nothing
+    // of its own left to return to, and the board-look gate picks the climber up
+    // on Climbs — the same exit the board step takes.
+    router.replace('/(tabs)/climbs');
+  }, []);
+
+  // Written on an ANSWER, never on arrival, mirroring `markBoardLookStepSeen`:
+  // a force-quit mid-step must leave the question live for the next launch rather
+  // than burning it in silence.
+  const resolve = useCallback(() => {
+    markLinkStepAnswered().catch((error: unknown) => {
+      // Failing to record the answer only costs one extra ask later, so it must
+      // never block the exit.
+      reportError(error);
+    });
+    leave();
+  }, [leave]);
+
+  const linkable = isLinkableBoard(boardType);
+
+  // Deep-linked here with no linkable board (the gate never does this, but the
+  // route is reachable on its own): there is no account to offer, so leave rather
+  // than show a card naming nothing.
+  useEffect(() => {
+    if (!linkable) leave();
+  }, [linkable, leave]);
+
+  // Android hardware back resolves as "not now" rather than being swallowed. This
+  // step deliberately does NOT call `useBlockBack` — see OnboardingLinkStep for
+  // why it is the one escapable screen in the flow — but back must still count as
+  // an answer, or a climber could reach Climbs with the question left live and be
+  // asked again on the next launch.
+  useEffect(() => {
+    if (!isFocused || !linkable) return;
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      resolve();
+      return true;
+    });
+    return () => subscription.remove();
+  }, [isFocused, linkable, resolve]);
+
+  if (!linkable || leaving) return <View style={{ flex: 1, backgroundColor }} />;
+
+  return (
+    <OnboardingLinkStep
+      boardType={boardType as AuroraBoardName}
+      accentColor={accentColor}
+      iconColor={iconColor}
+      bodyColor={bodyColor}
+      backgroundColor={backgroundColor}
+      onResolved={resolve}
+    />
+  );
+}

--- a/packages/mobile/src/components/onboarding/OnboardingLinkStep.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingLinkStep.tsx
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import { boardTypeLabel } from '@boardsesh/board-constants';
+import type { AuroraBoardName } from '@boardsesh/shared-schema';
+import { Button } from '../Button';
+import { Text } from '../Text';
+import { GlassSurface } from '../GlassSurface';
+import { OnboardingCard } from './OnboardingCard';
+import { LinkBoardAccountModal } from '../integrations/LinkBoardAccountModal';
+import { trackLinkPromptResolved, trackLinkPromptShown } from '../../lib/onboarding/link-step-analytics';
+import { hapticSelection } from '../../lib/haptics';
+import { useTheme } from '../../providers/theme-provider';
+import { selectByVariant } from '../../theme/variants';
+import { spacing } from '../../theme/tokens';
+
+type OnboardingLinkStepProps = {
+  /** The board bound in the previous step. Names the account being offered. */
+  boardType: AuroraBoardName;
+  accentColor: string;
+  iconColor: string;
+  bodyColor: string;
+  backgroundColor: string;
+  /** They answered — either way. Marks the step answered and leaves. */
+  onResolved: () => void;
+};
+
+/**
+ * The first-run "link your board account" card.
+ *
+ * **This is the one step in onboarding with a visible exit, and that is
+ * deliberate.** Issue #4961 stripped the escape hatches out of the other three
+ * because each guarantees state the app cannot run without — a bound board, a
+ * chosen drawing — and a "look around first" that dropped climbers onto empty
+ * screens was worse than no choice at all. This step is different in kind: it asks
+ * for a password to somebody else's service, and nobody may be compelled to type
+ * that. It also asks a question that is simply false for some people, because
+ * there is no way to detect whether a board account exists — Aurora has no
+ * lookup-by-email — so we can only ask.
+ *
+ * So: no `useBlockBack`. The route sets `gestureEnabled: false` for the whole
+ * `/onboarding` file, which means "skippable" here has to be a real button rather
+ * than a swipe, and Android hardware back reaches the same handler as "Not now".
+ *
+ * Every presentation resolves to exactly one outcome, including the nav-aways no
+ * button produced — the unmount guard reports `abandoned`. Without it this would
+ * repeat the hole `onboarding-analytics.ts` documents, where ~a third of tour
+ * Starts resolved to nothing and quietly deflated the completion rate.
+ */
+export function OnboardingLinkStep({
+  boardType,
+  accentColor,
+  iconColor,
+  bodyColor,
+  backgroundColor,
+  onResolved,
+}: OnboardingLinkStepProps) {
+  const { t } = useTranslation('common');
+  const insets = useSafeAreaInsets();
+  const { variant } = useTheme();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const resolvedRef = useRef(false);
+
+  useEffect(() => {
+    trackLinkPromptShown(boardType);
+    return () => {
+      if (!resolvedRef.current) trackLinkPromptResolved(boardType, 'abandoned');
+    };
+  }, [boardType]);
+
+  const boardName = boardTypeLabel(boardType);
+
+  const openDialog = useCallback(() => {
+    hapticSelection();
+    setDialogOpen(true);
+  }, []);
+
+  // Declining is an answer, so it is recorded like one — the step does not come
+  // back on the next launch. The empty-logbook prompt is what catches a climber
+  // who says "not now" here and later wonders where their sends are.
+  const decline = useCallback(() => {
+    if (resolvedRef.current) return;
+    resolvedRef.current = true;
+    trackLinkPromptResolved(boardType, 'declined');
+    hapticSelection();
+    onResolved();
+  }, [boardType, onResolved]);
+
+  // A successful link leaves immediately: the dialog already toasted, and holding
+  // onboarding open while the sends trickle in would be a worse lie than leaving.
+  const handleLinked = useCallback(() => {
+    if (resolvedRef.current) return;
+    resolvedRef.current = true;
+    trackLinkPromptResolved(boardType, 'linked');
+    onResolved();
+  }, [boardType, onResolved]);
+
+  // Closing the dialog WITHOUT linking returns to the card rather than leaving —
+  // a failed password is not a decision to skip, and dropping them out of
+  // onboarding on a typo would be the worst possible reading of it.
+  const closeDialog = useCallback(() => setDialogOpen(false), []);
+
+  const footerPadding = useMemo(() => Math.max(insets.bottom, spacing[4]), [insets.bottom]);
+
+  return (
+    <View style={[styles.root, { backgroundColor, paddingTop: insets.top }]} accessibilityViewIsModal>
+      <View style={styles.cardArea}>
+        <OnboardingCard
+          icon="link"
+          title={t('mobile.onboarding.link.title', { boardName })}
+          body={t('mobile.onboarding.link.body', { boardName })}
+          footnote={t('mobile.onboarding.link.footnote', { boardName })}
+          iconColor={iconColor}
+          bodyColor={bodyColor}
+        />
+      </View>
+
+      <GlassSurface glassEffectStyle="regular" style={[styles.footer, { paddingBottom: footerPadding }]}>
+        <Button
+          title={t('mobile.onboarding.link.continue', { boardName })}
+          onPress={openDialog}
+          variant="filled"
+          size="large"
+          tintColor={selectByVariant(variant, { material: undefined, liquidGlass: accentColor })}
+          haptic={false}
+          style={styles.primary}
+        />
+        <Button
+          title={t('mobile.onboarding.link.skip')}
+          onPress={decline}
+          variant="text"
+          size="large"
+          haptic={false}
+          style={styles.primary}
+        />
+        <Text variant="footnote" color={bodyColor} style={styles.skipHint}>
+          {t('mobile.onboarding.link.skipHint')}
+        </Text>
+      </GlassSurface>
+
+      <LinkBoardAccountModal
+        boardType={dialogOpen ? boardType : null}
+        source="onboarding"
+        onClose={closeDialog}
+        onLinked={handleLinked}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1 },
+  cardArea: { flex: 1 },
+  footer: {
+    paddingTop: spacing[3],
+    paddingHorizontal: spacing[5],
+    gap: spacing[2],
+  },
+  primary: { alignSelf: 'stretch' },
+  skipHint: { textAlign: 'center' },
+});

--- a/packages/mobile/src/components/onboarding/__tests__/OnboardingBoardRoute.test.tsx
+++ b/packages/mobile/src/components/onboarding/__tests__/OnboardingBoardRoute.test.tsx
@@ -14,6 +14,11 @@ const envCtrl = vi.hoisted(() => ({
   isOffline: false,
   offlineDownloadsEnabled: true,
   offlineState: 'off' as string,
+  // Link-step inputs. Default off, so every pre-existing test still asserts the
+  // unchanged hand-off straight to Climbs.
+  linkStepEnabled: false as boolean,
+  linkStepAnswered: false as boolean,
+  credentials: [] as { boardType: string }[] | undefined,
 }));
 
 const replaceMock = vi.hoisted(() => vi.fn());
@@ -49,6 +54,15 @@ vi.mock('../../../hooks/use-current-user-id', () => ({
 }));
 vi.mock('../../../providers/feature-flags-provider', () => ({
   useOfflineDownloadsEnabled: () => envCtrl.offlineDownloadsEnabled,
+  useFeatureFlag: (key: string) => (key === 'board-link-onboarding-step' ? envCtrl.linkStepEnabled : undefined),
+}));
+// Both reach real native modules (AsyncStorage, expo-web-browser) through their
+// implementations, so they are mocked at the seam like every other IO here.
+vi.mock('../../../lib/onboarding/link-step-answered', () => ({
+  hasAnsweredLinkStep: () => Promise.resolve(envCtrl.linkStepAnswered),
+}));
+vi.mock('../../../lib/integrations/use-board-account-credentials', () => ({
+  useBoardAccountCredentials: () => ({ data: envCtrl.credentials }),
 }));
 vi.mock('../../../offline/use-confirm-board-download', () => ({
   useConfirmBoardDownload: () => ({ confirmAndDownload: confirmAndDownloadMock }),
@@ -108,6 +122,9 @@ describe('OnboardingBoardRoute', () => {
     envCtrl.isOffline = false;
     envCtrl.offlineDownloadsEnabled = true;
     envCtrl.offlineState = 'off';
+    envCtrl.linkStepEnabled = false;
+    envCtrl.linkStepAnswered = false;
+    envCtrl.credentials = [];
     stepCtrl.props = null;
     activateOptionsCtrl.last = null;
     cleanup();
@@ -119,6 +136,65 @@ describe('OnboardingBoardRoute', () => {
     expect(activateOptionsCtrl.last?.source).toBe('onboarding');
     (activateOptionsCtrl.last?.navigate as () => void)();
     expect(replaceMock).toHaveBeenCalledWith('/(tabs)/climbs');
+  });
+
+  // The link card sits between the board pick and Climbs. It goes BEFORE the
+  // board-look step because `app/onboarding.tsx` forbids chaining past
+  // `BoardLookStepGate`, and because board-look may never run at all.
+  describe('the board-account link hand-off', () => {
+    /** Pick a board (which captures it) then run the post-bind navigation. */
+    const bindAndLeave = async (board: UserBoard = BOARD) => {
+      stepCtrl.props?.onSelect(board);
+      await waitFor(() => expect(activateOptionsCtrl.last?.navigate).toBeTypeOf('function'));
+      (activateOptionsCtrl.last?.navigate as () => void)();
+    };
+
+    it('goes straight to Climbs while the flag is off, exactly as before', async () => {
+      renderRoute();
+      await bindAndLeave();
+      expect(replaceMock).toHaveBeenCalledWith('/(tabs)/climbs');
+    });
+
+    it('offers the link card for the board that was just bound', async () => {
+      envCtrl.linkStepEnabled = true;
+      renderRoute();
+      await waitFor(() => expect(stepCtrl.props).not.toBeNull());
+      await bindAndLeave();
+      await waitFor(() =>
+        expect(replaceMock).toHaveBeenCalledWith({
+          pathname: '/onboarding',
+          params: { step: 'link', boardType: 'kilter' },
+        }),
+      );
+    });
+
+    it('skips the card for a climber who already linked an account', async () => {
+      envCtrl.linkStepEnabled = true;
+      envCtrl.credentials = [{ boardType: 'kilter' }];
+      renderRoute();
+      await waitFor(() => expect(stepCtrl.props).not.toBeNull());
+      await bindAndLeave();
+      expect(replaceMock).toHaveBeenCalledWith('/(tabs)/climbs');
+    });
+
+    // MoonBoard has no credential flow — its only route in is a CSV obtained by
+    // emailing Moon Climbing a GDPR request.
+    it('skips the card for MoonBoard, which cannot be linked', async () => {
+      envCtrl.linkStepEnabled = true;
+      renderRoute();
+      await waitFor(() => expect(stepCtrl.props).not.toBeNull());
+      await bindAndLeave({ ...BOARD, boardType: 'moonboard' } as unknown as UserBoard);
+      expect(replaceMock).toHaveBeenCalledWith('/(tabs)/climbs');
+    });
+
+    it('skips the card offline, where the form could not submit anyway', async () => {
+      envCtrl.linkStepEnabled = true;
+      envCtrl.isOffline = true;
+      renderRoute();
+      await waitFor(() => expect(stepCtrl.props).not.toBeNull());
+      await bindAndLeave();
+      expect(replaceMock).toHaveBeenCalledWith('/(tabs)/climbs');
+    });
   });
 
   describe('the download offer', () => {

--- a/packages/mobile/src/components/onboarding/__tests__/OnboardingLinkStep.test.tsx
+++ b/packages/mobile/src/components/onboarding/__tests__/OnboardingLinkStep.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, cleanup, fireEvent, act } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const mocks = vi.hoisted(() => ({
+  onResolved: vi.fn(),
+  shown: vi.fn(),
+  resolved: vi.fn(),
+  modalProps: null as Record<string, unknown> | null,
+}));
+
+vi.mock('../../../lib/onboarding/link-step-analytics', () => ({
+  trackLinkPromptShown: mocks.shown,
+  trackLinkPromptResolved: mocks.resolved,
+}));
+
+// Recorded rather than rendered: this test is about which board and surface the
+// step hands the dialog, and what it does with the dialog's callbacks.
+vi.mock('../../integrations/LinkBoardAccountModal', () => ({
+  LinkBoardAccountModal: (props: Record<string, unknown>) => {
+    mocks.modalProps = props;
+    return null;
+  },
+}));
+
+vi.mock('../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { boardName?: string }) => (opts?.boardName != null ? `${key}:${opts.boardName}` : key),
+  }),
+}));
+
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) }));
+vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ variant: 'material' }) }));
+vi.mock('../../../theme/variants', () => ({ selectByVariant: () => undefined }));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 2: 8, 3: 12, 4: 16, 5: 20 } }));
+
+type RNProps = { children?: ReactNode };
+vi.mock('react-native', () => ({
+  View: ({ children }: RNProps) => createElement('div', {}, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('../../Text', () => ({ Text: ({ children }: RNProps) => createElement('span', {}, children) }));
+vi.mock('../../GlassSurface', () => ({
+  GlassSurface: ({ children }: RNProps) => createElement('div', {}, children),
+}));
+vi.mock('../OnboardingCard', () => ({
+  OnboardingCard: ({ title, body, footnote }: { title: string; body: string; footnote?: string }) =>
+    createElement('div', {}, `${title}|${body}|${footnote ?? ''}`),
+}));
+vi.mock('../../Button', () => ({
+  Button: ({ title, onPress }: { title: string; onPress?: () => void }) =>
+    createElement('button', { 'data-button': title, onClick: onPress }),
+}));
+
+import { OnboardingLinkStep } from '../OnboardingLinkStep';
+
+const button = (root: HTMLElement, title: string) =>
+  root.querySelector(`[data-button="${title}"]`) as HTMLButtonElement | null;
+
+const renderStep = () =>
+  render(
+    <OnboardingLinkStep
+      boardType="tension"
+      accentColor="#6D28D9"
+      iconColor="#6D28D9"
+      bodyColor="#888"
+      backgroundColor="#000"
+      onResolved={mocks.onResolved}
+    />,
+  );
+
+describe('OnboardingLinkStep', () => {
+  beforeEach(() => {
+    mocks.onResolved.mockReset();
+    mocks.shown.mockReset();
+    mocks.resolved.mockReset();
+    mocks.modalProps = null;
+  });
+
+  it('names the board the climber just picked, and warns it wants a username', () => {
+    const { container } = renderStep();
+    expect(container.textContent).toContain('mobile.onboarding.link.title:Tension');
+    // The crux of the original report: the climber assumed same-email meant linked.
+    expect(container.textContent).toContain('mobile.onboarding.link.footnote:Tension');
+  });
+
+  it('reports the card was shown', () => {
+    renderStep();
+    expect(mocks.shown).toHaveBeenCalledWith('tension');
+  });
+
+  // This is the one escapable step in an otherwise mandatory flow, so the exit has
+  // to be a real, visible button — the route disables the iOS swipe for the whole
+  // onboarding file.
+  it('offers a visible way out', () => {
+    const { container } = renderStep();
+    expect(button(container, 'mobile.onboarding.link.skip')).not.toBeNull();
+  });
+
+  it('records a decline as an answer and leaves', () => {
+    const { container } = renderStep();
+    fireEvent.click(button(container, 'mobile.onboarding.link.skip')!);
+    expect(mocks.resolved).toHaveBeenCalledWith('tension', 'declined');
+    expect(mocks.onResolved).toHaveBeenCalledTimes(1);
+  });
+
+  it('hands the dialog the board and tags the funnel with this surface', () => {
+    const { container } = renderStep();
+    fireEvent.click(button(container, 'mobile.onboarding.link.continue:Tension')!);
+    expect(mocks.modalProps?.boardType).toBe('tension');
+    expect(mocks.modalProps?.source).toBe('onboarding');
+  });
+
+  it('records a successful link and leaves', () => {
+    const { container } = renderStep();
+    fireEvent.click(button(container, 'mobile.onboarding.link.continue:Tension')!);
+    act(() => (mocks.modalProps?.onLinked as (board: string) => void)('tension'));
+    expect(mocks.resolved).toHaveBeenCalledWith('tension', 'linked');
+    expect(mocks.onResolved).toHaveBeenCalledTimes(1);
+  });
+
+  // A wrong password is not a decision to skip. Dropping someone out of onboarding
+  // on a typo would be the worst possible reading of it.
+  it('returns to the card when the dialog closes without linking', () => {
+    const { container } = renderStep();
+    fireEvent.click(button(container, 'mobile.onboarding.link.continue:Tension')!);
+    act(() => (mocks.modalProps?.onClose as () => void)());
+    expect(mocks.onResolved).not.toHaveBeenCalled();
+    expect(mocks.resolved).not.toHaveBeenCalled();
+  });
+
+  // Without this, a nav-away would leave a Shown with no matching Resolved — the
+  // exact hole that once deflated the tour's completion metric.
+  it('resolves every presentation, including the exits no button produced', () => {
+    renderStep();
+    cleanup();
+    expect(mocks.resolved).toHaveBeenCalledWith('tension', 'abandoned');
+  });
+
+  it('reports exactly one outcome per presentation', () => {
+    const { container } = renderStep();
+    fireEvent.click(button(container, 'mobile.onboarding.link.skip')!);
+    cleanup();
+    expect(mocks.resolved).toHaveBeenCalledTimes(1);
+    expect(mocks.resolved).toHaveBeenCalledWith('tension', 'declined');
+  });
+});

--- a/packages/mobile/src/lib/onboarding/__tests__/should-offer-link.test.ts
+++ b/packages/mobile/src/lib/onboarding/__tests__/should-offer-link.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { shouldOfferLink, type ShouldOfferLinkInput } from '../should-offer-link';
+
+const base: ShouldOfferLinkInput = {
+  enabled: true,
+  boardType: 'tension',
+  isOffline: false,
+  answered: false,
+  hasLinkedAccount: false,
+};
+
+describe('shouldOfferLink', () => {
+  it('offers the step to a climber who just bound a linkable board and has no account linked', () => {
+    expect(shouldOfferLink(base)).toBe('show');
+  });
+
+  // A positive rollout flag, so the async-unresolved default is "no extra step".
+  it('does nothing when the flag is off', () => {
+    expect(shouldOfferLink({ ...base, enabled: false })).toBe('none');
+  });
+
+  // The important exclusion. MoonBoard has no credential flow at all — the only
+  // way in is a CSV obtained by emailing Moon Climbing a GDPR request, which takes
+  // days. A card promising sends "in a few minutes" would be a lie.
+  it('never offers a link for MoonBoard, which cannot be linked', () => {
+    expect(shouldOfferLink({ ...base, boardType: 'moonboard' })).toBe('none');
+  });
+
+  it('never offers a link when no board type came through', () => {
+    expect(shouldOfferLink({ ...base, boardType: undefined })).toBe('none');
+  });
+
+  // Offline the form cannot submit and the "already linked?" read cannot resolve.
+  // Skipping leaves the marker unwritten, so they are asked on a later launch.
+  it('skips the step offline rather than burning the question on a screen that cannot work', () => {
+    expect(shouldOfferLink({ ...base, isOffline: true })).toBe('none');
+  });
+
+  it('waits while the answered marker is still being read', () => {
+    expect(shouldOfferLink({ ...base, answered: undefined })).toBe('wait');
+  });
+
+  it('does not ask again once answered', () => {
+    expect(shouldOfferLink({ ...base, answered: true })).toBe('none');
+  });
+
+  it('does not ask a climber who already linked an account', () => {
+    expect(shouldOfferLink({ ...base, hasLinkedAccount: true })).toBe('none');
+  });
+
+  // The load-bearing one. The credentials query is `offlineFirst`, so it can stay
+  // pending; reading that as "not linked" would put a first-run card in front of
+  // someone whose account has been connected for months.
+  it('waits — never shows — while the credential read is unresolved', () => {
+    expect(shouldOfferLink({ ...base, hasLinkedAccount: undefined })).toBe('wait');
+  });
+
+  // Cheap certain `none`s must beat the async `wait`s, so a climber who will never
+  // see the step never blocks on a network read to find that out.
+  it('rules itself out on the cheap checks before waiting on anything async', () => {
+    const unresolvedAsync = { answered: undefined, hasLinkedAccount: undefined } as const;
+    expect(shouldOfferLink({ ...base, ...unresolvedAsync, enabled: false })).toBe('none');
+    expect(shouldOfferLink({ ...base, ...unresolvedAsync, boardType: 'moonboard' })).toBe('none');
+    expect(shouldOfferLink({ ...base, ...unresolvedAsync, isOffline: true })).toBe('none');
+  });
+});

--- a/packages/mobile/src/lib/onboarding/link-step-analytics.ts
+++ b/packages/mobile/src/lib/onboarding/link-step-analytics.ts
@@ -1,0 +1,27 @@
+// Thin wrappers around the first-run link-prompt events, mirroring the shape of
+// `onboarding-analytics.ts` so the step component stays free of property-key
+// bookkeeping.
+//
+// The invariant, and the reason the `abandoned` outcome exists at all: **every
+// Shown resolves to exactly one Resolved.** The tour learned this the hard way —
+// see the `trackTourDismissed` note in `onboarding-analytics.ts`, where ~a third
+// of Starts resolved to no terminal outcome and quietly deflated Completed. The
+// step's unmount guard reports `abandoned` for the exits no button produced.
+//
+// The link attempt itself is NOT re-counted here. It reports through the
+// `Board Account Link*` events with `source: 'onboarding'`, so the success rate of
+// an onboarding link is directly comparable to one started from Settings.
+
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import type { AuroraBoardName } from '@boardsesh/shared-schema';
+import { track } from '../analytics';
+
+export type LinkPromptOutcome = 'linked' | 'declined' | 'abandoned';
+
+export function trackLinkPromptShown(boardType: AuroraBoardName): void {
+  track(SHARED_EVENTS.OnboardingLinkPromptShown, { boardType });
+}
+
+export function trackLinkPromptResolved(boardType: AuroraBoardName, outcome: LinkPromptOutcome): void {
+  track(SHARED_EVENTS.OnboardingLinkPromptResolved, { boardType, outcome });
+}

--- a/packages/mobile/src/lib/onboarding/link-step-answered.ts
+++ b/packages/mobile/src/lib/onboarding/link-step-answered.ts
@@ -1,0 +1,48 @@
+import { getPreference, removePreference, setPreference } from '../preference-store';
+
+/**
+ * Whether this climber has answered the first-run "link your board account" step.
+ *
+ * Deliberately in AsyncStorage, NOT SecureStore, following the rule
+ * `board-look-step-seen.ts` spells out: a marker belongs in the same store, with
+ * the same lifecycle, as the thing it records. On iOS the keychain SURVIVES an
+ * uninstall while the app sandbox does not, so a SecureStore marker here would
+ * outlive every other trace of the account — a climber who reinstalled, still
+ * hadn't linked, and now had an empty logbook would never be asked again.
+ * Re-asking after a reinstall is the right failure; silently never asking is not.
+ *
+ * Note this is only the anti-nag marker. The real question — "is an account
+ * linked?" — is answered server-side by the credentials read, so a climber who
+ * says "not now" here and links later in Settings is never re-prompted regardless
+ * of this flag.
+ */
+const STORAGE_KEY = 'onboardingLinkStepAnswered';
+
+/**
+ * Errors read as "answered", matching `hasSeenTip` and `hasSeenBoardLookStep`: a
+ * flaky store must not turn a one-shot question into one that fires on every cold
+ * start.
+ */
+export async function hasAnsweredLinkStep(): Promise<boolean> {
+  // Screenshot mode reports answered so a captured store screen is never covered.
+  if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1') return true;
+  try {
+    return (await getPreference<boolean>(STORAGE_KEY)) === true;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Written when the climber ANSWERS — both "link" and "not now" — never on arrival.
+ * "Asked but walked away" must stay indistinguishable from "never asked", so a
+ * force-quit mid-step leaves the question live for the next launch rather than
+ * burning it in silence. Same contract as `markBoardLookStepSeen`.
+ */
+export async function markLinkStepAnswered(): Promise<void> {
+  await setPreference(STORAGE_KEY, true);
+}
+
+export async function clearLinkStepAnswered(): Promise<void> {
+  await removePreference(STORAGE_KEY);
+}

--- a/packages/mobile/src/lib/onboarding/should-offer-link.ts
+++ b/packages/mobile/src/lib/onboarding/should-offer-link.ts
@@ -1,0 +1,70 @@
+import { isLinkableBoard } from '../integrations/board-link-eligibility';
+
+/**
+ * Whether first-run should offer to link a board account, as one pure function so
+ * every branch is unit-testable without a renderer. Same shape as
+ * `decideBoardLookStep`.
+ *
+ * This step is the one skippable screen in an otherwise mandatory flow, and that
+ * is deliberate. Issue #4961 stripped the escape hatches out of the other three
+ * because each guarantees state the app cannot run without — a bound board, a
+ * chosen drawing. This one asks for a password to somebody else's service, and
+ * nobody may be compelled to type that. It also asks a question that is simply
+ * false for some climbers: we cannot detect whether an account exists (there is no
+ * lookup-by-email anywhere in Aurora's API), so plenty of people will be looking at
+ * a card about something they don't have.
+ */
+
+export type ShouldOfferLinkInput = {
+  /** The flag gate. A positive rollout flag, so unresolved reads as "don't". */
+  enabled: boolean;
+  /** The board just bound in the previous step. */
+  boardType: string | undefined;
+  /** No usable connection — a credential check would fail and the form can't submit. */
+  isOffline: boolean;
+  /** `undefined` while the persisted marker is still being read. */
+  answered: boolean | undefined;
+  /**
+   * `undefined` while the credentials read is in flight. The credentials query is
+   * `offlineFirst`, so this can stay unresolved indefinitely.
+   */
+  hasLinkedAccount: boolean | undefined;
+};
+
+/**
+ * `wait` — not enough is known yet; ask again when the inputs change.
+ * `none` — do nothing, this launch or ever.
+ * `show` — present the step.
+ */
+export type ShouldOfferLinkDecision = 'wait' | 'none' | 'show';
+
+/**
+ * Order matters, cheapest and most certain `none`s first, so a climber who will
+ * never see this step never waits on a network read to find that out.
+ */
+export function shouldOfferLink(input: ShouldOfferLinkInput): ShouldOfferLinkDecision {
+  if (!input.enabled) return 'none';
+
+  // MoonBoard is the important exclusion, not an edge case. It has no credential
+  // flow at all: the only way in is a CSV the climber obtains by emailing Moon
+  // Climbing a GDPR subject access request, which takes days. A card promising
+  // their sends "in a few minutes" would be a straight lie, so MoonBoard climbers
+  // are served by the empty-logbook prompt instead, which offers the import.
+  if (!isLinkableBoard(input.boardType)) return 'none';
+
+  // Offline the form cannot submit and the "already linked?" read cannot resolve,
+  // so asking would burn the one-shot question on a screen that can't work. The
+  // marker stays unwritten, so they are asked on a later launch instead.
+  if (input.isOffline) return 'none';
+
+  if (input.answered === undefined) return 'wait';
+  if (input.answered) return 'none';
+
+  // Never ask someone who already linked. Unresolved is `wait`, never `show`:
+  // treating a pending read as "not linked" would put a first-run card in front of
+  // a climber whose account has been connected for months.
+  if (input.hasLinkedAccount === undefined) return 'wait';
+  if (input.hasLinkedAccount) return 'none';
+
+  return 'show';
+}

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -54,6 +54,12 @@ export const FEATURE_FLAG_DEFINITIONS = [
     description: 'Search box and filter sheet on the logbook (shipped: 100% rollout since 2026-07-03).',
   },
   {
+    key: 'board-link-onboarding-step',
+    label: 'Onboarding board-account link step',
+    description:
+      'Offer to link a Kilter/Tension board account during first-run, after the board pick. Off (and unresolved, which reads off) means onboarding is unchanged — the empty-logbook prompt still catches climbers whose sends are missing.',
+  },
+  {
     key: 'kilter-oauth-linking',
     label: 'Kilter account linking',
     description: 'Show the Kilter username/password sign-in card in Integrations.',

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -386,6 +386,19 @@ export const SHARED_EVENTS = {
   //   BoardAccountError codes ('invalid_credentials' | 'account_already_linked' |
   //   'rate_limited' | 'not_allowed' | 'unauthorized' | 'request_failed') or
   //   'cancelled'.
+  // The first-run "link your board account" card (the one skippable step in an
+  // otherwise mandatory onboarding). Shown fires when the card is presented;
+  // Resolved fires exactly once per Shown with what the climber chose, INCLUDING
+  // the nav-aways that no button produced — `onboarding-analytics.ts` records that
+  // ~a third of tour Starts once resolved to nothing at all, which deflated the
+  // completion metric until an unmount guard was added. Props:
+  //   Shown:    { boardType }
+  //   Resolved: { boardType, outcome: 'linked' | 'declined' | 'abandoned' }
+  // The link attempt itself reports through the Board Account Link* events above
+  // with `source: 'onboarding'`, so success rate is comparable across surfaces and
+  // is not re-counted here.
+  OnboardingLinkPromptShown: 'Onboarding Link Prompt Shown',
+  OnboardingLinkPromptResolved: 'Onboarding Link Prompt Resolved',
   BoardAccountLinkStarted: 'Board Account Link Started',
   BoardAccountLinked: 'Board Account Linked',
   BoardAccountLinkFailed: 'Board Account Link Failed',

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -466,6 +466,14 @@
         "crew": "Kletterst du mit anderen? Startet eine Session und teilt euch eine Warteschlange. Jede*r legt den nächsten Run auf, ohne das Handy weiterzureichen.",
         "record": "Deine Begehungen landen unter Fortschritt im Diagramm: Gradverteilung und schwerste Begehung. Importier dein Kilter- und Tension-Routenbuch aus Aurora und starte mit deiner Historie.",
         "accessory": "Die Leiste unten zeigt immer, was auf dem Board liegt. Von dort wechselst du Boulder."
+      },
+      "link": {
+        "title": "Nimm deine {{boardName}}-Begehungen mit",
+        "body": "Dein {{boardName}}-Konto gehört denen, die das Board bauen. Boardsesh ist davon getrennt — gleiche E-Mail, aber die beiden wissen nichts voneinander. Verknüpf sie und deine Begehungen, Versuche und Bewertungen landen hier, dein Routenbuch startet also voll.",
+        "footnote": "Zum Verknüpfen brauchst du deinen {{boardName}}-Benutzernamen, nicht deine E-Mail.",
+        "continue": "Mein {{boardName}}-Konto verknüpfen",
+        "skip": "Jetzt nicht",
+        "skipHint": "Du kannst das jederzeit unter Einstellungen › Verbundene Apps machen."
       }
     },
     "nav": {

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -466,6 +466,14 @@
         "crew": "Climbing with people? Start a session and share one queue. Anyone sends the next burn, no passing the phone.",
         "record": "Your sends chart out here on Progress: grade spread and hardest send. Import your Kilter and Tension logbook from Aurora to start with your history.",
         "accessory": "The bar at the bottom is always what's on the board. Flip climbs from there."
+      },
+      "link": {
+        "title": "Bring your {{boardName}} sends with you",
+        "body": "Your {{boardName}} account lives with the people who make the board. Boardsesh is separate — same email, but the two don't know about each other. Link them and your sends, attempts and ratings land here, so your logbook starts full.",
+        "footnote": "Linking asks for your {{boardName}} username, not your email.",
+        "continue": "Link my {{boardName}} account",
+        "skip": "Not now",
+        "skipHint": "You can do this any time in Settings › Connected apps."
       }
     },
     "nav": {

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -731,6 +731,14 @@
         "crew": "¿Escalas con gente? Abre una sesión y compartid una cola: cualquiera manda la siguiente vía, sin ir pasando el móvil.",
         "record": "Tus encadenes salen aquí en Progreso: reparto de grados y tu vía más dura. Importa tu logbook de Kilter y Tension desde Aurora para empezar con tu historial.",
         "accessory": "La barra de abajo siempre muestra lo que hay en el muro. Cambia de vía desde ahí."
+      },
+      "link": {
+        "title": "Trae contigo tus encadenamientos de {{boardName}}",
+        "body": "Tu cuenta de {{boardName}} es de quienes fabrican el plafón. Boardsesh va aparte: mismo correo, pero ninguna de las dos sabe de la otra. Vincúlalas y tus encadenamientos, intentos y valoraciones llegan aquí, así tu historial empieza lleno.",
+        "footnote": "Para vincular necesitas tu usuario de {{boardName}}, no tu correo.",
+        "continue": "Vincular mi cuenta de {{boardName}}",
+        "skip": "Ahora no",
+        "skipHint": "Puedes hacerlo cuando quieras en Ajustes › Apps conectadas."
       }
     },
     "nav": {

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -466,6 +466,14 @@
         "crew": "Tu grimpes à plusieurs ? Lance une séance et partagez une file. N'importe qui allume la voie suivante, sans passer le téléphone.",
         "record": "Tes croix s'affichent ici dans Progression : éventail de cotations et ta plus grosse croix. Importe ton carnet Kilter et Tension depuis Aurora pour partir avec ton historique.",
         "accessory": "La barre du bas montre toujours ce qui est sur le mur. Change de voie depuis là."
+      },
+      "link": {
+        "title": "Emportez vos croix {{boardName}} avec vous",
+        "body": "Votre compte {{boardName}} appartient à ceux qui fabriquent le board. Boardsesh est séparé : même e-mail, mais les deux s'ignorent. Liez-les et vos croix, essais et cotations arrivent ici, votre carnet démarre plein.",
+        "footnote": "Pour lier, il faut votre identifiant {{boardName}}, pas votre e-mail.",
+        "continue": "Lier mon compte {{boardName}}",
+        "skip": "Pas maintenant",
+        "skipHint": "Vous pourrez le faire à tout moment dans Réglages › Apps connectées."
       }
     },
     "nav": {


### PR DESCRIPTION
## Summary

Stacked on #5234. Behind `board-link-onboarding-step`, off by default.

The last piece: after a new climber picks their board, offer to link their board
account. This is what the Discord report asked for — the user signed in with Google,
assumed his Tension sends would follow, and had no reason to think otherwise.

The card leads with what they get, states the correction as a fact about the system
rather than about them ("Your Tension account lives with the people who make the board.
Boardsesh is separate — same email, but the two don't know about each other"), and puts
the crux in the footnote **before** they hit a field they can't fill: *linking asks for
your Tension username, not your email.*

### It sits before the board-look step, and that is forced rather than chosen

`app/onboarding.tsx` forbids chaining past `BoardLookStepGate` — that gate's refusal to
run without a synced climb and a renderer probe is exactly what makes a no-exit step
safe, and chaining past it would throw the guarantee away. Board-look may also never run
at all. Sitting here also means the board type is warm, so the card can name the wall
they picked ninety seconds ago rather than asking again.

The offline-download dialog is awaited inside `onBound`, so the two interruptions never
overlap.

### The one escapable step in a flow that was just made mandatory

#5024 closed the last onboarding skip five days ago, so this needs justifying rather than
sneaking in. Steps 1–3 guarantee state the app cannot run without — a bound board, a
chosen drawing. This one asks for a password to somebody else's service, and nobody may
be compelled to type that. It also asks a question that is **false for some people**:
there is no lookup-by-email anywhere in Aurora's API, so we cannot detect whether an
account exists. We can only ask.

So it deliberately does **not** call `useBlockBack`. The route sets `gestureEnabled:
false` for the whole file, so skippable had to mean a real visible button; Android
hardware back routes to the same handler as "Not now" and counts as an answer.

### Who never sees it

`shouldOfferLink` is a pure function, tested without a renderer, mirroring
`decideBoardLookStep`. It returns `none` for: the flag off, **MoonBoard** (no credential
flow exists — its only route in is a CSV obtained by emailing Moon Climbing a GDPR
subject access request, so "a few minutes" would be a lie), offline, already answered, and
already linked. The credential read is tri-state: unresolved is `wait`, never `show`, or a
climber who linked months ago gets a first-run card.

Anything other than `show` goes to Climbs, including `wait`. This is a one-shot moment
with no second chance, and stalling first-run on a storage read is a worse trade than
skipping an optional card — the empty-logbook prompt from #5233 catches exactly that case.

### Measurement

`Onboarding Link Prompt Shown` / `Resolved {linked | declined | abandoned}`. Every Shown
resolves to exactly one Resolved, including the nav-aways no button produced — without
the unmount guard this would repeat the hole `onboarding-analytics.ts` documents, where
~a third of tour Starts resolved to nothing and deflated the completion metric. The link
attempt itself is not re-counted here; it reports through `Board Account Link*` with
`source: 'onboarding'`, so its success rate is directly comparable to Settings.

**Guardrail before raising the flag:** `Onboarding Board Activated` per `Onboarding Tour
Started`, split by flag cohort. Roll back on a visible drop, or if the decline rate
exceeds ~85% (which would mean the card is irrelevant to almost everyone).

### A note on the storage

The answered marker is AsyncStorage, not SecureStore, following the rule
`board-look-step-seen.ts` spells out: a marker belongs in the same store, with the same
lifecycle, as the thing it records. On iOS the keychain survives an uninstall while the
sandbox does not, so a SecureStore marker would outlive every other trace of the account —
a climber who reinstalled and still hadn't linked would never be asked again. Re-asking
after a reinstall is the right failure; silently never asking is not. It is written on an
**answer**, never on arrival, so a force-quit mid-step leaves the question live.

## Release Notes

New climbers now get asked, right after picking their board, whether they want to bring
their Kilter or Tension sends across — with a plain explanation that your board account
and your Boardsesh account are two different logins, even on the same email. Skip it and
nothing changes.

## Test plan

1. Sign in as a new climber. Pick a Tension board.
2. A card offers to link your Tension account.
3. Tap Not now → Climbs opens.
4. Repeat with a MoonBoard. No card appears.
5. Relaunch. The card does not come back.

## Risk

Risk: 4/5 — adds a step to first-run behind a flag that is off by default. Onboarding
conversion is the metric at risk; guardrail and rollback trigger above.
