### PR TITLE
fix: file ticks on the climber's own wall, not the shared config feed

### DIFF
--- a/packages/backend/src/__tests__/shared-feed-tick-board-attribution.test.ts
+++ b/packages/backend/src/__tests__/shared-feed-tick-board-attribution.test.ts
@@ -1,0 +1,250 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { setupWorkerDatabase } from './worker-db';
+
+// Side effects saveTick fires after the insert. None of them are under test and
+// they'd otherwise pull in Redis / the social event bus.
+vi.mock('../events', () => ({ publishSocialEvent: vi.fn(async () => undefined) }));
+vi.mock('../graphql/resolvers/ticks/debounced-climb-stats-publisher', () => ({
+  queueClimbStatsRecompute: vi.fn(),
+  recomputeClimbStatsNow: vi.fn(async () => {}),
+}));
+vi.mock('../graphql/resolvers/sessions/debounced-stats-publisher', () => ({
+  publishDebouncedSessionStats: vi.fn(),
+}));
+vi.mock('../graphql/resolvers/board-presence/stats', () => ({ queueBoardStatsPublish: vi.fn() }));
+vi.mock('../services/analytics/posthog', () => ({ captureBackendEvent: vi.fn(() => true) }));
+
+import { db } from '../db/client';
+import { tickMutations } from '../graphql/resolvers/ticks/mutations';
+import { BOARD_CONFIG_PRESENCE_SLUG_PREFIX, SYSTEM_BOARD_OWNER_ID } from '../graphql/resolvers/board-presence/shared';
+
+/**
+ * Real-DB coverage for how saveTick ranks a per-config SHARED FEED board
+ * against the climber's own wall (#5121).
+ *
+ * A wall with no BLE serial — every MoonBoard, and any serial-less
+ * Kilter/Tension controller — binds board presence through
+ * `resolveBoardForConfig`, which hands back one system-owned row per
+ * (type, layout, size, sets), shared by every climber on that configuration
+ * worldwide. The client then sends that row's id as the tick's `boardId`.
+ *
+ * It used to win outright, so a climber with their own board of that exact
+ * config had every tick filed under the global feed: 10,879 rows across 655
+ * climbers on production, and their own board read as empty everywhere it is
+ * scoped by `board_id` — including the Home tab's "Recent sessions", which is
+ * what #5121 reported.
+ *
+ * A shared feed is now the LAST rung, below the session's wall and below the
+ * owner's config lookup, and it still claims the tick when nothing better
+ * exists. The demotion keys on owner + slug namespace, never the display name:
+ * the ~520 seeded catalog boards are system-owned too and must keep winning.
+ */
+
+const USER_ID = 'shared-feed-attr-user';
+const GYM_OWNER_ID = 'shared-feed-attr-gym-owner';
+const PREFIX = 'SHARED-FEED-ATTR-';
+const CLIMB_UUID = `${PREFIX}CLIMB`;
+
+// The reported configuration: a MoonBoard home wall, which has no serial and so
+// always resolves presence through the shared per-config feed.
+const CONFIG = { boardType: 'moonboard', layoutId: 6, sizeId: 1, setIds: '24,25,26,27' };
+
+function authCtx(userId = USER_ID): ConnectionContext {
+  return {
+    connectionId: `conn-${Math.random().toString(36).slice(2)}`,
+    isAuthenticated: true,
+    userId,
+  } as ConnectionContext;
+}
+
+function tickInput(overrides: Record<string, unknown> = {}) {
+  return {
+    boardType: CONFIG.boardType,
+    climbUuid: CLIMB_UUID,
+    angle: 40,
+    isMirror: false,
+    status: 'send',
+    attemptCount: 1,
+    quality: null,
+    difficulty: 17,
+    isBenchmark: false,
+    comment: '',
+    climbedAt: new Date().toISOString(),
+    layoutId: CONFIG.layoutId,
+    sizeId: CONFIG.sizeId,
+    setIds: CONFIG.setIds,
+    ...overrides,
+  };
+}
+
+// Every board this suite creates, so cleanup can delete exactly those. The
+// system owner also owns the seeded catalog in a shared worker DB — deleting by
+// `owner_id` would take a sibling suite's boards with it.
+const createdBoardIds: number[] = [];
+
+async function insertBoard(opts: {
+  ownerId?: string;
+  setIds?: string;
+  slug?: string;
+  name: string;
+}): Promise<{ id: number; uuid: string }> {
+  const uuid = uuidv4();
+  const result = await db.execute(sql`
+    INSERT INTO user_boards
+      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, is_public, created_at, updated_at)
+    VALUES (${uuid}, ${opts.slug ?? uuid}, ${opts.ownerId ?? USER_ID}, ${CONFIG.boardType}, ${CONFIG.layoutId},
+            ${CONFIG.sizeId}, ${opts.setIds ?? CONFIG.setIds}, ${opts.name}, true, now(), now())
+    RETURNING id
+  `);
+  const id = Number(Array.from(result as Iterable<{ id: number }>)[0].id);
+  createdBoardIds.push(id);
+  return { id, uuid };
+}
+
+/** The system-owned row `resolveSharedBoardForConfig` mints for a config. */
+function insertSharedFeedBoard() {
+  return insertBoard({
+    ownerId: SYSTEM_BOARD_OWNER_ID,
+    slug: `${BOARD_CONFIG_PRESENCE_SLUG_PREFIX}${CONFIG.boardType}-${CONFIG.layoutId}-${CONFIG.sizeId}-${uuidv4().replace(/-/g, '').slice(0, 20)}`,
+    name: 'MoonBoard Board Shared Feed',
+  });
+}
+
+async function insertSession(opts: { boardId: number | null }): Promise<string> {
+  const id = `sess-${uuidv4()}`;
+  await db.execute(sql`
+    INSERT INTO board_sessions (id, board_path, board_id, created_by_user_id, status, created_at, last_activity)
+    VALUES (${id}, ${'moonboard/6/1/24,25,26,27/40'}, ${opts.boardId}, ${USER_ID}, 'active', now(), now())
+  `);
+  return id;
+}
+
+/** The board_id the tick actually landed on. */
+async function tickBoardId(tickUuid: string): Promise<number | null> {
+  const result = await db.execute(sql`SELECT board_id FROM boardsesh_ticks WHERE uuid = ${tickUuid}`);
+  const row = Array.from(result as Iterable<{ board_id: number | null }>)[0];
+  return row.board_id == null ? null : Number(row.board_id);
+}
+
+async function saveTick(overrides: Record<string, unknown> = {}) {
+  const uuid = uuidv4();
+  await tickMutations.saveTick(undefined, { input: { uuid, ...tickInput(overrides) } }, authCtx());
+  return tickBoardId(uuid);
+}
+
+describe('shared config feed tick attribution', () => {
+  beforeAll(async () => {
+    await setupWorkerDatabase();
+  });
+
+  // Re-seeded per test, not once in beforeAll: sibling suites TRUNCATE these
+  // same shared tables in their own beforeEach, and this file's tests can
+  // interleave with theirs within a worker's shared DB.
+  beforeEach(async () => {
+    for (const id of [USER_ID, GYM_OWNER_ID]) {
+      await db.execute(sql`
+        INSERT INTO users (id, email, name, created_at, updated_at)
+        VALUES (${id}, ${`${id}@test.com`}, ${`User ${id}`}, now(), now())
+        ON CONFLICT (id) DO NOTHING
+      `);
+    }
+    // The owner `resolveSharedBoardForConfig` mints shared feeds under, seeded
+    // the way `ensureSystemBoardOwner` does. Unqualified DO NOTHING because a
+    // sibling suite may already hold this id or this email.
+    await db.execute(sql`
+      INSERT INTO users (id, email, name, created_at, updated_at)
+      VALUES (${SYSTEM_BOARD_OWNER_ID}, 'system@boardsesh.com', 'System', now(), now())
+      ON CONFLICT DO NOTHING
+    `);
+    await db.execute(sql`
+      INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed)
+      VALUES (${CLIMB_UUID}, ${CONFIG.boardType}, ${CONFIG.layoutId}, 'setter', 'Test Climb', '', 'p1r1', true)
+      ON CONFLICT (uuid) DO NOTHING
+    `);
+  });
+
+  afterAll(async () => {
+    await db.execute(sql`DELETE FROM board_climbs WHERE uuid = ${CLIMB_UUID}`);
+    await db.execute(sql`DELETE FROM users WHERE id IN (${USER_ID}, ${GYM_OWNER_ID})`);
+  });
+
+  afterEach(async () => {
+    await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id = ${USER_ID}`);
+    await db.execute(sql`DELETE FROM board_sessions WHERE created_by_user_id = ${USER_ID}`);
+    if (createdBoardIds.length > 0) {
+      const ids = sql.join(
+        createdBoardIds.map((id) => sql`${id}`),
+        sql`, `,
+      );
+      await db.execute(sql`DELETE FROM user_boards WHERE id IN (${ids})`);
+      createdBoardIds.length = 0;
+    }
+  });
+
+  it("files the tick on the climber's own wall, not the shared feed bound to their phone", async () => {
+    // #5121 exactly: a MoonBoard home wall the climber named, and the global
+    // per-config feed their serial-less controller binds presence to.
+    const sharedFeed = await insertSharedFeedBoard();
+    const homeWall = await insertBoard({ name: 'Tranquility' });
+
+    expect(await saveTick({ boardId: sharedFeed.id })).toBe(homeWall.id);
+  });
+
+  it('still files on the shared feed when the climber owns no wall of this config', async () => {
+    // The feed is the last rung, not a removed one: without it these ticks would
+    // lose their board entirely and empty the wall's live stats.
+    const sharedFeed = await insertSharedFeedBoard();
+
+    expect(await saveTick({ boardId: sharedFeed.id })).toBe(sharedFeed.id);
+  });
+
+  it("prefers the session's wall over the shared feed", async () => {
+    const sharedFeed = await insertSharedFeedBoard();
+    const gymWall = await insertBoard({ ownerId: GYM_OWNER_ID, name: 'Gym MoonBoard' });
+    const sessionId = await insertSession({ boardId: gymWall.id });
+
+    expect(await saveTick({ boardId: sharedFeed.id, sessionId })).toBe(gymWall.id);
+  });
+
+  it('prefers the board the climber selected when its uuid is sent', async () => {
+    const sharedFeed = await insertSharedFeedBoard();
+    // Owned by the gym, not the climber, so only the uuid rung can reach it —
+    // this is the case the config lookup cannot serve.
+    const gymWall = await insertBoard({ ownerId: GYM_OWNER_ID, name: 'Gym MoonBoard' });
+
+    expect(await saveTick({ boardId: sharedFeed.id, boardUuid: gymWall.uuid })).toBe(gymWall.id);
+  });
+
+  it('keeps a seeded catalog board winning at the presence rung', async () => {
+    // Seeded gym boards are system-owned too (~520 of them, 15,565 ticks) but
+    // carry ordinary slugs and name real walls. Demoting on owner alone — or on
+    // the display name — would have moved their ticks onto whatever same-config
+    // board the climber happens to own.
+    const seededGymWall = await insertBoard({
+      ownerId: SYSTEM_BOARD_OWNER_ID,
+      slug: 'seeded-gym-moonboard',
+      name: 'MoonBoard Board Shared Feed',
+    });
+    await insertBoard({ name: 'Tranquility' });
+
+    expect(await saveTick({ boardId: seededGymWall.id })).toBe(seededGymWall.id);
+  });
+
+  it('leaves the tick on the shared feed when its config disagrees with the wall', async () => {
+    // Unchanged gate: a boardId whose config doesn't match the tick is dropped
+    // before the shared-feed question is even asked, and the owner's own board
+    // of the tick's config takes it.
+    const otherConfigFeed = await insertBoard({
+      ownerId: SYSTEM_BOARD_OWNER_ID,
+      setIds: '5,6,7,8,9,10',
+      slug: `${BOARD_CONFIG_PRESENCE_SLUG_PREFIX}moonboard-3-1-otherconfig`,
+      name: 'MoonBoard Board Shared Feed',
+    });
+    const homeWall = await insertBoard({ name: 'Tranquility' });
+
+    expect(await saveTick({ boardId: otherConfigFeed.id })).toBe(homeWall.id);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/board-presence/shared.ts
+++ b/packages/backend/src/graphql/resolvers/board-presence/shared.ts
@@ -34,6 +34,15 @@ export type ActivePresenceBoard = Pick<
   'id' | 'name' | 'boardType' | 'layoutId' | 'sizeId' | 'setIds' | 'serialNumber' | 'angle'
 >;
 
+/**
+ * The two columns that say WHOSE board a row is. Carried alongside
+ * `ActivePresenceBoard` by the lookups that have to tell a climber's own wall
+ * apart from the system-owned per-config shared feed (see
+ * `isSharedConfigFeedBoard`). Kept off `ActivePresenceBoard` itself so the
+ * serial-candidate and resolved-board shapes don't all have to grow a slug.
+ */
+export type PresenceBoardIdentity = Pick<typeof dbSchema.userBoards.$inferSelect, 'ownerId' | 'slug'>;
+
 export function toResolvedBoard(board: ActivePresenceBoard): ResolvedBoard {
   return {
     boardId: Number(board.id),
@@ -398,7 +407,9 @@ export async function rememberBoardForSerial(
     });
 }
 
-export async function findActiveBoardById(boardId: number): Promise<ActivePresenceBoard | undefined> {
+export async function findActiveBoardById(
+  boardId: number,
+): Promise<(ActivePresenceBoard & PresenceBoardIdentity) | undefined> {
   const [board] = await db
     .select({
       id: dbSchema.userBoards.id,
@@ -409,6 +420,8 @@ export async function findActiveBoardById(boardId: number): Promise<ActivePresen
       setIds: dbSchema.userBoards.setIds,
       serialNumber: dbSchema.userBoards.serialNumber,
       angle: dbSchema.userBoards.angle,
+      ownerId: dbSchema.userBoards.ownerId,
+      slug: dbSchema.userBoards.slug,
     })
     .from(dbSchema.userBoards)
     .where(and(eq(dbSchema.userBoards.id, boardId), isNull(dbSchema.userBoards.deletedAt)))
@@ -709,9 +722,36 @@ export function defaultBoardName(boardType: string): string {
   return `${BOARD_TYPE_LABELS[boardType] ?? boardType} Board`;
 }
 
+/**
+ * Slug namespace for the per-config shared feed boards minted by
+ * `resolveSharedBoardForConfig`. Exported so `isSharedConfigFeedBoard` tests the
+ * same prefix the builder below writes — the two cannot drift.
+ */
+export const BOARD_CONFIG_PRESENCE_SLUG_PREFIX = 'presence-';
+
 function boardConfigPresenceSlug(boardType: string, layoutId: number, sizeId: number, setIds: string): string {
   const digest = createHash('sha256').update(`${boardType}:${layoutId}:${sizeId}:${setIds}`).digest('hex').slice(0, 20);
-  return `presence-${boardType}-${layoutId}-${sizeId}-${digest}`;
+  return `${BOARD_CONFIG_PRESENCE_SLUG_PREFIX}${boardType}-${layoutId}-${sizeId}-${digest}`;
+}
+
+/**
+ * Whether a board is one of the system-owned per-config **shared feeds** that
+ * `resolveSharedBoardForConfig` mints for walls with no BLE serial (every
+ * MoonBoard, and any serial-less Kilter/Tension controller).
+ *
+ * Such a row means "some wall with this configuration" — there is exactly one
+ * globally per (type, layout, size, sets) — not "this climber's wall". Tick
+ * attribution therefore treats it as the weakest signal it has: see the board
+ * ladder in `saveTick` (#5121), where a shared feed only claims a tick once the
+ * session's board and the owner's own config-matching board have both come up
+ * empty.
+ *
+ * Identity is the owner plus the slug namespace, never the display name: the
+ * name is user-visible copy and could be edited, the slug is derived from the
+ * config and unique-indexed.
+ */
+export function isSharedConfigFeedBoard(board: PresenceBoardIdentity): boolean {
+  return board.ownerId === SYSTEM_BOARD_OWNER_ID && board.slug.startsWith(BOARD_CONFIG_PRESENCE_SLUG_PREFIX);
 }
 
 /**

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -18,7 +18,7 @@ import {
   readTimestampFractionalSeconds,
 } from '../../../validation/schemas';
 import { resolveBoardFromPath } from '../social/boards';
-import { boardConfigMatchesTick, findActiveBoardById } from '../board-presence/shared';
+import { boardConfigMatchesTick, findActiveBoardById, isSharedConfigFeedBoard } from '../board-presence/shared';
 import { queueBoardStatsPublish } from '../board-presence/stats';
 import { publishSocialEvent } from '../../../events';
 import { publishDebouncedSessionStats } from '../sessions/debounced-stats-publisher';
@@ -887,7 +887,7 @@ export const tickMutations = {
       }
     }
 
-    // Resolve the tick's board_id. Four rungs, most specific first:
+    // Resolve the tick's board_id. Five rungs, most specific first:
     //  1. boardUuid — a named-board route (`/b/<slug>/...`); attaches to that
     //     exact board entity even when the climber doesn't own it (e.g. a
     //     seeded gym board owned by the system user). Config-gated exactly like
@@ -899,7 +899,9 @@ export const tickMutations = {
     //     it, and none of them fall back to config resolution.
     //  2. boardId — the board-presence connected wall (resolveBoardForSerial),
     //     flag-gated. On a stale/mismatched id we warn and fall back to the
-    //     config lookup rather than surfacing a raw FK/type mismatch.
+    //     config lookup rather than surfacing a raw FK/type mismatch. A
+    //     per-config SHARED FEED board is the exception: it identifies a
+    //     configuration, not a wall, so it drops to rung 5 (#5121).
     //  3. the session's board — a session is held on one physical wall, so a
     //     tick logged into it belongs to that wall. Config-gated exactly like
     //     rung 2, and deliberately not ownership-gated: in party mode the
@@ -908,7 +910,15 @@ export const tickMutations = {
     //  4. the legacy `/[board_name]/[layout_id]/...` config lookup, which names
     //     a configuration rather than a board; it takes the owner's lowest-id
     //     board with that config.
+    //  5. the per-config shared feed set aside by rung 2. Serial-less walls
+    //     (every MoonBoard) bind presence to one system-owned row per
+    //     configuration, shared by every climber on that config worldwide. That
+    //     is the right home for a tick only when nothing better exists — before
+    //     #5121 it outranked rungs 3 and 4, so a climber with their own board of
+    //     that exact config had every tick filed under the global feed and their
+    //     own board read as empty everywhere it is scoped by board_id.
     let boardId: number | null = null;
+    let sharedConfigFeedBoardId: number | null = null;
     let boardAssociationSource: 'boardUuid' | 'explicitBoardId' | 'config' | null = null;
     if (validatedInput.boardUuid) {
       boardAssociationSource = 'boardUuid';
@@ -957,8 +967,15 @@ export const tickMutations = {
       // from a different layout/size/set would otherwise stamp this tick onto
       // the wrong wall and corrupt that board's presence stats.
       if (explicitBoard && boardConfigMatchesTick(explicitBoard, validatedInput)) {
-        boardId = explicitBoard.id;
-        boardAssociationSource = 'explicitBoardId';
+        if (isSharedConfigFeedBoard(explicitBoard)) {
+          // Hold it for rung 5 instead of claiming the tick here, so the
+          // session's wall and the climber's own board of this config get their
+          // turn first.
+          sharedConfigFeedBoardId = explicitBoard.id;
+        } else {
+          boardId = explicitBoard.id;
+          boardAssociationSource = 'explicitBoardId';
+        }
       } else {
         logger.warn(
           `[board-presence] Ignoring tick boardId ${validatedInput.boardId} — config mismatch for ${validatedInput.boardType}`,
@@ -1006,6 +1023,15 @@ export const tickMutations = {
         validatedInput.setIds,
       );
       if (boardId !== null) boardAssociationSource = 'config';
+    }
+
+    // Rung 5: the per-config shared feed rung 2 set aside. Reached when the
+    // climber owns no board with this configuration and no session named one —
+    // the wall feed everyone on this config shares is then the best home the
+    // tick has, and its board stats keep counting it exactly as before #5121.
+    if (boardId == null && sharedConfigFeedBoardId != null) {
+      boardId = sharedConfigFeedBoardId;
+      boardAssociationSource = 'explicitBoardId';
     }
 
     // Run write-time beta-link validation before opening the transaction so a

--- a/packages/mobile/src/components/play-drawer/__tests__/use-quick-tick-form.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-quick-tick-form.test.tsx
@@ -48,6 +48,15 @@ vi.mock('react-native', () => ({
 }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('../../../lib/graphql/hooks', () => ({ useGrades: () => ({ data: gradesState.current }) }));
+// The climber's selected board, which the save path sends as `boardUuid` when
+// it is the wall this tick is actually on. Mocked so the test doesn't pull the
+// AsyncStorage-backed store into the graph.
+const activeBoardState = vi.hoisted(() => ({
+  current: null as { uuid: string; boardType: string; layoutId: number; sizeId: number; setIds: string } | null,
+}));
+vi.mock('../../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: activeBoardState.current }),
+}));
 // Partial mock: keep the real exports (BOULDER_GRADES et al., pulled in
 // transitively via climbed-at.ts → @boardsesh/profile-stats) and override only
 // the board-name normaliser.
@@ -195,6 +204,7 @@ beforeEach(() => {
   toastMock.showToast.mockClear();
   gradesState.current = [];
   connectivityState.isOffline = false;
+  activeBoardState.current = null;
   vi.mocked(track).mockClear();
 });
 
@@ -545,5 +555,68 @@ describe('useQuickTickForm tries count', () => {
 
     fireEvent.click(getByTestId('save'));
     expect(saveMock.mutate.mock.calls[0][0]).toMatchObject({ status: 'flash', attemptCount: 1 });
+  });
+});
+
+describe('useQuickTickForm board attribution', () => {
+  // The wall the climber picked, and the config the drawer sends for a climb
+  // that lives on it. Set ids are stored in a different ORDER than the tick
+  // sends them, which is the same wall — the comparison has to normalise, the
+  // way the server's own config gate does.
+  const SELECTED_BOARD = {
+    uuid: 'board-uuid-tranquility',
+    boardType: 'moonboard',
+    layoutId: 6,
+    sizeId: 1,
+    setIds: '27,24,26,25',
+  };
+  const TICK_CONFIG = { layoutId: 6, sizeId: 1, setIds: '24,25,26,27' };
+
+  it("sends the selected board's uuid when the tick is on that wall", () => {
+    // Without this the tick carries only the config and the presence board id,
+    // and a serial-less wall's presence id is the shared per-config feed — so
+    // the tick lands on the global feed and the climber's own board reads as
+    // empty on Home (#5121).
+    boardState.current = boardWithoutHistory();
+    activeBoardState.current = SELECTED_BOARD;
+    const { getByTestId } = renderForm({ boardName: 'moonboard', ...TICK_CONFIG });
+
+    fireEvent.click(getByTestId('save'));
+
+    expect(saveMock.mutate.mock.calls[0][0]).toMatchObject({ boardUuid: SELECTED_BOARD.uuid });
+  });
+
+  it('omits the uuid when the drawer resolved a different board to render', () => {
+    // A climb that needs holds this wall hasn't got renders against another
+    // board, and the tick carries THAT config. The server drops a boardUuid
+    // whose config disagrees without falling back (#4219), so sending it here
+    // would leave the tick with no board at all.
+    boardState.current = boardWithoutHistory();
+    activeBoardState.current = SELECTED_BOARD;
+    const { getByTestId } = renderForm({ boardName: 'moonboard', layoutId: 3, sizeId: 1, setIds: '5,6,7,8,9,10' });
+
+    fireEvent.click(getByTestId('save'));
+
+    expect(saveMock.mutate.mock.calls[0][0]).not.toHaveProperty('boardUuid');
+  });
+
+  it('omits the uuid when no board is selected', () => {
+    boardState.current = boardWithoutHistory();
+    activeBoardState.current = null;
+    const { getByTestId } = renderForm({ boardName: 'moonboard', ...TICK_CONFIG });
+
+    fireEvent.click(getByTestId('save'));
+
+    expect(saveMock.mutate.mock.calls[0][0]).not.toHaveProperty('boardUuid');
+  });
+
+  it('omits the uuid when the drawer sent no config to check it against', () => {
+    boardState.current = boardWithoutHistory();
+    activeBoardState.current = SELECTED_BOARD;
+    const { getByTestId } = renderForm({ boardName: 'moonboard' });
+
+    fireEvent.click(getByTestId('save'));
+
+    expect(saveMock.mutate.mock.calls[0][0]).not.toHaveProperty('boardUuid');
   });
 });

--- a/packages/mobile/src/components/play-drawer/use-quick-tick-form.ts
+++ b/packages/mobile/src/components/play-drawer/use-quick-tick-form.ts
@@ -23,10 +23,11 @@ import {
   useSaveTick,
   logbookClimbAngleKey,
 } from '@boardsesh/board-react';
-import { toBoardName } from '@boardsesh/board-config';
+import { toBoardName, normaliseSetIds } from '@boardsesh/board-config';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { clampToNow, MAXIMUM_CLIMBED_AT_REFRESH_MS } from '../logbook/climbed-at';
 import { useGrades } from '../../lib/graphql/hooks';
+import { useActiveBoard } from '../../lib/graphql/use-active-board';
 import { useToast } from '../../providers/toast-provider';
 import { useOptionalRogueTimer } from '../../providers/rogue-timer-provider';
 import { useBoardPresenceControls } from '../../providers/board-presence-provider';
@@ -153,6 +154,27 @@ export function useQuickTickForm({
   const boardActions = useOptionalBoardActions();
   const boardLogbook = useOptionalBoardLogbook();
   const { data: localPendingTicks = 0 } = useLocalPendingTicks(climbUuid, boardName);
+
+  // The board the climber selected, sent so the tick attaches to THAT wall
+  // rather than to whatever the presence layer happens to be bound to. Every
+  // serial-less wall (all of MoonBoard) binds presence to one system-owned feed
+  // shared by that configuration globally, so without this the tick lands on
+  // the shared feed and the climber's own board reads as empty on Home (#5121).
+  //
+  // Guarded on a config match because the drawer sends the RENDER board's
+  // config for a climb that doesn't fit the selected wall, and the server drops
+  // a boardUuid whose config disagrees without falling back to anything
+  // (#4219) — sending it unguarded would leave those ticks with no board at all.
+  const { data: activeBoard } = useActiveBoard();
+  const selectedBoardUuid = useMemo(() => {
+    if (!activeBoard || layoutId == null || sizeId == null || !setIds) return null;
+    const isSelectedBoard =
+      activeBoard.boardType === boardName &&
+      activeBoard.layoutId === layoutId &&
+      activeBoard.sizeId === sizeId &&
+      normaliseSetIds(activeBoard.setIds) === normaliseSetIds(setIds);
+    return isSelectedBoard ? activeBoard.uuid : null;
+  }, [activeBoard, boardName, layoutId, sizeId, setIds]);
   // Read through a ref so the save handler's identity doesn't change on every
   // connectivity flip (the file's existing stable-identity idiom). A save that
   // fails while offline has already exhausted the local write, the retry ladder
@@ -299,6 +321,7 @@ export function useQuickTickForm({
           ...(layoutId != null ? { layoutId } : {}),
           ...(sizeId != null ? { sizeId } : {}),
           ...(setIds ? { setIds } : {}),
+          ...(selectedBoardUuid ? { boardUuid: selectedBoardUuid } : {}),
           ...(boardPresenceEnabled && boardPresenceBoardId != null ? { boardId: boardPresenceBoardId } : {}),
         },
         {
@@ -367,6 +390,7 @@ export function useQuickTickForm({
       setIds,
       boardPresenceEnabled,
       boardPresenceBoardId,
+      selectedBoardUuid,
       tickState,
       comment,
       climbedAt,


### PR DESCRIPTION
## Summary

A climber with a home MoonBoard called **Tranquility** picked it from the Home tab's board dropdown and got *"Quiet on Tranquility right now"* — the day after a recorded session on it. They said it had always been that way.

Home's board scope filters `boardsesh_ticks.board_id = <selected board's id>`. Their ticks carried a different board id.

**Why.** A wall with no BLE serial — every MoonBoard, and any serial-less Kilter/Tension controller — binds board presence through `resolveBoardForConfig`, which hands back one **system-owned row per (board type, layout, size, sets)**, shared by every climber on that configuration worldwide. The tick sheet sends that row's id as `boardId`, and `saveTick` let it win outright. So a climber who owns a board of that exact config had every tick filed under the global feed, and their own board read as empty everywhere it is scoped by `board_id`.

Verified against production (read-only) before writing any code:

| | |
| --- | --- |
| Reporter's live "Tranquility" row | id `770338`, `moonboard/6/1/24,25,26,27` @40 |
| Ticks on **any** of their Tranquility rows | **0** |
| Their MoonBoard ticks | 181, all on `261536` = "MoonBoard Board Shared Feed" (system-owned, same config) |
| Their explicit sessions | 13, all `board_path='moonboard/6/1/24,25,26,27/40'` |
| Fleet-wide ticks on a per-config shared feed | **12,653** across 46 feeds |
| …belonging to a climber who owns a board of that config | **10,704 ticks / 650 climbers** |

MoonBoard dominates (8,361 ticks / 678 climbers), then Kilter (4,110 / 175).

### The fix, in two halves

**Backend** — a per-config shared feed drops to the **last** rung of `saveTick`'s board ladder, below the session's wall and below the owner's config lookup. It still claims the tick when nothing better exists, so the wall feed's stats are unchanged for climbers who own no matching board.

The demotion keys on **owner + slug namespace**, never the display name: the ~520 seeded catalog boards are system-owned too, name real walls, and must keep winning. There is a test for exactly that.

This half reaches **every app build already in the field** — no release needed.

**Mobile** — the tick sheet now sends the selected board's uuid. It calls `useSaveTick` directly rather than `BoardProvider.saveTick`, which is the only thing that injected one, so **no mobile tick has ever carried a `boardUuid`** and rung 1 of the ladder has been dead code in practice. Guarded on a config match, because the drawer sends the *render* board's config for a cross-board climb and the server drops a mismatched uuid without falling back (#4219). This is what covers a gym wall the climber selected but doesn't own.

### Verification

- Both guards mutation-tested: removing the demotion fails 2 of the new backend tests; removing the slug-namespace check fails the seeded-catalog test.
- `save-tick-board-uuid-config-gate.test.ts` and `legacy-tick-board-attribution.test.ts` pass **unmodified** — #4219's rule is untouched.
- Full backend + mobile suites, `vp run typecheck`, `vp check`, Metro bundle check.

### Not in this PR

The 10,704 rows already written. That is a separate, sign-off-gated data repair — see #5240. This one is `Refs #5121` so the issue stays open until the history lands too.

Residual trade-off worth a reviewer's eye: `boardUuid` (rung 1) outranks a serial-resolved wall (rung 2), so a climber who has selected board A while physically connected to same-config board B attributes to A. That ordering is today's documented behaviour for named-board ticks; this change just makes mobile use it.

Refs #5121

## Release Notes

- Sessions you log on your own board now show up under that board on Home, instead of vanishing into a feed shared with every other wall like it.

## Test plan

1. Sign in, pick your board on Home's top dropdown.
2. Log a climb from the play drawer.
3. Open Home, pick that board again.
4. Your session appears under "Recent sessions".
5. Repeat on a MoonBoard with Bluetooth connected.

## Risk

Risk: 4/5 — changes how every client's ticks attach to a board. Bounded: the demotion only fires for system-owned `presence-…` feeds, and the feed stays the last-resort fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01724XLTFhu7gkLxBeYw8s5Y
