### PR TITLE
fix: generate resized thumbnails for new beta links

### DIFF
--- a/docs/user-media-storage.md
+++ b/docs/user-media-storage.md
@@ -75,7 +75,20 @@ Objects are reached through the backend's `/static/*` routes, which stream them 
 | `/static/gym-photos/<file>` | `handleStaticGymPhoto` |
 | `/static/beta-link-thumbnails/<platform>/<file>` | `handleStaticBetaThumbnail` |
 
-All four accept `?size=N` for `N` in `ALLOWED_IMAGE_SIZES` (`packages/shared-schema/src/image-sizes.ts`). Beta thumbnails persist the resized bytes at `<baseKey>@<size>.jpg` because their key is immutable; avatars and gym images resize on the fly, because their key is overwritten in place on re-upload and a cached variant would shadow the new image.
+All four accept `?size=N` for `N` in `ALLOWED_IMAGE_SIZES` (`packages/shared-schema/src/image-sizes.ts`). When the media bucket has a public base URL, these routes redirect to its CDN, with sized requests addressing `<baseKey>@<size>.jpg`. The bucket cannot resize on demand.
+
+New Instagram and TikTok thumbnails write the shared `BETA_THUMBNAIL_REQUEST_SIZE` (280px) variant before the original and before returning a URL for the feed. Avatars and gym images write every allowed size on each upload; their `?v=` parameter prevents stale images after replacement. Without a public base URL, the backend proxies images and resizes on demand, caching variants only for immutable beta thumbnails.
+
+### Repairing missing beta thumbnail variants
+
+An original returning 200 while its `@280.jpg` URL returns 404 means the resized object is missing. After deploying the upload fix, run the existing backfill with the production media bucket environment:
+
+```bash
+vp exec tsx packages/backend/src/scripts/backfill-image-variants.ts --prefix beta-link-thumbnails/ --dry-run
+vp exec tsx packages/backend/src/scripts/backfill-image-variants.ts --prefix beta-link-thumbnails/
+```
+
+The backfill creates only missing variants and skips existing objects. It does not change beta links or refetch Instagram/TikTok posts. Re-run the dry run to confirm no variants remain, then check the affected public URLs; cached CDN 404s may need time to expire.
 
 ### Feedback screenshots
 

