### PR TITLE
fix(db): re-file shared-feed ticks onto the climber's own board

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -97,6 +97,7 @@
     "db:repair-woods-rules": "tsx scripts/repair-woods-rules.ts",
     "db:repair-moonboard-8c-grades": "tsx scripts/repair-moonboard-8c-grades.ts",
     "db:backfill-clamped-send-attempts": "tsx scripts/backfill-clamped-send-attempts.ts",
+    "db:backfill-shared-feed-tick-boards": "tsx scripts/backfill-shared-feed-tick-boards.ts",
     "db:dedupe-gyms": "tsx scripts/dedupe-gym-locations.ts",
     "db:dedupe-serial-boards": "tsx scripts/dedupe-serial-boards.ts",
     "db:dedupe-beta-links": "tsx scripts/dedupe-beta-links.ts",

--- a/packages/db/scripts/backfill-shared-feed-tick-boards-helpers.test.ts
+++ b/packages/db/scripts/backfill-shared-feed-tick-boards-helpers.test.ts
@@ -1,0 +1,100 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  boardConfigKey,
+  planSharedFeedTickMoves,
+  type OwnedBoard,
+  type SharedFeedBoard,
+} from './backfill-shared-feed-tick-boards-helpers.js';
+
+const CONFIG = { boardType: 'moonboard', layoutId: 6, sizeId: 1, setIds: '24,25,26,27' };
+const FEED: SharedFeedBoard = { id: 261536, ...CONFIG };
+const CLIMBER = 'climber-1';
+
+function ownedBoard(overrides: Partial<OwnedBoard> = {}): OwnedBoard {
+  return { id: 770338, ownerId: CLIMBER, ...CONFIG, ...overrides };
+}
+
+function feedTick(uuid: string, overrides: { userId?: string; boardId?: number } = {}) {
+  return { uuid, userId: overrides.userId ?? CLIMBER, boardId: overrides.boardId ?? FEED.id };
+}
+
+test('moves a tick onto the one board its climber owns with that config', () => {
+  const plan = planSharedFeedTickMoves({
+    feeds: [FEED],
+    ticks: [feedTick('tick-1')],
+    ownedBoards: [ownedBoard()],
+  });
+
+  assert.deepEqual(plan.moves, [{ uuid: 'tick-1', oldBoardId: FEED.id, newBoardId: 770338 }]);
+  assert.deepEqual([...plan.movedUserIds], [CLIMBER]);
+  assert.equal(plan.ambiguous, 0);
+  assert.equal(plan.noOwnedBoard, 0);
+});
+
+test('matches a board whose set ids were stored in another order', () => {
+  // `createBoard` persists the order it was handed, so this is the same wall.
+  const plan = planSharedFeedTickMoves({
+    feeds: [FEED],
+    ticks: [feedTick('tick-1')],
+    ownedBoards: [ownedBoard({ setIds: '27,24,26,25' })],
+  });
+
+  assert.equal(plan.moves.length, 1);
+});
+
+test('leaves a tick alone when its climber owns two boards of that config', () => {
+  // #4174's "same wall at home and at the gym" — the row says nothing about
+  // which one the climber was standing at, so guessing would scatter history.
+  const plan = planSharedFeedTickMoves({
+    feeds: [FEED],
+    ticks: [feedTick('tick-1')],
+    ownedBoards: [ownedBoard({ id: 770338 }), ownedBoard({ id: 880001 })],
+  });
+
+  assert.deepEqual(plan.moves, []);
+  assert.equal(plan.ambiguous, 1);
+  assert.deepEqual([...plan.ambiguousUserIds], [CLIMBER]);
+});
+
+test('leaves a tick on the feed when its climber owns no board of that config', () => {
+  // The feed is where these belong, and the fixed code still files them there.
+  const plan = planSharedFeedTickMoves({
+    feeds: [FEED],
+    ticks: [feedTick('tick-1')],
+    ownedBoards: [ownedBoard({ layoutId: 3, setIds: '5,6,7,8,9,10' })],
+  });
+
+  assert.deepEqual(plan.moves, []);
+  assert.equal(plan.noOwnedBoard, 1);
+  assert.equal(plan.ambiguous, 0);
+});
+
+test("never files a tick onto another climber's board", () => {
+  const plan = planSharedFeedTickMoves({
+    feeds: [FEED],
+    ticks: [feedTick('tick-1', { userId: 'climber-2' })],
+    ownedBoards: [ownedBoard()],
+  });
+
+  assert.deepEqual(plan.moves, []);
+  assert.equal(plan.noOwnedBoard, 1);
+});
+
+test('ignores a tick that is no longer on a feed', () => {
+  // The feeds and the ticks are read separately; a tick re-filed by the fixed
+  // code in between must not be moved again on a stale plan.
+  const plan = planSharedFeedTickMoves({
+    feeds: [FEED],
+    ticks: [feedTick('tick-1', { boardId: 999999 })],
+    ownedBoards: [ownedBoard()],
+  });
+
+  assert.deepEqual(plan.moves, []);
+  assert.equal(plan.noOwnedBoard, 0);
+  assert.equal(plan.ambiguous, 0);
+});
+
+test('keeps configs that differ only by board type apart', () => {
+  assert.notEqual(boardConfigKey({ ...CONFIG, boardType: 'kilter' }), boardConfigKey(CONFIG));
+});

