### PR TITLE
fix(mobile): handle Android Board setup switch taps

### DIFF
--- a/docs/expo-ui-components.md
+++ b/docs/expo-ui-components.md
@@ -128,9 +128,10 @@ test/switch-row-stub.tsx              # passthrough stub (RN Pressable + Switch)
 - iOS: a single `Toggle` whose two `Text` children are title + subtitle (SwiftUI
   styles the second as secondary). Brand tint + disabled via modifiers; the native
   Toggle supplies the switch trait and on/off announcement.
-- Android: a `Row` that owns the toggle via the `toggleable` modifier
-  (`role: 'switch'`); the `Switch`'s own `onCheckedChange` is left undefined so a
-  tap fires once. Brand on-track colour via `switchBrandColors`.
+- Android: a `Row` that owns whole-row toggling via the `toggleable` modifier
+  (`role: 'switch'`), while its nested `Switch` calls the same handler for direct
+  thumb taps. Expo UI keeps that nested Compose control interactive even when its
+  JavaScript callback is omitted. Brand on-track colour via `switchBrandColors`.
 - Both call `makeToggleHandler(onValueChange, disabled)` so the haptic + disabled
   behaviour can't drift between platforms.
 

--- a/docs/expo-ui-components.md
+++ b/docs/expo-ui-components.md
@@ -78,6 +78,9 @@ The rule, for `packages/mobile/**`:
 - `@expo/ui/jetpack-compose` (and sub-paths) only from `*.android.{ts,tsx}`.
 - `@expo/ui` (root, the universal `Host` etc.) and `@expo/ui/community/*` are unrestricted.
 
+Node-only mocks in `__tests__/*.test.{ts,tsx}` are exempt: Metro cannot load
+them, and mocks need the literal module specifier.
+
 A misplaced import crashes the _other_ platform at runtime ("Unable to get view config").
 
 Enforcement is the CI check **`vp run check:mobile-platform-imports`**

--- a/packages/mobile/src/components/SwitchRow.android.tsx
+++ b/packages/mobile/src/components/SwitchRow.android.tsx
@@ -4,9 +4,11 @@
 // A Compose `Row` (label/description Column + Switch) inside its own `Host`. The
 // whole row owns the toggle via the `toggleable` modifier (role 'switch'), so a
 // tap anywhere flips it and TalkBack reads the row as a switch labelled by its
-// text. The Switch's own `onCheckedChange` is left undefined so the tap fires
-// once, not twice. We bridge only the brand on-track colour; M3 surface/label
-// colours come from the Compose Material theme the Host sets up.
+// text. Expo UI always makes the nested Compose Switch interactive, even when
+// its JavaScript callback is omitted, so it uses the same handler for direct
+// thumb taps. Compose consumes that child gesture before it reaches the row.
+// We bridge only the brand on-track colour; M3 surface/label colours come from
+// the Compose Material theme the Host sets up.
 //
 // One Host per row is intentional for PR-1 (SwitchRow is used one-per-card
 // today). PR-2 consolidates whole settings screens into a single Compose list.
