### PR TITLE
fix(backend): read no-match from characteristics, not just the description

### DIFF
--- a/packages/backend/src/__tests__/no-match-characteristics-payloads.test.ts
+++ b/packages/backend/src/__tests__/no-match-characteristics-payloads.test.ts
@@ -19,8 +19,12 @@ import { sessionFeedQueries } from '../graphql/resolvers/social/session-feed';
 const RUN_ID = crypto.randomUUID().slice(0, 8);
 // Per-run layout id, so `cleanup()` can wipe the whole layout — which is what
 // makes it leak-proof when a run dies before afterAll — without a concurrent
-// run on a shared DB ever deleting fixtures out from under this one.
-const LAYOUT_ID = 900000 + (parseInt(RUN_ID, 16) % 1000);
+// run on a shared DB ever deleting fixtures out from under this one. The range
+// is 50M wide (1-in-50M collision, off a 32-bit run id) and each of the two
+// no-match test files owns a disjoint band, so they cannot collide with each
+// other at all. Rows leaked by a crashed run land on a layout nobody queries
+// again, so they can never reach an assertion.
+const LAYOUT_ID = 900000000 + (parseInt(RUN_ID, 16) % 50_000_000);
 const OWNER_ID = `nm5127-owner-${RUN_ID}`;
 const BOARD_UUID = `nm5127-board-${RUN_ID}`;
 // The description that made the two disagree: the rule is declared after prose.

