### PR TITLE
perf(mobile): emit $screen once per screen per session

### DIFF
--- a/packages/mobile/src/components/analytics/AnalyticsScreenTracker.tsx
+++ b/packages/mobile/src/components/analytics/AnalyticsScreenTracker.tsx
@@ -3,10 +3,13 @@ import { useSegments } from 'expo-router';
 import { trackScreen } from '../../lib/analytics';
 import { normalizeScreenPath } from '../../lib/analytics-screen-path';
 
-// Fires a $screen event on every Expo Router navigation, using the route pattern
-// (e.g. /climbs/[climbUuid]) rather than the concrete path so PostHog sees one
-// screen per route, not one per climb. The lastPath ref dedupes the repeated
-// segment emissions Expo Router produces during a transition. Renders nothing.
+// Reports every Expo Router navigation using the route pattern (e.g.
+// /climbs/[climbUuid]) rather than the concrete path, so PostHog sees one screen
+// per route, not one per climb. The lastPath ref dedupes the repeated segment
+// emissions Expo Router produces during a transition; it stays FIRST because it
+// is a ref compare with no SDK call, so intermediate renders never reach the
+// session gate inside trackScreen. Whether a navigation actually emits $screen is
+// that gate's call — see lib/analytics-screen-session-gate.ts. Renders nothing.
 export function AnalyticsScreenTracker(): null {
   const segments = useSegments();
   const lastPath = useRef<string | null>(null);

--- a/packages/mobile/src/lib/__tests__/analytics-screen-session-gate.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-screen-session-gate.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { createScreenSessionGate } from '../analytics-screen-session-gate';
+
+const SESSION_A = '0199-aaaa';
+const SESSION_B = '0199-bbbb';
+
+function gateWith(initialSessionId: string | null | undefined) {
+  let sessionId = initialSessionId;
+  const gate = createScreenSessionGate(() => sessionId);
+  return {
+    gate,
+    setSession(next: string | null | undefined) {
+      sessionId = next;
+    },
+  };
+}
+
+describe('createScreenSessionGate', () => {
+  it('emits the first time a screen is seen in a session', () => {
+    const { gate } = gateWith(SESSION_A);
+    expect(gate.shouldEmit('/climbs')).toBe(true);
+  });
+
+  it('suppresses the /climbs ↔ /play ping-pong down to one event each', () => {
+    // The whole reason this gate exists: those two routes are 95k + 90k events a
+    // month, ~34 per person, almost all of it re-visits within one session.
+    const { gate } = gateWith(SESSION_A);
+    const path = ['/climbs', '/play', '/climbs', '/play', '/climbs'];
+
+    const emitted = path.filter((screen) => gate.shouldEmit(screen));
+
+    expect(emitted).toEqual(['/climbs', '/play']);
+  });
+
+  it('emits once per distinct screen within a session', () => {
+    const { gate } = gateWith(SESSION_A);
+    expect(gate.shouldEmit('/climbs')).toBe(true);
+    expect(gate.shouldEmit('/home')).toBe(true);
+    expect(gate.shouldEmit('/climbs')).toBe(false);
+  });
+
+  it('re-arms when the session rotates', () => {
+    const { gate, setSession } = gateWith(SESSION_A);
+    expect(gate.shouldEmit('/climbs')).toBe(true);
+    expect(gate.shouldEmit('/climbs')).toBe(false);
+
+    setSession(SESSION_B);
+
+    expect(gate.shouldEmit('/climbs')).toBe(true);
+  });
+
+  it('does not leak seen screens across a rotation in either direction', () => {
+    const { gate, setSession } = gateWith(SESSION_A);
+    gate.shouldEmit('/climbs');
+
+    setSession(SESSION_B);
+    // Seen only in A — must not be suppressed in B.
+    expect(gate.shouldEmit('/climbs')).toBe(true);
+    expect(gate.shouldEmit('/profile')).toBe(true);
+
+    setSession(SESSION_A);
+    // Only one session's set is retained by design, so B's /profile does not
+    // suppress here either.
+    expect(gate.shouldEmit('/profile')).toBe(true);
+  });
+
+  it('emits and records nothing while the session id is still empty', () => {
+    // getSessionId() returns '' until the SDK hydrates its persisted storage, so
+    // the first navigation of a cold launch lands here.
+    const { gate, setSession } = gateWith('');
+    expect(gate.shouldEmit('/home')).toBe(true);
+    expect(gate.shouldEmit('/home')).toBe(true);
+
+    setSession(SESSION_A);
+
+    // Nothing was recorded against the empty id, so the real session still gets
+    // its one event.
+    expect(gate.shouldEmit('/home')).toBe(true);
+    expect(gate.shouldEmit('/home')).toBe(false);
+  });
+
+  it('always emits when there is no client to report a session', () => {
+    const { gate } = gateWith(null);
+    expect(gate.shouldEmit('/home')).toBe(true);
+    expect(gate.shouldEmit('/home')).toBe(true);
+  });
+
+  it('emits rather than dropping when reading the session id throws', () => {
+    const gate = createScreenSessionGate(() => {
+      throw new Error('client exploded');
+    });
+
+    expect(gate.shouldEmit('/home')).toBe(true);
+    expect(gate.shouldEmit('/home')).toBe(true);
+  });
+
+  it('re-arms after reset, so a sign-out does not carry the gate to the next account', () => {
+    const { gate } = gateWith(SESSION_A);
+    expect(gate.shouldEmit('/climbs')).toBe(true);
+    expect(gate.shouldEmit('/climbs')).toBe(false);
+
+    gate.reset();
+
+    expect(gate.shouldEmit('/climbs')).toBe(true);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/analytics-track-screen.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-track-screen.test.ts
@@ -2,7 +2,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const screenMock = vi.fn();
 const registerForSessionMock = vi.fn();
-let client: { screen: typeof screenMock; registerForSession: typeof registerForSessionMock } | null = null;
+const resetMock = vi.fn();
+type FakeClient = {
+  screen: typeof screenMock;
+  registerForSession: typeof registerForSessionMock;
+  reset: typeof resetMock;
+  register: () => void;
+  unregister: () => void;
+};
+let client: FakeClient | null = null;
 
 vi.mock('../posthog-client', () => ({
   getPostHogClient: () => client,
@@ -12,6 +20,7 @@ vi.mock('../posthog-client', () => ({
 const shouldEmitScreenForSessionMock = vi.fn<(screenName: string) => boolean>(() => true);
 vi.mock('../analytics-screen-session-gate', () => ({
   shouldEmitScreenForSession: (screenName: string) => shouldEmitScreenForSessionMock(screenName),
+  resetScreenSessionGate: vi.fn(),
 }));
 
 import { trackScreen } from '../analytics';
@@ -21,7 +30,14 @@ beforeEach(() => {
   registerForSessionMock.mockClear();
   shouldEmitScreenForSessionMock.mockClear();
   shouldEmitScreenForSessionMock.mockReturnValue(true);
-  client = { screen: screenMock, registerForSession: registerForSessionMock };
+  resetMock.mockClear();
+  client = {
+    screen: screenMock,
+    registerForSession: registerForSessionMock,
+    reset: resetMock,
+    register: () => {},
+    unregister: () => {},
+  };
 });
 
 describe('trackScreen', () => {
@@ -64,5 +80,18 @@ describe('trackScreen', () => {
 
     expect(() => trackScreen('/home')).not.toThrow();
     expect(shouldEmitScreenForSessionMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('reset', () => {
+  it('clears the screen gate, so a new sign-out path cannot forget it', async () => {
+    // The gate is reset here rather than at each sign-out call site. This test is
+    // the guard on that: it fails if the call moves back out of reset().
+    const { reset } = await import('../analytics');
+    const { resetScreenSessionGate } = await import('../analytics-screen-session-gate');
+
+    reset();
+
+    expect(vi.mocked(resetScreenSessionGate)).toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/lib/__tests__/analytics-track-screen.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-track-screen.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const screenMock = vi.fn();
+const registerForSessionMock = vi.fn();
+let client: { screen: typeof screenMock; registerForSession: typeof registerForSessionMock } | null = null;
+
+vi.mock('../posthog-client', () => ({
+  getPostHogClient: () => client,
+  registerAppSuperProperties: vi.fn(),
+}));
+
+const shouldEmitScreenForSessionMock = vi.fn<(screenName: string) => boolean>(() => true);
+vi.mock('../analytics-screen-session-gate', () => ({
+  shouldEmitScreenForSession: (screenName: string) => shouldEmitScreenForSessionMock(screenName),
+}));
+
+import { trackScreen } from '../analytics';
+
+beforeEach(() => {
+  screenMock.mockClear();
+  registerForSessionMock.mockClear();
+  shouldEmitScreenForSessionMock.mockClear();
+  shouldEmitScreenForSessionMock.mockReturnValue(true);
+  client = { screen: screenMock, registerForSession: registerForSessionMock };
+});
+
+describe('trackScreen', () => {
+  it('captures $screen when the session gate allows it', () => {
+    trackScreen('/climbs');
+
+    expect(screenMock).toHaveBeenCalledExactlyOnceWith('/climbs');
+  });
+
+  it('does not capture $screen when the gate suppresses the screen', () => {
+    shouldEmitScreenForSessionMock.mockReturnValue(false);
+
+    trackScreen('/climbs');
+
+    expect(screenMock).not.toHaveBeenCalled();
+  });
+
+  it('updates $screen_name on EVERY navigation, gated or not', () => {
+    // The SDK stamps $screen_name onto every subsequent event, which is how
+    // `Tick Logged` knows it happened on /play. If the suppressed path skipped
+    // this, every other event would be attributed to whatever screen last got
+    // past the gate, and the drift would worsen the longer a session ran.
+    shouldEmitScreenForSessionMock.mockReturnValue(false);
+
+    trackScreen('/play');
+
+    expect(registerForSessionMock).toHaveBeenCalledExactlyOnceWith({ $screen_name: '/play' });
+    expect(screenMock).not.toHaveBeenCalled();
+  });
+
+  it('updates $screen_name on the emitting path too', () => {
+    trackScreen('/home');
+
+    expect(registerForSessionMock).toHaveBeenCalledExactlyOnceWith({ $screen_name: '/home' });
+    expect(screenMock).toHaveBeenCalledExactlyOnceWith('/home');
+  });
+
+  it('does nothing and does not throw when analytics is disabled', () => {
+    client = null;
+
+    expect(() => trackScreen('/home')).not.toThrow();
+    expect(shouldEmitScreenForSessionMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/analytics-track-screen.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-track-screen.test.ts
@@ -18,18 +18,20 @@ vi.mock('../posthog-client', () => ({
 }));
 
 const shouldEmitScreenForSessionMock = vi.fn<(screenName: string) => boolean>(() => true);
+const resetScreenSessionGateMock = vi.fn();
 vi.mock('../analytics-screen-session-gate', () => ({
   shouldEmitScreenForSession: (screenName: string) => shouldEmitScreenForSessionMock(screenName),
-  resetScreenSessionGate: vi.fn(),
+  resetScreenSessionGate: () => resetScreenSessionGateMock(),
 }));
 
-import { trackScreen } from '../analytics';
+import { reset, trackScreen } from '../analytics';
 
 beforeEach(() => {
   screenMock.mockClear();
   registerForSessionMock.mockClear();
   shouldEmitScreenForSessionMock.mockClear();
   shouldEmitScreenForSessionMock.mockReturnValue(true);
+  resetScreenSessionGateMock.mockClear();
   resetMock.mockClear();
   client = {
     screen: screenMock,
@@ -84,14 +86,15 @@ describe('trackScreen', () => {
 });
 
 describe('reset', () => {
-  it('clears the screen gate, so a new sign-out path cannot forget it', async () => {
+  it('clears the screen gate, so a new sign-out path cannot forget it', () => {
     // The gate is reset here rather than at each sign-out call site. This test is
-    // the guard on that: it fails if the call moves back out of reset().
-    const { reset } = await import('../analytics');
-    const { resetScreenSessionGate } = await import('../analytics-screen-session-gate');
+    // the guard on that: it fails if the call moves back out of reset(). The mock
+    // is cleared in beforeEach, so the count below cannot be inherited from an
+    // earlier test in this file.
+    expect(resetScreenSessionGateMock).not.toHaveBeenCalled();
 
     reset();
 
-    expect(vi.mocked(resetScreenSessionGate)).toHaveBeenCalled();
+    expect(resetScreenSessionGateMock).toHaveBeenCalledOnce();
   });
 });

--- a/packages/mobile/src/lib/analytics-screen-session-gate.ts
+++ b/packages/mobile/src/lib/analytics-screen-session-gate.ts
@@ -1,0 +1,86 @@
+import { getPostHogClient } from './posthog-client';
+
+// Suppresses repeat `$screen` events for a screen already seen in the current
+// PostHog session.
+//
+// `$screen` is the project's single biggest event — 327k/month, 29% of all
+// ingestion — but only ~96k of those are distinct (person, session, screen)
+// triples. The rest is the /climbs ↔ /play ping-pong: ~34 events per person per
+// month on each of those two routes alone. One event per screen per session
+// keeps every metric that counts PEOPLE (DAU/WAU/MAU, stickiness, lifecycle,
+// retention, first_time_for_user) bit-identical, because a person active in an
+// interval still has at least one session and therefore at least one $screen.
+//
+// What it gives up — per-navigation counts and ordered A→B→A paths — is already
+// recorded in full elsewhere: expo-observe writes a row per navigation per
+// device into `observe_metrics` on the xprem ClickHouse, at 100% sampling
+// (OBSERVE_DEFAULT_SAMPLE_RATE = 1 in observe-config.ts). See docs/railway.md.
+//
+// Sessions are the epoch on purpose: PostHog rotates a session id after 30
+// minutes idle (`sessionExpirationTimeSeconds`, SDK default, which
+// buildPostHogOptions does not override) with a hard 24h ceiling, so the gate
+// re-arms on its own and needs no day-boundary logic of its own.
+
+export type ScreenSessionGate = {
+  shouldEmit: (screenName: string) => boolean;
+  reset: () => void;
+};
+
+/**
+ * Pure factory — `readSessionId` is injected so the gate is testable with no
+ * PostHog client, mirroring `createOfflineUsageSignal`'s seam.
+ *
+ * State is deliberately in-memory only. A relaunch inside the 30-minute window
+ * re-arms the gate against a session id that has not rotated, so a killed app
+ * can re-emit a screen it already reported. That errs toward emitting, which is
+ * the safe direction for a metric whose failure mode is under-counting people.
+ */
+export function createScreenSessionGate(readSessionId: () => string | null | undefined): ScreenSessionGate {
+  const seen = new Set<string>();
+  let currentSessionId: string | null = null;
+
+  return {
+    shouldEmit(screenName: string): boolean {
+      let sessionId: string | null | undefined;
+      try {
+        sessionId = readSessionId();
+      } catch {
+        // A client that cannot report a session must never cost us an event.
+        return true;
+      }
+      // `getSessionId()` returns '' (never null) until the SDK finishes hydrating
+      // its persisted storage, so the first navigation of a cold launch can land
+      // here. Emit and record nothing: at worst one duplicate per launch, and the
+      // screen is still gated once a real id arrives.
+      if (!sessionId) return true;
+
+      if (sessionId !== currentSessionId) {
+        currentSessionId = sessionId;
+        seen.clear();
+      }
+      if (seen.has(screenName)) return false;
+      seen.add(screenName);
+      return true;
+    },
+    reset(): void {
+      seen.clear();
+      currentSessionId = null;
+    },
+  };
+}
+
+const screenSessionGate = createScreenSessionGate(() => getPostHogClient()?.getSessionId() ?? null);
+
+/** True when this screen has not yet been reported in the current session. */
+export function shouldEmitScreenForSession(screenName: string): boolean {
+  return screenSessionGate.shouldEmit(screenName);
+}
+
+/**
+ * Clear the gate on sign-out / account switch. `client.reset()` already rotates
+ * the session id, so this is belt-and-braces — but it keeps the behaviour
+ * explicit and testable rather than dependent on an SDK side effect.
+ */
+export function resetScreenSessionGate(): void {
+  screenSessionGate.reset();
+}

--- a/packages/mobile/src/lib/analytics.ts
+++ b/packages/mobile/src/lib/analytics.ts
@@ -1,6 +1,6 @@
 import type { PostHog } from 'posthog-react-native';
 import { createAnalytics, type GlowFalloffSource } from '@boardsesh/analytics';
-import { shouldEmitScreenForSession } from './analytics-screen-session-gate';
+import { resetScreenSessionGate, shouldEmitScreenForSession } from './analytics-screen-session-gate';
 import { getPostHogClient, registerAppSuperProperties } from './posthog-client';
 import { registerConnectivitySuperProperty } from './analytics-connectivity';
 import { reregisterOfflineEngineState } from './analytics-offline-engine-state';
@@ -223,6 +223,12 @@ export function registerRenderSuperProperties(effective: {
 // and every remaining event of the launch would lose its venue.
 export function reset(): boolean {
   const didReset = analytics.reset();
+  // Clear the screen gate here rather than at each sign-out call site, so a new
+  // "forget this person" path cannot forget it. analytics.reset() nulls the
+  // SDK's persisted SessionId, which would re-arm the gate on the next
+  // getSessionId() anyway — this just makes that explicit instead of a side
+  // effect a reader has to know about.
+  resetScreenSessionGate();
   const client = getClient();
   if (client) {
     registerAppSuperProperties(client);

--- a/packages/mobile/src/lib/analytics.ts
+++ b/packages/mobile/src/lib/analytics.ts
@@ -1,5 +1,6 @@
 import type { PostHog } from 'posthog-react-native';
 import { createAnalytics, type GlowFalloffSource } from '@boardsesh/analytics';
+import { shouldEmitScreenForSession } from './analytics-screen-session-gate';
 import { getPostHogClient, registerAppSuperProperties } from './posthog-client';
 import { registerConnectivitySuperProperty } from './analytics-connectivity';
 import { reregisterOfflineEngineState } from './analytics-offline-engine-state';
@@ -236,7 +237,20 @@ export function reset(): boolean {
 // autocapture can't read Expo Router's navigation, so AnalyticsScreenTracker
 // calls this from a route-change effect. `screen()` emits the native $screen
 // event PostHog's mobile insights key off.
+//
+// Only the CAPTURE is gated to once per screen per session (see
+// analytics-screen-session-gate.ts). `registerForSession` must run on EVERY
+// navigation: the SDK's `screen()` calls it internally to keep `$screen_name`
+// current, and that value is stamped onto every subsequent event — it is how
+// `Tick Logged` knows it happened on /play. Gating the whole call would silently
+// misattribute every other event to whatever screen last got past the gate, and
+// the drift would worsen the longer a session ran. It is redundant on the
+// emitting path and load-bearing on the suppressed one; keep it unconditional.
 export function trackScreen(path: string): void {
   if (__DEV__) console.info('[analytics] $screen', path);
-  void getClient()?.screen(path);
+  const client = getClient();
+  if (!client) return;
+  client.registerForSession({ $screen_name: path });
+  if (!shouldEmitScreenForSession(path)) return;
+  void client.screen(path);
 }

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -22,7 +22,6 @@ import {
 } from '../lib/auth';
 import { SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD } from '../lib/screenshot-mode';
 import { reset as resetAnalytics, track } from '../lib/analytics';
-import { resetScreenSessionGate } from '../lib/analytics-screen-session-gate';
 import { resetOfflineUsageSignal } from '../offline/offline-usage-signal';
 import { reportError, reportHandledError } from '../lib/error-reporting';
 import { setOnForcedSignOut } from '../lib/auth-interceptor';
@@ -173,7 +172,6 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       // user's counters and the new user's first offline day would never fire
       // (#4317).
       resetOfflineUsageSignal();
-      resetScreenSessionGate();
     }
   }, []);
 
@@ -301,7 +299,6 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       const localDb = getDatabaseHandle();
       if (localDb) await reportOutboxDiscardedOnSignOut(localDb);
       resetOfflineUsageSignal();
-      resetScreenSessionGate();
       const stopTokenCleanup = stopTokenManagement(async () => {});
       if (Platform.OS === 'web') await waitForCleanupPhase(stopTokenCleanup);
       else await stopTokenCleanup;

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -22,6 +22,7 @@ import {
 } from '../lib/auth';
 import { SCREENSHOT_USER_EMAIL, SCREENSHOT_USER_PASSWORD } from '../lib/screenshot-mode';
 import { reset as resetAnalytics, track } from '../lib/analytics';
+import { resetScreenSessionGate } from '../lib/analytics-screen-session-gate';
 import { resetOfflineUsageSignal } from '../offline/offline-usage-signal';
 import { reportError, reportHandledError } from '../lib/error-reporting';
 import { setOnForcedSignOut } from '../lib/auth-interceptor';
@@ -172,6 +173,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       // user's counters and the new user's first offline day would never fire
       // (#4317).
       resetOfflineUsageSignal();
+      resetScreenSessionGate();
     }
   }, []);
 
@@ -299,6 +301,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       const localDb = getDatabaseHandle();
       if (localDb) await reportOutboxDiscardedOnSignOut(localDb);
       resetOfflineUsageSignal();
+      resetScreenSessionGate();
       const stopTokenCleanup = stopTokenManagement(async () => {});
       if (Platform.OS === 'web') await waitForCleanupPhase(stopTokenCleanup);
       else await stopTokenCleanup;

--- a/packages/mobile/test/posthog-react-native-stub.ts
+++ b/packages/mobile/test/posthog-react-native-stub.ts
@@ -21,6 +21,10 @@ export class PostHog {
   reset(): void {}
   register(): void {}
   screen(): void {}
+  getSessionId(): string {
+    return '';
+  }
+  registerForSession(): void {}
   setPersonProperties(): void {}
   flush(): Promise<void> {
     return Promise.resolve();


### PR DESCRIPTION
## Summary

`$screen` is the biggest single event in the project — **327,269/month, 29% of all PostHog ingestion** — but only ~96k of those are distinct `(person, session, screen)` triples. The rest is the `/climbs` ↔ `/play` ping-pong: ~34 events per person per month on each of those two routes. Gating to one event per screen per session **saves ~231k events/month**, the largest cut available and the one that gets the project back under the 1M free tier.

**Every metric that counts people is unchanged.** DAU/WAU/MAU, stickiness, lifecycle, retention and `first_time_for_user` stay bit-identical, because a person active in an interval still has ≥1 session and therefore ≥1 `$screen`. I checked all 16 saved insights that reference `$screen`: 14 are presence-based and unaffected.

**What it gives up is already recorded in full elsewhere.** `expo-observe` writes a row per navigation per device into `observe_metrics` on the xprem ClickHouse, with route names plus `cold_ttr`/`warm_ttr`/`tti`, retained 90 days — at **100% sampling**, since `OBSERVE_DEFAULT_SAMPLE_RATE = 1` and neither `observe-sample-rate` nor `observe-dispatch-enabled` exists in PostHog, so the shipped defaults hold. See `docs/railway.md:155-169`.

### The subtle part: only the capture is gated

The SDK's `screen()` also calls `registerForSession({ $screen_name })`, and that value is stamped onto **every subsequent event** — it is how `Tick Logged` knows it happened on `/play` (20,293 of its 30-day events). Gating the whole call would silently misattribute every other mobile event to whatever screen last got past the gate, drifting worse the longer a session ran.

So `registerForSession` is unconditional and only the capture is gated. **The test pinning this is mutation-verified**: moving the call behind the gate makes `updates $screen_name on EVERY navigation, gated or not` fail.

### Design notes

- **Sessions are the epoch on purpose.** PostHog rotates a session id after 30 min idle (`sessionExpirationTimeSeconds`, SDK default, not overridden) with a hard 24 h ceiling — the gate re-arms itself and needs no day-boundary logic.
- **`getSessionId()` is synchronous and returns `''` (never `null`) until the SDK hydrates**, so the first navigation of a cold launch can read empty. That path emits and records nothing — never a silent drop. Same for a throw.
- **State is in-memory only.** A relaunch inside the 30-min window re-arms against a session that has not rotated, so a killed app can re-emit one screen. That errs toward emitting, which is the safe direction for a metric whose failure mode is under-counting people.
- **`lastPath` in `AnalyticsScreenTracker` stays first and untouched** — a ref compare with no SDK call, so Expo Router's repeated segment emissions during a transition never reach the gate.
- **Mobile-local, not shared.** Web uses `posthog-js` with a different session API and would never import this.

### Two insights need attention at rollout — not now

These only matter once the fleet picks up the OTA and the data actually changes (~30 days), so doing them now would just confuse readers:

- **`YByezpiv` [Engagement] Top screens** — `math: total` becomes "sessions that reached this screen" and **the ranking inverts**: today `/climbs` (97,975) > `/play` (92,247) > `/home` (39,959); after, `/home` (17,095) > `/play` (12,262) > `/climbs` (11,769). Rename it to "Screens reached (per session)" or the first reader will conclude `/climbs` collapsed.
- **`Y0QAF8JT` [UX] Navigation paths (screens)** — retire it. Every return edge and loop disappears, so the `/play → /climbs` half of the ping-pong vanishes and what remains is a spanning tree of first-visits, not a flow. `observe_metrics` answers this better anyway.

Verified locally: `vp run typecheck:mobile`, `vp run test:mobile` (850 files / 9,165 tests), `vp check` (0 errors), `vp run check:mobile-bundle` (OK).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. Open the app, sign in, go to the Climbs tab.
2. Tap a climb → play drawer opens normally.
3. Bounce between Climbs and Play tabs five times.
4. Log a tick from the play drawer → it saves.
5. Sign out, sign back in → boards and ticks load.

## Risk

Risk: 3/5 — shared analytics path touched on every navigation; no product behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgmuKPeUqaCXk34CauAXLg