--- a/packages/db/scripts/backfill-shared-feed-tick-boards-helpers.ts
+++ b/packages/db/scripts/backfill-shared-feed-tick-boards-helpers.ts
@@ -1,0 +1,100 @@
+/**
+ * The row-selection rule behind `backfill-shared-feed-tick-boards.ts`, kept
+ * pure so it can be tested without a database. See that script's header for why
+ * these ticks are misfiled in the first place (#5121).
+ */
+
+import { normaliseSetIds } from '@boardsesh/board-config';
+
+export type BoardConfigRow = {
+  boardType: string;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+};
+
+export type SharedFeedBoard = BoardConfigRow & { id: number };
+export type OwnedBoard = BoardConfigRow & { id: number; ownerId: string };
+export type FeedTick = { uuid: string; userId: string; boardId: number };
+
+export type PlannedMove = { uuid: string; oldBoardId: number; newBoardId: number };
+
+export type MovePlan = {
+  moves: PlannedMove[];
+  /** Climbers with at least one moved tick. */
+  movedUserIds: Set<string>;
+  /** Ticks left alone because their climber owns several boards of that config. */
+  ambiguous: number;
+  ambiguousUserIds: Set<string>;
+  /** Ticks left alone because their climber owns no board of that config. */
+  noOwnedBoard: number;
+};
+
+/**
+ * The identity a tick's feed and a climber's board have to agree on to be the
+ * same wall.
+ *
+ * Set ids are normalised because `createBoard` persists whatever order it was
+ * handed: a board saved as '25,26,27,24' is the same wall as a feed keyed
+ * '24,25,26,27', and a raw string compare would call them different and leave
+ * the tick on the feed.
+ */
+export function boardConfigKey(board: BoardConfigRow): string {
+  return `${board.boardType}|${board.layoutId}|${board.sizeId}|${normaliseSetIds(board.setIds)}`;
+}
+
+/**
+ * Which ticks can be moved off a per-config shared feed, and why the rest
+ * cannot.
+ *
+ * A tick moves only when its climber owns EXACTLY ONE non-deleted board with
+ * the feed's configuration. Two same-config boards is the #4174 "same wall at
+ * home and at the gym" case and nothing in the row says which one the climber
+ * was standing at; zero means the feed is where the tick belongs, and the fixed
+ * code still files it there. Both are counted rather than guessed at.
+ */
+export function planSharedFeedTickMoves(input: {
+  feeds: SharedFeedBoard[];
+  ticks: FeedTick[];
+  ownedBoards: OwnedBoard[];
+}): MovePlan {
+  const feedConfigById = new Map(input.feeds.map((feed) => [feed.id, boardConfigKey(feed)]));
+
+  const ownedByOwnerConfig = new Map<string, number[]>();
+  for (const board of input.ownedBoards) {
+    const key = `${board.ownerId}|${boardConfigKey(board)}`;
+    const bucket = ownedByOwnerConfig.get(key);
+    if (bucket) bucket.push(board.id);
+    else ownedByOwnerConfig.set(key, [board.id]);
+  }
+
+  const plan: MovePlan = {
+    moves: [],
+    movedUserIds: new Set(),
+    ambiguous: 0,
+    ambiguousUserIds: new Set(),
+    noOwnedBoard: 0,
+  };
+
+  for (const tick of input.ticks) {
+    const feedConfig = feedConfigById.get(tick.boardId);
+    // Not on a feed at all — the caller's query shouldn't return these, but a
+    // tick that moved between the two reads must not be re-filed on a guess.
+    if (!feedConfig) continue;
+
+    const candidates = ownedByOwnerConfig.get(`${tick.userId}|${feedConfig}`) ?? [];
+    if (candidates.length === 0) {
+      plan.noOwnedBoard += 1;
+      continue;
+    }
+    if (candidates.length > 1) {
+      plan.ambiguous += 1;
+      plan.ambiguousUserIds.add(tick.userId);
+      continue;
+    }
+    plan.movedUserIds.add(tick.userId);
+    plan.moves.push({ uuid: tick.uuid, oldBoardId: tick.boardId, newBoardId: candidates[0] });
+  }
+
+  return plan;
+}

