### PR TITLE
perf: reduce AI crawler load at Cloudflare and the web origin

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -339,7 +339,18 @@ back because GraphQL, WebSockets, and `/og` share that hostname.
   2. `block` for commercial SEO/backlink crawlers (Ahrefs, Semrush, DataForSEO,
      MJ12, DotBot, BLEXBot, Barkrowler, serpstat, Seznam, Zoominfo, Screaming
      Frog). Each was verified reaching our origin on 2026-08-24. They sell
-     backlink data and send Boardsesh no traffic.
+     backlink data and send Boardsesh no traffic. The same rule also blocks
+     automated AI training and search crawlers, using the shared tokens in
+     `packages/web/app/lib/crawler-policy.ts`. Google, Bing, Yandex, Brave and
+     share-card unfurlers remain allowed. Human-triggered AI fetchers are not
+     added to this automated-crawler list.
+
+  Web middleware rejects those AI agents before page rendering, including on
+  the direct Railway hostname. Robots.txt publishes the same opt-out plus
+  `Google-Extended` (a robots-only token). Production logs on 2026-09-07 showed
+  GPTBot using the Railway hostname and Claude-SearchBot reaching www despite
+  synthetic Cloudflare probes returning 403; the managed AI block alone is
+  insufficient. UA rules only catch agents that identify themselves.
 
   **Order is load-bearing and enforced by the tool.** `upsertCacheRule` rewrites
   our rules as one contiguous group in declared order, because a rule-by-rule
@@ -348,10 +359,8 @@ back because GraphQL, WebSockets, and `/og` share that hostname.
 
   Two things the tool will not do, both deliberate:
   - It never reorders our group relative to **foreign** rules. Cloudflare's own
-    AI-crawler block (which already 403s ClaudeBot, GPTBot, PerplexityBot,
-    Bytespider, CCBot and friends — verified 2026-08-24) runs ahead of ours and
-    stays there. That is also why those agents are absent from our block list:
-    duplicating them would be dead config that drifts.
+    AI-crawler block remains in its existing position. Our explicit policy
+    also covers these agents so it does not depend on that unmanaged rule.
   - It never uses `cf.client.bot` as the allowlist. Ahrefs and Semrush are
     themselves Cloudflare _verified bots_, so that field is true for precisely
     the crawlers we are blocking.

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -1,5 +1,7 @@
 /// <reference types="node" />
 
+import { AI_CRAWLER_TOKENS } from '../../packages/web/app/lib/crawler-policy';
+
 // Declarative desired-state for the Cloudflare-managed boardsesh.com zone. This
 // is plain typed data — no side effects, no API calls. scripts/cloudflare-apply.ts
 // reads it, diffs it against the live zone, and (only with --apply) converges the