--- a/packages/backend/src/__tests__/no-match-characteristics-payloads.test.ts
+++ b/packages/backend/src/__tests__/no-match-characteristics-payloads.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import { db } from '../db/client';
+import { newClimbSubscriptionResolvers } from '../graphql/resolvers/social/new-climb-subscriptions';
+import { sessionFeedQueries } from '../graphql/resolvers/social/session-feed';
+
+/**
+ * #5127 review gap: feed / tick / notification payloads derived `isNoMatch` from
+ * the description alone, so a climb whose author turned the rule OFF — the editor
+ * stores `[]` while keeping the setter's prose — published `isNoMatch: true` while
+ * the climb view said false. Every payload now goes through resolveClimbNoMatch,
+ * which needs `characteristics` selected in the query behind it.
+ *
+ * Real Postgres on purpose: a missing column in the drizzle select, or a typo'd
+ * alias in the raw-SQL select list, reads back as `undefined` and silently falls
+ * back to the description — exactly the bug. A mock cannot see that.
+ */
+
+const RUN_ID = crypto.randomUUID().slice(0, 8);
+const LAYOUT_ID = 900127;
+const OWNER_ID = `nm5127-owner-${RUN_ID}`;
+const BOARD_UUID = `nm5127-board-${RUN_ID}`;
+// The description that made the two disagree: the rule is declared after prose.
+const TRAILING_NO_MATCH = 'Kick board is off. No matching.';
+const CLIMB_EXPLICIT_FALSE = `nm5127-climb-off-${RUN_ID}`;
+const CLIMB_NULL_ARRAY = `nm5127-climb-null-${RUN_ID}`;
+const CLIMB_EXPLICIT_TRUE = `nm5127-climb-on-${RUN_ID}`;
+const SESSION_EXPLICIT_FALSE = `nm5127-session-off-${RUN_ID}`;
+const SESSION_NULL_ARRAY = `nm5127-session-null-${RUN_ID}`;
+
+let boardId: number;
+
+type NewClimbFeedItem = { uuid: string; isNoMatch: boolean };
+type SessionFeedResult = {
+  sessions: Array<{ sessionId: string; hardestSend: { climbUuid: string; isNoMatch: boolean } | null }>;
+};
+
+async function insertClimb(uuid: string, characteristics: string | null, description: string): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO board_climbs
+      (uuid, board_type, layout_id, angle, setter_username, name, description, characteristics, frames, is_draft, is_listed, created_at)
+    VALUES (
+      ${uuid}, 'kilter', ${LAYOUT_ID}, 40, 'nm5127-setter', 'No-match fixture', ${description},
+      ${characteristics}::text[], 'p1080r12', false, true, '2026-01-01'
+    )
+    ON CONFLICT (uuid) DO NOTHING
+  `);
+}
+
+async function insertSessionWithSend(sessionId: string, climbUuid: string, climbedAt: string): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO board_sessions (id, board_path, created_by_user_id, name, board_id, status)
+    VALUES (${sessionId}, ${`kilter/${LAYOUT_ID}/10/1,20/40`}, ${OWNER_ID}, 'No-match fixture session', ${boardId}, 'active')
+    ON CONFLICT (id) DO NOTHING
+  `);
+  await db.execute(sql`
+    INSERT INTO boardsesh_ticks
+      (uuid, user_id, board_type, board_id, climb_uuid, angle, status, attempt_count, difficulty, climbed_at, session_id)
+    VALUES (${`${sessionId}-tick`}, ${OWNER_ID}, 'kilter', ${boardId}, ${climbUuid}, 40, 'send', 1, 20, ${climbedAt}, ${sessionId})
+    ON CONFLICT (uuid) DO NOTHING
+  `);
+}
+
+// Scoped to the fixture LAYOUT_ID, not to this run's uuids: a run that dies
+// between beforeAll and afterAll would otherwise strand its rows forever, and
+// newClimbFeed reads this layout with a fixed limit — enough leaked runs and the
+// current one falls off the page.
+async function cleanup(): Promise<void> {
+  await db.execute(sql`DELETE FROM boardsesh_ticks WHERE climb_uuid IN (
+    SELECT uuid FROM board_climbs WHERE board_type = 'kilter' AND layout_id = ${LAYOUT_ID})`);
+  await db.execute(sql`DELETE FROM board_sessions WHERE created_by_user_id = ${OWNER_ID}`);
+  await db.execute(sql`DELETE FROM board_climbs WHERE board_type = 'kilter' AND layout_id = ${LAYOUT_ID}`);
+  await db.execute(sql`DELETE FROM user_boards WHERE owner_id = ${OWNER_ID}`);
+  await db.execute(sql`DELETE FROM "users" WHERE id = ${OWNER_ID}`);
+}
+
+describe('no-match payloads read characteristics, not just the description (#5127)', () => {
+  beforeAll(async () => {
+    await cleanup();
+
+    await db.execute(sql`
+      INSERT INTO "users" (id, email, name, created_at, updated_at)
+      VALUES (${OWNER_ID}, ${`${OWNER_ID}@test.invalid`}, 'No-match fixture owner', now(), now())
+      ON CONFLICT (id) DO NOTHING
+    `);
+    const boardRows = await db.execute(sql`
+      INSERT INTO user_boards (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name)
+      VALUES (${BOARD_UUID}, ${`nm5127-${RUN_ID}`}, ${OWNER_ID}, 'kilter', ${LAYOUT_ID}, 10, '1,20', 'No-match fixture board')
+      ON CONFLICT (uuid) DO UPDATE SET slug = excluded.slug
+      RETURNING id
+    `);
+    boardId = Number(Array.from(boardRows as Iterable<{ id: number }>)[0].id);
+
+    // The author turned the rule off; the prose still declares it.
+    await insertClimb(CLIMB_EXPLICIT_FALSE, '{}', TRAILING_NO_MATCH);
+    // Never edited on Boardsesh — the Aurora description is all there is.
+    await insertClimb(CLIMB_NULL_ARRAY, null, TRAILING_NO_MATCH);
+    // The rule is on, and the description says nothing about it.
+    await insertClimb(CLIMB_EXPLICIT_TRUE, '{no_match}', 'Crimpy start, big move off the gaston');
+
+    await insertSessionWithSend(SESSION_EXPLICIT_FALSE, CLIMB_EXPLICIT_FALSE, '2026-02-01 10:00:00');
+    await insertSessionWithSend(SESSION_NULL_ARRAY, CLIMB_NULL_ARRAY, '2026-02-02 10:00:00');
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it('newClimbFeed lets an empty characteristics array override the prose', async () => {
+    const result = (await newClimbSubscriptionResolvers.Query.newClimbFeed(null, {
+      input: { boardType: 'kilter', layoutId: LAYOUT_ID, limit: 100 },
+    })) as { items: NewClimbFeedItem[] };
+
+    const byUuid = new Map(result.items.map((item) => [item.uuid, item.isNoMatch]));
+    expect(byUuid.get(CLIMB_EXPLICIT_FALSE)).toBe(false);
+    // Same description, no array — the Aurora fallback still applies.
+    expect(byUuid.get(CLIMB_NULL_ARRAY)).toBe(true);
+    // The array is authoritative in both directions.
+    expect(byUuid.get(CLIMB_EXPLICIT_TRUE)).toBe(true);
+  });
+
+  it("sessionGroupedFeed's hardest send reads the array through the raw-SQL select list", async () => {
+    const result = (await sessionFeedQueries.sessionGroupedFeed(null, {
+      input: { boardUuid: BOARD_UUID, limit: 50 },
+    })) as SessionFeedResult;
+
+    const sends = new Map(result.sessions.map((session) => [session.sessionId, session.hardestSend]));
+    expect(sends.get(SESSION_EXPLICIT_FALSE)?.climbUuid).toBe(CLIMB_EXPLICIT_FALSE);
+    expect(sends.get(SESSION_EXPLICIT_FALSE)?.isNoMatch).toBe(false);
+    expect(sends.get(SESSION_NULL_ARRAY)?.climbUuid).toBe(CLIMB_NULL_ARRAY);
+    expect(sends.get(SESSION_NULL_ARRAY)?.isNoMatch).toBe(true);
+  });
+});

--- a/packages/backend/src/__tests__/no-match-characteristics-payloads.test.ts
+++ b/packages/backend/src/__tests__/no-match-characteristics-payloads.test.ts
@@ -17,7 +17,10 @@ import { sessionFeedQueries } from '../graphql/resolvers/social/session-feed';
  */
 
 const RUN_ID = crypto.randomUUID().slice(0, 8);
-const LAYOUT_ID = 900127;
+// Per-run layout id, so `cleanup()` can wipe the whole layout — which is what
+// makes it leak-proof when a run dies before afterAll — without a concurrent
+// run on a shared DB ever deleting fixtures out from under this one.
+const LAYOUT_ID = 900000 + (parseInt(RUN_ID, 16) % 1000);
 const OWNER_ID = `nm5127-owner-${RUN_ID}`;
 const BOARD_UUID = `nm5127-board-${RUN_ID}`;
 // The description that made the two disagree: the rule is declared after prose.

--- a/packages/backend/src/__tests__/no-match-characteristics-producers.test.ts
+++ b/packages/backend/src/__tests__/no-match-characteristics-producers.test.ts
@@ -22,7 +22,10 @@ import { setterFollowQueries } from '../graphql/resolvers/social/setter-follows'
 const RUN_ID = crypto.randomUUID().slice(0, 8);
 // Deliberately not the layout the payload test uses — the two files clean up by
 // layout id and can run against the same database.
-const LAYOUT_ID = 900128;
+// Per-run layout id, so `cleanup()` can wipe the whole layout — which is what
+// makes it leak-proof when a run dies before afterAll — without a concurrent
+// run on a shared DB ever deleting fixtures out from under this one.
+const LAYOUT_ID = 901000 + (parseInt(RUN_ID, 16) % 1000);
 const OWNER_ID = `nm5127p-owner-${RUN_ID}`;
 const SETTER = `nm5127p-setter-${RUN_ID}`;
 const ANGLE = 40;

--- a/packages/backend/src/__tests__/no-match-characteristics-producers.test.ts
+++ b/packages/backend/src/__tests__/no-match-characteristics-producers.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { Climb, ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { resolvers } from '../graphql/resolvers/index';
+import { favoriteClimbsQuery } from '../graphql/resolvers/favorites/favorite-climbs-query';
+import { hydrateClimbsByRefs } from '../graphql/resolvers/playlists/helpers/hydrate-climbs';
+import { setterFollowQueries } from '../graphql/resolvers/social/setter-follows';
+
+/**
+ * #5127 review gap, second layer: `Climb.is_no_match` reads `characteristics`
+ * off the parent object, and every field on that parent is optional. A producer
+ * that never selects the column therefore compiles, and its climbs silently fall
+ * back to Aurora's description convention — so favouriting a climb whose author
+ * turned the rule OFF flipped it back ON.
+ *
+ * Real Postgres on purpose: a column missing from a drizzle select, or from the
+ * raw-SQL select list behind `userClimbs`, reads back as `undefined` and takes
+ * the fallback. Feeding a mock row straight to the mapper cannot see either.
+ */
+
+const RUN_ID = crypto.randomUUID().slice(0, 8);
+// Deliberately not the layout the payload test uses — the two files clean up by
+// layout id and can run against the same database.
+const LAYOUT_ID = 900128;
+const OWNER_ID = `nm5127p-owner-${RUN_ID}`;
+const SETTER = `nm5127p-setter-${RUN_ID}`;
+const ANGLE = 40;
+// The description that made the surfaces disagree: the rule is declared after prose.
+const TRAILING_NO_MATCH = 'Kick board is off. No matching.';
+const CLIMB_EXPLICIT_FALSE = `nm5127p-climb-off-${RUN_ID}`;
+const CLIMB_NULL_ARRAY = `nm5127p-climb-null-${RUN_ID}`;
+const CLIMB_EXPLICIT_TRUE = `nm5127p-climb-on-${RUN_ID}`;
+
+/** Exactly what the `Climb.is_no_match` field resolver computes for this parent. */
+const isNoMatchField = (climb: Climb): boolean => (resolvers.Climb.is_no_match as (parent: Climb) => boolean)(climb);
+
+function makeCtx(): ConnectionContext {
+  return {
+    connectionId: `nm5127p-${RUN_ID}`,
+    isAuthenticated: true,
+    userId: OWNER_ID,
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+  } as unknown as ConnectionContext;
+}
+
+async function insertClimb(uuid: string, characteristics: string | null, description: string): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO board_climbs
+      (uuid, board_type, layout_id, angle, setter_username, user_id, name, description, characteristics,
+       frames, is_draft, is_listed, is_hidden, created_at)
+    VALUES (
+      ${uuid}, 'kilter', ${LAYOUT_ID}, ${ANGLE}, ${SETTER}, ${OWNER_ID}, 'No-match producer fixture', ${description},
+      ${characteristics}::text[], 'p1080r12', false, true, false, '2026-01-01'
+    )
+    ON CONFLICT (uuid) DO NOTHING
+  `);
+}
+
+// Scoped to the fixture layout / owner rather than this run's uuids: a run that
+// dies between beforeAll and afterAll would otherwise strand rows that the next
+// run's setter-wide queries could pick up.
+async function cleanup(): Promise<void> {
+  await db.execute(sql`DELETE FROM user_favorites WHERE user_id = ${OWNER_ID}`);
+  await db.execute(sql`DELETE FROM board_climbs WHERE board_type = 'kilter' AND layout_id = ${LAYOUT_ID}`);
+  await db.execute(sql`DELETE FROM "users" WHERE id = ${OWNER_ID}`);
+}
+
+/**
+ * Every producer must agree with the climb view on all three rows: the array
+ * wins in both directions, and only a NULL array falls back to the prose.
+ */
+function expectNoMatchAgreesWithCharacteristics(climbs: Climb[], surface: string): void {
+  const byUuid = new Map(climbs.map((climb) => [climb.uuid, climb]));
+
+  const turnedOff = byUuid.get(CLIMB_EXPLICIT_FALSE);
+  expect(turnedOff, `${surface} returned the explicit-false climb`).toBeDefined();
+  expect(turnedOff?.characteristics, `${surface} projects characteristics`).toEqual([]);
+  expect(isNoMatchField(turnedOff!), `${surface} is_no_match for the explicit-false climb`).toBe(false);
+
+  const neverEdited = byUuid.get(CLIMB_NULL_ARRAY);
+  expect(neverEdited?.characteristics, `${surface} keeps a NULL array null`).toBeNull();
+  expect(isNoMatchField(neverEdited!), `${surface} is_no_match for the Aurora-only climb`).toBe(true);
+
+  const turnedOn = byUuid.get(CLIMB_EXPLICIT_TRUE);
+  expect(turnedOn?.characteristics, `${surface} projects the no_match token`).toEqual(['no_match']);
+  expect(isNoMatchField(turnedOn!), `${surface} is_no_match for the explicit-true climb`).toBe(true);
+}
+
+describe('Climb producers project characteristics, so is_no_match matches the climb view (#5127)', () => {
+  beforeAll(async () => {
+    await cleanup();
+
+    await db.execute(sql`
+      INSERT INTO "users" (id, email, name, created_at, updated_at)
+      VALUES (${OWNER_ID}, ${`${OWNER_ID}@test.invalid`}, 'No-match producer fixture owner', now(), now())
+      ON CONFLICT (id) DO NOTHING
+    `);
+
+    // The author turned the rule off; the prose still declares it.
+    await insertClimb(CLIMB_EXPLICIT_FALSE, '{}', TRAILING_NO_MATCH);
+    // Never edited on Boardsesh — the Aurora description is all there is.
+    await insertClimb(CLIMB_NULL_ARRAY, null, TRAILING_NO_MATCH);
+    // The rule is on, and the description says nothing about it.
+    await insertClimb(CLIMB_EXPLICIT_TRUE, '{no_match}', 'Crimpy start, big move off the gaston');
+
+    for (const uuid of [CLIMB_EXPLICIT_FALSE, CLIMB_NULL_ARRAY, CLIMB_EXPLICIT_TRUE]) {
+      await db.execute(sql`
+        INSERT INTO user_favorites (user_id, board_name, climb_uuid, angle)
+        VALUES (${OWNER_ID}, 'kilter', ${uuid}, ${ANGLE})
+        ON CONFLICT DO NOTHING
+      `);
+    }
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it('userFavoriteClimbs', async () => {
+    const result = await favoriteClimbsQuery.userFavoriteClimbs(
+      null,
+      { input: { boardName: 'kilter', layoutId: LAYOUT_ID, sizeId: 10, setIds: '1,20', angle: ANGLE, pageSize: 100 } },
+      makeCtx(),
+    );
+
+    expectNoMatchAgreesWithCharacteristics(result.climbs, 'userFavoriteClimbs');
+    // Without boardType the resolver fails open, so a MoonBoard climb whose
+    // prose mentions matching would read as a no-match climb.
+    expect(result.climbs.every((climb) => climb.boardType === 'kilter')).toBe(true);
+  });
+
+  it('playlist climbs (hydrateClimbsByRefs)', async () => {
+    const climbs = await hydrateClimbsByRefs(
+      [CLIMB_EXPLICIT_FALSE, CLIMB_NULL_ARRAY, CLIMB_EXPLICIT_TRUE].map((climbUuid) => ({
+        climbUuid,
+        boardType: 'kilter',
+      })),
+    );
+
+    expectNoMatchAgreesWithCharacteristics(climbs, 'hydrateClimbsByRefs');
+  });
+
+  it('setterClimbsFull, specific-board mode', async () => {
+    const result = await setterFollowQueries.setterClimbsFull(
+      null,
+      { input: { username: SETTER, boardType: 'kilter', layoutId: LAYOUT_ID, angle: ANGLE, limit: 100 } },
+      makeCtx(),
+    );
+
+    expectNoMatchAgreesWithCharacteristics(result.climbs, 'setterClimbsFull (specific board)');
+  });
+
+  it('setterClimbsFull, all-boards mode', async () => {
+    const result = await setterFollowQueries.setterClimbsFull(
+      null,
+      { input: { username: SETTER, limit: 100 } },
+      makeCtx(),
+    );
+
+    expectNoMatchAgreesWithCharacteristics(result.climbs, 'setterClimbsFull (all boards)');
+  });
+
+  it('userClimbs, through the raw-SQL select list', async () => {
+    const result = await setterFollowQueries.userClimbs(null, { input: { userId: OWNER_ID, limit: 100 } }, makeCtx());
+
+    expectNoMatchAgreesWithCharacteristics(result.climbs, 'userClimbs');
+  });
+});

--- a/packages/backend/src/__tests__/no-match-characteristics-producers.test.ts
+++ b/packages/backend/src/__tests__/no-match-characteristics-producers.test.ts
@@ -24,8 +24,12 @@ const RUN_ID = crypto.randomUUID().slice(0, 8);
 // layout id and can run against the same database.
 // Per-run layout id, so `cleanup()` can wipe the whole layout — which is what
 // makes it leak-proof when a run dies before afterAll — without a concurrent
-// run on a shared DB ever deleting fixtures out from under this one.
-const LAYOUT_ID = 901000 + (parseInt(RUN_ID, 16) % 1000);
+// run on a shared DB ever deleting fixtures out from under this one. The range
+// is 50M wide (1-in-50M collision, off a 32-bit run id) and each of the two
+// no-match test files owns a disjoint band, so they cannot collide with each
+// other at all. Rows leaked by a crashed run land on a layout nobody queries
+// again, so they can never reach an assertion.
+const LAYOUT_ID = 950000000 + (parseInt(RUN_ID, 16) % 50_000_000);
 const OWNER_ID = `nm5127p-owner-${RUN_ID}`;
 const SETTER = `nm5127p-setter-${RUN_ID}`;
 const ANGLE = 40;

--- a/packages/backend/src/events/feed-fanout.ts
+++ b/packages/backend/src/events/feed-fanout.ts
@@ -4,7 +4,7 @@ import { db } from '../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { and, eq, or } from 'drizzle-orm';
 import { buildFeedItemMetadata } from './feed-metadata';
-import { isNoMatchClimb, usesAuroraNoMatchDescription } from '../graphql/resolvers/shared/helpers';
+import { resolveClimbNoMatch } from '../graphql/resolvers/shared/helpers';
 import { climbStatsJoinConditions, resolvedClimbAngleSql } from '../db/queries/util/climb-stats-join';
 
 export { buildFeedItemMetadata } from './feed-metadata';
@@ -134,6 +134,7 @@ async function buildNewClimbMetadata(event: SocialEvent): Promise<Record<string,
       angle: resolvedClimbAngleSql,
       frames: dbSchema.boardClimbs.frames,
       description: dbSchema.boardClimbs.description,
+      characteristics: dbSchema.boardClimbs.characteristics,
       isDraft: dbSchema.boardClimbs.isDraft,
       isListed: dbSchema.boardClimbs.isListed,
       difficultyName: dbSchema.boardDifficultyGrades.boulderName,
@@ -168,8 +169,7 @@ async function buildNewClimbMetadata(event: SocialEvent): Promise<Record<string,
     angle: metadata.angle ?? climb.angle ?? null,
     frames: metadata.frames || climb.frames || null,
     difficultyName: metadata.difficultyName || climb.difficultyName || null,
-    isNoMatch:
-      metadata.isNoMatch || (usesAuroraNoMatchDescription(climb.boardType) && isNoMatchClimb(climb.description)),
+    isNoMatch: metadata.isNoMatch || resolveClimbNoMatch(climb.boardType, climb.characteristics, climb.description),
   };
 }
 
@@ -196,6 +196,7 @@ async function getCommentContextMetadata(
         frames: dbSchema.boardClimbs.frames,
         setterUsername: dbSchema.boardClimbs.setterUsername,
         climbDescription: dbSchema.boardClimbs.description,
+        climbCharacteristics: dbSchema.boardClimbs.characteristics,
         climbIsDraft: dbSchema.boardClimbs.isDraft,
         climbIsListed: dbSchema.boardClimbs.isListed,
         difficultyName: dbSchema.boardDifficultyGrades.boulderName,
@@ -239,7 +240,11 @@ async function getCommentContextMetadata(
       frames: tickContext.frames,
       setterUsername: tickContext.setterUsername,
       difficultyName: tickContext.difficultyName,
-      isNoMatch: usesAuroraNoMatchDescription(tickContext.boardType) && isNoMatchClimb(tickContext.climbDescription),
+      isNoMatch: resolveClimbNoMatch(
+        tickContext.boardType,
+        tickContext.climbCharacteristics,
+        tickContext.climbDescription,
+      ),
     };
   }
 
@@ -254,6 +259,7 @@ async function getCommentContextMetadata(
         setterUsername: dbSchema.boardClimbs.setterUsername,
         angle: dbSchema.boardClimbs.angle,
         description: dbSchema.boardClimbs.description,
+        characteristics: dbSchema.boardClimbs.characteristics,
         isDraft: dbSchema.boardClimbs.isDraft,
         isListed: dbSchema.boardClimbs.isListed,
       })
@@ -272,7 +278,7 @@ async function getCommentContextMetadata(
       frames: climbContext.frames,
       setterUsername: climbContext.setterUsername,
       angle: climbContext.angle,
-      isNoMatch: usesAuroraNoMatchDescription(climbContext.boardType) && isNoMatchClimb(climbContext.description),
+      isNoMatch: resolveClimbNoMatch(climbContext.boardType, climbContext.characteristics, climbContext.description),
     };
   }
 
@@ -325,6 +331,7 @@ async function getProposalContextMetadata(proposalUuid: string): Promise<Record<
       frames: dbSchema.boardClimbs.frames,
       setterUsername: dbSchema.boardClimbs.setterUsername,
       description: dbSchema.boardClimbs.description,
+      characteristics: dbSchema.boardClimbs.characteristics,
     })
     .from(dbSchema.climbProposals)
     .leftJoin(
@@ -348,7 +355,11 @@ async function getProposalContextMetadata(proposalUuid: string): Promise<Record<
     layoutId: proposalContext.layoutId,
     frames: proposalContext.frames,
     setterUsername: proposalContext.setterUsername,
-    isNoMatch: usesAuroraNoMatchDescription(proposalContext.boardType) && isNoMatchClimb(proposalContext.description),
+    isNoMatch: resolveClimbNoMatch(
+      proposalContext.boardType,
+      proposalContext.characteristics,
+      proposalContext.description,
+    ),
   };
 }
 

--- a/packages/backend/src/events/feed-fanout.ts
+++ b/packages/backend/src/events/feed-fanout.ts
@@ -169,7 +169,11 @@ async function buildNewClimbMetadata(event: SocialEvent): Promise<Record<string,
     angle: metadata.angle ?? climb.angle ?? null,
     frames: metadata.frames || climb.frames || null,
     difficultyName: metadata.difficultyName || climb.difficultyName || null,
-    isNoMatch: metadata.isNoMatch || resolveClimbNoMatch(climb.boardType, climb.characteristics, climb.description),
+    // Recomputed, never taken from the event: the climb row is right here and its
+    // characteristics array outranks whatever the publisher derived. An `||` here
+    // would let a stale `true` — from an event queued by an older build — win over
+    // an author's explicit "matching is allowed".
+    isNoMatch: resolveClimbNoMatch(climb.boardType, climb.characteristics, climb.description),
   };
 }
 

--- a/packages/backend/src/events/index.ts
+++ b/packages/backend/src/events/index.ts
@@ -16,7 +16,7 @@ import {
   resolveClimbCreatedSubscriptionRecipients,
 } from './recipient-resolution';
 import { isHideProposalEvent } from './notification-worker';
-import { isNoMatchClimb, usesAuroraNoMatchDescription } from '../graphql/resolvers/shared/helpers';
+import { resolveClimbNoMatch } from '../graphql/resolvers/shared/helpers';
 import { logger } from '../utils/logger';
 import { climbStatsJoinConditions, resolvedClimbAngleSql } from '../db/queries/util/climb-stats-join';
 
@@ -159,6 +159,7 @@ async function createInlineNotification(event: SocialEvent): Promise<void> {
             uuid: dbSchema.boardClimbs.uuid,
             name: dbSchema.boardClimbs.name,
             description: dbSchema.boardClimbs.description,
+            characteristics: dbSchema.boardClimbs.characteristics,
             layoutId: dbSchema.boardClimbs.layoutId,
             angle: resolvedClimbAngleSql,
             frames: dbSchema.boardClimbs.frames,
@@ -258,7 +259,7 @@ async function createInlineNotification(event: SocialEvent): Promise<void> {
             angle: climb.angle ?? null,
             frames: climb.frames ?? null,
             difficultyName: climb.difficultyName ?? event.metadata.difficultyName ?? null,
-            isNoMatch: usesAuroraNoMatchDescription(boardType) && isNoMatchClimb(climb.description),
+            isNoMatch: resolveClimbNoMatch(boardType, climb.characteristics, climb.description),
             createdAt: climb.createdAt ?? new Date().toISOString(),
           },
         });

--- a/packages/backend/src/events/notification-worker.ts
+++ b/packages/backend/src/events/notification-worker.ts
@@ -27,7 +27,7 @@ import {
   fanoutNewClimbFeedItems,
   fanoutProposalApprovedFeedItems,
 } from './feed-fanout';
-import { isNoMatchClimb, usesAuroraNoMatchDescription } from '../graphql/resolvers/shared/helpers';
+import { resolveClimbNoMatch } from '../graphql/resolvers/shared/helpers';
 import crypto from 'crypto';
 
 /**
@@ -294,6 +294,7 @@ export class NotificationWorker {
         uuid: dbSchema.boardClimbs.uuid,
         name: dbSchema.boardClimbs.name,
         description: dbSchema.boardClimbs.description,
+        characteristics: dbSchema.boardClimbs.characteristics,
         layoutId: dbSchema.boardClimbs.layoutId,
         angle: resolvedClimbAngleSql,
         frames: dbSchema.boardClimbs.frames,
@@ -355,7 +356,7 @@ export class NotificationWorker {
         angle: climb.angle ?? null,
         frames: climb.frames ?? null,
         difficultyName: climb.difficultyName ?? event.metadata.difficultyName ?? null,
-        isNoMatch: usesAuroraNoMatchDescription(boardType) && isNoMatchClimb(climb.description),
+        isNoMatch: resolveClimbNoMatch(boardType, climb.characteristics, climb.description),
         createdAt: climb.createdAt ?? new Date().toISOString(),
       },
     });

--- a/packages/backend/src/graphql/resolvers/favorites/favorite-climbs-query.ts
+++ b/packages/backend/src/graphql/resolvers/favorites/favorite-climbs-query.ts
@@ -119,6 +119,10 @@ export const favoriteClimbsQuery = {
       framesPace: result.frames_pace ?? null,
       compatibleSizeIds: result.compatible_size_ids ?? null,
       characteristics: result.characteristics ?? null,
+      // Every row is scoped to this board by the join; carrying it keeps
+      // is_no_match from applying Aurora's description convention to a
+      // MoonBoard climb whose prose just happens to mention matching.
+      boardType: boardName,
       angle: input.angle,
       ascensionist_count: Number(result.ascensionist_count || 0),
       difficulty: getGradeLabel(result.difficulty_id),

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -70,7 +70,7 @@ import { integrationMutations } from './integrations/mutations';
 import { betaLinkQueries } from './beta-videos/queries';
 import { instagramBetaImportQueries } from './beta-videos/instagram-beta-import';
 import { syncQueries } from './sync/queries';
-import { isNoMatchClimb, isNoMatch, usesAuroraNoMatchDescription } from './shared/helpers';
+import { resolveClimbNoMatch } from './shared/helpers';
 
 export const resolvers = {
   // Scalar types
@@ -177,20 +177,14 @@ export const resolvers = {
 
   // Climb type resolvers (derived fields)
   Climb: {
-    // Prefer the structured characteristic; fall back to the Aurora description
-    // convention for any parent that didn't select the characteristics array
-    // (or for rows synced before the column was backfilled — the prefix persists).
-    // `boardType` is only populated in multi-board contexts, so the description
-    // fallback fails open when it is absent — today's exact behaviour.
+    // One definition for every surface — see resolveClimbNoMatch.
+    // A parent that doesn't select `characteristics` silently falls back to the
+    // description, so every Climb producer must project the column.
     is_no_match: (climb: {
       characteristics?: string[] | null;
       description?: string | null;
       boardType?: string | null;
-    }) =>
-      climb.characteristics != null
-        ? isNoMatch(climb.characteristics)
-        : (climb.boardType == null || usesAuroraNoMatchDescription(climb.boardType)) &&
-          isNoMatchClimb(climb.description),
+    }) => resolveClimbNoMatch(climb.boardType, climb.characteristics, climb.description),
   },
 
   // Union type resolvers

--- a/packages/backend/src/graphql/resolvers/shared/helpers.ts
+++ b/packages/backend/src/graphql/resolvers/shared/helpers.ts
@@ -13,7 +13,8 @@ import { logger } from '../../../utils/logger';
 export { validateInput, parseArrayTolerant } from '../../../validation/schemas';
 // Re-export MAX_RETRIES from types
 export { MAX_RETRIES } from './types';
-export { isNoMatchClimb, isNoMatch, usesAuroraNoMatchDescription } from '@boardsesh/shared-schema';
+// The one no-match read path — every feed/tick/notification payload goes through it.
+export { resolveClimbNoMatch } from '@boardsesh/shared-schema';
 
 /**
  * Configuration for session membership retry behavior.

--- a/packages/backend/src/graphql/resolvers/social/activity-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/activity-feed.ts
@@ -3,7 +3,7 @@ import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { withSerialPlan } from '@boardsesh/db/queries';
-import { requireAuthenticated, validateInput, isNoMatchClimb, usesAuroraNoMatchDescription } from '../shared/helpers';
+import { requireAuthenticated, validateInput, resolveClimbNoMatch } from '../shared/helpers';
 import { ActivityFeedInputSchema } from '../../../validation/schemas';
 import { encodeCursor, decodeCursor } from '../../../utils/feed-cursor';
 
@@ -75,6 +75,7 @@ type TickJoinRow = {
   userAvatarUrl: string | null;
   climbName: string | null;
   climbDescription: string | null;
+  climbCharacteristics: string[] | null;
   setterUsername: string | null;
   layoutId: number | null;
   frames: string | null;
@@ -89,6 +90,7 @@ function mapTickRowToFeedItem({
   userAvatarUrl,
   climbName,
   climbDescription,
+  climbCharacteristics,
   setterUsername,
   layoutId,
   frames,
@@ -115,7 +117,7 @@ function mapTickRowToFeedItem({
     commentBody: null,
     isMirror: tick.isMirror ?? false,
     isBenchmark: tick.isBenchmark ?? false,
-    isNoMatch: usesAuroraNoMatchDescription(tick.boardType) && isNoMatchClimb(climbDescription),
+    isNoMatch: resolveClimbNoMatch(tick.boardType, climbCharacteristics, climbDescription),
     difficulty: tick.difficulty,
     difficultyName,
     quality: tick.quality,
@@ -261,6 +263,7 @@ export const activityFeedQueries = {
           userAvatarUrl: dbSchema.userProfiles.avatarUrl,
           climbName: dbSchema.boardClimbs.name,
           climbDescription: dbSchema.boardClimbs.description,
+          climbCharacteristics: dbSchema.boardClimbs.characteristics,
           setterUsername: dbSchema.boardClimbs.setterUsername,
           layoutId: dbSchema.boardClimbs.layoutId,
           frames: dbSchema.boardClimbs.frames,

--- a/packages/backend/src/graphql/resolvers/social/new-climb-subscriptions.ts
+++ b/packages/backend/src/graphql/resolvers/social/new-climb-subscriptions.ts
@@ -8,13 +8,7 @@ import type {
 } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
-import {
-  requireAuthenticated,
-  applyRateLimit,
-  validateInput,
-  isNoMatchClimb,
-  usesAuroraNoMatchDescription,
-} from '../shared/helpers';
+import { requireAuthenticated, applyRateLimit, validateInput, resolveClimbNoMatch } from '../shared/helpers';
 import { NewClimbFeedInputSchema, NewClimbSubscriptionInputSchema } from '../../../validation/schemas';
 import { climbStatsJoinConditions, resolvedClimbAngleSql } from '../../../db/queries/util/climb-stats-join';
 
@@ -34,6 +28,7 @@ export const newClimbSubscriptionResolvers = {
           uuid: dbSchema.boardClimbs.uuid,
           name: dbSchema.boardClimbs.name,
           description: dbSchema.boardClimbs.description,
+          characteristics: dbSchema.boardClimbs.characteristics,
           boardType: dbSchema.boardClimbs.boardType,
           layoutId: dbSchema.boardClimbs.layoutId,
           angle: resolvedClimbAngleSql,
@@ -93,7 +88,7 @@ export const newClimbSubscriptionResolvers = {
         angle: c.angle ?? null,
         frames: c.frames ?? null,
         difficultyName: c.difficultyName ?? null,
-        isNoMatch: usesAuroraNoMatchDescription(c.boardType) && isNoMatchClimb(c.description),
+        isNoMatch: resolveClimbNoMatch(c.boardType, c.characteristics, c.description),
         createdAt: c.createdAt ?? new Date().toISOString(),
       }));
 

--- a/packages/backend/src/graphql/resolvers/social/proposals/enrichment.ts
+++ b/packages/backend/src/graphql/resolvers/social/proposals/enrichment.ts
@@ -2,7 +2,7 @@ import { eq, and, sql, inArray, count, isNull } from 'drizzle-orm';
 import { db } from '../../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { resolveCommunitySetting, DEFAULTS } from '../community-settings';
-import { isNoMatchClimb, usesAuroraNoMatchDescription } from '../../shared/helpers';
+import { resolveClimbNoMatch } from '../../shared/helpers';
 
 /**
  * Enrich a single proposal with proposer info, vote counts, climb data, and stats.
@@ -48,6 +48,7 @@ export async function enrichProposal(
       .select({
         name: dbSchema.boardClimbs.name,
         description: dbSchema.boardClimbs.description,
+        characteristics: dbSchema.boardClimbs.characteristics,
         frames: dbSchema.boardClimbs.frames,
         layoutId: dbSchema.boardClimbs.layoutId,
         setterUsername: dbSchema.boardClimbs.setterUsername,
@@ -183,7 +184,7 @@ export async function enrichProposal(
     climbAscensionistCount,
     climbDifficultyError,
     climbBenchmarkDifficulty,
-    climbIsNoMatch: usesAuroraNoMatchDescription(proposal.boardType) && isNoMatchClimb(climb?.description),
+    climbIsNoMatch: resolveClimbNoMatch(proposal.boardType, climb?.characteristics, climb?.description),
     upvoterCount,
     commentCount,
     climbIsHidden: climb?.isHidden ?? false,
@@ -268,6 +269,7 @@ export async function batchEnrichProposals(
       boardType: dbSchema.boardClimbs.boardType,
       name: dbSchema.boardClimbs.name,
       description: dbSchema.boardClimbs.description,
+      characteristics: dbSchema.boardClimbs.characteristics,
       frames: dbSchema.boardClimbs.frames,
       layoutId: dbSchema.boardClimbs.layoutId,
       setterUsername: dbSchema.boardClimbs.setterUsername,
@@ -451,7 +453,7 @@ export async function batchEnrichProposals(
         stats?.benchmarkDifficulty != null && stats.benchmarkDifficulty > 0
           ? String(stats.benchmarkDifficulty)
           : undefined,
-      climbIsNoMatch: usesAuroraNoMatchDescription(proposal.boardType) && isNoMatchClimb(climb?.description),
+      climbIsNoMatch: resolveClimbNoMatch(proposal.boardType, climb?.characteristics, climb?.description),
       upvoterCount: votes.upvoterCount,
       commentCount: commentCountMap.get(proposal.uuid) ?? 0,
       climbIsHidden: climb?.isHidden ?? false,

--- a/packages/backend/src/graphql/resolvers/social/session-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/session-feed.ts
@@ -3,7 +3,7 @@ import { dbRead } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { getGradeLabel, toConfidenceTier, withSerialPlan } from '@boardsesh/db/queries';
 import { rowsFromResult } from '@boardsesh/db/client';
-import { requireAuthenticated, validateInput, isNoMatchClimb, usesAuroraNoMatchDescription } from '../shared/helpers';
+import { requireAuthenticated, validateInput, resolveClimbNoMatch } from '../shared/helpers';
 import { fetchOwnerBoards, toTickBoardCandidate } from '../shared/render-board';
 import { resolveRenderBoard, type RenderBoardCandidate } from '@boardsesh/board-config';
 import { boardseshDifficultyExpr, boardseshConfidenceExpr, boardseshGradeTickJoin } from '../shared/sql-expressions';
@@ -523,6 +523,7 @@ export const sessionFeedQueries = {
         tick: dbSchema.boardseshTicks,
         climbName: dbSchema.boardClimbs.name,
         climbDescription: dbSchema.boardClimbs.description,
+        climbCharacteristics: dbSchema.boardClimbs.characteristics,
         setterUsername: dbSchema.boardClimbs.setterUsername,
         layoutId: dbSchema.boardClimbs.layoutId,
         frames: dbSchema.boardClimbs.frames,
@@ -652,7 +653,7 @@ export const sessionFeedQueries = {
         quality: row.tick.quality,
         isMirror: row.tick.isMirror ?? false,
         isBenchmark: row.tick.isBenchmark ?? false,
-        isNoMatch: usesAuroraNoMatchDescription(row.tick.boardType) && isNoMatchClimb(row.climbDescription),
+        isNoMatch: resolveClimbNoMatch(row.tick.boardType, row.climbCharacteristics, row.climbDescription),
         comment: row.tick.comment || null,
         frames: row.frames || null,
         setterUsername: row.setterUsername || null,
@@ -1156,6 +1157,7 @@ type TickHighlightRow = {
   climbUuid: string;
   climbName: string | null;
   climbDescription: string | null;
+  climbCharacteristics: string[] | null;
   boardType: string;
   layoutId: number | null;
   compatibleSizeIds: number[] | null;
@@ -1218,7 +1220,7 @@ function mapTickHighlightRow(row: TickHighlightRow, ownerBoards: RenderBoardCand
     quality: row.quality,
     isMirror: row.isMirror ?? false,
     isBenchmark: row.isBenchmark ?? false,
-    isNoMatch: usesAuroraNoMatchDescription(row.boardType) && isNoMatchClimb(row.climbDescription),
+    isNoMatch: resolveClimbNoMatch(row.boardType, row.climbCharacteristics, row.climbDescription),
     comment: row.comment || null,
     frames: row.frames,
     setterUsername: row.setterUsername,
@@ -1236,6 +1238,7 @@ function tickHighlightSelectSql(groupIdExpression: SQL = sql`NULL::text`) {
     t.climb_uuid AS "climbUuid",
     cf.name AS "climbName",
     cf.description AS "climbDescription",
+    cf.characteristics AS "climbCharacteristics",
     t.board_type AS "boardType",
     cf.layout_id AS "layoutId",
     cf.compatible_size_ids AS "compatibleSizeIds",

--- a/packages/backend/src/graphql/resolvers/ticks/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/mutations.ts
@@ -7,13 +7,7 @@ import { rowsFromResult } from '@boardsesh/db/client';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { sessions } from '../../../db/schema';
-import {
-  applyRateLimit,
-  requireAuthenticated,
-  validateInput,
-  isNoMatchClimb,
-  usesAuroraNoMatchDescription,
-} from '../shared/helpers';
+import { applyRateLimit, requireAuthenticated, validateInput, resolveClimbNoMatch } from '../shared/helpers';
 import { getConsensusDifficultyName } from '../shared/sql-expressions';
 import {
   SaveTickInputSchema,
@@ -1581,6 +1575,7 @@ async function publishAscentEvent(
         .select({
           name: dbSchema.boardClimbs.name,
           description: dbSchema.boardClimbs.description,
+          characteristics: dbSchema.boardClimbs.characteristics,
           setterUsername: dbSchema.boardClimbs.setterUsername,
           layoutId: dbSchema.boardClimbs.layoutId,
           frames: dbSchema.boardClimbs.frames,
@@ -1650,7 +1645,7 @@ async function publishAscentEvent(
           angle: String(tick.angle),
           isMirror: String(tick.isMirror ?? false),
           isBenchmark: String(tick.isBenchmark ?? false),
-          isNoMatch: String(usesAuroraNoMatchDescription(tick.boardType) && isNoMatchClimb(climbData?.description)),
+          isNoMatch: String(resolveClimbNoMatch(tick.boardType, climbData?.characteristics, climbData?.description)),
           quality: String(tick.quality ?? ''),
           attemptCount: String(tick.attemptCount),
           comment: tick.comment || '',

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -10,13 +10,7 @@ import {
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { toConfidenceTier, notAuroraTwinDuplicate, withSerialPlan } from '@boardsesh/db/queries';
-import {
-  requireAuthenticated,
-  applyRateLimit,
-  validateInput,
-  isNoMatchClimb,
-  usesAuroraNoMatchDescription,
-} from '../shared/helpers';
+import { requireAuthenticated, applyRateLimit, validateInput, resolveClimbNoMatch } from '../shared/helpers';
 import { fetchOwnerBoards, toTickBoardCandidate } from '../shared/render-board';
 import { resolveRenderBoard } from '@boardsesh/board-config';
 import {
@@ -560,6 +554,7 @@ export const tickQueries = {
         tick: dbSchema.boardseshTicks,
         climbName: dbSchema.boardClimbs.name,
         climbDescription: dbSchema.boardClimbs.description,
+        climbCharacteristics: dbSchema.boardClimbs.characteristics,
         setterUsername: dbSchema.boardClimbs.setterUsername,
         layoutId: dbSchema.boardClimbs.layoutId,
         frames: dbSchema.boardClimbs.frames,
@@ -746,6 +741,7 @@ export const tickQueries = {
         tick,
         climbName,
         climbDescription,
+        climbCharacteristics,
         setterUsername,
         layoutId,
         frames,
@@ -809,7 +805,7 @@ export const tickQueries = {
           boardseshDifficulty: boardseshDifficulty == null ? null : Number(boardseshDifficulty),
           boardseshConfidence: toConfidenceTier(boardseshConfidence),
           isBenchmark: Boolean(resolvedIsBenchmark),
-          isNoMatch: usesAuroraNoMatchDescription(tick.boardType) && isNoMatchClimb(climbDescription),
+          isNoMatch: resolveClimbNoMatch(tick.boardType, climbCharacteristics, climbDescription),
           qualityAverage: qualityAverage != null ? Number(qualityAverage) : null,
           comment: tick.comment || '',
           climbedAt: tick.climbedAt,
@@ -998,6 +994,7 @@ export const tickQueries = {
         tick: dbSchema.boardseshTicks,
         climbName: dbSchema.boardClimbs.name,
         climbDescription: dbSchema.boardClimbs.description,
+        climbCharacteristics: dbSchema.boardClimbs.characteristics,
         setterUsername: dbSchema.boardClimbs.setterUsername,
         layoutId: dbSchema.boardClimbs.layoutId,
         frames: dbSchema.boardClimbs.frames,
@@ -1146,6 +1143,7 @@ export const tickQueries = {
       tick,
       climbName,
       climbDescription,
+      climbCharacteristics,
       setterUsername,
       layoutId,
       frames,
@@ -1171,7 +1169,7 @@ export const tickQueries = {
       // Skip ticks that fell inside the date window but belong to a different group.
       if (!pageKeySet.has(key)) continue;
 
-      const isNoMatch = usesAuroraNoMatchDescription(tick.boardType) && isNoMatchClimb(climbDescription);
+      const isNoMatch = resolveClimbNoMatch(tick.boardType, climbCharacteristics, climbDescription);
 
       const canShowBoard =
         tick.boardId != null && (ctx?.userId === userId || (boardIsPublic === true && boardIsUnlisted !== true));

--- a/packages/mobile/src/db/queries/search-climbs-local.ts
+++ b/packages/mobile/src/db/queries/search-climbs-local.ts
@@ -1,6 +1,6 @@
 import { getLocalUserId, type OfflineDatabase } from '@boardsesh/offline-sync';
 import type { BoardName, Climb, ClimbSearchInput } from '@boardsesh/shared-schema';
-import { isNoMatch, isNoMatchClimb, usesAuroraNoMatchDescription } from '@boardsesh/shared-schema';
+import { resolveClimbNoMatch } from '@boardsesh/shared-schema';
 import { isSizeScopedBoard } from '@boardsesh/board-config';
 import { getTallWideScope } from '@boardsesh/board-constants';
 import { getGradeLabel, getClimbStars } from '../../lib/grade-label';
@@ -495,13 +495,7 @@ export function mapRowToClimb(row: LocalClimbRow, boardType: string, layoutId: n
     benchmark_difficulty: bench !== null && bench > 0 ? String(bench) : null,
     is_draft: !!row.is_draft,
     is_hidden: !!row.is_hidden,
-    // Mirrors the server's Climb.is_no_match resolver: a null array means the row
-    // predates the characteristics backfill, so fall back to Aurora's description
-    // convention rather than reading "no rule" off a column we never filled.
-    is_no_match:
-      characteristics != null
-        ? isNoMatch(characteristics)
-        : usesAuroraNoMatchDescription(boardType) && isNoMatchClimb(row.description),
+    is_no_match: resolveClimbNoMatch(boardType, characteristics, row.description),
     characteristics,
     published_at: row.published_at,
     created_at: row.created_at,

--- a/packages/shared-schema/src/__tests__/no-match.test.ts
+++ b/packages/shared-schema/src/__tests__/no-match.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getDisplayDescription, isNoMatchClimb, withNoMatch } from '../utils';
+import { getDisplayDescription, isNoMatchClimb, resolveClimbNoMatch, withNoMatch } from '../utils';
 
 describe('isNoMatchClimb', () => {
   it('detects a leading "no match" marker, case-insensitively', () => {
@@ -62,6 +62,42 @@ describe('isNoMatchClimb', () => {
     ]) {
       expect(isNoMatchClimb(description), description).toBe(true);
     }
+  });
+});
+
+describe('resolveClimbNoMatch', () => {
+  // The #5127 review gap: the editor stores `[]` as an explicit "matching IS
+  // allowed" while deliberately keeping the setter's prose, so a payload that
+  // reads the description alone contradicts the climb view.
+  it('lets a non-null characteristics array override the description', () => {
+    expect(resolveClimbNoMatch('kilter', [], 'Kick board is off. No matching.')).toBe(false);
+    expect(resolveClimbNoMatch('kilter', ['campus'], 'No match\nbeta')).toBe(false);
+    expect(resolveClimbNoMatch('kilter', ['no_match'], 'Crimpy start')).toBe(true);
+    expect(resolveClimbNoMatch('kilter', ['no_kickboard', 'no_match'], null)).toBe(true);
+  });
+
+  it('falls back to the description only when characteristics is null', () => {
+    expect(resolveClimbNoMatch('kilter', null, 'Kick board is off. No matching.')).toBe(true);
+    expect(resolveClimbNoMatch('kilter', undefined, 'No match\nbeta')).toBe(true);
+    expect(resolveClimbNoMatch('kilter', null, 'Crimpy start')).toBe(false);
+    expect(resolveClimbNoMatch('tension', null, null)).toBe(false);
+  });
+
+  // MoonBoard and Woods never had Aurora's description convention: there the
+  // same words are the setter's own prose.
+  it('never reads the description on the code-driven boards', () => {
+    expect(resolveClimbNoMatch('moonboard', null, 'No match\nbeta')).toBe(false);
+    expect(resolveClimbNoMatch('woods', null, 'Kick board is off. No matching.')).toBe(false);
+    // The array still wins on those boards.
+    expect(resolveClimbNoMatch('moonboard', ['no_match'], 'Crimpy start')).toBe(true);
+  });
+
+  // boardType is only populated in multi-board contexts, so an absent one keeps
+  // the pre-capability verdict rather than silently dropping the rule.
+  it('fails open when boardType is missing', () => {
+    expect(resolveClimbNoMatch(null, null, 'No match\nbeta')).toBe(true);
+    expect(resolveClimbNoMatch(undefined, null, 'Kick board is off. No matching.')).toBe(true);
+    expect(resolveClimbNoMatch(null, [], 'No match\nbeta')).toBe(false);
   });
 });
 

--- a/packages/shared-schema/src/utils.ts
+++ b/packages/shared-schema/src/utils.ts
@@ -1,4 +1,5 @@
 import type { UserBoard } from './types/board-entities';
+import { isNoMatch, usesAuroraNoMatchDescription } from './characteristics';
 
 /** The board config tuple needed to prefer a same-config serial match. */
 export type SerialBoardConfig = {
@@ -115,6 +116,32 @@ export const NO_MATCH_TRAILING_SQL_PATTERN =
 export function isNoMatchClimb(description: string | null | undefined): boolean {
   const value = description || '';
   return NO_MATCH_LEADING.test(value) || NO_MATCH_TRAILING.test(value);
+}
+
+/**
+ * Whether a climb forbids matching — the ONE read path every surface should use.
+ *
+ * A non-null `characteristics` array is authoritative and ends the question: it is
+ * what makes `noMatch: false` stick on a climb whose prose still declares the rule
+ * (the editor stores `[]` as an explicit false). Only a null array falls back to
+ * Aurora's description convention, and only on the boards that have one — on
+ * MoonBoard and Woods the same words are the setter's own prose.
+ *
+ * `boardType` fails open when absent, because it is only populated in multi-board
+ * contexts (see `Climb.boardType`); an unknown board keeps the pre-capability
+ * behaviour rather than silently losing the rule.
+ *
+ * Feed, tick and notification payloads used to derive this from the description
+ * alone, so they disagreed with the climb view for any climb whose author had
+ * turned the rule off without editing their prose (#5127 review).
+ */
+export function resolveClimbNoMatch(
+  boardType: string | null | undefined,
+  characteristics: readonly string[] | null | undefined,
+  description: string | null | undefined,
+): boolean {
+  if (characteristics != null) return isNoMatch(characteristics);
+  return (boardType == null || usesAuroraNoMatchDescription(boardType)) && isNoMatchClimb(description);
 }
 
 /** Canonical marker prepended to a description to flag a "no match" climb. */

--- a/packages/web/app/lib/data/queries.ts
+++ b/packages/web/app/lib/data/queries.ts
@@ -13,7 +13,7 @@ import { getGradeLabel } from '@boardsesh/db/queries';
 
 import type { Climb, ParsedBoardRouteParametersWithUuid, BoardName, LayoutId, Size } from '../types';
 import { getSizesForLayoutId, getAllLayouts, getSetsForLayoutAndSize } from '@/app/lib/board-constants';
-import { isNoMatchClimb, isNoMatch, usesAuroraNoMatchDescription } from '@/app/lib/no-match-climb';
+import { resolveClimbNoMatch } from '@/app/lib/no-match-climb';
 import { withReadDeadline } from '@/app/lib/db/read-deadline';
 import { remainingReadBudgetMs } from '@/app/lib/db/request-read-budget';
 
@@ -104,10 +104,7 @@ async function fetchClimbFromDb(
   return {
     ...row,
     difficulty: getGradeLabel(row.difficulty_id),
-    is_no_match:
-      row.characteristics != null
-        ? isNoMatch(row.characteristics)
-        : usesAuroraNoMatchDescription(boardName) && isNoMatchClimb(row.description),
+    is_no_match: resolveClimbNoMatch(boardName, row.characteristics, row.description),
   } as Climb;
 }
 

--- a/packages/web/app/lib/db/queries/climbs/search-climbs.ts
+++ b/packages/web/app/lib/db/queries/climbs/search-climbs.ts
@@ -5,7 +5,7 @@ import { searchClimbs as sharedSearchClimbs, mapSearchInputToParams } from '@boa
 import { getBoardClimbSearchTag } from '@/app/lib/climb-search-cache';
 import type { ParsedBoardRouteParameters, SearchRequestPagination, BoardName, Climb } from '@/app/lib/types';
 import { sortObjectKeys } from '@/app/lib/cache-utils';
-import { isNoMatch, isNoMatchClimb, usesAuroraNoMatchDescription } from '@/app/lib/no-match-climb';
+import { resolveClimbNoMatch } from '@/app/lib/no-match-climb';
 import { withReadDeadline } from '@/app/lib/db/read-deadline';
 
 /**
@@ -62,12 +62,7 @@ async function _executeClimbSearch(
   const climbs: Climb[] = result.climbs.map((row) => ({
     ...row,
     mirrored: undefined,
-    // Prefer the structured characteristic; fall back to the Aurora description
-    // convention for rows synced before the column was backfilled.
-    is_no_match:
-      row.characteristics != null
-        ? isNoMatch(row.characteristics)
-        : usesAuroraNoMatchDescription(params.board_name) && isNoMatchClimb(row.description),
+    is_no_match: resolveClimbNoMatch(params.board_name, row.characteristics, row.description),
   }));
 
   return { climbs, hasMore: result.hasMore };

--- a/packages/web/app/lib/no-match-climb.ts
+++ b/packages/web/app/lib/no-match-climb.ts
@@ -1,1 +1,1 @@
-export { isNoMatchClimb, isNoMatch, usesAuroraNoMatchDescription } from '@boardsesh/shared-schema';
+export { isNoMatchClimb, isNoMatch, usesAuroraNoMatchDescription, resolveClimbNoMatch } from '@boardsesh/shared-schema';


### PR DESCRIPTION
## Summary

Follow-up to #5243, which landed the trailing-declaration detection fix for #5127. Codex
reviewed that PR and found a real gap it made more reachable.

The tick, feed and notification payloads derive `isNoMatch` from the climb **description
alone** and never look at `board_climbs.characteristics`. A non-null array is authoritative:
the editor stores `[]` as an explicit "matching IS allowed" while deliberately keeping the
setter's prose. So a climb whose author turned the rule off could publish `isNoMatch: true`
into feeds and notifications while the climb view correctly said `false`.

This is pre-existing — those paths have always been prose-only — but #5243 widened the
detector, so one more description shape now reaches it.

**Exposure is currently zero.** No catalogue row carries the `[]` sentinel yet, so nothing
is wrong in production today; this closes it before the first setter hits it. The only
values that change now are 35 catalog rows (33 Kilter, 2 Tension) whose array already says
`no_match` while their prose does not — those flip `false → true`, which aligns the feed
with the climb view.

### One read path

`resolveClimbNoMatch(boardType, characteristics, description)` in `@boardsesh/shared-schema`
is now the single definition. A non-null array ends the question; only a null array falls
back to Aurora's description convention, and only on the boards that have one. `boardType`
fails open when absent, matching the previous behaviour of the `Climb.is_no_match` resolver.

- 15 payload sites across 9 backend files now call it, and **every query behind them selects
  `characteristics`** — none of them did before.
- `Climb.is_no_match` collapses into the same call, so the resolver got smaller.
- Web (`data/queries.ts`, `db/queries/climbs/search-climbs.ts`) and mobile
  (`search-climbs-local.ts`) hand-rolled the identical ternary; they call the helper now too.
  No behaviour change there — it removes the drift risk.

### The same gap one layer up

A paired review found five `Climb` producers that never projected the column either, so
favouriting a climb or adding it to a playlist could flip its rule:

`favorites/favorite-climbs-query.ts` · `playlists/helpers/hydrate-climbs.ts` ·
`social/setter-follows.ts` (×3)

Four of the five had already been fixed on `main` by #5214 while this was in flight — kept
that wording, which cites the issue. The favourites producer additionally never emitted
`boardType`, which made the resolver fail open even on MoonBoard, where a description
mentioning "no match" is just the setter's prose. That one is fixed here.

### Why two real-Postgres tests

`tsc` catches a dropped column in a drizzle `.select()` — verified, 4 of 5 producer
mutations failed to compile. It cannot see the two **raw-SQL** select lists
(`userClimbs`, `tickHighlightSelectSql`), whose row types are hand-written casts: removing a
column there compiles clean and reads back `undefined`, which `resolveClimbNoMatch` treats as
"no array" and silently falls back to the description — the bug itself.

Both tests were mutation-tested: delete the projection / typo the SQL alias → red; restore →
green.

### Known limitation

`feed_items.metadata` is a snapshot written at fan-out time, so items fanned out before this
deploy keep their old `isNoMatch` value. There is no backfill here; new items are correct.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 3/5 — backend resolvers and queries, no migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