--- a/packages/db/scripts/backfill-shared-feed-tick-boards.ts
+++ b/packages/db/scripts/backfill-shared-feed-tick-boards.ts
@@ -1,0 +1,250 @@
+/**
+ * Re-file ticks that landed on a per-config SHARED FEED board onto the wall
+ * their climber actually owns.
+ *
+ * Resolves the data half of #5121. The code path was fixed in the same issue's
+ * first PR; this is the separate decision about the rows already written.
+ *
+ * A wall with no BLE serial — every MoonBoard, and any serial-less
+ * Kilter/Tension controller — binds board presence through the backend's
+ * `resolveBoardForConfig`, which hands back ONE system-owned row per
+ * (board type, layout, size, sets), shared by every climber on that
+ * configuration worldwide. The mobile tick sheet sent that row's id and
+ * `saveTick` let it win outright, so a climber with their own board of that
+ * exact config had every tick filed under the global feed. Their board then
+ * reads as empty everywhere it is scoped by `board_id` — the Home tab's board
+ * picker ("Quiet on <board> right now"), board stats, board leaderboards.
+ *
+ * Measured on production 2026-09-07: 12,648 ticks sit on 31 shared feeds, and
+ * 10,879 of them (655 climbers) belong to someone who owns a board of that
+ * exact configuration.
+ *
+ * The rule, deliberately narrow: a tick moves only when its climber owns
+ * EXACTLY ONE non-deleted board with the same (board_type, layout_id, size_id,
+ * normalised set_ids). Two same-config boards is the #4174 "same wall at home
+ * and at the gym" case, and nothing in the row says which one the climber was
+ * standing at — those are counted and left alone. So are ticks from climbers
+ * who own no matching board: the shared feed is where those belong, and the
+ * fixed code still files them there.
+ *
+ * Set ids are compared normalised, not as raw strings. `createBoard` stores
+ * whatever order it was handed, so a board saved as '25,26,27,24' is the same
+ * wall as a feed keyed '24,25,26,27'.
+ *
+ * Approved by maintainer 2026-09-07.
+ *
+ * Usage (needs a DB_URL with UPDATE rights — the usual read-only credential can
+ * run --dry-run but not the apply step):
+ *   vp run db:backfill-shared-feed-tick-boards -- --dry-run
+ *   vp run db:backfill-shared-feed-tick-boards
+ *   vp run db:backfill-shared-feed-tick-boards -- --revert <snapshot.json>
+ *
+ * Options:
+ *   --dry-run        Match and report, write nothing. Still writes the plan file.
+ *   --revert <file>  Restore board ids from a snapshot written by a prior run.
+ *   --out <file>     Snapshot path (default ./shared-feed-tick-boards-<date>.json).
+ *
+ * Safe to re-run: a tick already moved off the feed stops matching.
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { and, eq, inArray, isNull, like } from 'drizzle-orm';
+import { createScriptDb } from './db-connection.js';
+import { planSharedFeedTickMoves } from './backfill-shared-feed-tick-boards-helpers.js';
+import { boardseshTicks } from '../src/schema/app/ascents.js';
+import { userBoards } from '../src/schema/app/boards.js';
+
+// Mirrors the backend's `SYSTEM_BOARD_OWNER_ID` and
+// `BOARD_CONFIG_PRESENCE_SLUG_PREFIX` (graphql/resolvers/board-presence/shared.ts).
+// Duplicated rather than imported: packages/db must not depend on the backend.
+// Identity is owner + slug namespace, never the display name — the ~520 seeded
+// catalog boards are system-owned too and name real walls.
+const SYSTEM_BOARD_OWNER_ID = '00000000-0000-0000-0000-000000000000';
+const PRESENCE_SLUG_PREFIX = 'presence-';
+
+const args = process.argv.slice(2);
+function flag(name: string): string | undefined {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+const revertPath = flag('--revert');
+const dryRun = args.includes('--dry-run');
+const outPath = flag('--out') ?? `./shared-feed-tick-boards-${new Date().toISOString().slice(0, 10)}.json`;
+
+type SnapshotEntry = { uuid: string; oldBoardId: number; newBoardId: number };
+type Snapshot = { writtenAt: string; entries: SnapshotEntry[] };
+
+async function revert(snapshotPath: string) {
+  const snapshot = JSON.parse(readFileSync(snapshotPath, 'utf8')) as Snapshot;
+  const { db, close } = createScriptDb();
+  try {
+    console.log(`Reverting ${snapshot.entries.length} rows from ${snapshotPath} (written ${snapshot.writtenAt})`);
+    if (dryRun) {
+      console.log('Dry run — nothing written.');
+      return;
+    }
+    // Atomic, same reasoning as the forward pass: a half-reverted logbook is
+    // the one state with no clean recovery path.
+    const restored = await db.transaction(async (txn) => {
+      let applied = 0;
+      for (const entry of snapshot.entries) {
+        // Only revert rows still holding the board we wrote, so a later change
+        // — the climber re-filing the tick, a board merge — is never clobbered.
+        const rows = await txn
+          .update(boardseshTicks)
+          .set({ boardId: entry.oldBoardId, updatedAt: new Date().toISOString() })
+          .where(and(eq(boardseshTicks.uuid, entry.uuid), eq(boardseshTicks.boardId, entry.newBoardId)))
+          .returning({ uuid: boardseshTicks.uuid });
+        applied += rows.length;
+      }
+      return applied;
+    });
+    console.log(`Reverted ${restored}/${snapshot.entries.length} rows (skipped rows changed since).`);
+  } finally {
+    await close();
+  }
+}
+
+async function main() {
+  if (revertPath) return revert(revertPath);
+
+  const { db, close } = createScriptDb();
+  try {
+    // Soft-deleted feeds are included on purpose: `deleted_at` stops a feed
+    // being handed out again, it does not move the ticks already on it, and
+    // those are misfiled in exactly the same way.
+    const feeds = await db
+      .select({
+        id: userBoards.id,
+        boardType: userBoards.boardType,
+        layoutId: userBoards.layoutId,
+        sizeId: userBoards.sizeId,
+        setIds: userBoards.setIds,
+      })
+      .from(userBoards)
+      .where(and(eq(userBoards.ownerId, SYSTEM_BOARD_OWNER_ID), like(userBoards.slug, `${PRESENCE_SLUG_PREFIX}%`)));
+
+    if (feeds.length === 0) {
+      console.log('No per-config shared feed boards found. Nothing to do.');
+      return;
+    }
+    const feedIds = feeds.map((feed) => Number(feed.id));
+    console.log(`Found ${feeds.length} per-config shared feed boards`);
+
+    const ticks = await db
+      .select({ uuid: boardseshTicks.uuid, userId: boardseshTicks.userId, boardId: boardseshTicks.boardId })
+      .from(boardseshTicks)
+      .where(inArray(boardseshTicks.boardId, feedIds));
+    console.log(`Found ${ticks.length} ticks filed on those feeds`);
+
+    if (ticks.length === 0) {
+      console.log('Nothing to do.');
+      return;
+    }
+
+    // Every candidate wall in one read, matched in memory so the report can
+    // tell "no board" apart from "two boards and no way to choose".
+    const ownerIds = [...new Set(ticks.map((tick) => tick.userId))];
+    const ownedBoards = await db
+      .select({
+        id: userBoards.id,
+        ownerId: userBoards.ownerId,
+        boardType: userBoards.boardType,
+        layoutId: userBoards.layoutId,
+        sizeId: userBoards.sizeId,
+        setIds: userBoards.setIds,
+      })
+      .from(userBoards)
+      .where(and(inArray(userBoards.ownerId, ownerIds), isNull(userBoards.deletedAt)));
+
+    const plan = planSharedFeedTickMoves({
+      feeds: feeds.map((feed) => ({
+        id: Number(feed.id),
+        boardType: feed.boardType,
+        layoutId: Number(feed.layoutId),
+        sizeId: Number(feed.sizeId),
+        setIds: feed.setIds,
+      })),
+      ticks: ticks.map((tick) => ({ uuid: tick.uuid, userId: tick.userId, boardId: Number(tick.boardId) })),
+      ownedBoards: ownedBoards.map((board) => ({
+        id: Number(board.id),
+        ownerId: board.ownerId,
+        boardType: board.boardType,
+        layoutId: Number(board.layoutId),
+        sizeId: Number(board.sizeId),
+        setIds: board.setIds,
+      })),
+    });
+    const entries: SnapshotEntry[] = plan.moves;
+
+    console.log('');
+    console.log(`Move       ${entries.length} ticks across ${plan.movedUserIds.size} climbers onto their own board`);
+    console.log(
+      `Ambiguous  ${plan.ambiguous} ticks from ${plan.ambiguousUserIds.size} climbers who own several boards of that config`,
+    );
+    console.log(`No board   ${plan.noOwnedBoard} ticks whose climber owns no board of that config (the feed is correct)`);
+    console.log('');
+
+    if (entries.length === 0) {
+      console.log('Nothing to do.');
+      return;
+    }
+
+    const snapshot: Snapshot = { writtenAt: new Date().toISOString(), entries };
+
+    if (dryRun) {
+      console.log(`Dry run — would re-file ${entries.length} ticks. Nothing written.`);
+      writeFileSync(outPath, JSON.stringify(snapshot, null, 2));
+      console.log(`Planned changes written to ${outPath} (inspect before re-running without --dry-run).`);
+      return;
+    }
+
+    // Snapshot BEFORE mutating, so an interrupted run is still revertible.
+    writeFileSync(outPath, JSON.stringify(snapshot, null, 2));
+    console.log(`Snapshot written to ${outPath} — revert with --revert ${outPath}`);
+
+    // Grouped by destination so each batch is one UPDATE, and guarded on the
+    // feed id the plan was built against: a tick re-filed by the fixed code
+    // between the read and the write keeps its newer board.
+    const byDestination = new Map<string, string[]>();
+    for (const entry of entries) {
+      const key = `${entry.oldBoardId}|${entry.newBoardId}`;
+      const bucket = byDestination.get(key);
+      if (bucket) bucket.push(entry.uuid);
+      else byDestination.set(key, [entry.uuid]);
+    }
+
+    const batchSize = 500;
+    // One transaction across every batch. Batching keeps each statement's
+    // parameter list sane, but a run interrupted between batches would leave
+    // the repair half-applied — recoverable from the snapshot, but only if the
+    // operator still has it. All-or-nothing is cheap at this size.
+    const updated = await db.transaction(async (txn) => {
+      let applied = 0;
+      for (const [key, uuids] of byDestination) {
+        const [oldBoardId, newBoardId] = key.split('|').map(Number);
+        for (let offset = 0; offset < uuids.length; offset += batchSize) {
+          const batch = uuids.slice(offset, offset + batchSize);
+          const rows = await txn
+            .update(boardseshTicks)
+            .set({ boardId: newBoardId, updatedAt: new Date().toISOString() })
+            .where(and(inArray(boardseshTicks.uuid, batch), eq(boardseshTicks.boardId, oldBoardId)))
+            .returning({ uuid: boardseshTicks.uuid });
+          applied += rows.length;
+        }
+      }
+      return applied;
+    });
+
+    console.log('');
+    console.log(`Re-filed ${updated} ticks onto their climber's own board.`);
+  } finally {
+    await close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/db/scripts/backfill-shared-feed-tick-boards.ts
+++ b/packages/db/scripts/backfill-shared-feed-tick-boards.ts
@@ -183,7 +183,9 @@ async function main() {
     console.log(
       `Ambiguous  ${plan.ambiguous} ticks from ${plan.ambiguousUserIds.size} climbers who own several boards of that config`,
     );
-    console.log(`No board   ${plan.noOwnedBoard} ticks whose climber owns no board of that config (the feed is correct)`);
+    console.log(
+      `No board   ${plan.noOwnedBoard} ticks whose climber owns no board of that config (the feed is correct)`,
+    );
     console.log('');
 
     if (entries.length === 0) {


### PR DESCRIPTION
## Summary

The data half of #5121. The code path is fixed in #5239; this is the separate decision about the rows already written.

Ticks logged on a wall with no BLE serial were filed against the **system-owned per-config shared feed** — one row globally per (board type, layout, size, sets) — instead of the board the climber owns. Their own board then reads as empty everywhere it is scoped by `board_id`: the Home tab's board picker, board stats, board leaderboards. The reporter's 172 MoonBoard ticks are all on feed `261536` and none on their board `770338`.

A code fix alone leaves that history invisible, so this re-files it.

### The rule

A tick moves only when its climber owns **exactly one** non-deleted board with the feed's `(board_type, layout_id, size_id, normalised set_ids)`.

- **Two same-config boards** is #4174's "same wall at home and at the gym". Nothing in the row says which one the climber was standing at, so those are counted and left alone.
- **No matching board** means the shared feed is where the tick belongs — the fixed code still files those there.
- Set ids are compared **normalised**: `createBoard` persists whatever order it was handed, so a board stored `25,26,27,24` is the same wall as a feed keyed `24,25,26,27`.

### Dry run against production (2026-09-07)

```
Found 46 per-config shared feed boards
Found 12653 ticks filed on those feeds

Move       10704 ticks across 650 climbers onto their own board
Ambiguous  180 ticks from 7 climbers who own several boards of that config
No board   1769 ticks whose climber owns no board of that config (the feed is correct)
```

The reporter's case is in there: 172 ticks, `261536` → `770338`.

### Safety

- Snapshot of every `(tick uuid, old board id, new board id)` is written **before** any UPDATE; `--revert <snapshot.json>` restores it.
- The revert only touches rows still holding the board this script wrote, so a later change is never clobbered.
- Every write is guarded on the feed id the plan was built against, so a tick re-filed by the fixed code between the read and the write keeps its newer board.
- One transaction across all batches — no half-applied state to reason about after a crash.
- Safe to re-run: a tick already moved off a feed stops matching.
- The Redis board-stats cache has a 60 s TTL, so board stats self-heal with no extra invalidation.

The selection rule is pure and unit-tested (`backfill-shared-feed-tick-boards-helpers.test.ts`): single match, ambiguous, no match, another climber's board, and a tick that moved off its feed between the two reads.

**Approved by maintainer 2026-09-07.**

Fixes #5121

## Release Notes

- Sessions you logged on your own board before today now show up under that board, instead of staying in a feed shared with every other wall like it.

## Test plan

1. Open Home, pick your board from the top dropdown.
2. Sessions from before today appear under "Recent sessions".
3. Open the board sheet — its stats count those sends.

## Risk

Risk: 4/5 — rewrites `board_id` on ~10.7k tick rows. Snapshot-backed and revertible; no rows are created or deleted, and ambiguous rows are skipped rather than guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01724XLTFhu7gkLxBeYw8s5Y