@@ -61,9 +63,9 @@ export function SwitchRow({ label, description, value, onValueChange, disabled =
         <Switch
           value={value}
           enabled={!disabled}
-          // The row's `toggleable` owns the tap — leave the Switch passive so a
-          // tap on it doesn't double-fire the toggle.
-          onCheckedChange={undefined}
+          // Direct taps land on the nested Compose control, not the row. Use the
+          // emitted value here; row taps still derive the next value above.
+          onCheckedChange={handleToggle}
           colors={switchColors}
         />
       </Row>

--- a/packages/mobile/src/components/__tests__/switch-row.android.test.tsx
+++ b/packages/mobile/src/components/__tests__/switch-row.android.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hapticSelectionMock = vi.hoisted(() => vi.fn());
+const composeSwitchProps = vi.hoisted(() => ({ last: null as null | Record<string, unknown> }));
+const rowToggle = vi.hoisted(() => ({ last: null as null | (() => void) }));
+
+vi.mock('../../lib/haptics', () => ({ hapticSelection: hapticSelectionMock }));
+vi.mock('react-native', () => ({ StyleSheet: { create: <Styles,>(styles: Styles) => styles } }));
+vi.mock('@expo/ui', () => ({
+  Host: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('@expo/ui/jetpack-compose', () => ({
+  Row: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Column: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+  Switch: (props: Record<string, unknown>) => {
+    composeSwitchProps.last = props;
+    const onCheckedChange = props.onCheckedChange as ((next: boolean) => void) | undefined;
+    const value = props.value as boolean;
+    return createElement('button', { onClick: () => onCheckedChange?.(!value), type: 'button' }, 'switch');
+  },
+}));
+vi.mock('@expo/ui/jetpack-compose/modifiers', () => ({
+  fillMaxWidth: () => ({ kind: 'fillMaxWidth' }),
+  weight: () => ({ kind: 'weight' }),
+  toggleable: (_value: boolean, handler: () => void) => {
+    rowToggle.last = handler;
+    return { kind: 'toggleable' };
+  },
+  padding: () => ({ kind: 'padding' }),
+  defaultMinSize: () => ({ kind: 'defaultMinSize' }),
+  alpha: () => ({ kind: 'alpha' }),
+}));
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({ brandColors: { primary: '#6D28D9' }, colorScheme: 'light' }),
+}));
+vi.mock('../../theme/expo-ui-modifiers', () => ({ switchBrandColors: () => ({}) }));
+vi.mock('../../theme/tokens', () => ({ spacing: { 2: 8, 4: 16 } }));
+
+import { SwitchRow } from '../SwitchRow.android';
+
+beforeEach(() => {
+  hapticSelectionMock.mockReset();
+  composeSwitchProps.last = null;
+  rowToggle.last = null;
+});
+
+describe('Android SwitchRow', () => {
+  it('toggles when the nested Compose switch is tapped directly', () => {
+    const onValueChange = vi.fn();
+    const { getByRole } = render(<SwitchRow label="Public board" value={false} onValueChange={onValueChange} />);
+
+    fireEvent.click(getByRole('button', { name: 'switch' }));
+
+    expect(composeSwitchProps.last?.onCheckedChange).toBeTypeOf('function');
+    expect(hapticSelectionMock).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenCalledOnce();
+    expect(onValueChange).toHaveBeenCalledWith(true);
+  });
+
+  it('keeps the label row tappable', () => {
+    const onValueChange = vi.fn();
+    render(<SwitchRow label="Public board" value={true} onValueChange={onValueChange} />);
+
+    rowToggle.last?.();
+
+    expect(onValueChange).toHaveBeenCalledOnce();
+    expect(onValueChange).toHaveBeenCalledWith(false);
+  });
+
+  it('keeps disabled controls inert', () => {
+    const onValueChange = vi.fn();
+    const { getByRole } = render(
+      <SwitchRow label="Public board" value={false} onValueChange={onValueChange} disabled />,
+    );
+
+    fireEvent.click(getByRole('button', { name: 'switch' }));
+    (composeSwitchProps.last?.onCheckedChange as ((next: boolean) => void) | undefined)?.(true);
+
+    expect(rowToggle.last).toBeNull();
+    expect(composeSwitchProps.last?.enabled).toBe(false);
+    expect(hapticSelectionMock).not.toHaveBeenCalled();
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/mobile-platform-imports-check.sh
+++ b/scripts/mobile-platform-imports-check.sh
@@ -45,6 +45,7 @@ compose_bad=$(
   grep -rlE "['\"]@expo/ui/jetpack-compose" "${scan_dirs[@]}" \
     --include='*.ts' --include='*.tsx' \
     | grep -vE '\.android\.(ts|tsx)$' \
+    | grep -vE '/__tests__/[^/]+\.test\.(ts|tsx)$' \
     || true
 )
 


### PR DESCRIPTION
## Summary

Closes #5265. Android Board setup switches now change when their thumb is tapped directly, while full-row taps keep working.

Added regression coverage for direct, row, and disabled interactions, plus documented the Expo UI touch behavior.

Validation: `vp check`; `vp run typecheck:mobile`; `vp run test:mobile`; `vp run check:mobile-bundle`.

## Release Notes

Board setup switches now respond when you tap them directly on Android.

## Test plan

1. Open Board setup → More options.
2. Tap a switch; it changes once.
3. Tap its label; it still changes once.

## Risk

Risk: 2/5 — shared Android toggle interaction with component coverage.
