### PR TITLE
feat(web): support Tension Board 2 CNC build packs

### DIFF
--- a/docs/cnc-packs.md
+++ b/docs/cnc-packs.md
@@ -1088,3 +1088,29 @@ The whole local loop with the bypass on, no Stripe anywhere:
 4. `finaliseCncOrder` → straight to `queued`, no payment.
 5. The worker claims it as a `full` job → `ready`, and
    `createCncDownloadGrant(licenceId)` serves the real pack.
+
+## Tension Board 2
+
+The catalogue supports five TB2 sizes: 10 × 8, 12 × 8, 10 × 12, 12 × 12
+and 12 × 16. Tension names sizes **height × width**. The configurator groups
+Mirror (layout 10) and Spray (layout 11) into one board choice.
+
+`tb2DimensionStandard` defaults to `metric`; `imperial` selects Tension's inch
+specification. The worker owns the dimensions and bore diameters. Boardsesh
+sends the standard, sheet stock and support-strip choice without Kilter pitch,
+T-nut, kicker or stud-offset defaults. Changing the standard clears artwork
+placements, which were measured against the previous geometry.
+
+`tb2Engraving` accepts `none`, `mirror`, `spray`, or `both` (the default).
+Spray alone uses layout 11; the other choices use layout 10. The reducer updates
+the tuple with the option and checkout validates this pairing. Both layouts
+share the complete drilling grid. The generated panels identify Mirror with
+left-side labels and single direction ticks, Spray with right-side labels and
+double ticks, and include a physical legend for the selected engravings.
+
+The saved options drive preview hashes, order summaries and regenerated jobs.
+The job envelope carries `output.engrave.layoutMode`; the nested layout request
+carries `manufacturing.dimension_standard`. Deploy the TB2-capable generator
+before exposing this catalogue revision. Existing Kilter worker requests retain
+their previous shape. Build-plan routes keep their existing feature gate and
+`noindex` metadata.

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -1230,6 +1230,8 @@ export const schemaSQL = `
     "by_tester" boolean DEFAULT true NOT NULL,
     "comment" text,
     "platform" text NOT NULL,
+    "device_model" text,
+    "os_version" text,
     "app_version" text,
     "update_id" text,
     "runtime_version" text,

--- a/packages/backend/src/graphql/resolvers/cnc-packs/__tests__/queries.test.ts
+++ b/packages/backend/src/graphql/resolvers/cnc-packs/__tests__/queries.test.ts
@@ -148,13 +148,20 @@ beforeEach(() => {
 });
 
 describe('cncCatalog', () => {
-  it('publishes the four Kilter Homewall walls', async () => {
+  it('publishes Kilter Homewall and both TB2 layouts', async () => {
     const catalog = await cncPackQueries.cncCatalog(undefined, undefined, anonCtx());
 
     expect(catalog.version).toBe(CNC_CATALOG_VERSION);
-    expect(catalog.entries).toHaveLength(4);
-    expect(catalog.entries.map((entry) => entry.label)).toEqual(['7x10', '10x10', '8x12', '10x12']);
-    expect(catalog.entries.map((entry) => entry.sizeId)).toEqual([17, 21, 23, 25]);
+    expect(catalog.entries).toHaveLength(14);
+    const kilterEntries = catalog.entries.filter((entry) => entry.boardName === 'kilter');
+    for (const layoutId of [10, 11]) {
+      const tensionEntries = catalog.entries.filter(
+        (entry) => entry.boardName === 'tension' && entry.layoutId === layoutId,
+      );
+      expect(tensionEntries.map((entry) => entry.sizeId)).toEqual([9, 8, 7, 6, 10]);
+    }
+    expect(kilterEntries.map((entry) => entry.label)).toEqual(['7x10', '10x10', '8x12', '10x12']);
+    expect(kilterEntries.map((entry) => entry.sizeId)).toEqual([17, 21, 23, 25]);
   });
 
   it('does not publish the LED-kit size aliases', async () => {

--- a/packages/backend/src/services/cnc/__tests__/catalog.test.ts
+++ b/packages/backend/src/services/cnc/__tests__/catalog.test.ts
@@ -27,18 +27,19 @@ function entryFor(sizeId: number) {
 
 describe('CNC catalogue', () => {
   it('sells exactly the four canonical Kilter Homewall sizes', () => {
-    expect(CNC_CATALOG.map((entry) => entry.sizeId)).toEqual([17, 21, 23, 25]);
-    expect(CNC_CATALOG.map((entry) => entry.label)).toEqual(['7x10', '10x10', '8x12', '10x12']);
-    expect(CNC_CATALOG.every((entry) => entry.boardName === 'kilter' && entry.layoutId === 8)).toBe(true);
+    const kilterEntries = CNC_CATALOG.filter((entry) => entry.boardName === 'kilter');
+    expect(kilterEntries.map((entry) => entry.sizeId)).toEqual([17, 21, 23, 25]);
+    expect(kilterEntries.map((entry) => entry.label)).toEqual(['7x10', '10x10', '8x12', '10x12']);
+    expect(kilterEntries.every((entry) => entry.boardName === 'kilter' && entry.layoutId === 8)).toBe(true);
   });
 
   it('has a version string orders can be pinned to', () => {
-    expect(CNC_CATALOG_VERSION).toBe('2026-09-07.3');
+    expect(CNC_CATALOG_VERSION).toBe('2026-09-07.4');
   });
 
   it('takes its default set ids from board-constants rather than a second hardcoded list', () => {
     for (const entry of CNC_CATALOG) {
-      const expected = getSetsForLayoutAndSize('kilter', 8, entry.sizeId)
+      const expected = getSetsForLayoutAndSize(entry.boardName, entry.layoutId, entry.sizeId)
         .map((set) => set.id)
         .join(',');
       expect(entry.setIds).toBe(expected);
@@ -283,5 +284,40 @@ describe('CNC_CATALOG_VERSION', () => {
 
   it('is a dated, sortable version string', () => {
     expect(CNC_CATALOG_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}\.\d+$/);
+  });
+});
+
+describe('Tension Board 2 catalogue', () => {
+  it.each([10, 11])('offers all five sizes for layout %i, without kickers or T-nut options', (layoutId) => {
+    const entries = CNC_CATALOG.filter((entry) => entry.boardName === 'tension' && entry.layoutId === layoutId);
+    expect(entries.map((entry) => entry.sizeId)).toEqual([9, 8, 7, 6, 10]);
+    for (const entry of entries) {
+      expect(entry.kickerOptional).toBe(false);
+      expect(entry.manufacturingOptions.map((option) => option.key)).not.toContain('tnutHoleDiameterMm');
+      const checked = validateCatalogOptions(entry, {});
+      expect(checked).toMatchObject({
+        ok: true,
+        options: {
+          tb2DimensionStandard: 'metric',
+          tb2Engraving: layoutId === 10 ? 'both' : 'spray',
+        },
+      });
+    }
+  });
+
+  it.each(['none', 'mirror', 'spray', 'both'])('validates the canonical tuple for %s', (mode) => {
+    const layoutId = mode === 'spray' ? 11 : 10;
+    const entry = findCatalogEntry({ boardName: 'tension', layoutId, sizeId: 10 })!;
+    expect(validateCatalogOptions(entry, { tb2Engraving: mode, tb2DimensionStandard: 'imperial' }).ok).toBe(true);
+    const other = findCatalogEntry({ boardName: 'tension', layoutId: layoutId === 10 ? 11 : 10, sizeId: 10 })!;
+    expect(validateCatalogOptions(other, { tb2Engraving: mode }).ok).toBe(false);
+    expect(entry.setIds).toBe(layoutId === 10 ? '12,13,14,15' : '12,13');
+  });
+
+  it('rejects arbitrary dimensions and dimensions from another board family', () => {
+    const entry = findCatalogEntry({ boardName: 'tension', layoutId: 10, sizeId: 9 })!;
+    expect(validateCatalogOptions(entry, { tb2DimensionStandard: 'custom' }).ok).toBe(false);
+    expect(validateCatalogOptions(entry, { gridPitchMm: 101.6 }).ok).toBe(false);
+    expect(validateCatalogOptions(entryFor(25), { tb2Engraving: 'both' }).ok).toBe(false);
   });
 });

--- a/packages/backend/src/services/cnc/__tests__/job-payload.test.ts
+++ b/packages/backend/src/services/cnc/__tests__/job-payload.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vite-plus/test';
+import type { CncOrder } from '@boardsesh/db/schema';
+import { buildWorkerJob } from '../job-payload';
+import { computeCncConfigHash } from '../config-hash';
+
+/** Only persisted fields read by the pure job mapper are needed here. */
+function savedOrder(mode: string, standard: string): CncOrder {
+  return {
+    id: 1042,
+    userId: 'buyer',
+    licenceId: 'BS-CNC-TEST23',
+    claimToken: 'claim',
+    generation: 1,
+    attempts: 1,
+    status: 'generating',
+    tier: 'personal',
+    licenseeName: 'Home climber',
+    licenseeEmail: 'buyer@example.com',
+    customerSiteName: null,
+    boardName: 'tension',
+    layoutId: mode === 'spray' ? 11 : 10,
+    sizeId: 10,
+    setIds: mode === 'spray' ? '12,13' : '12,13,14,15',
+    options: {
+      tb2DimensionStandard: standard,
+      tb2Engraving: mode,
+      sheetStock: '3600x1220',
+      supportStrips: false,
+      dxfFlavour: 'R12_circles',
+      paper: 'A3',
+    },
+    artwork: [],
+    catalogVersion: 'saved-catalogue-version',
+  } as unknown as CncOrder;
+}
+
+const context = { bucket: 'test-packs', issuedAt: new Date('2026-09-07T00:00:00Z') };
+
+describe('saved TB2 orders', () => {
+  it.each(['none', 'mirror', 'spray', 'both'])('regenerates %s from saved choices', (mode) => {
+    for (const standard of ['metric', 'imperial']) {
+      const order = savedOrder(mode, standard);
+      const job = buildWorkerJob(order, context);
+      expect(job.catalogVersion).toBe('saved-catalogue-version');
+      expect(job.output.engrave).toEqual({ layoutMode: mode, holdIds: false, angleTicks: false });
+      expect(job.layoutRequest.manufacturing).toEqual({
+        dimension_standard: standard,
+        sheet: { length_mm: 3600, width_mm: 1220 },
+        support_strips: false,
+      });
+      expect(job.config.options).toEqual(order.options);
+      expect(buildWorkerJob({ ...order, generation: 2 }, context).layoutRequest).toEqual(job.layoutRequest);
+      expect(buildWorkerJob({ ...order, status: 'preview_generating' }, context).output).toEqual(job.output);
+    }
+  });
+
+  it('gives every engraving and dimension combination a different preview identity', () => {
+    const hashes = ['none', 'mirror', 'spray', 'both'].flatMap((mode) =>
+      ['metric', 'imperial'].map((standard) => computeCncConfigHash(savedOrder(mode, standard))),
+    );
+    expect(new Set(hashes).size).toBe(8);
+  });
+});

--- a/packages/backend/src/services/cnc/__tests__/worker-client.test.ts
+++ b/packages/backend/src/services/cnc/__tests__/worker-client.test.ts
@@ -393,3 +393,24 @@ describe('validateArtwork', () => {
     expect(sentBody(init)).toEqual({ layout_request: request, artwork });
   });
 });
+
+describe('TB2 manufacturing contract', () => {
+  it.each(['metric', 'imperial'])('sends %s without Kilter dimensions or T-nuts', (standard) => {
+    for (const layoutId of [10, 11]) {
+      for (const sizeId of [9, 8, 7, 6, 10]) {
+        const entry = findCatalogEntry({ boardName: 'tension', layoutId, sizeId })!;
+        const options = validateCatalogOptions(entry, { tb2DimensionStandard: standard });
+        if (!options.ok) throw new Error('invalid TB2 options');
+        const setIds = entry.setIds.split(',').map(Number);
+        expect(toLayoutRequest({ entry, options: options.options, setIds })).toEqual({
+          board: { board_name: 'tension', layout_id: layoutId, size_id: sizeId, set_ids: setIds },
+          manufacturing: {
+            dimension_standard: standard,
+            sheet: { length_mm: 2440, width_mm: 1220 },
+            support_strips: true,
+          },
+        });
+      }
+    }
+  });
+});

--- a/packages/backend/src/services/cnc/catalog.ts
+++ b/packages/backend/src/services/cnc/catalog.ts
@@ -15,7 +15,7 @@ import type { CncOrderOptions } from '@boardsesh/db/schema';
  * stores the version it was priced and configured under, so a regenerate months
  * later rebuilds the pack the buyer paid for rather than today's defaults.
  */
-export const CNC_CATALOG_VERSION = '2026-09-07.3';
+export const CNC_CATALOG_VERSION = '2026-09-07.4';
 
 /**
  * sha256 of `JSON.stringify(CNC_CATALOG)`, pinned so the version above cannot
@@ -32,7 +32,7 @@ export const CNC_CATALOG_VERSION = '2026-09-07.3';
  * Never paste the new hash on its own — a hash change with an unchanged version
  * is exactly the bug this pair exists to catch.
  */
-export const CNC_CATALOG_CONTENT_HASH = '21dce30f1df9a4ab4a2be636dab86fdad3af5dd55838a92a4365aa64764b4e2b';
+export const CNC_CATALOG_CONTENT_HASH = 'c4023c73904d91946def3d530601ed4bff5429114b70fdd8f64c7e1167f161a8';
 
 export type CncLicenceTier = 'personal' | 'commercial_single';
 
@@ -157,17 +157,59 @@ function defaultSetIdsFor(sizeId: number): string {
   return sets.map((set) => set.id).join(',');
 }
 
-export const CNC_CATALOG: readonly CncCatalogEntry[] = KILTER_HOMEWALL_SIZES.map((size) => ({
-  boardName: 'kilter' as BoardName,
-  layoutId: KILTER_HOMEWALL_LAYOUT_ID,
-  sizeId: size.sizeId,
-  setIds: defaultSetIdsFor(size.sizeId),
-  label: size.label,
-  sizeAliases: size.sizeAliases,
-  kickerOptional: size.kickerOptional,
-  manufacturingOptions: KILTER_HOMEWALL_MANUFACTURING_OPTIONS,
-  tiers: KILTER_HOMEWALL_TIERS,
-}));
+/** TB2 sizes are named height × width by Tension. Never infer axes from Kilter labels. */
+const TENSION_BOARD_2_SIZES = [
+  { sizeId: 9, label: '10 × 8' },
+  { sizeId: 8, label: '12 × 8' },
+  { sizeId: 7, label: '10 × 12' },
+  { sizeId: 6, label: '12 × 12' },
+  { sizeId: 10, label: '12 × 16' },
+] as const;
+
+const TENSION_BOARD_2_OPTIONS: readonly CncManufacturingOption[] = [
+  ...KILTER_HOMEWALL_MANUFACTURING_OPTIONS.filter((option) =>
+    ['sheetStock', 'dxfFlavour', 'paper', 'supportStrips'].includes(option.key),
+  ),
+  { key: 'tb2DimensionStandard', values: ['metric', 'imperial'], defaultValue: 'metric', kickerOnly: false },
+  { key: 'tb2Engraving', values: ['none', 'mirror', 'spray', 'both'], defaultValue: 'both', kickerOnly: false },
+];
+
+export function isTensionBoard2(entry: { boardName: string; layoutId: number }): boolean {
+  return entry.boardName === 'tension' && (entry.layoutId === 10 || entry.layoutId === 11);
+}
+
+const TENSION_BOARD_2_CATALOG: readonly CncCatalogEntry[] = [10, 11].flatMap((layoutId) =>
+  TENSION_BOARD_2_SIZES.map((size) => ({
+    boardName: 'tension' as const,
+    layoutId,
+    sizeId: size.sizeId,
+    setIds: getSetsForLayoutAndSize('tension', layoutId, size.sizeId)
+      .map((set) => set.id)
+      .join(','),
+    label: size.label,
+    sizeAliases: [],
+    kickerOptional: false,
+    manufacturingOptions: TENSION_BOARD_2_OPTIONS.map((option) =>
+      option.key === 'tb2Engraving' && layoutId === 11 ? { ...option, defaultValue: 'spray' } : option,
+    ),
+    tiers: KILTER_HOMEWALL_TIERS,
+  })),
+);
+
+export const CNC_CATALOG: readonly CncCatalogEntry[] = [
+  ...KILTER_HOMEWALL_SIZES.map((size) => ({
+    boardName: 'kilter' as BoardName,
+    layoutId: KILTER_HOMEWALL_LAYOUT_ID,
+    sizeId: size.sizeId,
+    setIds: defaultSetIdsFor(size.sizeId),
+    label: size.label,
+    sizeAliases: size.sizeAliases,
+    kickerOptional: size.kickerOptional,
+    manufacturingOptions: KILTER_HOMEWALL_MANUFACTURING_OPTIONS,
+    tiers: KILTER_HOMEWALL_TIERS,
+  })),
+  ...TENSION_BOARD_2_CATALOG,
+];
 
 /**
  * The typefaces a text label may be routed in.
@@ -355,6 +397,16 @@ export function validateCatalogOptions(entry: CncCatalogEntry, options: unknown)
     normalisedOptions[option.key] = matched;
   }
 
+  if (isTensionBoard2(entry)) {
+    const expectedLayoutId = normalisedOptions.tb2Engraving === 'spray' ? 11 : 10;
+    if (entry.layoutId !== expectedLayoutId) {
+      errors.push({
+        key: 'tb2Engraving',
+        code: 'invalid_value',
+        message: `This engraving selection requires TB2 layout ${expectedLayoutId}.`,
+      });
+    }
+  }
   if (errors.length > 0) return { ok: false, errors };
   return { ok: true, options: normalisedOptions };
 }

--- a/packages/backend/src/services/cnc/catalog.ts
+++ b/packages/backend/src/services/cnc/catalog.ts
@@ -1,4 +1,4 @@
-import type { BoardName } from '@boardsesh/shared-schema';
+import { tb2LayoutIdForEngraving, type BoardName } from '@boardsesh/shared-schema';
 import { getSetsForLayoutAndSize, KILTER_HOMEWALL_LAYOUT_ID } from '@boardsesh/board-constants';
 import type { CncOrderOptions } from '@boardsesh/db/schema';
 
@@ -398,7 +398,7 @@ export function validateCatalogOptions(entry: CncCatalogEntry, options: unknown)
   }
 
   if (isTensionBoard2(entry)) {
-    const expectedLayoutId = normalisedOptions.tb2Engraving === 'spray' ? 11 : 10;
+    const expectedLayoutId = tb2LayoutIdForEngraving(String(normalisedOptions.tb2Engraving));
     if (entry.layoutId !== expectedLayoutId) {
       errors.push({
         key: 'tb2Engraving',

--- a/packages/backend/src/services/cnc/job-payload.ts
+++ b/packages/backend/src/services/cnc/job-payload.ts
@@ -1,5 +1,6 @@
 import type { CncOrder, CncOrderOptions } from '@boardsesh/db/schema';
-import { parseSetIds } from './catalog';
+import { isTensionBoard2, parseSetIds } from './catalog';
+import type { CncTb2Engraving } from '@boardsesh/shared-schema';
 import { deliverableForStatus, type CncDeliverable } from './order-state';
 import { toLayoutRequest, type CncWorkerLayoutRequest } from './worker-client';
 
@@ -118,6 +119,7 @@ export type CncWorkerJob = {
   layoutRequest: CncWorkerLayoutRequest;
   output: {
     engrave: {
+      layoutMode?: CncTb2Engraving;
       holdIds: boolean;
       angleTicks: boolean;
     };
@@ -177,6 +179,12 @@ export function cncPreviewOutputKey(order: Pick<CncOrder, 'userId' | 'licenceId'
  */
 export function cncPreviewPrefix(order: Pick<CncOrder, 'userId' | 'licenceId'>): string {
   return `cnc-packs/${order.userId ?? 'anon'}/${order.licenceId}/preview/`;
+}
+
+function tb2EngravingMode(options: CncOrderOptions): CncTb2Engraving {
+  const mode = options.tb2Engraving;
+  if (mode === 'none' || mode === 'mirror' || mode === 'spray' || mode === 'both') return mode;
+  throw new CncJobPayloadError('TB2 engraving mode is missing or invalid');
 }
 
 /** Read a boolean option. Anything that is not an explicit `true` is off — the engrave gates fail closed. */
@@ -331,6 +339,7 @@ export function buildWorkerJob(order: CncOrder, { bucket, issuedAt }: BuildWorke
     layoutRequest,
     output: {
       engrave: {
+        ...(isTensionBoard2(order) ? { layoutMode: tb2EngravingMode(order.options) } : {}),
         holdIds: optionFlag(order.options, 'engraveHoldIds'),
         angleTicks: optionFlag(order.options, 'engraveAngleTicks'),
       },

--- a/packages/backend/src/services/cnc/worker-client.ts
+++ b/packages/backend/src/services/cnc/worker-client.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { logger } from '../../utils/logger';
-import { CNC_KICKER_SET_IDS, type CncBoardTuple } from './catalog';
+import { CNC_KICKER_SET_IDS, isTensionBoard2, type CncBoardTuple } from './catalog';
 import type { CncOrderOptions } from '@boardsesh/db/schema';
 
 /**
@@ -307,7 +307,7 @@ export type ToLayoutRequestInput = {
  */
 export function toLayoutRequest({ entry, options, setIds }: ToLayoutRequestInput): CncWorkerLayoutRequest {
   const { lengthMm, widthMm } = parseSheetStock(options.sheetStock);
-  if (entry.boardName === 'tension' && (entry.layoutId === 10 || entry.layoutId === 11)) {
+  if (isTensionBoard2(entry)) {
     const standard = options.tb2DimensionStandard;
     if (standard !== 'metric' && standard !== 'imperial') {
       throw new CncConfigMappingError('TB2 dimension standard must be metric or imperial');

--- a/packages/backend/src/services/cnc/worker-client.ts
+++ b/packages/backend/src/services/cnc/worker-client.ts
@@ -184,16 +184,27 @@ export type CncWorkerKicker = {
 
 export type CncWorkerManufacturing = {
   sheet: CncWorkerSheet;
-  dimension_standard?: 'metric' | 'imperial';
-  grid_pitch_mm?: number;
-  tnut_hole_diameter_mm?: number;
-  led_hole_diameter_mm?: number;
-  stud_clearance_offset_mm?: number;
   /** Cut the seam backing strips. Changes the sheet count, so it is geometry. */
   support_strips: boolean;
-  /** Present only when the configuration includes kicker sets. */
-  kicker?: CncWorkerKicker;
-};
+} & (
+  | {
+      dimension_standard: 'metric' | 'imperial';
+      grid_pitch_mm?: never;
+      tnut_hole_diameter_mm?: never;
+      led_hole_diameter_mm?: never;
+      stud_clearance_offset_mm?: never;
+      kicker?: never;
+    }
+  | {
+      dimension_standard?: never;
+      grid_pitch_mm: number;
+      tnut_hole_diameter_mm: number;
+      led_hole_diameter_mm: number;
+      stud_clearance_offset_mm: number;
+      /** Present only when the configuration includes kicker sets. */
+      kicker?: CncWorkerKicker;
+    }
+);
 
 export type CncWorkerLayoutRequest = {
   board: CncWorkerBoardRef;

--- a/packages/backend/src/services/cnc/worker-client.ts
+++ b/packages/backend/src/services/cnc/worker-client.ts
@@ -184,10 +184,11 @@ export type CncWorkerKicker = {
 
 export type CncWorkerManufacturing = {
   sheet: CncWorkerSheet;
-  grid_pitch_mm: number;
-  tnut_hole_diameter_mm: number;
-  led_hole_diameter_mm: number;
-  stud_clearance_offset_mm: number;
+  dimension_standard?: 'metric' | 'imperial';
+  grid_pitch_mm?: number;
+  tnut_hole_diameter_mm?: number;
+  led_hole_diameter_mm?: number;
+  stud_clearance_offset_mm?: number;
   /** Cut the seam backing strips. Changes the sheet count, so it is geometry. */
   support_strips: boolean;
   /** Present only when the configuration includes kicker sets. */
@@ -306,6 +307,20 @@ export type ToLayoutRequestInput = {
  */
 export function toLayoutRequest({ entry, options, setIds }: ToLayoutRequestInput): CncWorkerLayoutRequest {
   const { lengthMm, widthMm } = parseSheetStock(options.sheetStock);
+  if (entry.boardName === 'tension' && (entry.layoutId === 10 || entry.layoutId === 11)) {
+    const standard = options.tb2DimensionStandard;
+    if (standard !== 'metric' && standard !== 'imperial') {
+      throw new CncConfigMappingError('TB2 dimension standard must be metric or imperial');
+    }
+    return {
+      board: { board_name: entry.boardName, layout_id: entry.layoutId, size_id: entry.sizeId, set_ids: setIds },
+      manufacturing: {
+        sheet: { length_mm: lengthMm, width_mm: widthMm },
+        dimension_standard: standard,
+        support_strips: booleanOption(options, 'supportStrips', true),
+      },
+    };
+  }
   // Including either kicker set is what tells the generator to emit the two
   // extra panels. `validateSetIds` has already ruled out the half-kicker case.
   const hasKicker = setIds.some((setId) => CNC_KICKER_SET_IDS.includes(setId));

--- a/packages/shared-schema/src/cnc-config.ts
+++ b/packages/shared-schema/src/cnc-config.ts
@@ -1,0 +1,4 @@
+/** Map a catalogue engraving choice to its canonical TB2 board layout. */
+export function tb2LayoutIdForEngraving(engraving: string): 10 | 11 {
+  return engraving === 'spray' ? 11 : 10;
+}

--- a/packages/shared-schema/src/index.ts
+++ b/packages/shared-schema/src/index.ts
@@ -12,3 +12,4 @@ export * from './aurora-import';
 export * from './moonboard-import';
 export * from './instagram-caption-parse';
 export * from './sync-error-codes';
+export * from './cnc-config';

--- a/packages/shared-schema/src/types/cnc-packs.ts
+++ b/packages/shared-schema/src/types/cnc-packs.ts
@@ -11,6 +11,9 @@
 /** What the buyer is allowed to build: one own wall, or one named customer installation. */
 export type CncLicenceTier = 'personal' | 'commercial_single';
 
+export type CncTb2DimensionStandard = 'metric' | 'imperial';
+export type CncTb2Engraving = 'none' | 'mirror' | 'spray' | 'both';
+
 /**
  * Lifecycle of one order. It begins as a free preview and only becomes a sale
  * at `pending_payment`. `refunded` is terminal for downloads; `cancelled` only

--- a/packages/shared/i18n/locales/de/cnc.json
+++ b/packages/shared/i18n/locales/de/cnc.json
@@ -2,7 +2,7 @@
   "metadata": {
     "buildPlans": {
       "title": "Baupläne für ein Board zu Hause",
-      "description": "Schnittfertige CNC-Dateien für eine Kletterwand zu Hause: jedes Panel, jede Einschlagmutter und jede LED-Bohrung gesetzt, aufgeteilt auf die Platten, die deine Werkstatt vorrätig hat."
+      "description": "CNC-Dateien für deine Kletterwand zu Hause: Platten und Bohrpositionen, passend zum Plattenmaterial deiner Werkstatt."
     },
     "orders": {
       "title": "Deine Baupläne",
@@ -15,8 +15,8 @@
   },
   "hero": {
     "title": "Baupläne für dein Board zu Hause",
-    "subtitle": "DXF-Dateien, die eine CNC-Werkstatt direkt fräst. Jedes Panel, das Einschlagmutter-Raster, die LED-Bohrungen und die Fußleiste, aufgeteilt auf die Platten, die deine Werkstatt ohnehin hat.",
-    "firstBoard": "Das Kilter Homewall ist das erste unterstützte Board. Weitere folgen.",
+    "subtitle": "DXF-Dateien für deine CNC-Werkstatt. Platten und Bohrpositionen, passend zum vorhandenen Plattenmaterial.",
+    "firstBoard": "Kompatibel mit Kilter Homewall und Tension Board 2, einschließlich Mirror und Spray.",
     "included": {
       "heading": "Was du bekommst",
       "dxf": "Montagezeichnungen für die ganze Wand sind dabei, damit die Panels ohne Rätselraten zusammenpassen.",
@@ -61,7 +61,8 @@
     },
     "board": {
       "label": "Board",
-      "help": "Das Kilter Homewall ist heute das einzige Board im Verkauf."
+      "help": "Wähle das Board, für das du die Platten baust.",
+      "kilterHomewall": "Kilter Homewall"
     },
     "size": {
       "label": "Wandgröße",
@@ -77,7 +78,7 @@
       "help": "Die Standardwerte sind die, mit denen wir bauen. Pass sie an deine Werkstatt an.",
       "sheetStock": {
         "label": "Plattenformat",
-        "help": "Das Sperrholz, aus dem deine Werkstatt schneidet. Mit einer 3,6-m-Platte lässt sich eine Wandreihe ohne Stoß schneiden.",
+        "help": "Wähle die Sperrholzplatte deiner Werkstatt. Die Wandplatten werden passend aufgeteilt.",
         "values": {
           "2440x1220": "2440 × 1220 mm",
           "3600x1220": "3600 × 1220 mm"
@@ -149,7 +150,7 @@
       },
       "supportStrips": {
         "label": "Stützleisten an den Stößen",
-        "help": "150 mm breite Sperrholzleisten mit Schlitzen für die Einschlagmuttern, die hinter jedem waagerechten Stoß sitzen. Lass sie an, außer dein Rahmen stützt die Stöße schon.",
+        "help": "150 mm breite Sperrholzstreifen stützen die waagerechten Fugen und halten die Löcher zugänglich.",
         "values": {
           "false": "Aus",
           "true": "An"
@@ -169,6 +170,24 @@
         "values": {
           "false": "Aus",
           "true": "An"
+        }
+      },
+      "tb2DimensionStandard": {
+        "label": "TB2-Maße",
+        "help": "Metrisch: Hauptraster 200 mm, LED-Löcher 12 mm. Imperial: Raster 7⅞ Zoll, Löcher ½ Zoll. Ein Wechsel der Maße entfernt platzierte Motive.",
+        "values": {
+          "metric": "Metrisch",
+          "imperial": "Imperial"
+        }
+      },
+      "tb2Engraving": {
+        "label": "TB2-Gravur",
+        "help": "Griffkennungen und Richtungsmarkierungen aus Tensions Montagezeichnungen.",
+        "values": {
+          "none": "Keine Gravur",
+          "mirror": "Mirror",
+          "spray": "Spray",
+          "both": "Mirror + Spray"
         }
       }
     },
@@ -320,6 +339,12 @@
       "heading": "Auf wen die Lizenz läuft",
       "help": "Die Lizenz steht in jeder Datei im Pack, eine geleakte Kopie führt also zu ihr zurück.",
       "stale": "Hol dir zuerst die Vorschau neu — die Wand hat sich seit diesen Bögen geändert."
+    },
+    "tb2": {
+      "boardName": "Tension Board 2",
+      "sizeHelp": "Höhe × Breite in Fuß. Tension nennt die Höhe zuerst.",
+      "engraveHelp": "Graviere Mirror, Spray oder beide Layouts auf dieselben Platten. Beide Layouts sind standardmäßig ausgewählt.",
+      "engraveNote": "Mirror-Beschriftungen stehen links neben jedem Loch mit einem Richtungsstrich. Spray-Beschriftungen stehen rechts mit zwei Strichen. Jede gravierte Platte enthält eine Legende."
     }
   },
   "cta": {

--- a/packages/shared/i18n/locales/de/cnc.json
+++ b/packages/shared/i18n/locales/de/cnc.json
@@ -342,6 +342,7 @@
     },
     "tb2": {
       "boardName": "Tension Board 2",
+      "savedConfigurationUnavailable": "Gespeicherte Konfiguration nicht verfügbar",
       "sizeHelp": "Höhe × Breite in Fuß. Tension nennt die Höhe zuerst.",
       "engraveHelp": "Graviere Mirror, Spray oder beide Layouts auf dieselben Platten. Beide Layouts sind standardmäßig ausgewählt.",
       "engraveNote": "Mirror-Beschriftungen stehen links neben jedem Loch mit einem Richtungsstrich. Spray-Beschriftungen stehen rechts mit zwei Strichen. Jede gravierte Platte enthält eine Legende."

--- a/packages/shared/i18n/locales/en-US/cnc.json
+++ b/packages/shared/i18n/locales/en-US/cnc.json
@@ -342,6 +342,7 @@
     },
     "tb2": {
       "boardName": "Tension Board 2",
+      "savedConfigurationUnavailable": "Saved configuration unavailable",
       "sizeHelp": "Height × width in feet. Tension names the height first.",
       "engraveHelp": "Engrave Mirror, Spray, or both on the same panels. Both layouts are selected by default.",
       "engraveNote": "Mirror labels sit left of each hole with one direction tick. Spray labels sit right with two ticks. Every engraved panel carries a legend."

--- a/packages/shared/i18n/locales/en-US/cnc.json
+++ b/packages/shared/i18n/locales/en-US/cnc.json
@@ -2,7 +2,7 @@
   "metadata": {
     "buildPlans": {
       "title": "Build plans for a home board",
-      "description": "Cut-ready CNC files for a home climbing wall: every panel, T-nut and LED hole placed, laid out on the sheets your shop stocks."
+      "description": "CNC files for a home climbing wall: panels and drilling positions laid out on the sheets your shop stocks."
     },
     "orders": {
       "title": "Your build plans",
@@ -15,8 +15,8 @@
   },
   "hero": {
     "title": "Build plans for your home board",
-    "subtitle": "DXF files a CNC shop cuts straight from. Every panel, the T-nut grid, the LED holes and the kicker, laid out on the sheets your shop already stocks.",
-    "firstBoard": "Kilter Homewall is the first supported board. More boards follow.",
+    "subtitle": "DXF files for your CNC shop. Panels and drilling positions laid out on the sheets your shop already stocks.",
+    "firstBoard": "Works with Kilter Homewall and Tension Board 2, including Mirror and Spray layouts.",
     "included": {
       "heading": "What you get",
       "dxf": "Assembly drawings included too, so panels line up without any guesswork.",
@@ -61,7 +61,8 @@
     },
     "board": {
       "label": "Board",
-      "help": "Kilter Homewall is the only board on sale today."
+      "help": "Choose the board you are building panels for.",
+      "kilterHomewall": "Kilter Homewall"
     },
     "size": {
       "label": "Wall size",
@@ -77,7 +78,7 @@
       "help": "Defaults are what we build to. Change them to match your shop.",
       "sheetStock": {
         "label": "Sheet size",
-        "help": "The plywood your shop cuts from. A 3.6 m sheet lets a wall row be cut without a seam.",
+        "help": "Choose the plywood sheet your shop uses. Panels are split to fit the stock.",
         "values": {
           "2440x1220": "2440 × 1220 mm",
           "3600x1220": "3600 × 1220 mm"
@@ -149,7 +150,7 @@
       },
       "supportStrips": {
         "label": "Seam backing strips",
-        "help": "150 mm plywood strips, slotted for the T-nuts, that sit behind each horizontal seam. Leave on unless your framing already supports the seams.",
+        "help": "150 mm plywood strips back the horizontal seams and keep access to the holes.",
         "values": {
           "false": "Off",
           "true": "On"
@@ -169,6 +170,24 @@
         "values": {
           "false": "Off",
           "true": "On"
+        }
+      },
+      "tb2DimensionStandard": {
+        "label": "TB2 dimensions",
+        "help": "Metric: 200 mm main grid and 12 mm LED holes. Imperial: 7⅞ in grid and ½ in holes. Changing dimensions clears placed artwork.",
+        "values": {
+          "metric": "Metric",
+          "imperial": "Imperial"
+        }
+      },
+      "tb2Engraving": {
+        "label": "TB2 engraving",
+        "help": "Hold IDs and direction marks from Tension’s installation drawings.",
+        "values": {
+          "none": "No engraving",
+          "mirror": "Mirror",
+          "spray": "Spray",
+          "both": "Mirror + Spray"
         }
       }
     },
@@ -320,6 +339,12 @@
       "heading": "Who the licence names",
       "help": "The licence goes on every file in the pack, so a leaked copy traces back to it.",
       "stale": "Update your preview first — the wall has changed since these sheets."
+    },
+    "tb2": {
+      "boardName": "Tension Board 2",
+      "sizeHelp": "Height × width in feet. Tension names the height first.",
+      "engraveHelp": "Engrave Mirror, Spray, or both on the same panels. Both layouts are selected by default.",
+      "engraveNote": "Mirror labels sit left of each hole with one direction tick. Spray labels sit right with two ticks. Every engraved panel carries a legend."
     }
   },
   "cta": {

--- a/packages/shared/i18n/locales/es/cnc.json
+++ b/packages/shared/i18n/locales/es/cnc.json
@@ -2,7 +2,7 @@
   "metadata": {
     "buildPlans": {
       "title": "Planos para construir un plafón en casa",
-      "description": "Archivos CNC listos para cortar de un muro de escalada en casa: cada panel, cada tuerca en T y cada agujero de LED colocados, repartidos en las planchas que tiene tu taller."
+      "description": "Archivos CNC para un muro de escalada en casa: paneles y puntos de perforación repartidos en las planchas de tu taller."
     },
     "orders": {
       "title": "Tus planos de construcción",
@@ -15,8 +15,8 @@
   },
   "hero": {
     "title": "Planos para construir tu plafón en casa",
-    "subtitle": "Archivos DXF que un taller CNC corta directamente. Cada panel, la retícula de tuercas en T, los agujeros de LED y la repisa, repartidos en las planchas que tu taller ya tiene.",
-    "firstBoard": "El Kilter Homewall es el primer plafón compatible. Vendrán más.",
+    "subtitle": "Archivos DXF para tu taller CNC. Paneles y puntos de perforación repartidos en las planchas que tu taller ya tiene.",
+    "firstBoard": "Compatible con Kilter Homewall y Tension Board 2, incluidas las distribuciones Mirror y Spray.",
     "included": {
       "heading": "Qué te llevas",
       "dxf": "Los planos de montaje del muro entero van incluidos, así los paneles encajan sin adivinar nada.",
@@ -61,7 +61,8 @@
     },
     "board": {
       "label": "Plafón",
-      "help": "El Kilter Homewall es el único plafón a la venta hoy."
+      "help": "Elige el plafón para el que vas a fabricar los paneles.",
+      "kilterHomewall": "Kilter Homewall"
     },
     "size": {
       "label": "Tamaño del muro",
@@ -77,7 +78,7 @@
       "help": "Los valores por defecto son con los que construimos nosotros. Cámbialos para que encajen con tu taller.",
       "sheetStock": {
         "label": "Tamaño de plancha",
-        "help": "El contrachapado del que corta tu taller. Con una plancha de 3,6 m sale una fila entera del muro sin junta.",
+        "help": "Elige la lámina de contrachapado que utiliza tu taller. Los paneles se dividen para ajustarse a ella.",
         "values": {
           "2440x1220": "2440 × 1220 mm",
           "3600x1220": "3600 × 1220 mm"
@@ -149,7 +150,7 @@
       },
       "supportStrips": {
         "label": "Listones de refuerzo de junta",
-        "help": "Listones de contrachapado de 150 mm, ranurados para las tuercas en T, que van detrás de cada junta horizontal. Déjalos activados salvo que tu estructura ya refuerce las juntas.",
+        "help": "Tiras de contrachapado de 150 mm refuerzan las juntas horizontales y mantienen el acceso a los orificios.",
         "values": {
           "false": "Desactivado",
           "true": "Activado"
@@ -169,6 +170,24 @@
         "values": {
           "false": "Desactivado",
           "true": "Activado"
+        }
+      },
+      "tb2DimensionStandard": {
+        "label": "Dimensiones de TB2",
+        "help": "Métricas: retícula principal de 200 mm y orificios LED de 12 mm. Imperiales: retícula de 7⅞ pulgadas y orificios de ½ pulgada. Cambiar las dimensiones elimina los diseños colocados.",
+        "values": {
+          "metric": "Métricas",
+          "imperial": "Imperiales"
+        }
+      },
+      "tb2Engraving": {
+        "label": "Grabado de TB2",
+        "help": "Identificadores de presas y marcas de orientación de los planos de instalación de Tension.",
+        "values": {
+          "none": "Sin grabado",
+          "mirror": "Mirror",
+          "spray": "Spray",
+          "both": "Mirror + Spray"
         }
       }
     },
@@ -320,6 +339,12 @@
       "heading": "A nombre de quién va la licencia",
       "help": "La licencia va en todos los archivos del pack, así que una copia filtrada se rastrea hasta ella.",
       "stale": "Actualiza antes la vista previa: el muro ha cambiado desde estas hojas."
+    },
+    "tb2": {
+      "boardName": "Tension Board 2",
+      "sizeHelp": "Alto × ancho en pies. Tension indica primero la altura.",
+      "engraveHelp": "Graba Mirror, Spray o ambas distribuciones en los mismos paneles. Ambas están seleccionadas por defecto.",
+      "engraveNote": "Las etiquetas de Mirror van a la izquierda de cada orificio, con una marca de orientación. Las de Spray van a la derecha, con dos marcas. Cada panel grabado incluye una leyenda."
     }
   },
   "cta": {

--- a/packages/shared/i18n/locales/es/cnc.json
+++ b/packages/shared/i18n/locales/es/cnc.json
@@ -342,6 +342,7 @@
     },
     "tb2": {
       "boardName": "Tension Board 2",
+      "savedConfigurationUnavailable": "Configuración guardada no disponible",
       "sizeHelp": "Alto × ancho en pies. Tension indica primero la altura.",
       "engraveHelp": "Graba Mirror, Spray o ambas distribuciones en los mismos paneles. Ambas están seleccionadas por defecto.",
       "engraveNote": "Las etiquetas de Mirror van a la izquierda de cada orificio, con una marca de orientación. Las de Spray van a la derecha, con dos marcas. Cada panel grabado incluye una leyenda."

--- a/packages/shared/i18n/locales/fr/cnc.json
+++ b/packages/shared/i18n/locales/fr/cnc.json
@@ -2,7 +2,7 @@
   "metadata": {
     "buildPlans": {
       "title": "Plans de construction pour une board maison",
-      "description": "Des fichiers CNC prêts à découper pour un mur d'escalade maison : chaque panneau, chaque écrou à griffes et chaque perçage LED placé, répartis sur les plaques que ton atelier a en stock."
+      "description": "Fichiers CNC pour un mur d’escalade à domicile : panneaux et perçages répartis sur les plaques de votre atelier."
     },
     "orders": {
       "title": "Tes plans de construction",
@@ -15,8 +15,8 @@
   },
   "hero": {
     "title": "Plans de construction pour ta board maison",
-    "subtitle": "Des fichiers DXF qu'un atelier CNC découpe tels quels. Chaque panneau, la trame d'écrous à griffes, les perçages LED et le kicker, répartis sur les plaques que ton atelier a déjà en stock.",
-    "firstBoard": "Le Kilter Homewall est la première board prise en charge. D'autres suivront.",
+    "subtitle": "Des fichiers DXF pour votre atelier CNC. Panneaux et perçages répartis sur les plaques que votre atelier utilise déjà.",
+    "firstBoard": "Compatible avec Kilter Homewall et Tension Board 2, avec les configurations Mirror et Spray.",
     "included": {
       "heading": "Ce que tu reçois",
       "dxf": "Les plans de montage du mur complet sont inclus, pour que les panneaux s'alignent sans deviner.",
@@ -61,7 +61,8 @@
     },
     "board": {
       "label": "Board",
-      "help": "Le Kilter Homewall est la seule board en vente aujourd'hui."
+      "help": "Choisis la board pour laquelle tu fabriques les panneaux.",
+      "kilterHomewall": "Kilter Homewall"
     },
     "size": {
       "label": "Taille du mur",
@@ -77,7 +78,7 @@
       "help": "Les valeurs par défaut sont celles avec lesquelles on construit. Change-les pour coller à ton atelier.",
       "sheetStock": {
         "label": "Format de plaque",
-        "help": "Le contreplaqué dans lequel ton atelier découpe. Une plaque de 3,6 m permet de sortir une rangée du mur sans raccord.",
+        "help": "Choisis la plaque de contreplaqué utilisée par ton atelier. Les panneaux sont divisés pour y tenir.",
         "values": {
           "2440x1220": "2440 × 1220 mm",
           "3600x1220": "3600 × 1220 mm"
@@ -149,7 +150,7 @@
       },
       "supportStrips": {
         "label": "Lattes de renfort des joints",
-        "help": "Lattes de contreplaqué de 150 mm, rainurées pour les écrous à griffes, qui se placent derrière chaque joint horizontal. Laissez-les activées sauf si votre ossature soutient déjà les joints.",
+        "help": "Des bandes de contreplaqué de 150 mm renforcent les joints horizontaux et préservent l’accès aux trous.",
         "values": {
           "false": "Désactivé",
           "true": "Activé"
@@ -169,6 +170,24 @@
         "values": {
           "false": "Désactivé",
           "true": "Activé"
+        }
+      },
+      "tb2DimensionStandard": {
+        "label": "Dimensions TB2",
+        "help": "Métriques : grille principale de 200 mm et trous LED de 12 mm. Impériales : grille de 7⅞ pouces et trous de ½ pouce. Changer les dimensions efface les motifs placés.",
+        "values": {
+          "metric": "Métriques",
+          "imperial": "Impériales"
+        }
+      },
+      "tb2Engraving": {
+        "label": "Gravure TB2",
+        "help": "Identifiants des prises et repères de direction issus des plans de montage de Tension.",
+        "values": {
+          "none": "Sans gravure",
+          "mirror": "Mirror",
+          "spray": "Spray",
+          "both": "Mirror + Spray"
         }
       }
     },
@@ -320,6 +339,12 @@
       "heading": "Au nom de qui est la licence",
       "help": "La licence figure sur chaque fichier du pack : une copie qui fuite y remonte.",
       "stale": "Mets d'abord ton aperçu à jour — le mur a changé depuis ces planches."
+    },
+    "tb2": {
+      "boardName": "Tension Board 2",
+      "sizeHelp": "Hauteur × largeur en pieds. Tension indique la hauteur en premier.",
+      "engraveHelp": "Grave Mirror, Spray ou les deux sur les mêmes panneaux. Les deux dispositions sont sélectionnées par défaut.",
+      "engraveNote": "Les repères Mirror sont à gauche de chaque trou avec un trait de direction. Les repères Spray sont à droite avec deux traits. Chaque panneau gravé comporte une légende."
     }
   },
   "cta": {

--- a/packages/shared/i18n/locales/fr/cnc.json
+++ b/packages/shared/i18n/locales/fr/cnc.json
@@ -342,6 +342,7 @@
     },
     "tb2": {
       "boardName": "Tension Board 2",
+      "savedConfigurationUnavailable": "Configuration enregistrée indisponible",
       "sizeHelp": "Hauteur × largeur en pieds. Tension indique la hauteur en premier.",
       "engraveHelp": "Grave Mirror, Spray ou les deux sur les mêmes panneaux. Les deux dispositions sont sélectionnées par défaut.",
       "engraveNote": "Les repères Mirror sont à gauche de chaque trou avec un trait de direction. Les repères Spray sont à droite avec deux traits. Chaque panneau gravé comporte une légende."

--- a/packages/shared/i18n/locales/fr/cnc.json
+++ b/packages/shared/i18n/locales/fr/cnc.json
@@ -2,7 +2,7 @@
   "metadata": {
     "buildPlans": {
       "title": "Plans de construction pour une board maison",
-      "description": "Fichiers CNC pour un mur d’escalade à domicile : panneaux et perçages répartis sur les plaques de votre atelier."
+      "description": "Fichiers CNC pour un mur d’escalade à domicile : panneaux et perçages répartis sur les plaques de ton atelier."
     },
     "orders": {
       "title": "Tes plans de construction",
@@ -15,7 +15,7 @@
   },
   "hero": {
     "title": "Plans de construction pour ta board maison",
-    "subtitle": "Des fichiers DXF pour votre atelier CNC. Panneaux et perçages répartis sur les plaques que votre atelier utilise déjà.",
+    "subtitle": "Des fichiers DXF pour ton atelier CNC. Panneaux et perçages répartis sur les plaques que ton atelier utilise déjà.",
     "firstBoard": "Compatible avec Kilter Homewall et Tension Board 2, avec les configurations Mirror et Spray.",
     "included": {
       "heading": "Ce que tu reçois",

--- a/packages/web/app/build-plans/__tests__/configurator-flow.test.tsx
+++ b/packages/web/app/build-plans/__tests__/configurator-flow.test.tsx
@@ -157,11 +157,11 @@ function respond(document: string) {
   return Promise.resolve({});
 }
 
-function renderConfigurator() {
+function renderConfigurator(selectedCatalog: CncCatalog = catalog()) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
-      <Configurator catalog={catalog()} locale="en-US" />
+      <Configurator catalog={selectedCatalog} locale="en-US" />
     </QueryClientProvider>,
   );
 }
@@ -338,4 +338,71 @@ describe('the finalise step', () => {
     });
     await waitFor(() => expect(locationAssign).toHaveBeenCalledWith(STRIPE_URL));
   });
+});
+
+it('selects TB2 dimensions and engraving and submits the matching tuple', async () => {
+  const supported = catalog();
+  for (const layoutId of [10, 11]) {
+    for (const sizeId of [9, 8, 7, 6, 10]) {
+      supported.entries.push({
+        ...supported.entries[0]!,
+        boardName: 'tension',
+        layoutId,
+        sizeId,
+        label: `TB2 size ${sizeId}`,
+        setIds: '12,13',
+        manufacturingOptions: [
+          {
+            key: 'tb2DimensionStandard',
+            values: ['metric', 'imperial'],
+            defaultValue: 'metric',
+            valueType: 'string',
+            kickerOnly: false,
+          },
+          {
+            key: 'tb2Engraving',
+            values: ['none', 'mirror', 'spray', 'both'],
+            defaultValue: layoutId === 11 ? 'spray' : 'both',
+            valueType: 'string',
+            kickerOnly: false,
+          },
+        ],
+      });
+    }
+  }
+  renderConfigurator(supported);
+  fireEvent.mouseDown(await screen.findByRole('combobox', { name: 'Board' }));
+  fireEvent.click(await screen.findByRole('option', { name: 'Tension Board 2' }));
+  expect(lastLayoutConfig()).toMatchObject({
+    boardName: 'tension',
+    sizeId: 9,
+    layoutId: 10,
+    options: { tb2DimensionStandard: 'metric', tb2Engraving: 'both' },
+  });
+  expect(screen.queryByRole('switch', { name: 'Engrave hold numbers' })).toBeNull();
+
+  fireEvent.mouseDown(screen.getByRole('combobox', { name: 'Wall size' }));
+  expect(await screen.findAllByRole('option')).toHaveLength(5);
+  fireEvent.click(screen.getByRole('option', { name: 'TB2 size 10' }));
+  fireEvent.mouseDown(screen.getByRole('combobox', { name: 'TB2 dimensions' }));
+  fireEvent.click(await screen.findByRole('option', { name: /Imperial/ }));
+  fireEvent.mouseDown(screen.getByRole('combobox', { name: 'TB2 engraving' }));
+  fireEvent.click(await screen.findByRole('option', { name: 'Spray' }));
+  expect(lastLayoutConfig()).toMatchObject({
+    boardName: 'tension',
+    layoutId: 11,
+    sizeId: 10,
+    options: { tb2DimensionStandard: 'imperial', tb2Engraving: 'spray' },
+  });
+  fireEvent.click(primaryAction());
+  await waitFor(() =>
+    expect(sentCall('mutation CreateCncPreview')).toMatchObject({
+      config: {
+        boardName: 'tension',
+        layoutId: 11,
+        sizeId: 10,
+        options: { tb2DimensionStandard: 'imperial', tb2Engraving: 'spray' },
+      },
+    }),
+  );
 });

--- a/packages/web/app/build-plans/__tests__/configurator-state.test.ts
+++ b/packages/web/app/build-plans/__tests__/configurator-state.test.ts
@@ -398,3 +398,90 @@ describe('option value keys', () => {
     expect(optionValueKey('true')).toBe('true');
   });
 });
+
+function tensionBoard2(layoutId = 10, sizeId = 9): CncCatalogEntry {
+  return {
+    ...tenByTwelve(),
+    boardName: 'tension',
+    layoutId,
+    sizeId,
+    setIds: '12,13',
+    kickerOptional: false,
+    label: '10 × 8',
+    manufacturingOptions: [
+      {
+        key: 'tb2Engraving',
+        values: ['none', 'mirror', 'spray', 'both'],
+        defaultValue: layoutId === 11 ? 'spray' : 'both',
+        valueType: 'string',
+        kickerOnly: false,
+      },
+      {
+        key: 'tb2DimensionStandard',
+        values: ['metric', 'imperial'],
+        defaultValue: 'metric',
+        valueType: 'string',
+        kickerOnly: false,
+      },
+    ],
+  };
+}
+
+describe('Tension Board 2 configuration', () => {
+  it('defaults to metric with both engravings and no kicker', () => {
+    expect(initialConfiguratorState(tensionBoard2())).toMatchObject({
+      layoutId: 10,
+      includeKicker: false,
+      options: { tb2Engraving: 'both', tb2DimensionStandard: 'metric' },
+    });
+  });
+
+  it.each(['none', 'mirror', 'spray', 'both'])('keeps %s synchronized with the board tuple and draft', (mode) => {
+    const entries = [tensionBoard2(), tensionBoard2(11)];
+    const initial = initialConfiguratorState(entries[0]!);
+    const state = configuratorReducer(initial, { type: 'setOption', key: 'tb2Engraving', value: mode });
+    expect(state.layoutId).toBe(mode === 'spray' ? 11 : 10);
+    const restored = fromDraft(toDraft(state), entries);
+    expect(restored).toMatchObject({ layoutId: state.layoutId, options: { tb2Engraving: mode } });
+    const selected = entries.find((entry) => entry.layoutId === state.layoutId)!;
+    expect(toBoardConfigInput(state, selected)).toMatchObject({
+      layoutId: state.layoutId,
+      options: { tb2Engraving: mode },
+    });
+    if (mode !== 'both')
+      expect(configKey(toBoardConfigInput(state, selected))).not.toBe(
+        configKey(toBoardConfigInput(initial, entries[0]!)),
+      );
+  });
+
+  it('clears artwork after changing dimensions but retains it when changing engraving', () => {
+    const initial = initialConfiguratorState(tensionBoard2());
+    const withArtwork = configuratorReducer(initial, {
+      type: 'addArtwork',
+      item: {
+        id: 'tb2-art',
+        assetId: null,
+        kind: 'text',
+        text: 'My wall',
+        font: 'liberation-sans',
+        mode: 'engrave',
+        panelIndex: 0,
+        xMm: 200,
+        yMm: 200,
+        widthMm: 100,
+        rotationDeg: 0,
+      },
+    });
+    expect(
+      configuratorReducer(withArtwork, { type: 'setOption', key: 'tb2Engraving', value: 'spray' }).artwork,
+    ).toEqual(withArtwork.artwork);
+    expect(
+      configuratorReducer(withArtwork, { type: 'setOption', key: 'tb2DimensionStandard', value: 'imperial' }).artwork,
+    ).toEqual([]);
+  });
+
+  it('rejects a draft whose tuple and engraving disagree', () => {
+    const draft = toDraft(initialConfiguratorState(tensionBoard2()));
+    expect(fromDraft({ ...draft, layoutId: 11 }, [tensionBoard2(), tensionBoard2(11)])).toBeNull();
+  });
+});

--- a/packages/web/app/build-plans/__tests__/order-display.test.ts
+++ b/packages/web/app/build-plans/__tests__/order-display.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from 'vite-plus/test';
 import type { CncCatalog, CncOrderStatus } from '@boardsesh/shared-schema';
 import {
+  boardDisplayLabel,
   finaliseHref,
   isPreviewStatus,
   newestPreviewReadyLicenceId,
   previewImageLabel,
   tierLabel,
+  tb2ConfigurationLabel,
   wallLabel,
 } from '../order-display';
 
@@ -33,6 +35,28 @@ const ORDER_10X12 = { boardName: 'kilter', layoutId: 8, sizeId: 25 };
 
 /** Stands in for `t`: returns the key so the assertion names the catalog entry. */
 const translateToKey = (key: string) => key;
+
+it.each<Record<string, string | number | boolean> | undefined>([
+  undefined,
+  {},
+  { tb2Engraving: 'unknown', tb2DimensionStandard: 'metric' },
+  { tb2Engraving: 'both', tb2DimensionStandard: 'unknown' },
+])('does not invent saved TB2 choices for incomplete options: %j', (options) => {
+  expect(tb2ConfigurationLabel(options, translateToKey)).toBe('configurator.tb2.savedConfigurationUnavailable');
+});
+
+it('names supported board layouts without relabelling other layouts', () => {
+  expect(boardDisplayLabel({ boardName: 'tension', layoutId: 10 }, translateToKey)).toBe('configurator.tb2.boardName');
+  expect(boardDisplayLabel({ boardName: 'kilter', layoutId: 8 }, translateToKey)).toBe(
+    'configurator.board.kilterHomewall',
+  );
+  expect(boardDisplayLabel({ boardName: 'tension', layoutId: 9 }, translateToKey)).not.toBe(
+    'configurator.tb2.boardName',
+  );
+  expect(boardDisplayLabel({ boardName: 'kilter', layoutId: 1 }, translateToKey)).not.toBe(
+    'configurator.board.kilterHomewall',
+  );
+});
 
 describe('wallLabel', () => {
   it('uses the catalogue label when the entry is still on sale', () => {

--- a/packages/web/app/build-plans/__tests__/order-display.test.ts
+++ b/packages/web/app/build-plans/__tests__/order-display.test.ts
@@ -36,26 +36,42 @@ const translateToKey = (key: string) => key;
 
 describe('wallLabel', () => {
   it('uses the catalogue label when the entry is still on sale', () => {
-    expect(wallLabel(CATALOG, ORDER_10X12)).toBe('10x12');
+    expect(wallLabel(CATALOG, ORDER_10X12, translateToKey)).toBe('10x12');
   });
 
   it('falls back to the size id when the entry has been retired', () => {
     // A licence outlives the catalogue. Blanking the wall on an order somebody
     // paid for would be the worst possible answer to a retired entry, and "25"
     // is still enough for a buyer to recognise their own.
-    expect(wallLabel(CATALOG, { ...ORDER_10X12, sizeId: 17 })).toBe('17');
+    expect(wallLabel(CATALOG, { ...ORDER_10X12, sizeId: 17 }, translateToKey)).toBe('17');
   });
 
   it('falls back when the catalogue could not be fetched at all', () => {
-    expect(wallLabel(null, ORDER_10X12)).toBe('25');
+    expect(wallLabel(null, ORDER_10X12, translateToKey)).toBe('25');
   });
 
   it('matches on the whole tuple, not the size id alone', () => {
     // Size ids are per-board, so a Tension 25 is not a Kilter 25 and must not
     // borrow its label.
-    expect(wallLabel(CATALOG, { ...ORDER_10X12, boardName: 'tension' })).toBe('25');
-    expect(wallLabel(CATALOG, { ...ORDER_10X12, layoutId: 1 })).toBe('25');
+    expect(wallLabel(CATALOG, { ...ORDER_10X12, boardName: 'tension' }, translateToKey)).toBe('25');
+    expect(wallLabel(CATALOG, { ...ORDER_10X12, layoutId: 1 }, translateToKey)).toBe('25');
   });
+});
+
+it('always includes saved TB2 engraving and dimensions in an order label', () => {
+  const label = wallLabel(
+    null,
+    {
+      boardName: 'tension',
+      layoutId: 11,
+      sizeId: 9,
+      options: { tb2Engraving: 'spray', tb2DimensionStandard: 'imperial' },
+    },
+    translateToKey,
+  );
+  expect(label).toBe(
+    '9 · configurator.options.tb2Engraving.values.spray · configurator.options.tb2DimensionStandard.values.imperial',
+  );
 });
 
 describe('tierLabel', () => {

--- a/packages/web/app/build-plans/__tests__/orders-list.test.tsx
+++ b/packages/web/app/build-plans/__tests__/orders-list.test.tsx
@@ -105,7 +105,7 @@ describe('OrdersList', () => {
     // labelled every one of these "Commercial, single build".
     await renderList([preview('BS-CNC-NEWEST', '2026-09-05T10:00:00.000Z')]);
 
-    expect(screen.getByText('Kilter 25 · Preview')).toBeTruthy();
+    expect(screen.getByText('Kilter Homewall 25 · Preview')).toBeTruthy();
     expect(screen.queryByText(/Commercial/)).toBeNull();
   });
 

--- a/packages/web/app/build-plans/configurator/configurator-state.ts
+++ b/packages/web/app/build-plans/configurator/configurator-state.ts
@@ -1,3 +1,4 @@
+import { tb2LayoutIdForEngraving } from '@boardsesh/shared-schema';
 import type {
   CncArtworkInput,
   CncArtworkKind,
@@ -262,7 +263,7 @@ export function configuratorReducer(state: CncConfiguratorState, action: CncConf
       return {
         ...state,
         ...(action.key === 'tb2Engraving' && state.boardName === 'tension'
-          ? { layoutId: action.value === 'spray' ? 11 : 10 }
+          ? { layoutId: tb2LayoutIdForEngraving(action.value) }
           : {}),
         // A dimension standard changes every placement coordinate.
         ...(action.key === 'tb2DimensionStandard' && action.value !== state.options.tb2DimensionStandard
@@ -749,7 +750,7 @@ export function fromDraft(raw: unknown, entries: readonly CncCatalogEntry[]): Cn
     boardFamilyKey(entry) === 'tension:tb2' &&
     (options.tb2DimensionStandard !== draft.options.tb2DimensionStandard ||
       options.tb2Engraving !== draft.options.tb2Engraving ||
-      entry.layoutId !== (options.tb2Engraving === 'spray' ? 11 : 10))
+      entry.layoutId !== tb2LayoutIdForEngraving(options.tb2Engraving))
   )
     return null;
 

--- a/packages/web/app/build-plans/configurator/configurator-state.ts
+++ b/packages/web/app/build-plans/configurator/configurator-state.ts
@@ -31,13 +31,11 @@ import type {
 export const CNC_KICKER_SET_IDS: readonly number[] = [28, 29];
 
 /**
- * The two manufacturing options that are engraving decisions rather than
- * machining ones.
+ * Manufacturing options that choose installation engravings.
  *
- * They live in the catalogue's `manufacturingOptions` like everything else, but
- * they get their own step in the UI: both are Kilter-specific, both are off
- * pending the IP review, and burying them among sheet sizes and hole diameters
- * would have people flipping them without reading why they are off.
+ * They live in the catalogue's `manufacturingOptions`, but have their own UI
+ * step: Kilter offers hold IDs and angle ticks; TB2 selects Mirror, Spray,
+ * both layouts, or neither.
  */
 export const CNC_ENGRAVE_OPTION_KEYS: readonly string[] = ['engraveHoldIds', 'engraveAngleTicks', 'tb2Engraving'];
 

--- a/packages/web/app/build-plans/configurator/configurator-state.ts
+++ b/packages/web/app/build-plans/configurator/configurator-state.ts
@@ -39,7 +39,7 @@ export const CNC_KICKER_SET_IDS: readonly number[] = [28, 29];
  * pending the IP review, and burying them among sheet sizes and hole diameters
  * would have people flipping them without reading why they are off.
  */
-export const CNC_ENGRAVE_OPTION_KEYS: readonly string[] = ['engraveHoldIds', 'engraveAngleTicks'];
+export const CNC_ENGRAVE_OPTION_KEYS: readonly string[] = ['engraveHoldIds', 'engraveAngleTicks', 'tb2Engraving'];
 
 /** IndexedDB key the in-progress configuration is parked under across a sign-in round trip. */
 export const CNC_CONFIGURATOR_DRAFT_KEY = 'cnc:configurator-draft';
@@ -215,6 +215,17 @@ export function initialConfiguratorState(entry: CncCatalogEntry): CncConfigurato
   };
 }
 
+/** TB2 installation layouts share one physical board choice. */
+export function boardFamilyKey(entry: Pick<CncCatalogEntry, 'boardName' | 'layoutId'>): string {
+  return entry.boardName === 'tension' && (entry.layoutId === 10 || entry.layoutId === 11)
+    ? 'tension:tb2'
+    : `${entry.boardName}:${entry.layoutId}`;
+}
+
+export function catalogEntryKey(entry: Pick<CncCatalogEntry, 'boardName' | 'layoutId' | 'sizeId'>): string {
+  return `${entry.boardName}:${entry.layoutId}:${entry.sizeId}`;
+}
+
 export function findEntry(entries: readonly CncCatalogEntry[], state: CncConfiguratorState): CncCatalogEntry | null {
   return (
     entries.find(
@@ -250,7 +261,17 @@ export function configuratorReducer(state: CncConfiguratorState, action: CncConf
     case 'setKicker':
       return { ...state, includeKicker: action.includeKicker };
     case 'setOption':
-      return { ...state, options: { ...state.options, [action.key]: action.value } };
+      return {
+        ...state,
+        ...(action.key === 'tb2Engraving' && state.boardName === 'tension'
+          ? { layoutId: action.value === 'spray' ? 11 : 10 }
+          : {}),
+        // A dimension standard changes every placement coordinate.
+        ...(action.key === 'tb2DimensionStandard' && action.value !== state.options.tb2DimensionStandard
+          ? { artwork: [] }
+          : {}),
+        options: { ...state.options, [action.key]: action.value },
+      };
     case 'addArtwork':
       return { ...state, artwork: [...state.artwork, action.item] };
     case 'updateArtwork':
@@ -724,6 +745,15 @@ export function fromDraft(raw: unknown, entries: readonly CncCatalogEntry[]): Cn
     const stored = draft.options[option.key];
     options[option.key] = stored !== undefined && option.values.includes(stored) ? stored : option.defaultValue;
   }
+
+  // A stale TB2 draft cannot silently change dimensions or installation layout.
+  if (
+    boardFamilyKey(entry) === 'tension:tb2' &&
+    (options.tb2DimensionStandard !== draft.options.tb2DimensionStandard ||
+      options.tb2Engraving !== draft.options.tb2Engraving ||
+      entry.layoutId !== (options.tb2Engraving === 'spray' ? 11 : 10))
+  )
+    return null;
 
   // All three or none. A licence id with no config key behind it would restore
   // a gallery the buyer cannot tell is stale, and an order id with no licence id

--- a/packages/web/app/build-plans/configurator/configurator.tsx
+++ b/packages/web/app/build-plans/configurator/configurator.tsx
@@ -38,13 +38,12 @@ import {
   type CncConfigProps,
   type CncConfiguratorStep,
 } from '@boardsesh/analytics';
-import { getBoardDisplayName } from '@boardsesh/climb-actions';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { trackCncFunnelEvent } from '@/app/lib/cnc-funnel-analytics';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
-import { tb2ConfigurationLabel } from '../order-display';
+import { boardDisplayLabel, tb2ConfigurationLabel } from '../order-display';
 import {
   FieldGrid,
   KeyValueList,
@@ -959,11 +958,7 @@ function WallStep({
         >
           {families.map((candidate) => (
             <MenuItem key={boardFamilyKey(candidate)} value={boardFamilyKey(candidate)}>
-              {candidate.boardName === 'tension'
-                ? t('configurator.tb2.boardName')
-                : candidate.boardName === 'kilter' && candidate.layoutId === 8
-                  ? t('configurator.board.kilterHomewall')
-                  : getBoardDisplayName(candidate.boardName)}
+              {boardDisplayLabel(candidate, t)}
             </MenuItem>
           ))}
         </Select>

--- a/packages/web/app/build-plans/configurator/configurator.tsx
+++ b/packages/web/app/build-plans/configurator/configurator.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { tb2ConfigurationLabel } from '../order-display';
 import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useTranslation } from 'react-i18next';
@@ -63,6 +64,8 @@ import {
   configKey,
   configuratorReducer,
   engraveOptions,
+  boardFamilyKey,
+  catalogEntryKey,
   finaliseBlockers,
   findEntry,
   formatPrice,
@@ -193,7 +196,7 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
   const { toggles: machiningToggles, choices: machiningChoices } = partitionByControl(
     visibleMachiningOptions(entry, state.includeKicker),
   );
-  const engraveToggles = engraveOptions(entry);
+  const { toggles: engraveToggles, choices: engraveChoices } = partitionByControl(engraveOptions(entry));
 
   // Which labels the placement editor can already see are in trouble. Reported
   // by id rather than counted, so removing an item takes its verdict with it.
@@ -322,16 +325,11 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
   }, [session, isDraftRestored, isLicenseeEmailEmpty, isLicenseeNameEmpty]);
 
   // ------------------------------------------------------------------- actions
-  const handleSizeChange = (sizeId: number) => {
-    const next = entries.find((candidate) => candidate.sizeId === sizeId);
+  const handleEntryChange = (entryKey: string) => {
+    const next = entries.find((candidate) => catalogEntryKey(candidate) === entryKey);
     if (!next) return;
     dispatch({ type: 'selectSize', entry: next });
-    // Picking a size is also picking a board, because a catalogue entry names
-    // both. Today every entry is a Kilter Homewall so this branch never fires,
-    // and `board` would be the one step in the funnel contract that never
-    // appears — leaving a gap in the funnel the day a second board goes on
-    // sale and the size select starts spanning two of them.
-    if (next.boardName !== entry.boardName) reportStep('board');
+    if (boardFamilyKey(next) !== boardFamilyKey(entry)) reportStep('board');
     reportStep('size');
   };
 
@@ -450,6 +448,7 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
           rail={
             <SummaryRail
               summary={summary}
+              configurationLabel={entry.boardName === 'tension' ? tb2ConfigurationLabel(state.options, t) : null}
               isLoading={isLayoutLoading}
               hasError={layoutErrorKey !== null}
               price={price ? formatPrice(price.amountCents, price.currency, locale) : null}
@@ -483,7 +482,7 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
                 description={t('configurator.wall.help')}
               />
               <Box className={styles.stepBody}>
-                <WallStep entries={entries} state={state} onSizeChange={handleSizeChange} />
+                <WallStep entries={entries} state={state} onEntryChange={handleEntryChange} />
                 {hasKickerSets(entry) && entry.kickerOptional && (
                   <Box className={styles.switchRow}>
                     <FormControlLabel
@@ -561,15 +560,40 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
               </Box>
             </SectionCard>
 
-            {engraveToggles.length > 0 && (
+            {(engraveToggles.length > 0 || engraveChoices.length > 0) && (
               <SectionCard>
                 <StepHeading
                   step={3}
                   done
                   title={t('configurator.engrave.heading')}
-                  description={t('configurator.engrave.help')}
+                  description={
+                    entry.boardName === 'tension' ? t('configurator.tb2.engraveHelp') : t('configurator.engrave.help')
+                  }
                 />
                 <Box className={styles.stepBody}>
+                  {engraveChoices.map((option) => (
+                    <FormControl key={option.key} fullWidth size="small">
+                      <InputLabel id={`cnc-engrave-${option.key}`}>
+                        {t(`configurator.options.${option.key}.label`)}
+                      </InputLabel>
+                      <Select
+                        labelId={`cnc-engrave-${option.key}`}
+                        label={t(`configurator.options.${option.key}.label`)}
+                        value={state.options[option.key] ?? option.defaultValue}
+                        onChange={(event) => {
+                          dispatch({ type: 'setOption', key: option.key, value: event.target.value });
+                          reportStep('engrave');
+                        }}
+                      >
+                        {option.values.map((optionValue) => (
+                          <MenuItem key={optionValue} value={optionValue}>
+                            {t(`configurator.options.${option.key}.values.${optionValueKey(optionValue)}`)}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                      <FormHelperText>{t(`configurator.options.${option.key}.help`)}</FormHelperText>
+                    </FormControl>
+                  ))}
                   {engraveToggles.map((option) => (
                     <Box key={option.key} className={styles.switchRow}>
                       <FormControlLabel
@@ -592,7 +616,7 @@ export default function Configurator({ catalog, locale }: ConfiguratorProps) {
                     </Box>
                   ))}
                   <Typography variant="body2" component="p" className={styles.stepNote}>
-                    {t('configurator.engrave.note')}
+                    {entry.boardName === 'tension' ? t('configurator.tb2.engraveNote') : t('configurator.engrave.note')}
                   </Typography>
                 </Box>
               </SectionCard>
@@ -907,45 +931,62 @@ function PreviewStep({
 function WallStep({
   entries,
   state,
-  onSizeChange,
+  onEntryChange,
 }: {
   entries: readonly CncCatalogEntry[];
   state: CncConfiguratorState;
-  onSizeChange: (sizeId: number) => void;
+  onEntryChange: (entryKey: string) => void;
 }) {
   const { t } = useTranslation('cnc');
-  // Boards, not sizes: v1 sells one board, so the board control is a read-only
-  // statement of that rather than a select with a single option pretending to
-  // be a choice. It becomes a select the day a second board is on sale.
-  const boardNames = [...new Set(entries.map((candidate) => getBoardDisplayName(candidate.boardName)))];
+  const families = [...new Map(entries.map((candidate) => [boardFamilyKey(candidate), candidate])).values()];
+  const selectedFamily = boardFamilyKey(state);
+  const sizes = entries.filter(
+    (candidate) => boardFamilyKey(candidate) === selectedFamily && candidate.layoutId === state.layoutId,
+  );
 
   return (
     <FieldGrid>
-      <Box>
-        <Typography variant="body2" component="p" className={styles.readOnlyLabel}>
-          {t('configurator.board.label')}
-        </Typography>
-        <Typography variant="body1" component="p">
-          {boardNames.join(', ')}
-        </Typography>
+      <FormControl fullWidth size="small">
+        <InputLabel id="cnc-board">{t('configurator.board.label')}</InputLabel>
+        <Select
+          labelId="cnc-board"
+          label={t('configurator.board.label')}
+          value={selectedFamily}
+          onChange={(event) => {
+            const next = entries.find((candidate) => boardFamilyKey(candidate) === event.target.value);
+            if (next) onEntryChange(catalogEntryKey(next));
+          }}
+        >
+          {families.map((candidate) => (
+            <MenuItem key={boardFamilyKey(candidate)} value={boardFamilyKey(candidate)}>
+              {candidate.boardName === 'tension'
+                ? t('configurator.tb2.boardName')
+                : candidate.boardName === 'kilter' && candidate.layoutId === 8
+                  ? t('configurator.board.kilterHomewall')
+                  : getBoardDisplayName(candidate.boardName)}
+            </MenuItem>
+          ))}
+        </Select>
         <FormHelperText>{t('configurator.board.help')}</FormHelperText>
-      </Box>
+      </FormControl>
 
       <FormControl fullWidth size="small">
         <InputLabel id="cnc-size">{t('configurator.size.label')}</InputLabel>
         <Select
           labelId="cnc-size"
           label={t('configurator.size.label')}
-          value={String(state.sizeId)}
-          onChange={(event) => onSizeChange(Number(event.target.value))}
+          value={catalogEntryKey(state)}
+          onChange={(event) => onEntryChange(event.target.value)}
         >
-          {entries.map((candidate) => (
-            <MenuItem key={candidate.sizeId} value={String(candidate.sizeId)}>
+          {sizes.map((candidate) => (
+            <MenuItem key={catalogEntryKey(candidate)} value={catalogEntryKey(candidate)}>
               {candidate.label}
             </MenuItem>
           ))}
         </Select>
-        <FormHelperText>{t('configurator.size.help')}</FormHelperText>
+        <FormHelperText>
+          {state.boardName === 'tension' ? t('configurator.tb2.sizeHelp') : t('configurator.size.help')}
+        </FormHelperText>
       </FormControl>
     </FieldGrid>
   );
@@ -962,6 +1003,7 @@ function WallStep({
  */
 function SummaryRail({
   summary,
+  configurationLabel,
   isLoading,
   hasError,
   price,
@@ -979,6 +1021,7 @@ function SummaryRail({
   onFinalise,
 }: {
   summary: CncLayoutSummary | null;
+  configurationLabel: string | null;
   isLoading: boolean;
   hasError: boolean;
   /** Already formatted for the request's locale, or null when the tier has no price. */
@@ -1079,6 +1122,7 @@ function SummaryRail({
 
   return (
     <SectionCard tone="raised" title={t('configurator.summary.heading')}>
+      {configurationLabel && <Typography variant="body2">{configurationLabel}</Typography>}
       {hasError ? (
         // An outage does not blank the rail: the error above already says what
         // happened, and a card full of dashes says nothing.

--- a/packages/web/app/build-plans/configurator/configurator.tsx
+++ b/packages/web/app/build-plans/configurator/configurator.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { tb2ConfigurationLabel } from '../order-display';
 import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useTranslation } from 'react-i18next';
@@ -45,6 +44,7 @@ import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { trackCncFunnelEvent } from '@/app/lib/cnc-funnel-analytics';
 import { getPreference, setPreference } from '@/app/lib/user-preferences-db';
+import { tb2ConfigurationLabel } from '../order-display';
 import {
   FieldGrid,
   KeyValueList,

--- a/packages/web/app/build-plans/order-display.ts
+++ b/packages/web/app/build-plans/order-display.ts
@@ -43,7 +43,7 @@ export function tb2ConfigurationLabel(
 export function wallLabel(
   catalog: CncCatalog | null,
   order: { boardName: string; layoutId: number; sizeId: number; options?: Record<string, string | number | boolean> },
-  translate?: (key: string) => string,
+  translate: (key: string) => string,
 ): string {
   const entry = catalog?.entries.find(
     (candidate) =>
@@ -52,7 +52,7 @@ export function wallLabel(
       candidate.sizeId === order.sizeId,
   );
   const size = entry?.label ?? String(order.sizeId);
-  return order.boardName === 'tension' && translate
+  return order.boardName === 'tension' && (order.layoutId === 10 || order.layoutId === 11)
     ? `${size} · ${tb2ConfigurationLabel(order.options, translate)}`
     : size;
 }

--- a/packages/web/app/build-plans/order-display.ts
+++ b/packages/web/app/build-plans/order-display.ts
@@ -1,3 +1,5 @@
+import { getBoardDisplayName } from '@boardsesh/climb-actions';
+import { KILTER_HOMEWALL_LAYOUT_ID } from '@boardsesh/board-constants';
 import type { CncCatalog, CncLicenceTier, CncOrderStatus } from '@boardsesh/shared-schema';
 
 /**
@@ -12,19 +14,41 @@ import type { CncCatalog, CncLicenceTier, CncOrderStatus } from '@boardsesh/shar
  */
 
 /**
- * The wall's catalogue label ("10x12"), or the raw size id when the catalogue
- * no longer carries that entry.
- *
- * A retired entry must not blank out an order somebody paid for — the licence
- * outlives the catalogue, and "25" is still enough for a buyer to recognise
- * their own wall.
+ * Board names shared by configuration, order history and the admin queue.
+ * Layout guards keep other Tension and Kilter layouts from inheriting TB2 or
+ * Homewall names if the catalogue expands.
+ * i18n-keep cnc:configurator.tb2.boardName
+ * i18n-keep cnc:configurator.board.kilterHomewall
  */
-/** Saved manufacturing choices, also used on previews before an order exists. */
+export function boardDisplayLabel(
+  board: { boardName: string; layoutId: number },
+  translate: (key: string) => string,
+): string {
+  if (board.boardName === 'tension' && (board.layoutId === 10 || board.layoutId === 11)) {
+    return translate('configurator.tb2.boardName');
+  }
+  if (board.boardName === 'kilter' && board.layoutId === KILTER_HOMEWALL_LAYOUT_ID) {
+    return translate('configurator.board.kilterHomewall');
+  }
+  return getBoardDisplayName(board.boardName);
+}
+
+/**
+ * Saved manufacturing choices, also used on previews before an order exists.
+ * i18n-keep cnc:configurator.tb2.savedConfigurationUnavailable
+ */
 export function tb2ConfigurationLabel(
   options: Record<string, string | number | boolean> | undefined,
   translate: (key: string) => string,
 ): string {
   const mode = options?.tb2Engraving;
+  const standard = options?.tb2DimensionStandard;
+  if (
+    (mode !== 'none' && mode !== 'mirror' && mode !== 'spray' && mode !== 'both') ||
+    (standard !== 'metric' && standard !== 'imperial')
+  ) {
+    return translate('configurator.tb2.savedConfigurationUnavailable');
+  }
   const engraving =
     mode === 'none'
       ? translate('configurator.options.tb2Engraving.values.none')
@@ -34,12 +58,20 @@ export function tb2ConfigurationLabel(
           ? translate('configurator.options.tb2Engraving.values.spray')
           : translate('configurator.options.tb2Engraving.values.both');
   const dimensions =
-    options?.tb2DimensionStandard === 'imperial'
+    standard === 'imperial'
       ? translate('configurator.options.tb2DimensionStandard.values.imperial')
       : translate('configurator.options.tb2DimensionStandard.values.metric');
   return `${engraving} · ${dimensions}`;
 }
 
+/**
+ * The wall's catalogue label ("10x12"), or the raw size id when the catalogue
+ * no longer carries that entry.
+ *
+ * A retired entry must not blank out an order somebody paid for — the licence
+ * outlives the catalogue, and "25" is still enough for a buyer to recognise
+ * their own wall.
+ */
 export function wallLabel(
   catalog: CncCatalog | null,
   order: { boardName: string; layoutId: number; sizeId: number; options?: Record<string, string | number | boolean> },

--- a/packages/web/app/build-plans/order-display.ts
+++ b/packages/web/app/build-plans/order-display.ts
@@ -19,9 +19,31 @@ import type { CncCatalog, CncLicenceTier, CncOrderStatus } from '@boardsesh/shar
  * outlives the catalogue, and "25" is still enough for a buyer to recognise
  * their own wall.
  */
+/** Saved manufacturing choices, also used on previews before an order exists. */
+export function tb2ConfigurationLabel(
+  options: Record<string, string | number | boolean> | undefined,
+  translate: (key: string) => string,
+): string {
+  const mode = options?.tb2Engraving;
+  const engraving =
+    mode === 'none'
+      ? translate('configurator.options.tb2Engraving.values.none')
+      : mode === 'mirror'
+        ? translate('configurator.options.tb2Engraving.values.mirror')
+        : mode === 'spray'
+          ? translate('configurator.options.tb2Engraving.values.spray')
+          : translate('configurator.options.tb2Engraving.values.both');
+  const dimensions =
+    options?.tb2DimensionStandard === 'imperial'
+      ? translate('configurator.options.tb2DimensionStandard.values.imperial')
+      : translate('configurator.options.tb2DimensionStandard.values.metric');
+  return `${engraving} · ${dimensions}`;
+}
+
 export function wallLabel(
   catalog: CncCatalog | null,
-  order: { boardName: string; layoutId: number; sizeId: number },
+  order: { boardName: string; layoutId: number; sizeId: number; options?: Record<string, string | number | boolean> },
+  translate?: (key: string) => string,
 ): string {
   const entry = catalog?.entries.find(
     (candidate) =>
@@ -29,7 +51,10 @@ export function wallLabel(
       candidate.layoutId === order.layoutId &&
       candidate.sizeId === order.sizeId,
   );
-  return entry?.label ?? String(order.sizeId);
+  const size = entry?.label ?? String(order.sizeId);
+  return order.boardName === 'tension' && translate
+    ? `${size} · ${tb2ConfigurationLabel(order.options, translate)}`
+    : size;
 }
 
 /**

--- a/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
+++ b/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
@@ -7,7 +7,6 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import MuiLink from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
-import { getBoardDisplayName } from '@boardsesh/climb-actions';
 import type { CncDownloadKind, CncOrder, CncOrderStatus } from '@boardsesh/shared-schema';
 import {
   CREATE_CNC_DOWNLOAD_GRANT,
@@ -20,7 +19,7 @@ import { createGraphQLHttpClient, getGraphQLHttpUrl } from '@/app/lib/graphql/cl
 import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
 import { cncErrorKey, type CncErrorKey } from '../../cnc-error';
 import { createOrderDateFormatter } from '../../format-date';
-import { finaliseHref, previewImageLabel, tierLabel } from '../../order-display';
+import { boardDisplayLabel, finaliseHref, previewImageLabel, tierLabel } from '../../order-display';
 import { KeyValueList, PageFrame, PreviewGallery, SectionCard, StatusChip, type KeyValueItem } from '../../ui';
 import { orderRefetchInterval, useCncOrderPoll } from '../../use-cnc-order-poll';
 import styles from '../orders.module.css';
@@ -181,7 +180,7 @@ export default function OrderStatus({ initialOrder, wallLabel, checkoutOutcome, 
     {
       key: 'board',
       label: t('order.board'),
-      value: `${order.boardName === 'tension' ? t('configurator.tb2.boardName') : getBoardDisplayName(order.boardName)} ${wallLabel}`,
+      value: `${boardDisplayLabel(order, t)} ${wallLabel}`,
     },
     { key: 'tier', label: t('order.tier'), value: tierLabel(order.tier, t) },
   ];

--- a/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
+++ b/packages/web/app/build-plans/orders/[licenceId]/order-status.tsx
@@ -178,7 +178,11 @@ export default function OrderStatus({ initialOrder, wallLabel, checkoutOutcome, 
   const previewFailedSubject = encodeURIComponent(t('order.previewFailed.subject', { licenceId }));
 
   const facts: KeyValueItem[] = [
-    { key: 'board', label: t('order.board'), value: `${getBoardDisplayName(order.boardName)} ${wallLabel}` },
+    {
+      key: 'board',
+      label: t('order.board'),
+      value: `${order.boardName === 'tension' ? t('configurator.tb2.boardName') : getBoardDisplayName(order.boardName)} ${wallLabel}`,
+    },
     { key: 'tier', label: t('order.tier'), value: tierLabel(order.tier, t) },
   ];
   // Chronological, because these are two moments in one order's life and a

--- a/packages/web/app/build-plans/orders/[licenceId]/page.tsx
+++ b/packages/web/app/build-plans/orders/[licenceId]/page.tsx
@@ -126,7 +126,7 @@ export default async function BuildPlanOrderPage(props: OrderRouteProps) {
           chip, so it cannot be rendered on the server half of this page. */}
       <OrderStatus
         initialOrder={order}
-        wallLabel={wallLabel(catalog, order)}
+        wallLabel={wallLabel(catalog, order, t)}
         checkoutOutcome={checkoutOutcome}
         locale={locale}
       />

--- a/packages/web/app/build-plans/orders/orders-list.tsx
+++ b/packages/web/app/build-plans/orders/orders-list.tsx
@@ -77,7 +77,7 @@ export default async function OrdersList({
                   {order.licenceId}
                 </Typography>
                 <Typography variant="body2" component="p" className={styles.rowMeta}>
-                  {`${getBoardDisplayName(order.boardName)} ${wallLabel(catalog, order)} · ${tierLabel(order.tier, t)}`}
+                  {`${order.boardName === 'tension' ? t('configurator.tb2.boardName') : getBoardDisplayName(order.boardName)} ${wallLabel(catalog, order, t)} · ${tierLabel(order.tier, t)}`}
                 </Typography>
                 <Typography variant="body2" component="p" className={styles.rowMeta}>
                   {dateLine}

--- a/packages/web/app/build-plans/orders/orders-list.tsx
+++ b/packages/web/app/build-plans/orders/orders-list.tsx
@@ -4,12 +4,18 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import MuiLink from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
-import { getBoardDisplayName } from '@boardsesh/climb-actions';
 import type { CncCatalog, CncOrder } from '@boardsesh/shared-schema';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { createOrderDateFormatter } from '../format-date';
-import { finaliseHref, isPreviewStatus, newestPreviewReadyLicenceId, tierLabel, wallLabel } from '../order-display';
+import {
+  boardDisplayLabel,
+  finaliseHref,
+  isPreviewStatus,
+  newestPreviewReadyLicenceId,
+  tierLabel,
+  wallLabel,
+} from '../order-display';
 import { EmptyPanel, SectionCard, StatusChip } from '../ui';
 import styles from './orders.module.css';
 
@@ -77,7 +83,7 @@ export default async function OrdersList({
                   {order.licenceId}
                 </Typography>
                 <Typography variant="body2" component="p" className={styles.rowMeta}>
-                  {`${order.boardName === 'tension' ? t('configurator.tb2.boardName') : getBoardDisplayName(order.boardName)} ${wallLabel(catalog, order, t)} · ${tierLabel(order.tier, t)}`}
+                  {`${boardDisplayLabel(order, t)} ${wallLabel(catalog, order, t)} · ${tierLabel(order.tier, t)}`}
                 </Typography>
                 <Typography variant="body2" component="p" className={styles.rowMeta}>
                   {dateLine}

--- a/packages/web/app/components/admin/build-plans-panel.tsx
+++ b/packages/web/app/components/admin/build-plans-panel.tsx
@@ -274,7 +274,7 @@ export default function BuildPlansPanel({ catalog, locale }: { catalog: CncCatal
                       one of them "Commercial, single build". */}
                     <TableCell>{tierLabel(entry.order.tier, tCnc)}</TableCell>
                     <TableCell>
-                      {`${getBoardDisplayName(entry.order.boardName)} ${wallLabel(catalog, entry.order)}`}
+                      {`${entry.order.boardName === 'tension' ? tCnc('configurator.tb2.boardName') : getBoardDisplayName(entry.order.boardName)} ${wallLabel(catalog, entry.order, tCnc)}`}
                     </TableCell>
                     <TableCell>
                       <StatusChip status={entry.order.status} label={statusLabel(tCnc, entry.order.status)} />

--- a/packages/web/app/components/admin/build-plans-panel.tsx
+++ b/packages/web/app/components/admin/build-plans-panel.tsx
@@ -21,7 +21,6 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
-import { getBoardDisplayName } from '@boardsesh/climb-actions';
 import {
   ADMIN_CNC_ORDERS,
   REGENERATE_CNC_PACK,
@@ -35,7 +34,7 @@ import LocaleLink from '@/app/components/i18n/locale-link';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import { createOrderDateFormatter } from '@/app/build-plans/format-date';
-import { tierLabel, wallLabel } from '@/app/build-plans/order-display';
+import { boardDisplayLabel, tierLabel, wallLabel } from '@/app/build-plans/order-display';
 import { SectionCard, StatusChip } from '@/app/build-plans/ui';
 
 /**
@@ -274,7 +273,7 @@ export default function BuildPlansPanel({ catalog, locale }: { catalog: CncCatal
                       one of them "Commercial, single build". */}
                     <TableCell>{tierLabel(entry.order.tier, tCnc)}</TableCell>
                     <TableCell>
-                      {`${entry.order.boardName === 'tension' ? tCnc('configurator.tb2.boardName') : getBoardDisplayName(entry.order.boardName)} ${wallLabel(catalog, entry.order, tCnc)}`}
+                      {`${boardDisplayLabel(entry.order, tCnc)} ${wallLabel(catalog, entry.order, tCnc)}`}
                     </TableCell>
                     <TableCell>
                       <StatusChip status={entry.order.status} label={statusLabel(tCnc, entry.order.status)} />


### PR DESCRIPTION
## Summary

Companion PR: https://github.com/boardsesh/climbing-wall-panels-scad-model/pull/3

Builders can configure CNC packs compatible with Tension Board 2 in all five sizes, using metric or imperial dimensions and Mirror, Spray, both, or no installation engraving. Metric and both engravings are selected by default.

The configurator keeps board, size and engraving selections synchronized, clears placed artwork when dimensions change, and records both choices in previews and order summaries. The catalogue and saved worker jobs carry TB2-specific options without Kilter T-nut or kicker defaults. Shared board labels keep the configurator and order screens consistent. Missing or invalid saved TB2 choices display an unavailable message instead of guessed defaults. Updated copy covers all four locales.

Stacked on #5236 (`feat/cnc-packs-integration`). The companion generator PR must deploy before this catalogue becomes available; build-plan feature gates and existing metadata remain in place.

Validation: 346 backend CNC tests, 269 build-plan web tests and 113 translation tests pass. Desktop and phone browser checks against the local backend and Python layout worker confirm size, dimension and layout changes without browser errors or horizontal overflow. Workspace typechecking, focused lint and pre-commit hooks pass. Review follow-ups preserve strict Kilter worker types and share the canonical TB2 engraving-to-layout mapping; all 81 affected backend tests pass after these changes. CI exposed two missing device-metadata columns in the existing QA test fixture; the fixture now matches the runtime schema and all 34 QA-verdict tests pass against Postgres.

## Release Notes

Build panels for Tension Board 2 with Mirror, Spray, or both layouts engraved.
Choose metric or imperial dimensions across all five board sizes.

## Test plan

1. Sign in, open Build plans; choose Tension Board 2.
2. Choose a size; metric and both engravings are selected.
3. Choose Spray; the summary identifies Spray.
4. Choose imperial; the preview uses the updated dimensions.
5. Request a preview; order details retain both selections.

## Risk

Risk: 3/5 — new board catalogue and generator contract; deploy generator support first.
