### PR TITLE
feat: add Kilter Original build plans with Homewall-compatible drilling

### DIFF
--- a/docs/cnc-packs.md
+++ b/docs/cnc-packs.md
@@ -14,6 +14,40 @@ The generator itself lives in a private repo and runs as a separate worker
 service. This document covers the Boardsesh half: previews, orders, payment,
 the job API the generator pulls work from, and the download routes.
 
+## Supported layouts and OG drilling
+
+The catalogue offers Kilter Homewall (layout `8`) and Kilter Original (layout
+`1`). Original sizes are `14` (7×10), `8` (8×12), `10` (12×12), and `28`
+(16×12). Both Original sets, `1` and `20`, are required at every size. Pricing
+uses the existing personal and commercial single-build tiers.
+
+Original orders store `options.includeKicker`: false for 7×10, true by default
+and optional for the other three sizes. Original main-wall and kicker holds
+share their set IDs, so removing sets cannot remove its kicker. Layout previews,
+artwork validation and claimed jobs send this as `manufacturing.include_kicker`;
+when true they also send the selected `kicker.mat_clearance_mm`. Homewall still
+selects the kicker with sets `28,29`, and older stored orders continue to infer
+that selection without acquiring an Original default.
+
+Original foot positions have a 13 mm center bore, plus LED bores 20 mm above
+and below. An Original foot LED uses the center bore instead of a T-nut. The
+additional pair allows that position to serve a Homewall hold later. Original
+LED bores default to 12.7 mm; the configurable bolt bore remains 12.5 mm by
+default elsewhere. Packs include the complete matching Homewall pattern:
+7×10, 8×12, or a centered 10×12 within either larger Original wall. They do not
+claim compatibility with a nonexistent larger Homewall layout.
+
+The worker layout JSON distinguishes `dual` center bores from ordinary bolt
+and LED bores. Installed hardware counts are separate from spare compatibility
+holes. Original orientation engraving follows the manufacturer's **Number
+Angle** column; it indicates the hold number's orientation rather than a
+set-screw drilling direction. The source workbooks, normalization and geometry
+are maintained in the private generator repo.
+
+Deploy the generator with Original support before deploying this catalogue
+version. The existing `cnc-packs` feature gate still controls the shop; there
+are no new public routes or database migrations.
+
 ## The order row is the queue
 
 One row in `cnc_orders` per configuration a buyer previewed, and the same row
@@ -876,16 +910,16 @@ still leave a publicly browsable shop.
 
 ### The configurator
 
-Seven steps, in the order they appear: **board**, **size**, **kicker**,
+Seven steps, in the order they appear: **layout**, **size**, **kicker**,
 **options**, **engrave**, **licensee**, **tier**. Each one fires a
 `CNC Configurator Changed` funnel event debounced by 900 ms, so a buyer
 dragging through the option list produces one event describing where they
 stopped rather than twenty describing where they passed through.
 
-Board is a read-only statement rather than a select, because v1 sells one board
-and a select with a single option is a choice that is not one. It becomes a
-select the day a second board goes on sale, and the `board` step is already in
-the funnel contract so that day does not also need an analytics change.
+The layout selector offers Kilter Homewall and Kilter Original. Sizes are
+filtered by layout; switching layout resets manufacturing options and artwork
+so a drawing cannot silently carry into different panel geometry. The existing
+`board` funnel step records layout changes.
 
 State lives in a reducer in `configurator-state.ts`, and the options a wall may
 carry come from the backend catalogue rather than the client — the same registry