@@ -495,6 +497,7 @@ export const CRAWLER_ALLOW_TOKENS = [
   'brave-search',
   'bravebot',
   'applebot',
+  'yandexbot',
   // Share-card unfurlers. Blocking these breaks link previews, not crawling.
   'twitterbot',
   'facebookexternalhit',
@@ -514,15 +517,17 @@ export const CRAWLER_ALLOW_TOKENS = [
  * `dotbot/` keeps its slash because the bare token is short enough to collide with
  * an unrelated UA; the rest are distinctive on their own.
  *
+ * AI training/search crawlers are explicit too: September 7 origin logs showed
+ * Claude-SearchBot on www and GPTBot bypassing Cloudflare via the Railway domain,
+ * despite synthetic probes receiving 403. The shared list also drives robots.txt
+ * and the web origin's early rejection. Do not rely on the unmanaged AI rule.
+ *
  * NOT listed, on purpose:
- * - The AI crawlers (ClaudeBot, GPTBot, PerplexityBot, Bytespider, CCBot, ...) —
- *   the same probe got `HTTP/2 403` from `server: cloudflare` for every one, so a
- *   separate zone rule already stops them and duplicating it here would be dead
- *   config that drifts.
  * - `archive.org_bot` — it reaches us and it loops, but it is the Internet Archive,
  *   it is low volume, and excluding it is a values call rather than a cost one.
  */
 export const CRAWLER_BLOCK_TOKENS = [
+  ...AI_CRAWLER_TOKENS,
   'ahrefsbot',
   'ahrefssiteaudit',
   'semrushbot',

--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -12,6 +12,29 @@ function sp(params: Record<string, string> = {}): URLSearchParams {
   return new URLSearchParams(params);
 }
 
+describe('AI crawler origin rejection', () => {
+  it.each(['GPTBot/1.4', 'Claude-SearchBot/1.0', 'AMZN-SEARCHBOT/0.1'])('rejects %s before rendering', (userAgent) => {
+    const response = middleware(
+      new NextRequest('https://boardsesh-web-production.up.railway.app/fr/setter/test', {
+        headers: { 'user-agent': userAgent },
+      }),
+    );
+    expect(response.status).toBe(403);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.has('x-middleware-rewrite')).toBe(false);
+  });
+
+  it.each(['Googlebot/2.1', 'bingbot/2.0', 'YandexBot/3.0', 'facebookexternalhit/1.1', 'Mozilla/5.0'])(
+    'preserves %s',
+    (userAgent) => {
+      const response = middleware(
+        new NextRequest('https://www.boardsesh.com/', { headers: { 'user-agent': userAgent } }),
+      );
+      expect(response.status).not.toBe(403);
+    },
+  );
+});
+
 const TTL_24H = 86400;
 const LEGACY_LIST = '/kilter/original/12x12-square/screw_bolt/40/list';
 const SLUG_LIST = '/b/kilter-original-12x12/40/list';

--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -24,15 +24,20 @@ describe('AI crawler origin rejection', () => {
     expect(response.headers.has('x-middleware-rewrite')).toBe(false);
   });
 
-  it.each(['Googlebot/2.1', 'bingbot/2.0', 'YandexBot/3.0', 'facebookexternalhit/1.1', 'Mozilla/5.0'])(
-    'preserves %s',
-    (userAgent) => {
-      const response = middleware(
-        new NextRequest('https://www.boardsesh.com/', { headers: { 'user-agent': userAgent } }),
-      );
-      expect(response.status).not.toBe(403);
-    },
-  );
+  it.each([
+    'Googlebot/2.1',
+    'bingbot/2.0',
+    'YandexBot/3.0',
+    'facebookexternalhit/1.1',
+    'ChatGPT-User/1.0',
+    'Claude-User/1.0',
+    'Mozilla/5.0',
+  ])('preserves %s', (userAgent) => {
+    const response = middleware(
+      new NextRequest('https://www.boardsesh.com/', { headers: { 'user-agent': userAgent } }),
+    );
+    expect(response.status).not.toBe(403);
+  });
 });
 
 const TTL_24H = 86400;