--- a/packages/backend/src/__tests__/beta-link-thumbnails.test.ts
+++ b/packages/backend/src/__tests__/beta-link-thumbnails.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
+import sharp from 'sharp';
+import { BETA_THUMBNAIL_REQUEST_SIZE } from '@boardsesh/shared-schema';
+import { staticPathToMediaRedirect } from '../lib/media-url';
 
 vi.mock('../storage/s3', () => ({
   isS3Configured: vi.fn(() => true),
@@ -96,8 +99,8 @@ describe('cacheInstagramThumbnail', () => {
     // handleStaticBetaThumbnail), not the direct S3 URL — Tigris on Railway
     // doesn't honor public-read ACLs.
     expect(url).toBe('/static/beta-link-thumbnails/instagram/ABC123.jpg');
-    expect(uploadToS3).toHaveBeenCalledTimes(1);
-    const [, buffer, key, contentType] = vi.mocked(uploadToS3).mock.calls[0];
+    expect(uploadToS3).toHaveBeenCalledTimes(2);
+    const [, buffer, key, contentType] = vi.mocked(uploadToS3).mock.calls[1];
     expect(Buffer.isBuffer(buffer)).toBe(true);
     expect(key).toBe('beta-link-thumbnails/instagram/ABC123.jpg');
     expect(contentType).toBe('image/jpeg');
@@ -123,6 +126,9 @@ describe('cacheInstagramThumbnail', () => {
     vi.mocked(uploadToS3).mockRejectedValueOnce(new Error('s3 down'));
     const url = await cacheInstagramThumbnail('ABC123', 'https://scontent.cdninstagram.com/photo.jpg');
     expect(url).toBeNull();
+    // A failed variant must not publish the base or a URL for the feed.
+    expect(uploadToS3).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(uploadToS3).mock.calls[0][2]).toBe('beta-link-thumbnails/instagram/ABC123.jpg@280.jpg');
   });
 
   it('falls back to image/jpeg when content-type header is missing', async () => {
@@ -155,8 +161,72 @@ describe('cacheTikTokThumbnail', () => {
     const url = await cacheTikTokThumbnail('cache_42', 'https://p16-sign.tiktokcdn.com/photo.webp');
 
     expect(url).toBe('/static/beta-link-thumbnails/tiktok/cache_42.jpg');
-    const [, , key, contentType] = vi.mocked(uploadToS3).mock.calls[0];
+    const [, , key, contentType] = vi.mocked(uploadToS3).mock.calls[1];
     expect(key).toBe('beta-link-thumbnails/tiktok/cache_42.jpg');
     expect(contentType).toBe('image/webp');
+  });
+});
+
+describe('new beta thumbnails served from the media bucket', () => {
+  beforeEach(() => {
+    vi.mocked(uploadToS3).mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    ['Instagram', cacheInstagramThumbnail, 'https://scontent.cdninstagram.com/photo.jpg'],
+    ['TikTok', cacheTikTokThumbnail, 'https://p16-sign.tiktokcdn.com/photo.webp'],
+  ] as const)(
+    'writes a readable %s image at the exact CDN redirect target before publishing',
+    async (_platform, cacheThumbnail, sourceUrl) => {
+      const original = await sharp({
+        create: { width: 600, height: 800, channels: 3, background: { r: 10, g: 20, b: 30 } },
+      })
+        .webp()
+        .toBuffer();
+      mockFetchImageOnce({ contentType: 'image/webp', body: new Uint8Array(original) });
+
+      const thumbnailUrl = await cacheThumbnail('fresh_beta', sourceUrl);
+
+      expect(thumbnailUrl).not.toBeNull();
+      const mediaBaseUrl = 'https://media.boardsesh.com';
+      const redirectUrl = staticPathToMediaRedirect(
+        thumbnailUrl!,
+        new URLSearchParams({ size: String(BETA_THUMBNAIL_REQUEST_SIZE) }),
+        mediaBaseUrl,
+      );
+      const [variantUpload, originalUpload] = vi.mocked(uploadToS3).mock.calls;
+      expect(uploadToS3).toHaveBeenCalledTimes(2);
+      const [bucket, variantBody, variantKey, variantContentType, options] = variantUpload;
+      expect(bucket).toBe('media');
+      expect(`${mediaBaseUrl}/${variantKey}`).toBe(redirectUrl);
+      expect(variantContentType).toBe('image/jpeg');
+      expect(options).toEqual({ cacheControl: 'public, max-age=31536000, immutable' });
+      expect(await sharp(variantBody).metadata()).toMatchObject({
+        format: 'jpeg',
+        width: BETA_THUMBNAIL_REQUEST_SIZE,
+        height: BETA_THUMBNAIL_REQUEST_SIZE,
+      });
+      expect(originalUpload).toEqual(['media', original, thumbnailUrl!.slice('/static/'.length), 'image/webp']);
+    },
+  );
+
+  it('keeps original bytes and MIME type at the variant key when resizing fails', async () => {
+    const original = new Uint8Array([1, 2, 3]);
+    mockFetchImageOnce({ contentType: 'image/webp', body: original });
+
+    expect(await cacheTikTokThumbnail('unresizable', 'https://p16-sign.tiktokcdn.com/photo.webp')).not.toBeNull();
+
+    expect(uploadToS3).toHaveBeenNthCalledWith(
+      1,
+      'media',
+      Buffer.from(original),
+      'beta-link-thumbnails/tiktok/unresizable.jpg@280.jpg',
+      'image/webp',
+      { cacheControl: 'public, max-age=31536000, immutable' },
+    );
   });
 });

--- a/packages/backend/src/lib/beta-link-thumbnails.ts
+++ b/packages/backend/src/lib/beta-link-thumbnails.ts
@@ -1,6 +1,8 @@
 import { getPublicUrl, isS3Configured, uploadToS3 } from '../storage/s3';
 import { assertAllowedImageHost, type ImageHostKind } from './safe-image-fetch';
 import { logger } from '../utils/logger';
+import { BETA_THUMBNAIL_REQUEST_SIZE } from '@boardsesh/shared-schema';
+import { writeImageVariants } from './image-resize';
 
 export { isS3Configured };
 
@@ -170,6 +172,18 @@ async function cacheRemoteThumbnail(key: string, sourceUrl: string, kind: ImageH
       logger.warn(`[BetaLinks] thumbnail body exceeded ${MAX_THUMBNAIL_BYTES} bytes; aborted`);
       return null;
     }
+    // The public media bucket cannot resize on demand. Publish the size used
+    // by web and mobile before returning a URL that can enter the beta feed.
+    await writeImageVariants(
+      buffer,
+      key,
+      (variantKey, body, variantContentType) =>
+        uploadToS3('media', body, variantKey, variantContentType, {
+          cacheControl: 'public, max-age=31536000, immutable',
+        }),
+      [BETA_THUMBNAIL_REQUEST_SIZE],
+      contentType,
+    );
     await uploadToS3('media', buffer, key, contentType);
     return getStaticThumbnailUrl(key);
   } catch (err) {


### PR DESCRIPTION
## Summary

New beta thumbnails were saved only at their original object key. The media CDN redirects homepage and app thumbnail requests to `@280.jpg`, which does not exist for new uploads because that route no longer resizes on demand. All 20 homepage thumbnails sampled returned 404 for the resized image and 200 for the original.

Generate the shared 280px variant before publishing the original or returning the beta thumbnail URL. Reuse the existing image variant writer, including original-byte/MIME fallback when resizing fails. Document how to backfill existing missing variants.

Validation: 122 tests passed across seven backend suites, full `vp run typecheck` passed after rebasing, and the pre-commit format/lint checks passed. Regression coverage decodes both Instagram and TikTok variants at the exact CDN redirect target and checks failed writes cannot publish a thumbnail URL.

Production repair: the existing backfill generated 894 missing variants with zero failures, leaving existing objects and beta links unchanged. New uploads can still need a follow-up sweep until this fix deploys.

## Release Notes

Fresh beta links show their thumbnail when you browse climbs.

## Test plan

1. Open the homepage → Fresh beta cards show climbing photos.
2. Open a beta card → its linked video opens.
3. Add fresh Instagram beta → its thumbnail appears beside the climb.
4. Add fresh TikTok beta → its thumbnail appears beside the climb.

## Risk

Risk: 2/5 — isolated thumbnail upload fix using the existing resize writer.