--- a/packages/backend/src/graphql/resolvers/cnc-packs/__tests__/mutations.test.ts
+++ b/packages/backend/src/graphql/resolvers/cnc-packs/__tests__/mutations.test.ts
@@ -499,32 +499,43 @@ describe('validateCncArtwork', () => {
 });
 
 describe('createCncPreview', () => {
-  it.each([true, false])('persists OG kicker inclusion %s through the claimed worker job', async (includeKicker) => {
-    await cncPackMutations.createCncPreview(
-      undefined,
-      {
-        config: config({ layoutId: 1, sizeId: 28, setIds: '1,20', options: { includeKicker }, artwork: [] }),
-      },
-      authCtx(),
-    );
-    const [orderInput] = createPreviewOrderMock.mock.calls[0] as [Record<string, unknown>];
-    expect(orderInput).toMatchObject({
-      layoutId: 1,
-      sizeId: 28,
-      setIds: '1,20',
-      options: { includeKicker, ledHoleDiameterMm: 12.7 },
-    });
-    const claimedOrder = previewOrder({
-      ...orderInput,
-      status: 'preview_generating',
-      claimToken: 'claim-token',
-    }) as unknown as CncOrder;
-    const job = buildWorkerJob(claimedOrder, { bucket: 'test-private', issuedAt: new Date('2026-09-07T00:00:00Z') });
-    expect(job.config.options.includeKicker).toBe(includeKicker);
-    expect(job.layoutRequest.manufacturing.include_kicker).toBe(includeKicker);
-    expect(job.layoutRequest.manufacturing.kicker).toEqual(includeKicker ? { mat_clearance_mm: 50 } : undefined);
-    expect(job.layoutRequest.board.set_ids).toEqual([1, 20]);
-  });
+  it.each([
+    [14, false],
+    [8, false],
+    [8, true],
+    [10, false],
+    [10, true],
+    [28, false],
+    [28, true],
+  ] as const)(
+    'persists OG size %i kicker inclusion %s through the claimed worker job',
+    async (sizeId, includeKicker) => {
+      await cncPackMutations.createCncPreview(
+        undefined,
+        {
+          config: config({ layoutId: 1, sizeId, setIds: '1,20', options: { includeKicker }, artwork: [] }),
+        },
+        authCtx(),
+      );
+      const [orderInput] = createPreviewOrderMock.mock.calls[0] as [Record<string, unknown>];
+      expect(orderInput).toMatchObject({
+        layoutId: 1,
+        sizeId,
+        setIds: '1,20',
+        options: { includeKicker, ledHoleDiameterMm: 12.7 },
+      });
+      const claimedOrder = previewOrder({
+        ...orderInput,
+        status: 'preview_generating',
+        claimToken: 'claim-token',
+      }) as unknown as CncOrder;
+      const job = buildWorkerJob(claimedOrder, { bucket: 'test-private', issuedAt: new Date('2026-09-07T00:00:00Z') });
+      expect(job.config.options.includeKicker).toBe(includeKicker);
+      expect(job.layoutRequest.manufacturing.include_kicker).toBe(includeKicker);
+      expect(job.layoutRequest.manufacturing.kicker).toEqual(includeKicker ? { mat_clearance_mm: 50 } : undefined);
+      expect(job.layoutRequest.board.set_ids).toEqual([1, 20]);
+    },
+  );
 
   it('rejects an OG 7x10 kicker before writing an order', async () => {
     await expect(

--- a/packages/backend/src/graphql/resolvers/cnc-packs/__tests__/mutations.test.ts
+++ b/packages/backend/src/graphql/resolvers/cnc-packs/__tests__/mutations.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
+import type { CncOrder } from '@boardsesh/db/schema';
+import { buildWorkerJob } from '../../../../services/cnc/job-payload';
 
 vi.mock('../../../../db/client', () => ({ db: {}, dbRead: {} }));
 
@@ -497,6 +499,46 @@ describe('validateCncArtwork', () => {
 });
 
 describe('createCncPreview', () => {
+  it.each([true, false])('persists OG kicker inclusion %s through the claimed worker job', async (includeKicker) => {
+    await cncPackMutations.createCncPreview(
+      undefined,
+      {
+        config: config({ layoutId: 1, sizeId: 28, setIds: '1,20', options: { includeKicker }, artwork: [] }),
+      },
+      authCtx(),
+    );
+    const [orderInput] = createPreviewOrderMock.mock.calls[0] as [Record<string, unknown>];
+    expect(orderInput).toMatchObject({
+      layoutId: 1,
+      sizeId: 28,
+      setIds: '1,20',
+      options: { includeKicker, ledHoleDiameterMm: 12.7 },
+    });
+    const claimedOrder = previewOrder({
+      ...orderInput,
+      status: 'preview_generating',
+      claimToken: 'claim-token',
+    }) as unknown as CncOrder;
+    const job = buildWorkerJob(claimedOrder, { bucket: 'test-private', issuedAt: new Date('2026-09-07T00:00:00Z') });
+    expect(job.config.options.includeKicker).toBe(includeKicker);
+    expect(job.layoutRequest.manufacturing.include_kicker).toBe(includeKicker);
+    expect(job.layoutRequest.manufacturing.kicker).toEqual(includeKicker ? { mat_clearance_mm: 50 } : undefined);
+    expect(job.layoutRequest.board.set_ids).toEqual([1, 20]);
+  });
+
+  it('rejects an OG 7x10 kicker before writing an order', async () => {
+    await expect(
+      cncPackMutations.createCncPreview(
+        undefined,
+        {
+          config: config({ layoutId: 1, sizeId: 14, setIds: '1,20', options: { includeKicker: true }, artwork: [] }),
+        },
+        authCtx(),
+      ),
+    ).rejects.toMatchObject({ extensions: { code: 'CNC_INVALID_CONFIG' } });
+    expect(createPreviewOrderMock).not.toHaveBeenCalled();
+  });
+
   /** A configuration carrying one uploaded asset. */
   function configWithAsset(assetId: string) {
     return config({

--- a/packages/backend/src/graphql/resolvers/cnc-packs/__tests__/queries.test.ts
+++ b/packages/backend/src/graphql/resolvers/cnc-packs/__tests__/queries.test.ts
@@ -148,13 +148,22 @@ beforeEach(() => {
 });
 
 describe('cncCatalog', () => {
-  it('publishes the four Kilter Homewall walls', async () => {
+  it('publishes the Homewall and Original walls', async () => {
     const catalog = await cncPackQueries.cncCatalog(undefined, undefined, anonCtx());
 
     expect(catalog.version).toBe(CNC_CATALOG_VERSION);
-    expect(catalog.entries).toHaveLength(4);
-    expect(catalog.entries.map((entry) => entry.label)).toEqual(['7x10', '10x10', '8x12', '10x12']);
-    expect(catalog.entries.map((entry) => entry.sizeId)).toEqual([17, 21, 23, 25]);
+    expect(catalog.entries).toHaveLength(8);
+    expect(catalog.entries.map((entry) => entry.label)).toEqual([
+      '7x10',
+      '10x10',
+      '8x12',
+      '10x12',
+      '7x10',
+      '8x12',
+      '12x12',
+      '16x12',
+    ]);
+    expect(catalog.entries.map((entry) => entry.sizeId)).toEqual([17, 21, 23, 25, 14, 8, 10, 28]);
   });
 
   it('does not publish the LED-kit size aliases', async () => {

--- a/packages/backend/src/services/cnc/__tests__/catalog.test.ts
+++ b/packages/backend/src/services/cnc/__tests__/catalog.test.ts
@@ -6,6 +6,7 @@ import {
   CNC_CATALOG_CONTENT_HASH,
   CNC_CATALOG_VERSION,
   findCatalogEntry,
+  describeBoard,
   parseSetIds,
   RETIRED_OPTION_KEYS,
   validateCatalogOptions,
@@ -26,19 +27,24 @@ function entryFor(sizeId: number) {
 }
 
 describe('CNC catalogue', () => {
-  it('sells exactly the four canonical Kilter Homewall sizes', () => {
-    expect(CNC_CATALOG.map((entry) => entry.sizeId)).toEqual([17, 21, 23, 25]);
-    expect(CNC_CATALOG.map((entry) => entry.label)).toEqual(['7x10', '10x10', '8x12', '10x12']);
-    expect(CNC_CATALOG.every((entry) => entry.boardName === 'kilter' && entry.layoutId === 8)).toBe(true);
+  it('sells the four canonical Homewall sizes and four Original sizes', () => {
+    expect(CNC_CATALOG.filter((entry) => entry.layoutId === 8).map((entry) => entry.sizeId)).toEqual([17, 21, 23, 25]);
+    expect(CNC_CATALOG.filter((entry) => entry.layoutId === 1).map((entry) => [entry.sizeId, entry.label])).toEqual([
+      [14, '7x10'],
+      [8, '8x12'],
+      [10, '12x12'],
+      [28, '16x12'],
+    ]);
+    expect(CNC_CATALOG.every((entry) => entry.boardName === 'kilter')).toBe(true);
   });
 
   it('has a version string orders can be pinned to', () => {
-    expect(CNC_CATALOG_VERSION).toBe('2026-09-07.3');
+    expect(CNC_CATALOG_VERSION).toBe('2026-09-07.4');
   });
 
   it('takes its default set ids from board-constants rather than a second hardcoded list', () => {
     for (const entry of CNC_CATALOG) {
-      const expected = getSetsForLayoutAndSize('kilter', 8, entry.sizeId)
+      const expected = getSetsForLayoutAndSize('kilter', entry.layoutId, entry.sizeId)
         .map((set) => set.id)
         .join(',');
       expect(entry.setIds).toBe(expected);
@@ -283,5 +289,33 @@ describe('CNC_CATALOG_VERSION', () => {
 
   it('is a dated, sortable version string', () => {
     expect(CNC_CATALOG_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}\.\d+$/);
+  });
+});
+
+describe('Kilter Original catalogue', () => {
+  it.each([14, 8, 10, 28])(
+    'keeps both sets mandatory and publishes explicit kicker inclusion for size %i',
+    (sizeId) => {
+      const entry = findCatalogEntry({ boardName: 'kilter', layoutId: 1, sizeId });
+      if (!entry) throw new Error('Original entry missing');
+      expect(entry.setIds).toBe('1,20');
+      expect(validateSetIds(entry, [1, 20])).toEqual({ ok: true, setIds: [1, 20] });
+      expect(validateSetIds(entry, [1])).toMatchObject({ ok: false });
+      expect(validateSetIds(entry, [20])).toMatchObject({ ok: false });
+      expect(validateSetIds(entry, [1, 20, 28, 29])).toMatchObject({ ok: false });
+      expect(validateCatalogOptions(entry, {})).toMatchObject({
+        ok: true,
+        options: { includeKicker: sizeId !== 14, ledHoleDiameterMm: 12.7, tnutHoleDiameterMm: 12.5 },
+      });
+      expect(validateCatalogOptions(entry, { includeKicker: false })).toMatchObject({ ok: true });
+      expect(validateCatalogOptions(entry, { includeKicker: true })).toMatchObject({ ok: sizeId !== 14 });
+      expect(entry.tiers).toEqual(entryFor(25).tiers);
+    },
+  );
+
+  it('distinguishes Original and Homewall in order notifications', () => {
+    expect(describeBoard({ boardName: 'kilter', layoutId: 1, sizeId: 8 })).toBe('Kilter Original 8x12');
+    expect(describeBoard({ boardName: 'kilter', layoutId: 8, sizeId: 23 })).toBe('Kilter Homewall 8x12');
+    expect(describeBoard({ boardName: 'kilter', layoutId: 1, sizeId: 999 })).toBe('kilter 999');
   });
 });

--- a/packages/backend/src/services/cnc/__tests__/catalog.test.ts
+++ b/packages/backend/src/services/cnc/__tests__/catalog.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { describe, it, expect } from 'vite-plus/test';
+import { describe, it, expect, vi } from 'vite-plus/test';
 import { getSetsForLayoutAndSize } from '@boardsesh/board-constants';
 import {
   CNC_CATALOG,
@@ -318,4 +318,17 @@ describe('Kilter Original catalogue', () => {
     expect(describeBoard({ boardName: 'kilter', layoutId: 8, sizeId: 23 })).toBe('Kilter Homewall 8x12');
     expect(describeBoard({ boardName: 'kilter', layoutId: 1, sizeId: 999 })).toBe('kilter 999');
   });
+});
+
+it.each([
+  ['tension', 1],
+  ['kilter', 99],
+] as const)('uses a generic label for a future %s layout %i catalogue entry', (boardName, layoutId) => {
+  const futureEntry = { ...entryFor(23), boardName, layoutId };
+  const catalogLookup = vi.spyOn(CNC_CATALOG, 'find').mockReturnValue(futureEntry);
+  try {
+    expect(describeBoard({ boardName, layoutId, sizeId: futureEntry.sizeId })).toBe(`${boardName} 8x12`);
+  } finally {
+    catalogLookup.mockRestore();
+  }
 });

--- a/packages/backend/src/services/cnc/__tests__/worker-client.test.ts
+++ b/packages/backend/src/services/cnc/__tests__/worker-client.test.ts
@@ -106,6 +106,21 @@ function toLayoutRequestForDefaults(): CncWorkerLayoutRequest {
 }
 
 describe('toLayoutRequest', () => {
+  it.each([14, 8, 10, 28])('maps explicit OG kicker inclusion independently of its sets for size %i', (sizeId) => {
+    const entry = findCatalogEntry({ boardName: 'kilter', layoutId: 1, sizeId });
+    if (!entry) throw new Error('Original entry missing');
+    const options = defaultOptions(entry);
+    const request = toLayoutRequest({ entry, options, setIds: [1, 20] });
+    expect(request.board).toEqual({ board_name: 'kilter', layout_id: 1, size_id: sizeId, set_ids: [1, 20] });
+    expect(request.manufacturing.include_kicker).toBe(sizeId !== 14);
+    expect(request.manufacturing.led_hole_diameter_mm).toBe(12.7);
+    expect(request.manufacturing.kicker).toEqual(sizeId !== 14 ? { mat_clearance_mm: 50 } : undefined);
+    const withoutKicker = toLayoutRequest({ entry, options: { ...options, includeKicker: false }, setIds: [1, 20] });
+    expect(withoutKicker.manufacturing.include_kicker).toBe(false);
+    expect(withoutKicker.manufacturing.kicker).toBeUndefined();
+    expect(withoutKicker.board.set_ids).toEqual([1, 20]);
+  });
+
   it('maps catalogue option keys onto the generator contract', () => {
     const entry = entry10x12();
     const request = toLayoutRequest({ entry, options: defaultOptions(entry), setIds: [26, 27, 28, 29] });

--- a/packages/backend/src/services/cnc/catalog.ts
+++ b/packages/backend/src/services/cnc/catalog.ts
@@ -484,6 +484,7 @@ export const CNC_KICKER_SET_IDS: readonly number[] = KICKER_SET_IDS;
 export function describeBoard({ boardName, layoutId, sizeId }: CncBoardTuple): string {
   const entry = findCatalogEntry({ boardName, layoutId, sizeId });
   if (!entry) return `${boardName} ${String(sizeId)}`;
-  const layoutLabel = layoutId === KILTER_ORIGINAL_LAYOUT_ID ? 'Original' : 'Homewall';
-  return `Kilter ${layoutLabel} ${entry.label}`;
+  if (boardName === 'kilter' && layoutId === KILTER_ORIGINAL_LAYOUT_ID) return `Kilter Original ${entry.label}`;
+  if (boardName === 'kilter' && layoutId === KILTER_HOMEWALL_LAYOUT_ID) return `Kilter Homewall ${entry.label}`;
+  return `${boardName} ${entry.label}`;
 }

--- a/packages/backend/src/services/cnc/catalog.ts
+++ b/packages/backend/src/services/cnc/catalog.ts
@@ -1,5 +1,9 @@
 import type { BoardName } from '@boardsesh/shared-schema';
-import { getSetsForLayoutAndSize, KILTER_HOMEWALL_LAYOUT_ID } from '@boardsesh/board-constants';
+import {
+  getSetsForLayoutAndSize,
+  KILTER_HOMEWALL_LAYOUT_ID,
+  KILTER_ORIGINAL_LAYOUT_ID,
+} from '@boardsesh/board-constants';
 import type { CncOrderOptions } from '@boardsesh/db/schema';
 
 /**
@@ -16,8 +20,6 @@ import type { CncOrderOptions } from '@boardsesh/db/schema';
  * later rebuilds the pack the buyer paid for rather than today's defaults.
  */
 export const CNC_CATALOG_VERSION = '2026-09-07.4';
-
-export const CNC_KILTER_ORIGINAL_LAYOUT_ID = 1;
 
 /**
  * sha256 of `JSON.stringify(CNC_CATALOG)`, pinned so the version above cannot
@@ -178,9 +180,9 @@ export const CNC_CATALOG: readonly CncCatalogEntry[] = [
   })),
   ...KILTER_ORIGINAL_SIZES.map((size) => ({
     boardName: 'kilter' as BoardName,
-    layoutId: CNC_KILTER_ORIGINAL_LAYOUT_ID,
+    layoutId: KILTER_ORIGINAL_LAYOUT_ID,
     ...size,
-    setIds: defaultSetIdsFor(CNC_KILTER_ORIGINAL_LAYOUT_ID, size.sizeId),
+    setIds: defaultSetIdsFor(KILTER_ORIGINAL_LAYOUT_ID, size.sizeId),
     manufacturingOptions: [
       ...KILTER_HOMEWALL_MANUFACTURING_OPTIONS.map((option) =>
         option.key === 'ledHoleDiameterMm' ? { ...option, defaultValue: 12.7 } : option,
@@ -482,6 +484,6 @@ export const CNC_KICKER_SET_IDS: readonly number[] = KICKER_SET_IDS;
 export function describeBoard({ boardName, layoutId, sizeId }: CncBoardTuple): string {
   const entry = findCatalogEntry({ boardName, layoutId, sizeId });
   if (!entry) return `${boardName} ${String(sizeId)}`;
-  const layoutLabel = layoutId === CNC_KILTER_ORIGINAL_LAYOUT_ID ? 'Original' : 'Homewall';
+  const layoutLabel = layoutId === KILTER_ORIGINAL_LAYOUT_ID ? 'Original' : 'Homewall';
   return `Kilter ${layoutLabel} ${entry.label}`;
 }

--- a/packages/backend/src/services/cnc/catalog.ts
+++ b/packages/backend/src/services/cnc/catalog.ts
@@ -15,7 +15,9 @@ import type { CncOrderOptions } from '@boardsesh/db/schema';
  * stores the version it was priced and configured under, so a regenerate months
  * later rebuilds the pack the buyer paid for rather than today's defaults.
  */
-export const CNC_CATALOG_VERSION = '2026-09-07.3';
+export const CNC_CATALOG_VERSION = '2026-09-07.4';
+
+export const CNC_KILTER_ORIGINAL_LAYOUT_ID = 1;
 
 /**
  * sha256 of `JSON.stringify(CNC_CATALOG)`, pinned so the version above cannot
@@ -32,7 +34,7 @@ export const CNC_CATALOG_VERSION = '2026-09-07.3';
  * Never paste the new hash on its own — a hash change with an unchanged version
  * is exactly the bug this pair exists to catch.
  */
-export const CNC_CATALOG_CONTENT_HASH = '21dce30f1df9a4ab4a2be636dab86fdad3af5dd55838a92a4365aa64764b4e2b';
+export const CNC_CATALOG_CONTENT_HASH = 'c95193951e15e5b8008a81946471585370ff01acb9297e35fc43feb012901ba1';
 
 export type CncLicenceTier = 'personal' | 'commercial_single';
 
@@ -75,7 +77,7 @@ export type CncCatalogEntry = {
    * panels are identical, so they all buy the same pack.
    */
   sizeAliases: readonly number[];
-  /** True when this size has kicker sets (28/29) the buyer can include or leave off. */
+  /** True when the buyer can include or leave off this size's kicker. */
   kickerOptional: boolean;
   manufacturingOptions: readonly CncManufacturingOption[];
   tiers: readonly CncTierPrice[];
@@ -125,7 +127,7 @@ const KILTER_HOMEWALL_TIERS: readonly CncTierPrice[] = [
   { tier: 'commercial_single', priceCents: 75000, currency: 'AUD', stripePriceEnv: 'STRIPE_PRICE_CNC_COMMERCIAL' },
 ];
 
-type KilterHomewallSize = {
+type KilterSize = {
   sizeId: number;
   label: string;
   sizeAliases: readonly number[];
@@ -140,34 +142,59 @@ type KilterHomewallSize = {
  * walls (23, 25) carry kicker sets, which is why `kickerOptional` is false for
  * the 10 ft ones — there is no kicker to opt out of.
  */
-const KILTER_HOMEWALL_SIZES: readonly KilterHomewallSize[] = [
+const KILTER_HOMEWALL_SIZES: readonly KilterSize[] = [
   { sizeId: 17, label: '7x10', sizeAliases: [18, 19], kickerOptional: false },
   { sizeId: 21, label: '10x10', sizeAliases: [22, 29], kickerOptional: false },
   { sizeId: 23, label: '8x12', sizeAliases: [24], kickerOptional: true },
   { sizeId: 25, label: '10x12', sizeAliases: [26], kickerOptional: true },
 ];
 
-function defaultSetIdsFor(sizeId: number): string {
-  const sets = getSetsForLayoutAndSize('kilter', KILTER_HOMEWALL_LAYOUT_ID, sizeId);
+function defaultSetIdsFor(layoutId: number, sizeId: number): string {
+  const sets = getSetsForLayoutAndSize('kilter', layoutId, sizeId);
   if (sets.length === 0) {
     // A catalogue entry whose sets vanished would silently sell an empty wall,
     // so fail at module load rather than at generation time.
-    throw new Error(`[cnc-catalog] no sets for kilter layout ${KILTER_HOMEWALL_LAYOUT_ID} size ${sizeId}`);
+    throw new Error(`[cnc-catalog] no sets for kilter layout ${layoutId} size ${sizeId}`);
   }
   return sets.map((set) => set.id).join(',');
 }
 
-export const CNC_CATALOG: readonly CncCatalogEntry[] = KILTER_HOMEWALL_SIZES.map((size) => ({
-  boardName: 'kilter' as BoardName,
-  layoutId: KILTER_HOMEWALL_LAYOUT_ID,
-  sizeId: size.sizeId,
-  setIds: defaultSetIdsFor(size.sizeId),
-  label: size.label,
-  sizeAliases: size.sizeAliases,
-  kickerOptional: size.kickerOptional,
-  manufacturingOptions: KILTER_HOMEWALL_MANUFACTURING_OPTIONS,
-  tiers: KILTER_HOMEWALL_TIERS,
-}));
+/** OG hands and feet share their sets with the kicker: inclusion must be explicit. */
+const KILTER_ORIGINAL_SIZES: readonly KilterSize[] = [
+  { sizeId: 14, label: '7x10', sizeAliases: [], kickerOptional: false },
+  { sizeId: 8, label: '8x12', sizeAliases: [], kickerOptional: true },
+  { sizeId: 10, label: '12x12', sizeAliases: [], kickerOptional: true },
+  { sizeId: 28, label: '16x12', sizeAliases: [], kickerOptional: true },
+];
+
+export const CNC_CATALOG: readonly CncCatalogEntry[] = [
+  ...KILTER_HOMEWALL_SIZES.map((size) => ({
+    boardName: 'kilter' as BoardName,
+    layoutId: KILTER_HOMEWALL_LAYOUT_ID,
+    ...size,
+    setIds: defaultSetIdsFor(KILTER_HOMEWALL_LAYOUT_ID, size.sizeId),
+    manufacturingOptions: KILTER_HOMEWALL_MANUFACTURING_OPTIONS,
+    tiers: KILTER_HOMEWALL_TIERS,
+  })),
+  ...KILTER_ORIGINAL_SIZES.map((size) => ({
+    boardName: 'kilter' as BoardName,
+    layoutId: CNC_KILTER_ORIGINAL_LAYOUT_ID,
+    ...size,
+    setIds: defaultSetIdsFor(CNC_KILTER_ORIGINAL_LAYOUT_ID, size.sizeId),
+    manufacturingOptions: [
+      ...KILTER_HOMEWALL_MANUFACTURING_OPTIONS.map((option) =>
+        option.key === 'ledHoleDiameterMm' ? { ...option, defaultValue: 12.7 } : option,
+      ),
+      {
+        key: 'includeKicker',
+        values: size.kickerOptional ? [true, false] : [false],
+        defaultValue: size.kickerOptional,
+        kickerOnly: false,
+      },
+    ],
+    tiers: KILTER_HOMEWALL_TIERS,
+  })),
+];
 
 /**
  * The typefaces a text label may be routed in.
@@ -454,5 +481,7 @@ export const CNC_KICKER_SET_IDS: readonly number[] = KICKER_SET_IDS;
  */
 export function describeBoard({ boardName, layoutId, sizeId }: CncBoardTuple): string {
   const entry = findCatalogEntry({ boardName, layoutId, sizeId });
-  return entry ? `${boardName} ${entry.label}` : `${boardName} ${String(sizeId)}`;
+  if (!entry) return `${boardName} ${String(sizeId)}`;
+  const layoutLabel = layoutId === CNC_KILTER_ORIGINAL_LAYOUT_ID ? 'Original' : 'Homewall';
+  return `Kilter ${layoutLabel} ${entry.label}`;
 }

--- a/packages/backend/src/services/cnc/worker-client.ts
+++ b/packages/backend/src/services/cnc/worker-client.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { logger } from '../../utils/logger';
-import { CNC_KICKER_SET_IDS, type CncBoardTuple } from './catalog';
+import { CNC_KICKER_SET_IDS, CNC_KILTER_ORIGINAL_LAYOUT_ID, type CncBoardTuple } from './catalog';
 import type { CncOrderOptions } from '@boardsesh/db/schema';
 
 /**
@@ -190,7 +190,9 @@ export type CncWorkerManufacturing = {
   stud_clearance_offset_mm: number;
   /** Cut the seam backing strips. Changes the sheet count, so it is geometry. */
   support_strips: boolean;
-  /** Present only when the configuration includes kicker sets. */
+  /** Explicit for OG, whose main wall and kicker share the same sets. */
+  include_kicker?: boolean;
+  /** Present only when the configuration includes a kicker. */
   kicker?: CncWorkerKicker;
 };
 
@@ -306,9 +308,12 @@ export type ToLayoutRequestInput = {
  */
 export function toLayoutRequest({ entry, options, setIds }: ToLayoutRequestInput): CncWorkerLayoutRequest {
   const { lengthMm, widthMm } = parseSheetStock(options.sheetStock);
-  // Including either kicker set is what tells the generator to emit the two
-  // extra panels. `validateSetIds` has already ruled out the half-kicker case.
-  const hasKicker = setIds.some((setId) => CNC_KICKER_SET_IDS.includes(setId));
+  // OG sets cannot express kicker inclusion. Homewall retains its stored set
+  // selection, including orders created before the explicit option existed.
+  const isOriginal = entry.boardName === 'kilter' && entry.layoutId === CNC_KILTER_ORIGINAL_LAYOUT_ID;
+  const hasKicker = isOriginal
+    ? booleanOption(options, 'includeKicker', entry.sizeId !== 14)
+    : setIds.some((setId) => CNC_KICKER_SET_IDS.includes(setId));
 
   return {
     board: {
@@ -333,9 +338,8 @@ export function toLayoutRequest({ entry, options, setIds }: ToLayoutRequestInput
       // switching them off is the difference between a nine-sheet and an
       // eight-sheet cut summary on the reference 10x12.
       support_strips: booleanOption(options, 'supportStrips', true),
-      // Omitted rather than sent as null for a wall with no kicker: the
-      // generator's pydantic model treats a present kicker block as "build
-      // one", and a 10 ft wall has no kicker sets to build from.
+      ...(isOriginal ? { include_kicker: hasKicker } : {}),
+      // Keep the clearance alongside the inclusion choice for preview and jobs.
       ...(hasKicker ? { kicker: { mat_clearance_mm: numericOption(options, 'kickerMatClearanceMm') } } : {}),
     },
   };

--- a/packages/backend/src/services/cnc/worker-client.ts
+++ b/packages/backend/src/services/cnc/worker-client.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { logger } from '../../utils/logger';
-import { CNC_KICKER_SET_IDS, CNC_KILTER_ORIGINAL_LAYOUT_ID, type CncBoardTuple } from './catalog';
+import { KILTER_ORIGINAL_LAYOUT_ID } from '@boardsesh/board-constants';
+import { CNC_KICKER_SET_IDS, type CncBoardTuple } from './catalog';
 import type { CncOrderOptions } from '@boardsesh/db/schema';
 
 /**
@@ -310,7 +311,7 @@ export function toLayoutRequest({ entry, options, setIds }: ToLayoutRequestInput
   const { lengthMm, widthMm } = parseSheetStock(options.sheetStock);
   // OG sets cannot express kicker inclusion. Homewall retains its stored set
   // selection, including orders created before the explicit option existed.
-  const isOriginal = entry.boardName === 'kilter' && entry.layoutId === CNC_KILTER_ORIGINAL_LAYOUT_ID;
+  const isOriginal = entry.boardName === 'kilter' && entry.layoutId === KILTER_ORIGINAL_LAYOUT_ID;
   const hasKicker = isOriginal
     ? booleanOption(options, 'includeKicker', entry.sizeId !== 14)
     : setIds.some((setId) => CNC_KICKER_SET_IDS.includes(setId));

--- a/packages/board-constants/src/__tests__/product-sizes.test.ts
+++ b/packages/board-constants/src/__tests__/product-sizes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test';
 import {
+  KILTER_ORIGINAL_LAYOUT_ID,
   KILTER_HOMEWALL_LAYOUT_ID,
   KILTER_HOMEWALL_PRODUCT_ID,
   getLayoutName,
@@ -12,7 +13,7 @@ const EMPTY_SCOPE = { narrowerSizeIds: [], shorterSizeIds: [], hasNarrower: fals
 
 describe('getLayoutName', () => {
   it('returns the human-readable name for a known board + layoutId', () => {
-    expect(getLayoutName('kilter', 1)).toBe('Kilter Board Original');
+    expect(getLayoutName('kilter', KILTER_ORIGINAL_LAYOUT_ID)).toBe('Kilter Board Original');
   });
 
   it("returns '' for an unknown layoutId", () => {
@@ -20,8 +21,9 @@ describe('getLayoutName', () => {
   });
 });
 
-describe('Kilter Homewall identifiers', () => {
+describe('Kilter identifiers', () => {
   it('pins the Aurora layout and product ids the filters key off', () => {
+    expect(KILTER_ORIGINAL_LAYOUT_ID).toBe(1);
     expect(KILTER_HOMEWALL_LAYOUT_ID).toBe(8);
     expect(KILTER_HOMEWALL_PRODUCT_ID).toBe(7);
   });

--- a/packages/board-constants/src/product-sizes.ts
+++ b/packages/board-constants/src/product-sizes.ts
@@ -53,6 +53,10 @@ export const PRODUCT_SIZES: Record<BoardName, Record<number, ProductSizeData>> =
 
 export { LAYOUTS, SETS, IMAGE_FILENAMES, HOLE_PLACEMENTS, getBoardHolePlacements };
 
+// The Kilter Original layout in Aurora's catalogue. Shared by build plans and
+// other consumers that distinguish Original from Homewall.
+export const KILTER_ORIGINAL_LAYOUT_ID = 1;
+
 // The Kilter Homewall is layout 8 / product 7 in Aurora's data. These gate the
 // tall/wide climb filters and the expansion-aware hold filtering, so web,
 // mobile, and the db query layer all read the same value from here rather than

--- a/packages/shared/i18n/locales/de/cnc.json
+++ b/packages/shared/i18n/locales/de/cnc.json
@@ -63,7 +63,8 @@
       "label": "Board",
       "help": "Wähle das Griff-Layout für dein Board.",
       "original": "Kilter Original (OG)",
-      "homewall": "Kilter Homewall"
+      "homewall": "Kilter Homewall",
+      "unknownLayout": "{{board}} · Layout {{layoutId}}"
     },
     "size": {
       "label": "Wandgröße",

--- a/packages/shared/i18n/locales/de/cnc.json
+++ b/packages/shared/i18n/locales/de/cnc.json
@@ -16,7 +16,7 @@
   "hero": {
     "title": "Baupläne für dein Board zu Hause",
     "subtitle": "DXF-Dateien, die eine CNC-Werkstatt direkt fräst. Jedes Panel, das Einschlagmutter-Raster, die LED-Bohrungen und die Fußleiste, aufgeteilt auf die Platten, die deine Werkstatt ohnehin hat.",
-    "firstBoard": "Das Kilter Homewall ist das erste unterstützte Board. Weitere folgen.",
+    "firstBoard": "Baupläne passend für Kilter Homewall und Kilter Original (OG).",
     "included": {
       "heading": "Was du bekommst",
       "dxf": "Eine DXF-Datei pro Panel, dazu Montagezeichnungen für die ganze Wand.",
@@ -61,14 +61,16 @@
     },
     "board": {
       "label": "Board",
-      "help": "Das Kilter Homewall ist heute das einzige Board im Verkauf."
+      "help": "Wähle das Griff-Layout für dein Board.",
+      "original": "Kilter Original (OG)",
+      "homewall": "Kilter Homewall"
     },
     "size": {
       "label": "Wandgröße",
       "help": "Die Kilter-Größe, die du baust. Sie legt das Griffraster und die Wandmaße fest."
     },
     "kicker": {
-      "help": "Das schräge Panel ganz unten. Nur die 12-ft-Wände haben eine.",
+      "help": "Das untere Panel. Bei Wänden mit 12 Fuß Höhe verfügbar.",
       "include": "Fußleiste einbauen",
       "exclude": "Ohne Fußleiste"
     },
@@ -280,12 +282,16 @@
       "sheets": "Platten",
       "sheetsValue_one": "{{count}} Platte",
       "sheetsValue_other": "{{count}} Platten",
-      "tnuts": "Einschlagmutter-Bohrungen",
-      "leds": "LED-Bohrungen",
-      "seamNotches": "LED-Bohrungen auf einem Stoß",
-      "seamNotchesHelp": "Diese LED-Bohrungen liegen auf einem Stoß zwischen zwei Panelen. Jede wird als Aussparung in beide Panele gefräst, und die LED sitzt in der Aussparung, sobald die Panele verbunden sind.",
+      "tnuts": "Einzubauende Einschlagmuttern",
+      "leds": "Einzubauende LEDs",
       "warningsHeading": "Gut zu wissen",
-      "unavailable": "Die Frästeileliste lädt gerade nicht. Alles, was du gewählt hast, ist noch da."
+      "unavailable": "Die Frästeileliste lädt gerade nicht. Alles, was du gewählt hast, ist noch da.",
+      "spareMounts": "Zusätzliche Befestigungsbohrungen",
+      "spareMountsHelp": "Zusätzliche Positionen für das passende Homewall-Layout. Das sind Bohrungen, keine zusätzlichen Beschläge für deinen OG-Aufbau.",
+      "skippedSeamLeds": "LED-Bohrungen nach dem Zusammenbau",
+      "skippedSeamLedsHelp": "Diese Positionen liegen auf einem Panelstoß. Verbinde die Panele und bohre dann die nötigen Löcher mit den Montagekoordinaten und Durchmessern aus deinem Paket.",
+      "seamNotches": "LED-Bohrungen auf einem Stoß",
+      "seamNotchesHelp": "Diese LED-Bohrungen liegen auf einem Stoß zwischen zwei Panelen. Jede wird als Aussparung in beide Panele gefräst, und die LED sitzt in der Aussparung, sobald die Panele verbunden sind."
     },
     "licensee": {
       "name": "Name auf der Lizenz",
@@ -320,6 +326,14 @@
       "heading": "Auf wen die Lizenz läuft",
       "help": "Die Lizenz steht in jeder Datei im Pack, eine geleakte Kopie führt also zu ihr zurück.",
       "stale": "Hol dir zuerst die Vorschau neu — die Wand hat sich seit diesen Bögen geändert."
+    },
+    "original": {
+      "drilling": "Wir empfehlen drei Bohrungen pro angeschraubtem OG-Tritt: eine 13-mm-Mitte für eine LED und zwei LED-Bohrungen jeweils 20 mm darüber und darunter. Lass die Mitte bei OG-Tritten ohne Einschlagmutter.",
+      "compatibility": "Zusätzliche Bohrungen decken das vollständige passende Homewall-Layout ab: 7×10 oder 8×12 sowie ein mittiges 10×12 auf den größeren OG-Wänden.",
+      "angleLabel": "Ausrichtungsmarken für Griffnummern gravieren",
+      "angleHelp": "Nutzt den OG Number Angle, um die Ausrichtung der aufgedruckten Griffnummer zu markieren. Fehlende Winkel bleiben ohne Markierung.",
+      "engraveHelp": "Griffnummern und Ausrichtungsmarken werden beim Zuschnitt eingraviert. Beide sind standardmäßig aktiviert.",
+      "engraveNote": "OG-Markierungen folgen der Griffnummer, nicht der Sicherungsschraube. Daraus werden keine Schraubenlöcher gebohrt."
     }
   },
   "cta": {

--- a/packages/shared/i18n/locales/en-US/cnc.json
+++ b/packages/shared/i18n/locales/en-US/cnc.json
@@ -63,7 +63,8 @@
       "label": "Board",
       "help": "Choose the hold layout your wall will use.",
       "original": "Kilter Original (OG)",
-      "homewall": "Kilter Homewall"
+      "homewall": "Kilter Homewall",
+      "unknownLayout": "{{board}} · layout {{layoutId}}"
     },
     "size": {
       "label": "Wall size",

--- a/packages/shared/i18n/locales/en-US/cnc.json
+++ b/packages/shared/i18n/locales/en-US/cnc.json
@@ -16,7 +16,7 @@
   "hero": {
     "title": "Build plans for your home board",
     "subtitle": "DXF files a CNC shop cuts straight from. Every panel, the T-nut grid, the LED holes and the kicker, laid out on the sheets your shop already stocks.",
-    "firstBoard": "Kilter Homewall is the first supported board. More boards follow.",
+    "firstBoard": "Plans compatible with Kilter Homewall and Kilter Original (OG).",
     "included": {
       "heading": "What you get",
       "dxf": "One DXF per panel, plus assembly drawings for the whole wall.",
@@ -61,14 +61,16 @@
     },
     "board": {
       "label": "Board",
-      "help": "Kilter Homewall is the only board on sale today."
+      "help": "Choose the hold layout your wall will use.",
+      "original": "Kilter Original (OG)",
+      "homewall": "Kilter Homewall"
     },
     "size": {
       "label": "Wall size",
       "help": "The Kilter size you are building. It sets the hold grid and the wall dimensions."
     },
     "kicker": {
-      "help": "The angled panel at the bottom. Only the 12 ft walls have one.",
+      "help": "The bottom panel. Available on the 12 ft-high walls.",
       "include": "Include the kicker",
       "exclude": "No kicker"
     },
@@ -280,12 +282,16 @@
       "sheets": "Sheets",
       "sheetsValue_one": "{{count}} sheet",
       "sheetsValue_other": "{{count}} sheets",
-      "tnuts": "T-nut holes",
-      "leds": "LED holes",
-      "seamNotches": "LED holes on a seam",
-      "seamNotchesHelp": "These LED holes sit on a panel seam. Each one is cut as a notch in both panels, and the LED sits in the notch once the panels are joined.",
+      "tnuts": "T-nuts to install",
+      "leds": "LEDs to install",
       "warningsHeading": "Worth knowing",
-      "unavailable": "The cut list is not loading right now. Everything you picked is still here."
+      "unavailable": "The cut list is not loading right now. Everything you picked is still here.",
+      "spareMounts": "Spare mounting holes",
+      "spareMountsHelp": "Extra positions for the compatible Homewall layout. These are drilled holes, not extra hardware for your OG setup.",
+      "skippedSeamLeds": "LED holes to drill after assembly",
+      "skippedSeamLedsHelp": "These positions cross a panel seam. Join the panels, then drill the required holes using the assembly coordinates and diameters in your pack.",
+      "seamNotches": "LED holes on a seam",
+      "seamNotchesHelp": "These LED holes sit on a panel seam. Each one is cut as a notch in both panels, and the LED sits in the notch once the panels are joined."
     },
     "licensee": {
       "name": "Name on the licence",
@@ -320,6 +326,14 @@
       "heading": "Who the licence names",
       "help": "The licence goes on every file in the pack, so a leaked copy traces back to it.",
       "stale": "Update your preview first — the wall has changed since these sheets."
+    },
+    "original": {
+      "drilling": "We recommend three holes at each OG screw-on foot: a 13 mm center for one LED, plus two LED holes 20 mm above and below. Leave the center free of a T-nut while using OG feet.",
+      "compatibility": "Extra holes cover the complete matching Homewall layout: 7×10 or 8×12, and a centered 10×12 on the larger OG walls.",
+      "angleLabel": "Engrave hold-number orientation marks",
+      "angleHelp": "Uses the OG Number Angle to mark how the printed hold number should face. Missing angles are left unmarked.",
+      "engraveHelp": "Hold numbers and their orientation marks, engraved while the panel is cut. Both are on by default.",
+      "engraveNote": "OG orientation marks follow the hold number, not the set screw. Screw-hole positions are not drilled from these marks."
     }
   },
   "cta": {

--- a/packages/shared/i18n/locales/es/cnc.json
+++ b/packages/shared/i18n/locales/es/cnc.json
@@ -63,7 +63,8 @@
       "label": "Plafón",
       "help": "Elige el layout de presas que usará tu plafón.",
       "original": "Kilter Original (OG)",
-      "homewall": "Kilter Homewall"
+      "homewall": "Kilter Homewall",
+      "unknownLayout": "{{board}} · layout {{layoutId}}"
     },
     "size": {
       "label": "Tamaño del muro",

--- a/packages/shared/i18n/locales/es/cnc.json
+++ b/packages/shared/i18n/locales/es/cnc.json
@@ -16,7 +16,7 @@
   "hero": {
     "title": "Planos para construir tu plafón en casa",
     "subtitle": "Archivos DXF que un taller CNC corta directamente. Cada panel, la retícula de tuercas en T, los agujeros de LED y la repisa, repartidos en las planchas que tu taller ya tiene.",
-    "firstBoard": "El Kilter Homewall es el primer plafón compatible. Vendrán más.",
+    "firstBoard": "Planos compatibles con Kilter Homewall y Kilter Original (OG).",
     "included": {
       "heading": "Qué te llevas",
       "dxf": "Un DXF por panel, más los planos de montaje del muro entero.",
@@ -61,14 +61,16 @@
     },
     "board": {
       "label": "Plafón",
-      "help": "El Kilter Homewall es el único plafón a la venta hoy."
+      "help": "Elige el layout de presas que usará tu plafón.",
+      "original": "Kilter Original (OG)",
+      "homewall": "Kilter Homewall"
     },
     "size": {
       "label": "Tamaño del muro",
       "help": "El tamaño de Kilter que vas a construir. Define la retícula de presas y las medidas del muro."
     },
     "kicker": {
-      "help": "El panel inclinado de abajo. Solo la tienen los muros de 12 ft.",
+      "help": "El panel inferior. Disponible en los muros de 12 pies de alto.",
       "include": "Incluir la repisa",
       "exclude": "Sin repisa"
     },
@@ -280,12 +282,16 @@
       "sheets": "Planchas",
       "sheetsValue_one": "{{count}} plancha",
       "sheetsValue_other": "{{count}} planchas",
-      "tnuts": "Agujeros de tuerca en T",
-      "leds": "Agujeros de LED",
-      "seamNotches": "Agujeros de LED en una junta",
-      "seamNotchesHelp": "Estos agujeros de LED caen sobre una junta entre paneles. Cada uno se corta como una muesca en los dos paneles, y el LED queda alojado en la muesca cuando los paneles se unen.",
+      "tnuts": "Tuercas de araña a instalar",
+      "leds": "LED a instalar",
       "warningsHeading": "Conviene saberlo",
-      "unavailable": "La lista de corte no carga ahora mismo. Todo lo que has elegido sigue aquí."
+      "unavailable": "La lista de corte no carga ahora mismo. Todo lo que has elegido sigue aquí.",
+      "spareMounts": "Agujeros de montaje adicionales",
+      "spareMountsHelp": "Posiciones adicionales para el layout Homewall compatible. Son agujeros perforados, no herrajes adicionales para tu montaje OG.",
+      "skippedSeamLeds": "Agujeros LED a perforar tras el montaje",
+      "skippedSeamLedsHelp": "Estas posiciones cruzan una junta. Une los paneles y perfora los agujeros necesarios con las coordenadas de montaje y los diámetros incluidos en tu pack.",
+      "seamNotches": "Agujeros de LED en una junta",
+      "seamNotchesHelp": "Estos agujeros de LED caen sobre una junta entre paneles. Cada uno se corta como una muesca en los dos paneles, y el LED queda alojado en la muesca cuando los paneles se unen."
     },
     "licensee": {
       "name": "Nombre en la licencia",
@@ -320,6 +326,14 @@
       "heading": "A nombre de quién va la licencia",
       "help": "La licencia va en todos los archivos del pack, así que una copia filtrada se rastrea hasta ella.",
       "stale": "Actualiza antes la vista previa: el muro ha cambiado desde estas hojas."
+    },
+    "original": {
+      "drilling": "Recomendamos tres agujeros en cada presa de pie OG atornillada: un centro de 13 mm para un LED y dos agujeros LED a 20 mm por encima y por debajo. Deja el centro sin tuerca de araña al usar los pies OG.",
+      "compatibility": "Los agujeros adicionales cubren el layout Homewall completo correspondiente: 7×10 u 8×12, y un 10×12 centrado en los muros OG más grandes.",
+      "angleLabel": "Grabar marcas de orientación del número de presa",
+      "angleHelp": "Usa el Number Angle de OG para indicar hacia dónde debe mirar el número impreso de la presa. Los ángulos ausentes quedan sin marcar.",
+      "engraveHelp": "Números de presa y sus marcas de orientación, grabados al cortar el panel. Ambos están activados por defecto.",
+      "engraveNote": "Las marcas OG siguen la orientación del número de presa, no del tornillo de fijación. Estas marcas no se usan para perforar agujeros de tornillo."
     }
   },
   "cta": {

--- a/packages/shared/i18n/locales/fr/cnc.json
+++ b/packages/shared/i18n/locales/fr/cnc.json
@@ -16,7 +16,7 @@
   "hero": {
     "title": "Plans de construction pour ta board maison",
     "subtitle": "Des fichiers DXF qu'un atelier CNC découpe tels quels. Chaque panneau, la trame d'écrous à griffes, les perçages LED et le kicker, répartis sur les plaques que ton atelier a déjà en stock.",
-    "firstBoard": "Le Kilter Homewall est la première board prise en charge. D'autres suivront.",
+    "firstBoard": "Plans compatibles avec Kilter Homewall et Kilter Original (OG).",
     "included": {
       "heading": "Ce que tu reçois",
       "dxf": "Un DXF par panneau, plus les plans de montage du mur complet.",
@@ -61,14 +61,16 @@
     },
     "board": {
       "label": "Board",
-      "help": "Le Kilter Homewall est la seule board en vente aujourd'hui."
+      "help": "Choisis le layout de prises de ta board.",
+      "original": "Kilter Original (OG)",
+      "homewall": "Kilter Homewall"
     },
     "size": {
       "label": "Taille du mur",
       "help": "La taille Kilter que tu construis. Elle fixe la trame de prises et les dimensions du mur."
     },
     "kicker": {
-      "help": "Le panneau incliné du bas. Seuls les murs de 12 ft en ont un.",
+      "help": "Le panneau du bas. Disponible sur les murs de 12 pieds de haut.",
       "include": "Inclure le kicker",
       "exclude": "Sans kicker"
     },
@@ -280,12 +282,16 @@
       "sheets": "Plaques",
       "sheetsValue_one": "{{count}} plaque",
       "sheetsValue_other": "{{count}} plaques",
-      "tnuts": "Perçages d'écrous à griffes",
-      "leds": "Perçages LED",
-      "seamNotches": "Perçages LED sur un raccord",
-      "seamNotchesHelp": "Ces perçages LED tombent sur un raccord entre panneaux. Chacun est découpé en encoche dans les deux panneaux, et la LED se loge dans l’encoche une fois les panneaux assemblés.",
+      "tnuts": "Écrous à griffes à installer",
+      "leds": "LED à installer",
       "warningsHeading": "Bon à savoir",
-      "unavailable": "La liste de découpe ne charge pas pour l’instant. Tout ce que tu as choisi est toujours là."
+      "unavailable": "La liste de découpe ne charge pas pour l’instant. Tout ce que tu as choisi est toujours là.",
+      "spareMounts": "Trous de fixation supplémentaires",
+      "spareMountsHelp": "Positions supplémentaires pour le layout Homewall compatible. Ce sont des perçages, pas du matériel supplémentaire à installer sur ton OG.",
+      "skippedSeamLeds": "Trous LED à percer après assemblage",
+      "skippedSeamLedsHelp": "Ces positions croisent un raccord. Assemble les panneaux, puis perce les trous nécessaires avec les coordonnées d’assemblage et les diamètres fournis dans ton pack.",
+      "seamNotches": "Perçages LED sur un raccord",
+      "seamNotchesHelp": "Ces perçages LED tombent sur un raccord entre panneaux. Chacun est découpé en encoche dans les deux panneaux, et la LED se loge dans l’encoche une fois les panneaux assemblés."
     },
     "licensee": {
       "name": "Nom sur la licence",
@@ -320,6 +326,14 @@
       "heading": "Au nom de qui est la licence",
       "help": "La licence figure sur chaque fichier du pack : une copie qui fuite y remonte.",
       "stale": "Mets d'abord ton aperçu à jour — le mur a changé depuis ces planches."
+    },
+    "original": {
+      "drilling": "Nous recommandons trois trous pour chaque prise de pied OG vissée : un centre de 13 mm pour une LED et deux trous LED à 20 mm au-dessus et en dessous. Laisse le centre sans écrou à griffes avec les pieds OG.",
+      "compatibility": "Les trous supplémentaires couvrent le layout Homewall complet correspondant : 7×10 ou 8×12, et un 10×12 centré sur les grands murs OG.",
+      "angleLabel": "Graver les repères d’orientation du numéro de prise",
+      "angleHelp": "Utilise le Number Angle OG pour indiquer l’orientation du numéro imprimé sur la prise. Les angles manquants restent sans repère.",
+      "engraveHelp": "Numéros de prises et repères d’orientation, gravés pendant la découpe du panneau. Les deux sont activés par défaut.",
+      "engraveNote": "Les repères OG suivent l’orientation du numéro de prise, pas celle de la vis de blocage. Ils ne servent pas à percer les trous de vis."
     }
   },
   "cta": {

--- a/packages/shared/i18n/locales/fr/cnc.json
+++ b/packages/shared/i18n/locales/fr/cnc.json
@@ -63,7 +63,8 @@
       "label": "Board",
       "help": "Choisis le layout de prises de ta board.",
       "original": "Kilter Original (OG)",
-      "homewall": "Kilter Homewall"
+      "homewall": "Kilter Homewall",
+      "unknownLayout": "{{board}} · layout {{layoutId}}"
     },
     "size": {
       "label": "Taille du mur",

--- a/packages/web/app/build-plans/__tests__/artwork-step.test.ts
+++ b/packages/web/app/build-plans/__tests__/artwork-step.test.ts
@@ -119,7 +119,7 @@ describe('configuratorReducer artwork actions', () => {
       item: label(),
     });
 
-    const switched = configuratorReducer(base, { type: 'selectSize', entry: { ...entry(), sizeId: 17 } });
+    const switched = configuratorReducer(base, { type: 'selectEntry', entry: { ...entry(), sizeId: 17 } });
 
     expect(switched.artwork).toEqual([]);
   });

--- a/packages/web/app/build-plans/__tests__/configurator-flow.test.tsx
+++ b/packages/web/app/build-plans/__tests__/configurator-flow.test.tsx
@@ -389,3 +389,13 @@ it('switches layouts, filters sizes, clears the preview and sends the OG kicker 
   fireEvent.click(screen.getByRole('switch', { name: 'Include the kicker' }));
   expect(lastLayoutConfig()).toMatchObject({ setIds: '1,20', options: { includeKicker: false } });
 });
+
+it('shows the layout number when the catalog introduces an unknown layout', async () => {
+  const futureCatalog = catalog();
+  futureCatalog.entries.push({ ...futureCatalog.entries[0], layoutId: 99 });
+  renderConfigurator(futureCatalog);
+  fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Board' }));
+  expect(screen.getByRole('option', { name: 'Kilter · layout 99' })).toBeDefined();
+  fireEvent.click(screen.getByRole('option', { name: 'Kilter · layout 99' }));
+  expect(lastLayoutConfig()).toMatchObject({ layoutId: 99 });
+});

--- a/packages/web/app/build-plans/__tests__/configurator-flow.test.tsx
+++ b/packages/web/app/build-plans/__tests__/configurator-flow.test.tsx
@@ -157,11 +157,11 @@ function respond(document: string) {
   return Promise.resolve({});
 }
 
-function renderConfigurator() {
+function renderConfigurator(catalogOverride = catalog()) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
-      <Configurator catalog={catalog()} locale="en-US" />
+      <Configurator catalog={catalogOverride} locale="en-US" />
     </QueryClientProvider>,
   );
 }
@@ -338,4 +338,54 @@ describe('the finalise step', () => {
     });
     await waitFor(() => expect(locationAssign).toHaveBeenCalledWith(STRIPE_URL));
   });
+});
+
+it('switches layouts, filters sizes, clears the preview and sends the OG kicker option', async () => {
+  const mixedCatalog = catalog();
+  const homewall = mixedCatalog.entries[0];
+  mixedCatalog.entries.push(
+    ...[14, 28].map((sizeId) => ({
+      ...homewall,
+      layoutId: 1,
+      sizeId,
+      label: sizeId === 14 ? '7x10' : '16x12',
+      setIds: '1,20',
+      kickerOptional: sizeId === 28,
+      manufacturingOptions: [
+        ...homewall.manufacturingOptions,
+        {
+          key: 'includeKicker',
+          values: ['true', 'false'],
+          defaultValue: String(sizeId === 28),
+          valueType: 'boolean',
+          kickerOnly: false,
+        },
+      ],
+    })),
+  );
+  renderConfigurator(mixedCatalog);
+  await previewThisWall();
+
+  fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Board' }));
+  fireEvent.click(screen.getByRole('option', { name: 'Kilter Original (OG)' }));
+  await waitFor(() => expect(screen.queryByRole('img', { name: 'Panel 1' })).toBeNull());
+  expect(screen.getByRole('button', { name: 'Get a free preview' })).toBeDefined();
+  expect(lastLayoutConfig()).toMatchObject({
+    layoutId: 1,
+    sizeId: 14,
+    setIds: '1,20',
+    options: { includeKicker: false },
+  });
+
+  fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Wall size' }));
+  expect(screen.queryByRole('option', { name: '10x12' })).toBeNull();
+  fireEvent.click(screen.getByRole('option', { name: '16x12' }));
+  expect(lastLayoutConfig()).toMatchObject({
+    layoutId: 1,
+    sizeId: 28,
+    setIds: '1,20',
+    options: { includeKicker: true },
+  });
+  fireEvent.click(screen.getByRole('switch', { name: 'Include the kicker' }));
+  expect(lastLayoutConfig()).toMatchObject({ setIds: '1,20', options: { includeKicker: false } });
 });

--- a/packages/web/app/build-plans/__tests__/configurator-state.test.ts
+++ b/packages/web/app/build-plans/__tests__/configurator-state.test.ts
@@ -398,3 +398,68 @@ describe('option value keys', () => {
     expect(optionValueKey('true')).toBe('true');
   });
 });
+
+describe('Kilter Original configuration', () => {
+  function original(kickerOptional = true): CncCatalogEntry {
+    const homewall = tenByTwelve();
+    return {
+      ...homewall,
+      layoutId: 1,
+      sizeId: kickerOptional ? 28 : 14,
+      label: kickerOptional ? '16x12' : '7x10',
+      setIds: '1,20',
+      kickerOptional,
+      manufacturingOptions: [
+        ...homewall.manufacturingOptions,
+        {
+          key: 'includeKicker',
+          values: ['true', 'false'],
+          defaultValue: String(kickerOptional),
+          valueType: 'boolean',
+          kickerOnly: false,
+        },
+      ],
+    };
+  }
+
+  it('keeps both OG sets when the kicker is off and sends the explicit option', () => {
+    const entry = original();
+    const initial = initialConfiguratorState(entry);
+    expect(toBoardConfigInput(initial, entry).options?.includeKicker).toBe(true);
+    const withoutKicker = configuratorReducer(initial, { type: 'setKicker', includeKicker: false });
+    expect(toBoardConfigInput(withoutKicker, entry)).toMatchObject({
+      setIds: '1,20',
+      options: { includeKicker: false },
+    });
+    expect(hasKickerSets(entry)).toBe(true);
+    expect(visibleMachiningOptions(entry, true).map((option) => option.key)).not.toContain('includeKicker');
+  });
+
+  it('cannot include a kicker on the OG 7x10', () => {
+    const entry = original(false);
+    expect(hasKickerSets(entry)).toBe(false);
+    expect(
+      toBoardConfigInput({ ...initialConfiguratorState(entry), includeKicker: true }, entry).options?.includeKicker,
+    ).toBe(false);
+  });
+
+  it('drops the old layout artwork and preview when switching to OG', () => {
+    const previous = {
+      ...initialConfiguratorState(tenByTwelve()),
+      previewOrderId: 'order-1',
+      previewLicenceId: 'licence-1',
+      previewConfigKey: 'homewall-config',
+      licenseeName: 'Sam',
+    };
+    const next = configuratorReducer(previous, { type: 'selectSize', entry: original() });
+    expect(next).toMatchObject({
+      layoutId: 1,
+      sizeId: 28,
+      artwork: [],
+      previewOrderId: null,
+      previewLicenceId: null,
+      previewConfigKey: null,
+      licenseeName: 'Sam',
+    });
+  });
+});

--- a/packages/web/app/build-plans/__tests__/configurator-state.test.ts
+++ b/packages/web/app/build-plans/__tests__/configurator-state.test.ts
@@ -9,7 +9,7 @@ import {
   finaliseBlockers,
   fromDraft,
   isPreviewStale,
-  hasKickerSets,
+  supportsKicker,
   initialConfiguratorState,
   optionValueKey,
   partitionByControl,
@@ -117,7 +117,7 @@ describe('option defaults', () => {
       licenseeEmail: 'sam@example.com',
     };
 
-    const next = configuratorReducer(start, { type: 'selectSize', entry: sevenByTen() });
+    const next = configuratorReducer(start, { type: 'selectEntry', entry: sevenByTen() });
 
     // A value carried onto a size that does not allow it is a checkout the
     // backend rejects with an error the buyer cannot act on.
@@ -202,7 +202,7 @@ describe('set ids', () => {
   });
 
   it('leaves a kickerless wall alone', () => {
-    expect(hasKickerSets(sevenByTen())).toBe(false);
+    expect(supportsKicker(sevenByTen())).toBe(false);
     expect(setIdsFor(sevenByTen(), false)).toBe('26,27');
   });
 });
@@ -431,16 +431,63 @@ describe('Kilter Original configuration', () => {
       setIds: '1,20',
       options: { includeKicker: false },
     });
-    expect(hasKickerSets(entry)).toBe(true);
+    expect(supportsKicker(entry)).toBe(true);
     expect(visibleMachiningOptions(entry, true).map((option) => option.key)).not.toContain('includeKicker');
   });
 
   it('cannot include a kicker on the OG 7x10', () => {
     const entry = original(false);
-    expect(hasKickerSets(entry)).toBe(false);
+    expect(supportsKicker(entry)).toBe(false);
     expect(
       toBoardConfigInput({ ...initialConfiguratorState(entry), includeKicker: true }, entry).options?.includeKicker,
     ).toBe(false);
+  });
+
+  it('resets an OG 8x12 to OG 12x12 while preserving both sets and the buyer', () => {
+    const eightByTwelve = { ...original(), sizeId: 8, label: '8x12' };
+    const twelveByTwelve = { ...original(), sizeId: 10, label: '12x12' };
+    const previous: CncConfiguratorState = {
+      ...initialConfiguratorState(eightByTwelve),
+      includeKicker: false,
+      options: { ...defaultOptions(eightByTwelve), sheetStock: '3600x1220' },
+      artwork: [
+        {
+          id: 'placed-label',
+          kind: 'text',
+          assetId: null,
+          text: 'Crew',
+          font: 'liberation-sans',
+          mode: 'engrave',
+          panelIndex: 1,
+          xMm: 400,
+          yMm: 600,
+          widthMm: 100,
+          rotationDeg: 0,
+        },
+      ],
+      previewOrderId: '8x12-order',
+      previewLicenceId: '8x12-licence',
+      previewConfigKey: '8x12-preview',
+      licenseeName: 'Sam',
+    };
+    expect(toBoardConfigInput(previous, eightByTwelve).setIds).toBe('1,20');
+    const next = configuratorReducer(previous, { type: 'selectEntry', entry: twelveByTwelve });
+    expect(toBoardConfigInput(next, twelveByTwelve)).toMatchObject({
+      layoutId: 1,
+      sizeId: 10,
+      setIds: '1,20',
+      options: { includeKicker: true, sheetStock: '2440x1220' },
+    });
+    expect(next).toMatchObject({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 10,
+      artwork: [],
+      previewOrderId: null,
+      previewLicenceId: null,
+      previewConfigKey: null,
+      licenseeName: 'Sam',
+    });
   });
 
   it('drops the old layout artwork and preview when switching to OG', () => {
@@ -451,7 +498,7 @@ describe('Kilter Original configuration', () => {
       previewConfigKey: 'homewall-config',
       licenseeName: 'Sam',
     };
-    const next = configuratorReducer(previous, { type: 'selectSize', entry: original() });
+    const next = configuratorReducer(previous, { type: 'selectEntry', entry: original() });
     expect(next).toMatchObject({
       layoutId: 1,
       sizeId: 28,

--- a/packages/web/app/build-plans/__tests__/layout-summary.test.ts
+++ b/packages/web/app/build-plans/__tests__/layout-summary.test.ts
@@ -64,7 +64,19 @@ describe('readLayoutSummary', () => {
   });
 
   it('reads generator warning messages and drops malformed warnings', () => {
-    const noisy = { ...GENERATOR_LAYOUT, warnings: ['a real warning', 42, null, { message: 'an object' }] };
+    const noisy = {
+      ...GENERATOR_LAYOUT,
+      warnings: [
+        'a real warning',
+        42,
+        null,
+        '',
+        '  \t\n',
+        { message: 'an object' },
+        { message: '' },
+        { message: ' \n ' },
+      ],
+    };
 
     expect(readLayoutSummary(noisy).warnings).toEqual(['a real warning', 'an object']);
   });

--- a/packages/web/app/build-plans/__tests__/layout-summary.test.ts
+++ b/packages/web/app/build-plans/__tests__/layout-summary.test.ts
@@ -34,6 +34,8 @@ describe('readLayoutSummary', () => {
       tnutCount: 812,
       ledCount: 411,
       seamNotches: 7,
+      skippedSeamLeds: null,
+      spareMountCount: null,
       warnings: ['Kicker clearance is below the recommended 60 mm'],
     });
   });
@@ -61,10 +63,10 @@ describe('readLayoutSummary', () => {
     expect(readLayoutSummary(broken).wallHeightMm).toBeNull();
   });
 
-  it('drops non-string warnings rather than rendering them', () => {
+  it('reads generator warning messages and drops malformed warnings', () => {
     const noisy = { ...GENERATOR_LAYOUT, warnings: ['a real warning', 42, null, { message: 'an object' }] };
 
-    expect(readLayoutSummary(noisy).warnings).toEqual(['a real warning']);
+    expect(readLayoutSummary(noisy).warnings).toEqual(['a real warning', 'an object']);
   });
 
   it.each([
@@ -84,7 +86,40 @@ describe('readLayoutSummary', () => {
       tnutCount: null,
       ledCount: null,
       seamNotches: null,
+      skippedSeamLeds: null,
+      spareMountCount: null,
       warnings: [],
     });
+  });
+});
+
+it('shows installed hardware separately from spare bores and retains assembly warnings', () => {
+  const summary = readLayoutSummary({
+    bom_preview: {
+      tnut_count: 100,
+      led_count: 200,
+      installed_tnut_count: 60,
+      installed_led_count: 80,
+      spare_mount_count: 40,
+    },
+    warnings: [{ code: 'seam_led', message: 'Drill this LED position after assembly.' }],
+  });
+  expect(summary).toMatchObject({
+    tnutCount: 60,
+    ledCount: 80,
+    spareMountCount: 40,
+    warnings: ['Drill this LED position after assembly.'],
+  });
+});
+
+it('keeps CNC notches separate from holes awaiting assembly drilling', () => {
+  expect(
+    readLayoutSummary({
+      bom_preview: { led_count: 200, installed_led_count: 80, seam_notches: 7, skipped_seam_leds: 3 },
+    }),
+  ).toMatchObject({
+    seamNotches: 7,
+    skippedSeamLeds: 3,
+    ledCount: 80,
   });
 });

--- a/packages/web/app/build-plans/__tests__/order-display.test.ts
+++ b/packages/web/app/build-plans/__tests__/order-display.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vite-plus/test';
 import type { CncCatalog, CncOrderStatus } from '@boardsesh/shared-schema';
 import {
+  boardLayoutLabel,
   finaliseHref,
   isPreviewStatus,
   newestPreviewReadyLicenceId,
@@ -175,4 +176,9 @@ describe('previewImageLabel', () => {
     // captioned; disappearing would be the worse answer.
     expect(previewImageLabel('kicker_detail.png', (key) => key)).toBe('kicker_detail');
   });
+});
+
+it('distinguishes Original and Homewall orders sharing the Kilter board name', () => {
+  expect(boardLayoutLabel({ boardName: 'kilter', layoutId: 1 }, translateToKey)).toBe('configurator.board.original');
+  expect(boardLayoutLabel({ boardName: 'kilter', layoutId: 8 }, translateToKey)).toBe('configurator.board.homewall');
 });

--- a/packages/web/app/build-plans/__tests__/order-display.test.ts
+++ b/packages/web/app/build-plans/__tests__/order-display.test.ts
@@ -1,3 +1,4 @@
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 import { describe, it, expect } from 'vite-plus/test';
 import type { CncCatalog, CncOrderStatus } from '@boardsesh/shared-schema';
 import {
@@ -181,4 +182,11 @@ describe('previewImageLabel', () => {
 it('distinguishes Original and Homewall orders sharing the Kilter board name', () => {
   expect(boardLayoutLabel({ boardName: 'kilter', layoutId: 1 }, translateToKey)).toBe('configurator.board.original');
   expect(boardLayoutLabel({ boardName: 'kilter', layoutId: 8 }, translateToKey)).toBe('configurator.board.homewall');
+});
+
+it('names an unknown layout without presenting it as Homewall', () => {
+  const label = boardLayoutLabel({ boardName: 'kilter', layoutId: 99 }, (key, options) =>
+    tFromCatalog('cnc', key, options),
+  );
+  expect(label).toBe('Kilter · layout 99');
 });

--- a/packages/web/app/build-plans/__tests__/order-status.test.tsx
+++ b/packages/web/app/build-plans/__tests__/order-status.test.tsx
@@ -403,3 +403,9 @@ describe('terminal states', () => {
     expect(screen.getByText('Payment went through. Your pack is being cut now.')).toBeTruthy();
   });
 });
+
+it('keeps the Original drilling and Homewall compatibility instructions with the order', async () => {
+  renderStatus(order({ layoutId: 1, sizeId: 28, setIds: '1,20', options: { includeKicker: true } }));
+  expect(await screen.findByText(/13 mm center for one LED/)).toBeDefined();
+  expect(screen.getByText(/centered 10×12/)).toBeDefined();
+});

--- a/packages/web/app/build-plans/__tests__/orders-list.test.tsx
+++ b/packages/web/app/build-plans/__tests__/orders-list.test.tsx
@@ -105,7 +105,7 @@ describe('OrdersList', () => {
     // labelled every one of these "Commercial, single build".
     await renderList([preview('BS-CNC-NEWEST', '2026-09-05T10:00:00.000Z')]);
 
-    expect(screen.getByText('Kilter 25 · Preview')).toBeTruthy();
+    expect(screen.getByText('Kilter Homewall 25 · Preview')).toBeTruthy();
     expect(screen.queryByText(/Commercial/)).toBeNull();
   });
 

--- a/packages/web/app/build-plans/__tests__/placement-editor.test.tsx
+++ b/packages/web/app/build-plans/__tests__/placement-editor.test.tsx
@@ -37,7 +37,7 @@ const RAW_LAYOUT = {
   seams: [{ kind: 'vertical', x_mm: 1200, extent: [0, 1200], between: [0, 1] }],
   holes: [
     { panel_index: 0, set_id: 26, kind: 'tnut', x_mm: 300, y_mm: 300, diameter_mm: 12.5, keepout_radius_mm: 26 },
-    { panel_index: 0, set_id: 26, kind: 'led', x_mm: 900, y_mm: 900, diameter_mm: 12.5, keepout_radius_mm: 11 },
+    { panel_index: 0, set_id: 20, kind: 'dual', x_mm: 900, y_mm: 900, diameter_mm: 13, keepout_radius_mm: 11 },
     { panel_index: 1, set_id: 26, kind: 'tnut', x_mm: 1500, y_mm: 300, diameter_mm: 12.5, keepout_radius_mm: 26 },
     // 10 mm inside panel 1, just across the seam from panel 0 — too far for a
     // 1x keep-out to reach, but within a cut-through's 1.5x one.
@@ -321,4 +321,12 @@ describe('an uploaded logo', () => {
     fireEvent.keyDown(screen.getByRole('application'), { key: 'ArrowUp' });
     expect(lastPlacement(onChange)).toMatchObject({ xMm: 600, yMm: 610 });
   });
+});
+
+it('draws the 13 mm OG foot center separately from its artwork clearance', () => {
+  renderEditor();
+  const footCenter = screen.getAllByTestId('cnc-bore').find((circle) => circle.getAttribute('data-kind') === 'dual');
+  expect(footCenter?.getAttribute('r')).toBe('6.5');
+  const footKeepout = screen.getAllByTestId('cnc-hole').find((circle) => circle.getAttribute('cx') === '900');
+  expect(footKeepout?.getAttribute('r')).toBe('11');
 });

--- a/packages/web/app/build-plans/configurator/configurator-state.ts
+++ b/packages/web/app/build-plans/configurator/configurator-state.ts
@@ -245,6 +245,9 @@ export function configuratorReducer(state: CncConfiguratorState, action: CncConf
         // entirely — most likely off the panel, which is a checkout the
         // generator refuses with a collision the buyer never caused.
         artwork: [],
+        previewOrderId: null,
+        previewLicenceId: null,
+        previewConfigKey: null,
       };
     }
     case 'setKicker':
@@ -306,7 +309,10 @@ export function visibleMachiningOptions(
   includeKicker: boolean,
 ): readonly CncManufacturingOption[] {
   return entry.manufacturingOptions.filter(
-    (option) => !CNC_ENGRAVE_OPTION_KEYS.includes(option.key) && (includeKicker || !option.kickerOnly),
+    (option) =>
+      option.key !== 'includeKicker' &&
+      !CNC_ENGRAVE_OPTION_KEYS.includes(option.key) &&
+      (includeKicker || !option.kickerOnly),
   );
 }
 
@@ -353,7 +359,7 @@ export function setIdsFor(entry: CncCatalogEntry, includeKicker: boolean): strin
     .split(',')
     .map((segment) => segment.trim())
     .filter((segment) => segment.length > 0);
-  if (includeKicker) {
+  if (includeKicker || (entry.boardName === 'kilter' && entry.layoutId === 1)) {
     return setIds.join(',');
   }
   return setIds.filter((setId) => !CNC_KICKER_SET_IDS.includes(Number(setId))).join(',');
@@ -361,6 +367,7 @@ export function setIdsFor(entry: CncCatalogEntry, includeKicker: boolean): strin
 
 /** Whether this entry's set list actually contains kicker sets to drop. */
 export function hasKickerSets(entry: CncCatalogEntry): boolean {
+  if (entry.boardName === 'kilter' && entry.layoutId === 1) return entry.kickerOptional;
   return entry.setIds.split(',').some((segment) => CNC_KICKER_SET_IDS.includes(Number(segment.trim())));
 }
 
@@ -393,7 +400,10 @@ export function coerceOptionValue(raw: string, valueType: string): string | numb
 export function toBoardConfigInput(state: CncConfiguratorState, entry: CncCatalogEntry): CncBoardConfigInput {
   const options: Record<string, string | number | boolean> = {};
   for (const option of entry.manufacturingOptions) {
-    const raw = state.options[option.key] ?? option.defaultValue;
+    const raw =
+      option.key === 'includeKicker'
+        ? String(entry.kickerOptional && state.includeKicker)
+        : (state.options[option.key] ?? option.defaultValue);
     options[option.key] = coerceOptionValue(raw, option.valueType);
   }
 

--- a/packages/web/app/build-plans/configurator/configurator-state.ts
+++ b/packages/web/app/build-plans/configurator/configurator-state.ts
@@ -1,3 +1,4 @@
+import { KILTER_ORIGINAL_LAYOUT_ID } from '@boardsesh/board-constants';
 import type {
   CncArtworkInput,
   CncArtworkKind,
@@ -359,7 +360,7 @@ export function setIdsFor(entry: CncCatalogEntry, includeKicker: boolean): strin
     .split(',')
     .map((segment) => segment.trim())
     .filter((segment) => segment.length > 0);
-  if (includeKicker || (entry.boardName === 'kilter' && entry.layoutId === 1)) {
+  if (includeKicker) {
     return setIds.join(',');
   }
   return setIds.filter((setId) => !CNC_KICKER_SET_IDS.includes(Number(setId))).join(',');
@@ -367,7 +368,7 @@ export function setIdsFor(entry: CncCatalogEntry, includeKicker: boolean): strin
 
 /** Whether this entry's set list actually contains kicker sets to drop. */
 export function hasKickerSets(entry: CncCatalogEntry): boolean {
-  if (entry.boardName === 'kilter' && entry.layoutId === 1) return entry.kickerOptional;
+  if (entry.boardName === 'kilter' && entry.layoutId === KILTER_ORIGINAL_LAYOUT_ID) return entry.kickerOptional;
   return entry.setIds.split(',').some((segment) => CNC_KICKER_SET_IDS.includes(Number(segment.trim())));
 }
 

--- a/packages/web/app/build-plans/configurator/configurator-state.ts
+++ b/packages/web/app/build-plans/configurator/configurator-state.ts
@@ -168,7 +168,7 @@ export type CncConfiguratorState = {
 };
 
 export type CncConfiguratorAction =
-  | { type: 'selectSize'; entry: CncCatalogEntry }
+  | { type: 'selectEntry'; entry: CncCatalogEntry }
   | { type: 'setKicker'; includeKicker: boolean }
   | { type: 'setOption'; key: string; value: string }
   | { type: 'addArtwork'; item: CncArtworkDraft }
@@ -227,7 +227,7 @@ export function findEntry(entries: readonly CncCatalogEntry[], state: CncConfigu
 
 export function configuratorReducer(state: CncConfiguratorState, action: CncConfiguratorAction): CncConfiguratorState {
   switch (action.type) {
-    case 'selectSize': {
+    case 'selectEntry': {
       // Options are reset to the new entry's defaults rather than carried over.
       // Two entries can publish different option sets, and a value carried onto
       // a size that does not allow it is a checkout the backend rejects with an
@@ -366,8 +366,8 @@ export function setIdsFor(entry: CncCatalogEntry, includeKicker: boolean): strin
   return setIds.filter((setId) => !CNC_KICKER_SET_IDS.includes(Number(setId))).join(',');
 }
 
-/** Whether this entry's set list actually contains kicker sets to drop. */
-export function hasKickerSets(entry: CncCatalogEntry): boolean {
+/** Whether the entry supports a kicker, through separate sets or an explicit option. */
+export function supportsKicker(entry: CncCatalogEntry): boolean {
   if (entry.boardName === 'kilter' && entry.layoutId === KILTER_ORIGINAL_LAYOUT_ID) return entry.kickerOptional;
   return entry.setIds.split(',').some((segment) => CNC_KICKER_SET_IDS.includes(Number(segment.trim())));
 }

--- a/packages/web/app/build-plans/configurator/configurator.tsx
+++ b/packages/web/app/build-plans/configurator/configurator.tsx
@@ -38,7 +38,6 @@ import {
   type CncConfigProps,
   type CncConfiguratorStep,
 } from '@boardsesh/analytics';
-import { getBoardDisplayName } from '@boardsesh/climb-actions';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
@@ -323,16 +322,22 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
 
   // ------------------------------------------------------------------- actions
   const handleSizeChange = (sizeId: number) => {
-    const next = entries.find((candidate) => candidate.sizeId === sizeId);
+    const next = entries.find(
+      (candidate) =>
+        candidate.boardName === state.boardName && candidate.layoutId === state.layoutId && candidate.sizeId === sizeId,
+    );
     if (!next) return;
     dispatch({ type: 'selectSize', entry: next });
-    // Picking a size is also picking a board, because a catalogue entry names
-    // both. Today every entry is a Kilter Homewall so this branch never fires,
-    // and `board` would be the one step in the funnel contract that never
-    // appears — leaving a gap in the funnel the day a second board goes on
-    // sale and the size select starts spanning two of them.
-    if (next.boardName !== entry.boardName) reportStep('board');
     reportStep('size');
+  };
+
+  const handleLayoutChange = (layoutId: number) => {
+    const next = entries.find(
+      (candidate) => candidate.boardName === state.boardName && candidate.layoutId === layoutId,
+    );
+    if (!next) return;
+    dispatch({ type: 'selectSize', entry: next });
+    reportStep('board');
   };
 
   const handleAddArtwork = () => {
@@ -483,7 +488,17 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
                 description={t('configurator.wall.help')}
               />
               <Box className={styles.stepBody}>
-                <WallStep entries={entries} state={state} onSizeChange={handleSizeChange} />
+                <WallStep
+                  entries={entries}
+                  state={state}
+                  onSizeChange={handleSizeChange}
+                  onLayoutChange={handleLayoutChange}
+                />
+                {entry.layoutId === 1 && (
+                  <Typography variant="body2" component="p" className={styles.stepNote}>
+                    {t('configurator.original.drilling')} {t('configurator.original.compatibility')}
+                  </Typography>
+                )}
                 {hasKickerSets(entry) && entry.kickerOptional && (
                   <Box className={styles.switchRow}>
                     <FormControlLabel
@@ -567,7 +582,9 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
                   step={3}
                   done
                   title={t('configurator.engrave.heading')}
-                  description={t('configurator.engrave.help')}
+                  description={
+                    entry.layoutId === 1 ? t('configurator.original.engraveHelp') : t('configurator.engrave.help')
+                  }
                 />
                 <Box className={styles.stepBody}>
                   {engraveToggles.map((option) => (
@@ -586,13 +603,21 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
                             }}
                           />
                         }
-                        label={t(`configurator.options.${option.key}.label`)}
+                        label={
+                          entry.layoutId === 1 && option.key === 'engraveAngleTicks'
+                            ? t('configurator.original.angleLabel')
+                            : t(`configurator.options.${option.key}.label`)
+                        }
                       />
-                      <FormHelperText>{t(`configurator.options.${option.key}.help`)}</FormHelperText>
+                      <FormHelperText>
+                        {entry.layoutId === 1 && option.key === 'engraveAngleTicks'
+                          ? t('configurator.original.angleHelp')
+                          : t(`configurator.options.${option.key}.help`)}
+                      </FormHelperText>
                     </Box>
                   ))}
                   <Typography variant="body2" component="p" className={styles.stepNote}>
-                    {t('configurator.engrave.note')}
+                    {entry.layoutId === 1 ? t('configurator.original.engraveNote') : t('configurator.engrave.note')}
                   </Typography>
                 </Box>
               </SectionCard>
@@ -908,28 +933,41 @@ function WallStep({
   entries,
   state,
   onSizeChange,
+  onLayoutChange,
 }: {
   entries: readonly CncCatalogEntry[];
   state: CncConfiguratorState;
   onSizeChange: (sizeId: number) => void;
+  onLayoutChange: (layoutId: number) => void;
 }) {
   const { t } = useTranslation('cnc');
-  // Boards, not sizes: v1 sells one board, so the board control is a read-only
-  // statement of that rather than a select with a single option pretending to
-  // be a choice. It becomes a select the day a second board is on sale.
-  const boardNames = [...new Set(entries.map((candidate) => getBoardDisplayName(candidate.boardName)))];
+  const layoutIds = [
+    ...new Set(
+      entries.filter((candidate) => candidate.boardName === state.boardName).map((candidate) => candidate.layoutId),
+    ),
+  ];
+  const sizeEntries = entries.filter(
+    (candidate) => candidate.boardName === state.boardName && candidate.layoutId === state.layoutId,
+  );
 
   return (
     <FieldGrid>
-      <Box>
-        <Typography variant="body2" component="p" className={styles.readOnlyLabel}>
-          {t('configurator.board.label')}
-        </Typography>
-        <Typography variant="body1" component="p">
-          {boardNames.join(', ')}
-        </Typography>
+      <FormControl fullWidth size="small">
+        <InputLabel id="cnc-board">{t('configurator.board.label')}</InputLabel>
+        <Select
+          labelId="cnc-board"
+          label={t('configurator.board.label')}
+          value={String(state.layoutId)}
+          onChange={(event) => onLayoutChange(Number(event.target.value))}
+        >
+          {layoutIds.map((layoutId) => (
+            <MenuItem key={layoutId} value={String(layoutId)}>
+              {layoutId === 1 ? t('configurator.board.original') : t('configurator.board.homewall')}
+            </MenuItem>
+          ))}
+        </Select>
         <FormHelperText>{t('configurator.board.help')}</FormHelperText>
-      </Box>
+      </FormControl>
 
       <FormControl fullWidth size="small">
         <InputLabel id="cnc-size">{t('configurator.size.label')}</InputLabel>
@@ -939,7 +977,7 @@ function WallStep({
           value={String(state.sizeId)}
           onChange={(event) => onSizeChange(Number(event.target.value))}
         >
-          {entries.map((candidate) => (
+          {sizeEntries.map((candidate) => (
             <MenuItem key={candidate.sizeId} value={String(candidate.sizeId)}>
               {candidate.label}
             </MenuItem>
@@ -1043,9 +1081,19 @@ function SummaryRail({
     },
   ];
 
+  const spareMountCount = summary?.spareMountCount ?? null;
+  if (spareMountCount !== null && spareMountCount > 0) {
+    items.push({
+      key: 'spareMounts',
+      label: t('configurator.summary.spareMounts'),
+      value: String(spareMountCount),
+      hint: t('configurator.summary.spareMountsHelp'),
+    });
+  }
+
   // Two rows that only exist for some walls, so they are appended rather than
   // held open: a wall with no kicker has no kicker height to skeleton, and a
-  // wall whose seams miss every LED has no notches to explain.
+  // wall whose seams miss every LED has no assembly drilling to explain.
   const kickerHeightMm = summary?.kickerHeightMm ?? null;
   if (kickerHeightMm !== null) {
     items.push({
@@ -1060,10 +1108,17 @@ function SummaryRail({
       key: 'seamNotches',
       label: t('configurator.summary.seamNotches'),
       value: String(seamNotches),
-      // A figure nobody can act on without knowing what it means: a notch on a
-      // seam looks like a mistake on the sheet until you are told the LED goes
-      // in it.
       hint: t('configurator.summary.seamNotchesHelp'),
+    });
+  }
+  const skippedSeamLeds = summary?.skippedSeamLeds ?? null;
+  if (skippedSeamLeds !== null && skippedSeamLeds > 0) {
+    items.push({
+      key: 'skippedSeamLeds',
+      label: t('configurator.summary.skippedSeamLeds'),
+      value: String(skippedSeamLeds),
+      // The assembly instructions retain these positions for drilling after joining panels.
+      hint: t('configurator.summary.skippedSeamLedsHelp'),
     });
   }
 

--- a/packages/web/app/build-plans/configurator/configurator.tsx
+++ b/packages/web/app/build-plans/configurator/configurator.tsx
@@ -67,7 +67,7 @@ import {
   findEntry,
   formatPrice,
   fromDraft,
-  hasKickerSets,
+  supportsKicker,
   initialConfiguratorState,
   isPreviewStale,
   optionValueKey,
@@ -330,7 +330,7 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
         candidate.boardName === state.boardName && candidate.layoutId === state.layoutId && candidate.sizeId === sizeId,
     );
     if (!next) return;
-    dispatch({ type: 'selectSize', entry: next });
+    dispatch({ type: 'selectEntry', entry: next });
     reportStep('size');
   };
 
@@ -339,7 +339,7 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
       (candidate) => candidate.boardName === state.boardName && candidate.layoutId === layoutId,
     );
     if (!next) return;
-    dispatch({ type: 'selectSize', entry: next });
+    dispatch({ type: 'selectEntry', entry: next });
     reportStep('board');
   };
 
@@ -502,7 +502,7 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
                     {t('configurator.original.drilling')} {t('configurator.original.compatibility')}
                   </Typography>
                 )}
-                {hasKickerSets(entry) && entry.kickerOptional && (
+                {supportsKicker(entry) && entry.kickerOptional && (
                   <Box className={styles.switchRow}>
                     <FormControlLabel
                       control={

--- a/packages/web/app/build-plans/configurator/configurator.tsx
+++ b/packages/web/app/build-plans/configurator/configurator.tsx
@@ -21,6 +21,7 @@ import Skeleton from '@mui/material/Skeleton';
 import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import { KILTER_ORIGINAL_LAYOUT_ID } from '@boardsesh/board-constants';
 import type {
   CncArtworkKind,
   CncCatalog,
@@ -81,6 +82,7 @@ import {
   type CncArtworkDraft,
   type CncConfiguratorState,
 } from './configurator-state';
+import { boardLayoutLabel } from '../order-display';
 import type { CncErrorKey } from '../cnc-error';
 import type { CncLayoutPanel, CncLayoutSummary } from './layout-summary';
 import ArtworkStep from './artwork-step';
@@ -141,6 +143,7 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
   const entries = catalog.entries;
   const [state, dispatch] = useReducer(configuratorReducer, entries[0], initialConfiguratorState);
   const entry = findEntry(entries, state) ?? entries[0];
+  const isOriginal = entry.boardName === 'kilter' && entry.layoutId === KILTER_ORIGINAL_LAYOUT_ID;
 
   const configInput = useMemo(() => toBoardConfigInput(state, entry), [state, entry]);
   const currentConfigKey = useMemo(() => configKey(configInput), [configInput]);
@@ -494,7 +497,7 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
                   onSizeChange={handleSizeChange}
                   onLayoutChange={handleLayoutChange}
                 />
-                {entry.layoutId === 1 && (
+                {isOriginal && (
                   <Typography variant="body2" component="p" className={styles.stepNote}>
                     {t('configurator.original.drilling')} {t('configurator.original.compatibility')}
                   </Typography>
@@ -582,9 +585,7 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
                   step={3}
                   done
                   title={t('configurator.engrave.heading')}
-                  description={
-                    entry.layoutId === 1 ? t('configurator.original.engraveHelp') : t('configurator.engrave.help')
-                  }
+                  description={isOriginal ? t('configurator.original.engraveHelp') : t('configurator.engrave.help')}
                 />
                 <Box className={styles.stepBody}>
                   {engraveToggles.map((option) => (
@@ -604,20 +605,20 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
                           />
                         }
                         label={
-                          entry.layoutId === 1 && option.key === 'engraveAngleTicks'
+                          isOriginal && option.key === 'engraveAngleTicks'
                             ? t('configurator.original.angleLabel')
                             : t(`configurator.options.${option.key}.label`)
                         }
                       />
                       <FormHelperText>
-                        {entry.layoutId === 1 && option.key === 'engraveAngleTicks'
+                        {isOriginal && option.key === 'engraveAngleTicks'
                           ? t('configurator.original.angleHelp')
                           : t(`configurator.options.${option.key}.help`)}
                       </FormHelperText>
                     </Box>
                   ))}
                   <Typography variant="body2" component="p" className={styles.stepNote}>
-                    {entry.layoutId === 1 ? t('configurator.original.engraveNote') : t('configurator.engrave.note')}
+                    {isOriginal ? t('configurator.original.engraveNote') : t('configurator.engrave.note')}
                   </Typography>
                 </Box>
               </SectionCard>
@@ -962,7 +963,7 @@ function WallStep({
         >
           {layoutIds.map((layoutId) => (
             <MenuItem key={layoutId} value={String(layoutId)}>
-              {layoutId === 1 ? t('configurator.board.original') : t('configurator.board.homewall')}
+              {boardLayoutLabel({ boardName: state.boardName, layoutId }, t)}
             </MenuItem>
           ))}
         </Select>

--- a/packages/web/app/build-plans/configurator/layout-model.ts
+++ b/packages/web/app/build-plans/configurator/layout-model.ts
@@ -92,9 +92,13 @@ function readHoles(raw: unknown): { holes: HoleMm[]; holePanelIndex: number[] } 
     const yMm = readNumber(hole, 'y_mm');
     const keepoutRadiusMm = readNumber(hole, 'keepout_radius_mm');
     const panelIndex = readNumber(hole, 'panel_index');
+    const diameterMm = readNumber(hole, 'diameter_mm');
+    const kind = readString(hole, 'kind');
     if (xMm === null || yMm === null || keepoutRadiusMm === null || panelIndex === null) return;
     holes.push({
       id: `${readString(hole, 'kind') ?? 'hole'}-${String(position)}`,
+      ...(diameterMm !== null && diameterMm > 0 ? { diameterMm } : {}),
+      ...(kind !== null ? { kind } : {}),
       xMm,
       yMm,
       keepoutRadiusMm,

--- a/packages/web/app/build-plans/configurator/layout-model.ts
+++ b/packages/web/app/build-plans/configurator/layout-model.ts
@@ -96,7 +96,7 @@ function readHoles(raw: unknown): { holes: HoleMm[]; holePanelIndex: number[] } 
     const kind = readString(hole, 'kind');
     if (xMm === null || yMm === null || keepoutRadiusMm === null || panelIndex === null) return;
     holes.push({
-      id: `${readString(hole, 'kind') ?? 'hole'}-${String(position)}`,
+      id: `${kind ?? 'hole'}-${String(position)}`,
       ...(diameterMm !== null && diameterMm > 0 ? { diameterMm } : {}),
       ...(kind !== null ? { kind } : {}),
       xMm,

--- a/packages/web/app/build-plans/configurator/layout-summary.ts
+++ b/packages/web/app/build-plans/configurator/layout-summary.ts
@@ -125,7 +125,7 @@ export function readLayoutSummary(layout: unknown): CncLayoutSummary {
     warnings: Array.isArray(warnings)
       ? warnings.flatMap((entry) => {
           const message = typeof entry === 'string' ? entry : readString(readRecord(entry), 'message');
-          return message === null ? [] : [message];
+          return message === null || message.trim().length === 0 ? [] : [message];
         })
       : [],
   };

--- a/packages/web/app/build-plans/configurator/layout-summary.ts
+++ b/packages/web/app/build-plans/configurator/layout-summary.ts
@@ -42,15 +42,10 @@ export type CncLayoutSummary = {
   sheets: number | null;
   tnutCount: number | null;
   ledCount: number | null;
-  /**
-   * LED holes that land on a panel seam.
-   *
-   * Not a count of anything lost: the generator cuts each of these as a
-   * notch in both neighbouring panels, and the LED drops into the notch once
-   * the wall is bolted together. It is on the card because a notch is a thing
-   * somebody will see on their sheets and wonder about.
-   */
+  /** LED holes cut as notches across adjoining panels. */
   seamNotches: number | null;
+  skippedSeamLeds: number | null;
+  spareMountCount: number | null;
   /** Every panel, in the generator's own order. Empty when the response had none. */
   panels: CncLayoutPanel[];
   warnings: string[];
@@ -122,9 +117,16 @@ export function readLayoutSummary(layout: unknown): CncLayoutSummary {
     panelCount: Array.isArray(panels) ? panels.length : null,
     panels: readPanels(panels),
     sheets: readNumber(bom, 'sheets'),
-    tnutCount: readNumber(bom, 'tnut_count'),
-    ledCount: readNumber(bom, 'led_count'),
+    tnutCount: readNumber(bom, 'installed_tnut_count') ?? readNumber(bom, 'tnut_count'),
+    ledCount: readNumber(bom, 'installed_led_count') ?? readNumber(bom, 'led_count'),
+    spareMountCount: readNumber(bom, 'spare_mount_count'),
+    skippedSeamLeds: readNumber(bom, 'skipped_seam_leds'),
     seamNotches: readNumber(bom, 'seam_notches'),
-    warnings: Array.isArray(warnings) ? warnings.filter((entry): entry is string => typeof entry === 'string') : [],
+    warnings: Array.isArray(warnings)
+      ? warnings.flatMap((entry) => {
+          const message = typeof entry === 'string' ? entry : readString(readRecord(entry), 'message');
+          return message === null ? [] : [message];
+        })
+      : [],
   };
 }

--- a/packages/web/app/build-plans/configurator/placement-editor/geometry.ts
+++ b/packages/web/app/build-plans/configurator/placement-editor/geometry.ts
@@ -60,6 +60,9 @@ export type SeamLineMm = {
 /** A drilled hole reduced to what a keep-out test needs, plus an id to point at. */
 export type HoleMm = {
   id: string;
+  /** Actual bore, separate from the artwork clearance. Optional for older generators. */
+  diameterMm?: number;
+  kind?: string;
   xMm: number;
   yMm: number;
   keepoutRadiusMm: number;

--- a/packages/web/app/build-plans/configurator/placement-editor/wall-svg.tsx
+++ b/packages/web/app/build-plans/configurator/placement-editor/wall-svg.tsx
@@ -346,15 +346,28 @@ export default function WallSvg({
         ))}
 
         {holes.map((hole) => (
-          <circle
-            key={hole.id}
-            data-testid="cnc-hole"
-            cx={hole.xMm}
-            cy={hole.yMm}
-            r={hole.keepoutRadiusMm}
-            fill={collidingHoles.has(hole.id) ? theme.palette.error.main : theme.palette.action.disabledBackground}
-            fillOpacity={collidingHoles.has(hole.id) ? 0.55 : 0.35}
-          />
+          <g key={hole.id}>
+            <circle
+              data-testid="cnc-hole"
+              cx={hole.xMm}
+              cy={hole.yMm}
+              r={hole.keepoutRadiusMm}
+              fill={collidingHoles.has(hole.id) ? theme.palette.error.main : theme.palette.action.disabledBackground}
+              fillOpacity={collidingHoles.has(hole.id) ? 0.55 : 0.35}
+            />
+            {hole.diameterMm !== undefined && (
+              <circle
+                data-testid="cnc-bore"
+                data-kind={hole.kind}
+                cx={hole.xMm}
+                cy={hole.yMm}
+                r={hole.diameterMm / 2}
+                fill={theme.palette.background.paper}
+                stroke={theme.palette.text.secondary}
+                strokeWidth={1}
+              />
+            )}
+          </g>
         ))}
       </g>
 

--- a/packages/web/app/build-plans/order-display.ts
+++ b/packages/web/app/build-plans/order-display.ts
@@ -1,3 +1,4 @@
+import { KILTER_HOMEWALL_LAYOUT_ID, KILTER_ORIGINAL_LAYOUT_ID } from '@boardsesh/board-constants';
 import { getBoardDisplayName } from '@boardsesh/climb-actions';
 import type { CncCatalog, CncLicenceTier, CncOrderStatus } from '@boardsesh/shared-schema';
 
@@ -127,12 +128,18 @@ export function finaliseHref(licenceId: string): string {
 
 /** i18n-keep cnc:configurator.board.original
  * i18n-keep cnc:configurator.board.homewall
+ * i18n-keep cnc:configurator.board.unknownLayout
  */
 export function boardLayoutLabel(
   order: { boardName: string; layoutId: number },
-  translate: (key: string) => string,
+  translate: (key: string, options?: Record<string, unknown>) => string,
 ): string {
-  if (order.boardName === 'kilter' && order.layoutId === 1) return translate('configurator.board.original');
-  if (order.boardName === 'kilter' && order.layoutId === 8) return translate('configurator.board.homewall');
-  return getBoardDisplayName(order.boardName);
+  if (order.boardName === 'kilter' && order.layoutId === KILTER_ORIGINAL_LAYOUT_ID)
+    return translate('configurator.board.original');
+  if (order.boardName === 'kilter' && order.layoutId === KILTER_HOMEWALL_LAYOUT_ID)
+    return translate('configurator.board.homewall');
+  return translate('configurator.board.unknownLayout', {
+    board: getBoardDisplayName(order.boardName),
+    layoutId: order.layoutId,
+  });
 }

--- a/packages/web/app/build-plans/order-display.ts
+++ b/packages/web/app/build-plans/order-display.ts
@@ -1,3 +1,4 @@
+import { getBoardDisplayName } from '@boardsesh/climb-actions';
 import type { CncCatalog, CncLicenceTier, CncOrderStatus } from '@boardsesh/shared-schema';
 
 /**
@@ -122,4 +123,16 @@ export function newestPreviewReadyLicenceId(
  */
 export function finaliseHref(licenceId: string): string {
   return `/build-plans?order=${encodeURIComponent(licenceId)}`;
+}
+
+/** i18n-keep cnc:configurator.board.original
+ * i18n-keep cnc:configurator.board.homewall
+ */
+export function boardLayoutLabel(
+  order: { boardName: string; layoutId: number },
+  translate: (key: string) => string,
+): string {
+  if (order.boardName === 'kilter' && order.layoutId === 1) return translate('configurator.board.original');
+  if (order.boardName === 'kilter' && order.layoutId === 8) return translate('configurator.board.homewall');
+  return getBoardDisplayName(order.boardName);
 }

--- a/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
+++ b/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
@@ -7,7 +7,6 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import MuiLink from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
-import { getBoardDisplayName } from '@boardsesh/climb-actions';
 import type { CncDownloadKind, CncOrder, CncOrderStatus } from '@boardsesh/shared-schema';
 import {
   CREATE_CNC_DOWNLOAD_GRANT,
@@ -20,7 +19,7 @@ import { createGraphQLHttpClient, getGraphQLHttpUrl } from '@/app/lib/graphql/cl
 import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
 import { cncErrorKey, type CncErrorKey } from '../../cnc-error';
 import { createOrderDateFormatter } from '../../format-date';
-import { finaliseHref, previewImageLabel, tierLabel } from '../../order-display';
+import { boardLayoutLabel, finaliseHref, previewImageLabel, tierLabel } from '../../order-display';
 import { KeyValueList, PageFrame, PreviewGallery, SectionCard, StatusChip, type KeyValueItem } from '../../ui';
 import { orderRefetchInterval, useCncOrderPoll } from '../../use-cnc-order-poll';
 import styles from '../orders.module.css';
@@ -169,7 +168,7 @@ export default function OrderStatus({ initialOrder, wallLabel, checkoutOutcome, 
   const previewFailedSubject = encodeURIComponent(t('order.previewFailed.subject', { licenceId }));
 
   const facts: KeyValueItem[] = [
-    { key: 'board', label: t('order.board'), value: `${getBoardDisplayName(order.boardName)} ${wallLabel}` },
+    { key: 'board', label: t('order.board'), value: `${boardLayoutLabel(order, t)} ${wallLabel}` },
     { key: 'tier', label: t('order.tier'), value: tierLabel(order.tier, t) },
   ];
   // Chronological, because these are two moments in one order's life and a
@@ -230,6 +229,11 @@ export default function OrderStatus({ initialOrder, wallLabel, checkoutOutcome, 
 
       <SectionCard title={t('order.facts.heading')} headingLevel="h2">
         <KeyValueList items={facts} aria-label={t('order.facts.heading')} />
+        {order.boardName === 'kilter' && order.layoutId === 1 && (
+          <Typography variant="body2" component="p" className={styles.timelineNote}>
+            {t('configurator.original.drilling')} {t('configurator.original.compatibility')}
+          </Typography>
+        )}
       </SectionCard>
 
       <SectionCard title={t('order.timeline.heading')} headingLevel="h2">

--- a/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
+++ b/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
@@ -7,6 +7,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import MuiLink from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
+import { KILTER_ORIGINAL_LAYOUT_ID } from '@boardsesh/board-constants';
 import type { CncDownloadKind, CncOrder, CncOrderStatus } from '@boardsesh/shared-schema';
 import {
   CREATE_CNC_DOWNLOAD_GRANT,
@@ -229,7 +230,7 @@ export default function OrderStatus({ initialOrder, wallLabel, checkoutOutcome, 
 
       <SectionCard title={t('order.facts.heading')} headingLevel="h2">
         <KeyValueList items={facts} aria-label={t('order.facts.heading')} />
-        {order.boardName === 'kilter' && order.layoutId === 1 && (
+        {order.boardName === 'kilter' && order.layoutId === KILTER_ORIGINAL_LAYOUT_ID && (
           <Typography variant="body2" component="p" className={styles.timelineNote}>
             {t('configurator.original.drilling')} {t('configurator.original.compatibility')}
           </Typography>

--- a/packages/web/app/build-plans/orders/orders-list.tsx
+++ b/packages/web/app/build-plans/orders/orders-list.tsx
@@ -4,12 +4,18 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import MuiLink from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
-import { getBoardDisplayName } from '@boardsesh/climb-actions';
 import type { CncCatalog, CncOrder } from '@boardsesh/shared-schema';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { createOrderDateFormatter } from '../format-date';
-import { finaliseHref, isPreviewStatus, newestPreviewReadyLicenceId, tierLabel, wallLabel } from '../order-display';
+import {
+  boardLayoutLabel,
+  finaliseHref,
+  isPreviewStatus,
+  newestPreviewReadyLicenceId,
+  tierLabel,
+  wallLabel,
+} from '../order-display';
 import { EmptyPanel, SectionCard, StatusChip } from '../ui';
 import styles from './orders.module.css';
 
@@ -77,7 +83,7 @@ export default async function OrdersList({
                   {order.licenceId}
                 </Typography>
                 <Typography variant="body2" component="p" className={styles.rowMeta}>
-                  {`${getBoardDisplayName(order.boardName)} ${wallLabel(catalog, order)} · ${tierLabel(order.tier, t)}`}
+                  {`${boardLayoutLabel(order, t)} ${wallLabel(catalog, order)} · ${tierLabel(order.tier, t)}`}
                 </Typography>
                 <Typography variant="body2" component="p" className={styles.rowMeta}>
                   {dateLine}

--- a/packages/web/app/components/admin/__tests__/build-plans-panel.test.tsx
+++ b/packages/web/app/components/admin/__tests__/build-plans-panel.test.tsx
@@ -275,3 +275,9 @@ describe('BuildPlansPanel', () => {
     expect(screen.getByRole('button', { name: 'Retry' })).toBeDefined();
   });
 });
+
+it('uses CNC translations for the Original layout in the admin queue', async () => {
+  mockRequest.mockResolvedValue(page([makeEntry({}, { layoutId: 1, sizeId: 28, setIds: '1,20' })]));
+  renderPanel();
+  expect(await screen.findByText('Kilter Original (OG) 28')).toBeDefined();
+});

--- a/packages/web/app/components/admin/build-plans-panel.tsx
+++ b/packages/web/app/components/admin/build-plans-panel.tsx
@@ -21,7 +21,6 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
-import { getBoardDisplayName } from '@boardsesh/climb-actions';
 import {
   ADMIN_CNC_ORDERS,
   REGENERATE_CNC_PACK,
@@ -35,7 +34,7 @@ import LocaleLink from '@/app/components/i18n/locale-link';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { createOrderDateFormatter } from '@/app/build-plans/format-date';
-import { tierLabel, wallLabel } from '@/app/build-plans/order-display';
+import { boardLayoutLabel, tierLabel, wallLabel } from '@/app/build-plans/order-display';
 import { SectionCard, StatusChip } from '@/app/build-plans/ui';
 
 /**
@@ -273,9 +272,7 @@ export default function BuildPlansPanel({ catalog, locale }: { catalog: CncCatal
                       yet is a free preview, and the old ternary labelled every
                       one of them "Commercial, single build". */}
                     <TableCell>{tierLabel(entry.order.tier, tCnc)}</TableCell>
-                    <TableCell>
-                      {`${getBoardDisplayName(entry.order.boardName)} ${wallLabel(catalog, entry.order)}`}
-                    </TableCell>
+                    <TableCell>{`${boardLayoutLabel(entry.order, tCnc)} ${wallLabel(catalog, entry.order)}`}</TableCell>
                     <TableCell>
                       <StatusChip status={entry.order.status} label={statusLabel(tCnc, entry.order.status)} />
                     </TableCell>


### PR DESCRIPTION
## Summary

Build Plans now offers Kilter Original 7×10, 8×12, 12×12, and 16×12 alongside Homewall. Original orders preserve an explicit kicker choice because hands and feet share their sets with the kicker. Layout changes reset incompatible artwork and preview state.

Original previews show 13 mm dual-purpose foot centers with vertical LED pairs, the matching Homewall drilling footprint, and installed hardware separately from spare holes. Order history, admin, and all four locales identify the layout and explain the drilling choices. Existing Homewall defaults and pricing remain unchanged.

Stacked on #5236 (`feat/cnc-packs-integration`). Companion: https://github.com/boardsesh/climbing-wall-panels-scad-model/pull/2. Requires that models change before enabling Original orders in production; deploy the generator first. The original feature flag remains the access gate.

Validation: 199 focused backend tests; web/configurator/admin and locale regression tests; `vp check`; all package and root-script TypeScript checks without starting a Next build; pre-commit lint, formatting, and translation checks. Independent UI and geometry review completed.

## Release Notes

Build panels for Kilter Original with spare drilling for a future Homewall setup.

## Test plan

1. Build Plans → choose Original; four board sizes appear.
2. Select 8×12 → disable kicker; preview removes the kicker.
3. Inspect hardware summary → installed hardware and spare holes appear separately.
4. Switch to Homewall → its sizes and machining defaults appear.
5. Open an Original order → layout, kicker, and drilling notes appear.

## Risk

Risk: 3/5 — adds manufacturing catalogue entries and worker payload options; deploy generator first.