--- a/packages/web/app/__tests__/robots.test.ts
+++ b/packages/web/app/__tests__/robots.test.ts
@@ -33,6 +33,17 @@ function isPathCrawlable(rules: ReturnType<typeof getRules>, url: string): boole
 }
 
 describe('robots', () => {
+  it('opts AI crawlers out without closing traditional search or share previews', () => {
+    const rules = robots().rules;
+    expect(Array.isArray(rules)).toBe(true);
+    const allRules = Array.isArray(rules) ? rules : [rules];
+    const aiRule = allRules.find((rule) => toList(rule.userAgent).includes('gptbot'));
+    expect(aiRule?.disallow).toBe('/');
+    expect(aiRule?.allow).toBeUndefined();
+    expect(toList(aiRule?.userAgent)).toEqual(expect.arrayContaining(['claude-searchbot', 'Google-Extended']));
+    expect(toList(aiRule?.userAgent)).not.toContain('googlebot');
+    expect(toList(aiRule?.userAgent)).not.toContain('facebookexternalhit');
+  });
   it('allows crawling the root path', () => {
     const result = robots();
     const rules = getRules(result);

--- a/packages/web/app/lib/crawler-policy.ts
+++ b/packages/web/app/lib/crawler-policy.ts
@@ -1,0 +1,18 @@
+/** Automated AI training/search crawlers. Human-triggered unfurlers are separate. */
+export const AI_CRAWLER_TOKENS = [
+  'gptbot',
+  'oai-searchbot',
+  'claudebot',
+  'claude-searchbot',
+  'perplexitybot',
+  'amzn-searchbot',
+  'amazonbot',
+  'bytespider',
+  'ccbot',
+  'meta-externalagent',
+] as const;
+
+export function isBlockedAiCrawler(userAgent: string | null): boolean {
+  const normalizedUserAgent = userAgent?.toLowerCase() ?? '';
+  return AI_CRAWLER_TOKENS.some((token) => normalizedUserAgent.includes(token));
+}

--- a/packages/web/app/lib/is-crawler.ts
+++ b/packages/web/app/lib/is-crawler.ts
@@ -24,14 +24,10 @@
  * while Googlebot (named by Next) correctly got a 200. Those thirteen are the
  * extension list.
  *
- * Deliberately NOT listed: the AI crawlers (ClaudeBot, Claude-User,
- * PerplexityBot, GPTBot, OAI-SearchBot, ChatGPT-User, Bytespider, Amazonbot,
- * CCBot, PetalBot, meta-externalagent). The same probe returned `HTTP/2 403`
- * from `server: cloudflare` with no `x-vercel-cache` header for every one of
- * them — Cloudflare's AI-bot block stops them before Vercel, so a middleware UA
- * regex can never see them and adding them would be dead code. Re-run the probe
- * and revisit this list if that Cloudflare rule is ever relaxed, and as part of
- * the Railway cutover (#4652), which moves the edge.
+ * Automated AI crawling is rejected before locale handling by crawler-policy.ts.
+ * Production logs on 2026-09-07 showed GPTBot bypassing Cloudflare through the
+ * Railway hostname and Claude-SearchBot reaching www. The locale classifier
+ * below remains separate from that access policy and includes share unfurlers.
  *
  * `Google-Extended` is also absent on purpose: it is a robots.txt-only opt-out
  * control token and never appears in a User-Agent header.

--- a/packages/web/app/robots.ts
+++ b/packages/web/app/robots.ts
@@ -1,24 +1,31 @@
 import type { MetadataRoute } from 'next';
 import { absoluteUrl } from '@/app/lib/seo/base-url';
+import { AI_CRAWLER_TOKENS } from './lib/crawler-policy';
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: {
-      userAgent: '*',
-      // robots.txt precedence is longest-path-match, not file order: these
-      // two allow rules are more specific than the blanket `/api/` disallow
-      // below, so they carve out Googlebot-Image access to the setter,
-      // profile, playlist and session OG cards (buildVersionedOgImagePath
-      // returns relative /api/og/... paths) and to /api/internal/board-render,
-      // the climb page's LCP image. Climb OG cards use the absolute
-      // https://ws.boardsesh.com/og/climb URL and never hit this rule.
-      allow: ['/', '/api/og/', '/api/internal/board-render'],
-      // `/feed`, `/you` and `/you/*` came out with W-19 (#4437): those pages are
-      // deleted and now 307 into the app. A surviving `Disallow` would stop
-      // Googlebot fetching the URL at all, so it would never see the redirect
-      // and the dead URL would stay indexed.
-      disallow: ['/api/', '/auth/', '/settings'],
-    },
+    rules: [
+      {
+        userAgent: '*',
+        // robots.txt precedence is longest-path-match, not file order: these
+        // two allow rules are more specific than the blanket `/api/` disallow
+        // below, so they carve out Googlebot-Image access to the setter,
+        // profile, playlist and session OG cards (buildVersionedOgImagePath
+        // returns relative /api/og/... paths) and to /api/internal/board-render,
+        // the climb page's LCP image. Climb OG cards use the absolute
+        // https://ws.boardsesh.com/og/climb URL and never hit this rule.
+        allow: ['/', '/api/og/', '/api/internal/board-render'],
+        // `/feed`, `/you` and `/you/*` came out with W-19 (#4437): those pages are
+        // deleted and now 307 into the app. A surviving `Disallow` would stop
+        // Googlebot fetching the URL at all, so it would never see the redirect
+        // and the dead URL would stay indexed.
+        disallow: ['/api/', '/auth/', '/settings'],
+      },
+      {
+        userAgent: [...AI_CRAWLER_TOKENS, 'Google-Extended'],
+        disallow: '/',
+      },
+    ],
     sitemap: absoluteUrl('/sitemap.xml'),
   };
 }

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -15,6 +15,7 @@ import {
   isSupportedLocale,
 } from './app/lib/i18n/config';
 import { detectLocale } from './app/lib/i18n/detect-locale';
+import { isBlockedAiCrawler } from './app/lib/crawler-policy';
 
 const SPECIAL_ROUTES = ['angles', 'grades']; // routes that don't need board validation
 
@@ -44,6 +45,14 @@ function isExpoWebProxyEnabled(): boolean {
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+
+  // Cheap origin fallback for crawlers that bypass Cloudflare's public hostname.
+  if (isBlockedAiCrawler(request.headers.get('user-agent'))) {
+    return new NextResponse(null, {
+      status: 403,
+      headers: { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex, nofollow' },
+    });
+  }
 
   // Block PHP requests
   if (pathname.includes('.php')) {

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -752,6 +752,11 @@ describe('www cost-control rules (#4650)', () => {
 
   it('matches the scrapers it is meant to block', () => {
     const blockedUserAgents = [
+      'Mozilla/5.0 (compatible; GPTBot/1.4; +https://openai.com/gptbot)',
+      'Mozilla/5.0 (compatible; Claude-SearchBot/1.0; +searchbot@anthropic.com)',
+      'Mozilla/5.0 (compatible; Amzn-SearchBot/0.1)',
+      'OAI-SearchBot/1.0',
+      'PerplexityBot/1.0',
       'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)',
       'Mozilla/5.0 (compatible; SemrushBot/7~bl; +http://www.semrush.com/bot.html)',
       'Mozilla/5.0 (compatible; DataForSeoBot/1.0; +https://dataforseo.com/dataforseo-bot)',

--- a/scripts/production-deploy-changes.mjs
+++ b/scripts/production-deploy-changes.mjs
@@ -75,6 +75,7 @@ function isProductionDeployTestFile(filePath) {
 function isCloudflareAffecting(filePath) {
   return (
     filePath.startsWith('infra/cloudflare/') ||
+    filePath === 'packages/web/app/lib/crawler-policy.ts' ||
     filePath === 'scripts/cloudflare-apply.ts' ||
     filePath === 'scripts/cloudflare-apply.test.ts'
   );
@@ -125,7 +126,7 @@ function isWebAffecting(filePath) {
     filePath === 'scripts/production-backend-smoke.mjs' ||
     isProductionDeployTestFile(filePath) ||
     isProductionDeployWatchdogFile(filePath) ||
-    isCloudflareAffecting(filePath)
+    (isCloudflareAffecting(filePath) && filePath !== 'packages/web/app/lib/crawler-policy.ts')
   );
 }
 

--- a/scripts/production-deploy-changes.test.mjs
+++ b/scripts/production-deploy-changes.test.mjs
@@ -513,3 +513,9 @@ void test('the human-readable summary names every target the outputs do', () => 
   // And it must not leak the base sha, which the caller prints separately.
   assert.ok(!summary.includes('deployment_base_sha'), summary);
 });
+
+void test('deploys both web and Cloudflare when the shared crawler policy changes', () => {
+  const targets = classifyChangedFiles(['packages/web/app/lib/crawler-policy.ts']);
+  assert.equal(targets.web, true);
+  assert.equal(targets.cloudflare, true);
+});


### PR DESCRIPTION
## Summary
Production logs showed GPTBot bypassing Cloudflare through the Railway hostname and Claude-SearchBot reaching www. Block automated AI training/search crawlers at Cloudflare and before web page rendering, and publish the same robots.txt policy. Traditional search engines and share previews remain allowed.

Keep one token list in the web package so Docker includes it; changes trigger both web and Cloudflare deployment. Validation: 319 focused tests, 26 deploy-classifier tests, lint and full repository typecheck passed.

The crawler and origin-protection branches merge cleanly; all 378 combined tests passed.

## Release Notes
none

## Test plan
1. CI green.

## Risk
Risk: 2/5 — crawler access changes; human browsing and traditional search remain allowed.
