### PR TITLE
fix: stage verification for requests reaching the web origin

### DIFF
--- a/.github/workflows/cloudflare-origin-protection.yml
+++ b/.github/workflows/cloudflare-origin-protection.yml
@@ -1,0 +1,34 @@
+name: Cloudflare origin protection
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: Apply the www request header after the stripping middleware is deployed
+        type: boolean
+        default: false
+permissions:
+  contents: read
+concurrency:
+  group: cloudflare-origin-protection
+  cancel-in-progress: false
+jobs:
+  configure:
+    runs-on: ubuntu-latest
+    environment: Production
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+      - name: Configure origin header
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          WEB_ORIGIN_VERIFY_SECRET: ${{ secrets.WEB_ORIGIN_VERIFY_SECRET }}
+          APPLY: ${{ inputs.apply }}
+        run: |
+          if [ "$APPLY" = true ]; then
+            node scripts/cloudflare-origin-apply.ts --apply
+          else
+            node scripts/cloudflare-origin-apply.ts
+          fi

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -692,6 +692,7 @@ jobs:
         if: steps.railway-redeploy.outcome == 'success'
         continue-on-error: true
         env:
+          WEB_ORIGIN_VERIFY_SECRET: ${{ secrets.WEB_ORIGIN_VERIFY_SECRET }}
           RAILWAY_WEB_ORIGIN: ${{ needs.resolve-web-targets.outputs.web_railway_origin }}
           SMOKE_EXPECTED_DEPLOYMENT_ID: ${{ steps.railway-redeploy.outputs.deployment_id }}
           SMOKE_EXPECTED_RELEASE: ${{ github.sha }}
@@ -722,6 +723,7 @@ jobs:
           && steps.railway-smoke.outcome == 'failure'
           && steps.railway-rollback.outcome == 'success'
         env:
+          WEB_ORIGIN_VERIFY_SECRET: ${{ secrets.WEB_ORIGIN_VERIFY_SECRET }}
           RAILWAY_WEB_ORIGIN: ${{ needs.resolve-web-targets.outputs.web_railway_origin }}
           SMOKE_KIOSK_GYM_SLUG: ${{ vars.SMOKE_KIOSK_GYM_SLUG }}
           SMOKE_EMBED_BOARD_UUID: ${{ vars.SMOKE_EMBED_BOARD_UUID }}

--- a/docs/web-origin-protection.md
+++ b/docs/web-origin-protection.md
@@ -1,0 +1,70 @@
+# Web origin protection
+
+The Railway-generated web hostname is required by deployment identity checks,
+but crawlers have used it to bypass Cloudflare. The web middleware can require
+`X-Boardsesh-Origin-Verify` before any rendering, routing or API handling.
+Cloudflare overwrites that request header for `www.boardsesh.com`. It does not
+add the secret to responses. Browser clients never need to know the secret.
+
+`WEB_ORIGIN_VERIFY_ENABLED=1` activates the guard. Missing or short secrets then
+fail closed. With the flag absent, the middleware only strips the header, so the
+preparation deployment does not interrupt existing traffic. Preview and local
+services leave the flag unset. The only unauthenticated production exception is
+GET/HEAD on the exact `/api/health` route used by Railway health probes.
+
+The guard covers API routes, dotted paths, Next assets and image optimization,
+well-known files, and monitoring routes. Locale/session/CORS handling retains its
+previous narrower scope. The verification header is removed before forwarding,
+including Next external rewrites. Existing user authorization and POST bodies
+remain intact. A rejected request gets an empty, non-cacheable 403.
+
+## Deployment order
+
+1. Merge/deploy the middleware and CI support with the activation flag unset.
+   Verify the existing direct-origin smoke remains green.
+2. Generate 32 random bytes as 64 lowercase hex characters in a secret manager.
+   Set the same `WEB_ORIGIN_VERIFY_SECRET` on the Railway web service and in
+   the GitHub **Production** environment. Keep it out of public/build variables,
+   shell arguments, logs, artifacts and PR text.
+3. Run **Cloudflare origin protection** with `apply=false`, then `apply=true`.
+   It manages only the www request-header rule, preserves other rules, rejects
+   conflicting ownership and verifies its write. The token needs zone transform
+   rules edit access. No credential or rule-body diff is printed.
+4. Verify www still renders, including with a deliberately incorrect incoming
+   header: Cloudflare must overwrite it. Verify the direct Railway smoke with
+   the GitHub secret. A unit test also prevents cross-origin redirect leakage.
+5. Set `WEB_ORIGIN_VERIFY_ENABLED=1` on the Railway **web** service and allow its
+   rolling redeploy. Run the authenticated direct-origin smoke again. Verify
+   unauthenticated direct page/API/asset requests return 403, `/api/health`
+   remains 200, and www, traditional search and share previews still work.
+6. Confirm direct-origin crawler requests stop rendering. Compare public backend
+   egress and web CPU against the cost baseline after a full day.
+
+Steps 2–5 require the preparation deployment to be live; do not inject the header
+into the old deployment, which does not yet strip it before external rewrites.
+The workflow is manual so a routine zone-config change cannot prematurely
+activate or rotate the secret. CI's normal and rollback web smokes both use it.
+
+Cloudflare's [request header transform API](https://developers.cloudflare.com/rules/transform/request-header-modification/create-api/)
+uses `http_request_late_transform` with a `set` operation to replace a supplied
+header. The managed rule is scoped to www; the apex redirect and backend domains
+are not web origins. The direct Railway domain remains available to CI.
+
+## Rollback and rotation
+
+For an outage, first unset `WEB_ORIGIN_VERIFY_ENABLED` on the web service and
+redeploy. Verify www and direct-origin smoke before changing Cloudflare. Keep the
+stripping middleware deployed while the edge still sends a secret.
+
+For rotation, disable enforcement first, rotate both stored copies, apply the
+Cloudflare rule, verify authenticated smoke, then re-enable. A zero-downtime
+rotation with overlapping secrets is not implemented. Reverting to a pre-guard
+image requires removing the Cloudflare header rule first; disabling the flag alone
+retains stripping on the new image. Never publish the secret to help diagnose a
+403; check only presence, matching configuration and sanitized status results.
+
+## Current rollout state
+
+This PR prepares protection; enforcement is not active until the deployment order
+above is completed. The crawler-policy PR is independent and reduces identified
+AI traffic while origin protection closes the direct-host bypass for other UAs.

--- a/docs/web-origin-protection.md
+++ b/docs/web-origin-protection.md
@@ -16,7 +16,9 @@ The guard covers API routes, dotted paths, Next assets and image optimization,
 well-known files, and monitoring routes. Locale/session/CORS handling retains its
 previous narrower scope. The verification header is removed before forwarding,
 including Next external rewrites. Existing user authorization and POST bodies
-remain intact. A rejected request gets an empty, non-cacheable 403.
+remain intact. Server and edge Sentry hooks also strip the incoming header from
+errors, transactions, span attributes and structured-log attributes, because
+Sentry can capture headers before middleware runs. A rejected request gets an empty, non-cacheable 403.
 
 ## Deployment order
 

--- a/packages/web/app/__tests__/expo-web-header-parity.test.ts
+++ b/packages/web/app/__tests__/expo-web-header-parity.test.ts
@@ -1,5 +1,7 @@
+vi.mock('server-only', () => ({}));
+
 import { createRequire } from 'node:module';
-import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vite-plus/test';
 import { NextRequest } from 'next/server';
 
 // The /app response-header set lives in two places that can each serve a

--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, beforeEach, describe, it, expect } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
 import { NextRequest } from 'next/server';
 import { CLIMB_SESSION_COOKIE } from '@/app/lib/climb-session-cookie';
 import { DEFAULT_LOCALE, LOCALE_COOKIE, LOCALE_HEADER } from '@/app/lib/i18n/config';

--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -7,6 +7,7 @@ import { PATHNAME_HEADER } from '@/app/lib/request-pathname-header';
 const { getClimbViewPageCacheTTL, getListPageCacheTTL, hasUserSpecificFilters } =
   await import('@/app/lib/list-page-cache');
 const { middleware, config } = await import('@/middleware');
+const { needsPageMiddleware } = await import('@/app/lib/web-origin');
 
 function sp(params: Record<string, string> = {}): URLSearchParams {
   return new URLSearchParams(params);
@@ -314,35 +315,18 @@ function makeRequest(url: string): NextRequest {
 }
 
 describe('middleware matcher config', () => {
-  it('pins the exact matcher entries', () => {
-    // Vercel bills/logs per invocation — this literal is the whole point of
-    // the fix, so a drift here (an accidental widening back to /api/:path*,
-    // or a narrowing that drops an auth path) must fail the suite outright.
-    expect(config.matcher).toEqual([
-      '/api/v1/:path*',
-      '/api/auth/:path*',
-      '/api/internal/ws-auth',
-      '/((?!api/|_next/static|_next/image|favicon.ico|monitoring|\\.well-known/|.*\\..*).*)',
-    ]);
+  it('runs the origin guard on every route', () => {
+    expect(config.matcher).toEqual(['/:path*']);
   });
 
-  // Coverage helper mirroring how Next compiles each matcher shape: entries
-  // 1-2 are `:path*` prefixes, entry 3 is an exact path, entry 4 is the full
-  // page-routes regex tested anchored end-to-end.
-  function isMatchedByConfig(pathname: string): boolean {
-    const [v1Prefix, authPrefix, wsAuthExact, pageRoutesRegex] = config.matcher;
-    if (pathname.startsWith(v1Prefix.replace(':path*', ''))) return true;
-    if (pathname.startsWith(authPrefix.replace(':path*', ''))) return true;
-    if (pathname === wsAuthExact) return true;
-    return new RegExp(`^${pageRoutesRegex}$`).test(pathname);
-  }
+  const isMatchedByConfig = needsPageMiddleware;
 
   it.each([
     '/api/internal/board-render',
     '/api/og/setter',
     '/api/internal/prewarm-heatmap/kilter',
     '/api/internal/revalidate-climb',
-  ])('does not run middleware on %s (no CORS/locale/board-validation work needed there)', (pathname) => {
+  ])('skips page middleware on %s after origin verification', (pathname) => {
     expect(isMatchedByConfig(pathname)).toBe(false);
   });
 
@@ -358,9 +342,12 @@ describe('middleware matcher config', () => {
     expect(isMatchedByConfig(pathname)).toBe(true);
   });
 
-  it.each(['/_next/static/chunk.js', '/logo.png'])('does not run middleware on static asset %s', (pathname) => {
-    expect(isMatchedByConfig(pathname)).toBe(false);
-  });
+  it.each(['/_next/static/chunk.js', '/logo.png'])(
+    'skips page middleware on static asset %s after origin verification',
+    (pathname) => {
+      expect(isMatchedByConfig(pathname)).toBe(false);
+    },
+  );
 });
 
 describe('middleware /api/v1 board validation', () => {

--- a/packages/web/app/__tests__/web-origin.test.ts
+++ b/packages/web/app/__tests__/web-origin.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { NextRequest } from 'next/server';
+import { middleware } from '@/middleware';
+import { WEB_ORIGIN_HEADER } from '@/app/lib/web-origin';
+
+const secret = 'test-origin-secret-with-at-least-32-characters';
+afterEach(() => vi.unstubAllEnvs());
+
+function request(path: string, suppliedSecret?: string, method = 'GET') {
+  return new NextRequest(`https://origin.up.railway.app${path}`, {
+    method,
+    headers: {
+      cookie: 'boardsesh-locale=fr',
+      ...(suppliedSecret ? { [WEB_ORIGIN_HEADER]: suppliedSecret } : {}),
+    },
+  });
+}
+
+function enableGuard() {
+  vi.stubEnv('WEB_ORIGIN_VERIFY_ENABLED', '1');
+  vi.stubEnv('WEB_ORIGIN_VERIFY_SECRET', secret);
+}
+
+describe('web origin protection', () => {
+  it.each([
+    '/',
+    '/api/auth/session',
+    '/api/internal/revalidate',
+    '/_next/image?url=x',
+    '/_next/static/app.js',
+    '/robots.txt',
+    '/.well-known/assetlinks.json',
+    '/monitoring',
+    '/api/health/extra',
+    '/fr/api/health',
+  ])('rejects unauthenticated %s before routing', (path) => {
+    enableGuard();
+    const response = middleware(request(path));
+    expect(response.status).toBe(403);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.has('location')).toBe(false);
+  });
+  it.each(['incorrect', `${secret}extra`, secret.slice(0, -1)])('rejects a mismatching secret', (suppliedSecret) => {
+    enableGuard();
+    expect(middleware(request('/', suppliedSecret)).status).toBe(403);
+  });
+  it('fails closed when enabled without a configured secret', () => {
+    enableGuard();
+    vi.stubEnv('WEB_ORIGIN_VERIFY_SECRET', '');
+    expect(middleware(request('/')).status).toBe(403);
+  });
+  it.each(['GET', 'HEAD'])('allows the exact Railway health route for %s', (method) => {
+    enableGuard();
+    expect(middleware(request('/api/health', undefined, method)).status).toBe(200);
+  });
+  it('does not exempt POST health requests', () => {
+    enableGuard();
+    expect(middleware(request('/api/health', undefined, 'POST')).status).toBe(403);
+  });
+  it.each([
+    '/fr/gyms',
+    '/api/auth/session',
+    '/api/internal/revalidate',
+    '/_next/static/app.js',
+    '/robots.txt',
+    '/.well-known/assetlinks.json',
+  ])('strips the secret before forwarding %s', (path) => {
+    enableGuard();
+    const response = middleware(request(path, secret));
+    expect(response.status).toBe(200);
+    expect(JSON.stringify([...response.headers])).not.toContain(secret);
+    expect(response.headers.get('x-middleware-override-headers')).not.toContain(WEB_ORIGIN_HEADER);
+    if (path.includes('.')) expect(response.headers.has('x-middleware-rewrite')).toBe(false);
+  });
+  it('preserves request bodies and existing auth while stripping the header', async () => {
+    enableGuard();
+    const incoming = new NextRequest('https://origin.up.railway.app/api/internal/revalidate', {
+      method: 'POST',
+      body: 'payload',
+      headers: { [WEB_ORIGIN_HEADER]: secret, authorization: 'Bearer user-token' },
+    });
+    const response = middleware(incoming);
+    expect(response.headers.get('x-middleware-request-authorization')).toBe('Bearer user-token');
+    expect(await incoming.text()).toBe('payload');
+  });
+  it('keeps staging disabled by default but still strips the secret', () => {
+    vi.stubEnv('WEB_ORIGIN_VERIFY_ENABLED', '');
+    const response = middleware(request('/robots.txt', secret));
+    expect(response.status).toBe(200);
+    expect(JSON.stringify([...response.headers])).not.toContain(secret);
+  });
+});

--- a/packages/web/app/__tests__/web-origin.test.ts
+++ b/packages/web/app/__tests__/web-origin.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
 import { NextRequest } from 'next/server';
 import { middleware } from '@/middleware';
 import { WEB_ORIGIN_HEADER } from '@/app/lib/web-origin';

--- a/packages/web/app/lib/observability/__tests__/web-origin-redaction.test.ts
+++ b/packages/web/app/lib/observability/__tests__/web-origin-redaction.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vite-plus/test';
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
 import { redactWebOriginEvent, redactWebOriginLog, redactWebOriginSpan } from '../web-origin-redaction';
 
 describe('origin verification telemetry redaction', () => {

--- a/packages/web/app/lib/observability/__tests__/web-origin-redaction.test.ts
+++ b/packages/web/app/lib/observability/__tests__/web-origin-redaction.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { redactWebOriginEvent, redactWebOriginLog, redactWebOriginSpan } from '../web-origin-redaction';
+
+describe('origin verification telemetry redaction', () => {
+  it('removes incoming headers from errors and transactions while preserving correlation', () => {
+    const event = {
+      request: { headers: { 'X-Boardsesh-Origin-Verify': 'secret', 'x-railway-request-id': 'request-id' } },
+      contexts: { trace: { data: { 'http.request.header.x-boardsesh-origin-verify': 'secret' } } },
+      spans: [{ data: { 'http.request.header.x_boardsesh_origin_verify': ['secret'], 'http.status_code': 200 } }],
+    };
+    redactWebOriginEvent(event);
+    expect(JSON.stringify(event)).not.toContain('secret');
+    expect(event.request.headers['x-railway-request-id']).toBe('request-id');
+    expect(event.spans[0].data['http.status_code']).toBe(200);
+  });
+  it('removes header attributes from standalone spans and structured logs', () => {
+    const span = { data: { 'http.request.header.x-boardsesh-origin-verify': 'secret' } };
+    const log = { attributes: { 'x-boardsesh-origin-verify': { value: 'secret' }, route: '/' } };
+    expect(redactWebOriginSpan(span).data).toEqual({});
+    expect(redactWebOriginLog(log).attributes).toEqual({ route: '/' });
+  });
+  it('accepts telemetry without request headers', () => {
+    expect(redactWebOriginEvent({})).toEqual({});
+    expect(redactWebOriginSpan({})).toEqual({});
+    expect(redactWebOriginLog({})).toEqual({});
+  });
+});

--- a/packages/web/app/lib/observability/request-logger.ts
+++ b/packages/web/app/lib/observability/request-logger.ts
@@ -54,12 +54,9 @@ function resolveRoute(url: string): string {
  *  - `headers()` is async in Next 16. Sourcing the request id from it would
  *    make every `log.info(...)` an `await`, in catch blocks and `after()`
  *    callbacks included.
- *  - There is no middleware hook to seed a store from. `packages/web/middleware.ts`
- *    matches only `/api/v1/:path*`, `/api/auth/:path*` and `/api/internal/ws-auth`
- *    under `/api`; its page matcher excludes `api/` outright via the
- *    `(?!api/…)` lookahead. That narrowing was deliberate (~50k/day board-render
- *    fetches were paying for middleware that did nothing for them), so most
- *    `/api/**` handlers never run middleware at all.
+ *  - Origin verification now runs on all routes, but locale/session handling
+ *    still has a narrower scope. Taking the Request directly keeps correlation
+ *    independent of either middleware path and never copies its header bag.
  */
 export function createRequestLogger(request: Request, options: RequestLoggerOptions = {}): RequestLogger {
   const requestId = request.headers.get(RAILWAY_REQUEST_ID_HEADER) ?? undefined;

--- a/packages/web/app/lib/observability/web-origin-redaction.ts
+++ b/packages/web/app/lib/observability/web-origin-redaction.ts
@@ -1,0 +1,32 @@
+import { WEB_ORIGIN_HEADER } from '../web-origin';
+
+function stripOriginAttributes(attributes: Record<string, unknown> | undefined): void {
+  if (!attributes) return;
+  for (const key of Object.keys(attributes)) {
+    if (key.toLowerCase().replaceAll('_', '-').endsWith(WEB_ORIGIN_HEADER)) delete attributes[key];
+  }
+}
+
+/** Sentry captures incoming headers before middleware constructs its routing view. */
+export function redactWebOriginEvent<
+  Event extends {
+    request?: { headers?: Record<string, string> };
+    contexts?: { trace?: { data?: Record<string, unknown> } };
+    spans?: Array<{ data?: Record<string, unknown> }>;
+  },
+>(event: Event): Event {
+  stripOriginAttributes(event.request?.headers);
+  stripOriginAttributes(event.contexts?.trace?.data);
+  for (const span of event.spans ?? []) stripOriginAttributes(span.data);
+  return event;
+}
+
+export function redactWebOriginSpan<Span extends { data?: Record<string, unknown> }>(span: Span): Span {
+  stripOriginAttributes(span.data);
+  return span;
+}
+
+export function redactWebOriginLog<Log extends { attributes?: Record<string, unknown> }>(log: Log): Log {
+  stripOriginAttributes(log.attributes);
+  return log;
+}

--- a/packages/web/app/lib/web-origin.ts
+++ b/packages/web/app/lib/web-origin.ts
@@ -1,0 +1,26 @@
+/** Shared secret is server-only; never use a NEXT_PUBLIC_ variable for it. */
+export const WEB_ORIGIN_HEADER = 'x-boardsesh-origin-verify';
+
+export function acceptsWebOrigin(request: Request, pathname: string): boolean {
+  if (process.env.WEB_ORIGIN_VERIFY_ENABLED !== '1') return true;
+  // Railway probes only this cheap endpoint; no prefix or locale exceptions.
+  if (pathname === '/api/health' && (request.method === 'GET' || request.method === 'HEAD')) return true;
+  const expectedSecret = process.env.WEB_ORIGIN_VERIFY_SECRET;
+  const suppliedSecret = request.headers.get(WEB_ORIGIN_HEADER);
+  if (!expectedSecret || expectedSecret.length < 32 || !suppliedSecret) return false;
+  // Compare every expected character rather than exposing the matching prefix.
+  let difference = expectedSecret.length ^ suppliedSecret.length;
+  for (let index = 0; index < expectedSecret.length; index++) {
+    difference |= expectedSecret.charCodeAt(index) ^ suppliedSecret.charCodeAt(index);
+  }
+  return difference === 0;
+}
+
+/** Paths that used locale/session/CORS middleware before origin protection. */
+export function needsPageMiddleware(pathname: string): boolean {
+  if (/^\/api\/(v1|auth)(\/|$)/.test(pathname) || pathname === '/api/internal/ws-auth') return true;
+  return (
+    !/^(?:\/api\/|\/_next\/static|\/_next\/image|\/favicon.ico|\/monitoring|\/\.well-known\/)/.test(pathname) &&
+    !pathname.includes('.')
+  );
+}

--- a/packages/web/app/lib/web-origin.ts
+++ b/packages/web/app/lib/web-origin.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 /** Shared secret is server-only; never use a NEXT_PUBLIC_ variable for it. */
 export const WEB_ORIGIN_HEADER = 'x-boardsesh-origin-verify';
 

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -1,5 +1,5 @@
 // middleware.ts
-import { NextResponse, type NextRequest } from 'next/server';
+import { NextResponse, NextRequest } from 'next/server';
 import { SUPPORTED_BOARDS } from './app/lib/board-data';
 import { getClimbViewPageCacheTTL, getListPageCacheTTL } from './app/lib/list-page-cache';
 import { isCrawlerUserAgent } from './app/lib/is-crawler';
@@ -15,6 +15,8 @@ import {
   isSupportedLocale,
 } from './app/lib/i18n/config';
 import { detectLocale } from './app/lib/i18n/detect-locale';
+
+import { acceptsWebOrigin, needsPageMiddleware, WEB_ORIGIN_HEADER } from './app/lib/web-origin';
 
 const SPECIAL_ROUTES = ['angles', 'grades']; // routes that don't need board validation
 
@@ -42,7 +44,28 @@ function isExpoWebProxyEnabled(): boolean {
   return isExpoWebEnabled() && Boolean(process.env.BOARDSESH_EXPO_WEB_ORIGIN);
 }
 
-export function middleware(request: NextRequest) {
+export function middleware(incomingRequest: NextRequest) {
+  if (!acceptsWebOrigin(incomingRequest, incomingRequest.nextUrl.pathname)) {
+    return new NextResponse(null, {
+      status: 403,
+      headers: { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex, nofollow' },
+    });
+  }
+  const sanitizedHeaders = new Headers(incomingRequest.headers);
+  sanitizedHeaders.delete(WEB_ORIGIN_HEADER);
+  // Routing only reads URL, method and headers. Do not transfer or read the
+  // incoming body: Next must still forward it to the eventual POST handler.
+  const request = new NextRequest(incomingRequest.url, {
+    method: incomingRequest.method,
+    headers: sanitizedHeaders,
+  });
+  if (!needsPageMiddleware(request.nextUrl.pathname)) {
+    return NextResponse.next({ request: { headers: sanitizedHeaders } });
+  }
+  return pageMiddleware(request);
+}
+
+function pageMiddleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Block PHP requests
@@ -279,29 +302,6 @@ export function middleware(request: NextRequest) {
   return response;
 }
 
-// Vercel bills and logs per middleware invocation. The previous catch-all
-// matcher (`/api/:path*`-shaped, via the page-routes negative-lookahead not
-// excluding /api/) ran this middleware on every /api/** request, including
-// ~50k+/day board-render image fetches that take nothing from it — the
-// function does no locale/session/CORS work for those paths and every
-// invocation was pure cost. Only three /api families actually need it:
-//   - /api/v1/:path* — board-name validation (404s an unsupported board).
-//   - /api/auth/:path* — all 9 CORS_AUTH_PATHS auth endpoints live here
-//     (see cross-subdomain-cors.ts) and need the credentialed-CORS handling.
-//   - /api/internal/ws-auth — the one /api/internal path in CORS_AUTH_PATHS;
-//     its OPTIONS preflight is answered by middleware itself, so it must stay
-//     matched even though the rest of /api/internal/** is now excluded.
-// Pre-verified safe: no route under packages/web/app/api reads the
-// locale/pathname headers middleware sets, and nothing excluded here accepts
-// a `?session=` query param that middleware needs to intercept.
-export const config = {
-  matcher: [
-    '/api/v1/:path*',
-    '/api/auth/:path*',
-    '/api/internal/ws-auth',
-    // Match all page routes but skip static files, Next.js internals, and
-    // /.well-known/ (apple-app-site-association, assetlinks.json — files the
-    // OS fetches, which must never take a locale redirect or a rewrite).
-    '/((?!api/|_next/static|_next/image|favicon.ico|monitoring|\\.well-known/|.*\\..*).*)',
-  ],
-};
+// Origin verification must cover API routes, static assets and Next internals.
+// The cheap guard runs everywhere; locale/session work retains its old scope.
+export const config = { matcher: ['/:path*'] };

--- a/packages/web/sentry.edge.config.ts
+++ b/packages/web/sentry.edge.config.ts
@@ -4,6 +4,11 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
+import {
+  redactWebOriginEvent,
+  redactWebOriginSpan,
+  redactWebOriginLog,
+} from './app/lib/observability/web-origin-redaction';
 import { isProductionSentryEnvironment, resolveSentryEnvironment } from '@boardsesh/db/client/config';
 import { resolveWebTracesSampleRate, WEB_TRACE_PROPAGATION_TARGETS } from './app/lib/observability/sentry-tracing';
 
@@ -23,6 +28,10 @@ Sentry.init({
 
   // Enable logs to be sent to Sentry
   enableLogs: true,
+  beforeSend: redactWebOriginEvent,
+  beforeSendTransaction: redactWebOriginEvent,
+  beforeSendLog: redactWebOriginLog,
+  beforeSendSpan: redactWebOriginSpan,
 
   // Enable sending user PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii

--- a/packages/web/sentry.server.config.ts
+++ b/packages/web/sentry.server.config.ts
@@ -3,6 +3,11 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
+import {
+  redactWebOriginEvent,
+  redactWebOriginSpan,
+  redactWebOriginLog,
+} from './app/lib/observability/web-origin-redaction';
 import { isProductionSentryEnvironment, resolveSentryEnvironment } from '@boardsesh/db/client/config';
 import {
   redactSensitiveSpanUrls,
@@ -27,6 +32,9 @@ Sentry.init({
 
   // Enable logs to be sent to Sentry
   enableLogs: true,
+  beforeSend: redactWebOriginEvent,
+  beforeSendTransaction: redactWebOriginEvent,
+  beforeSendLog: redactWebOriginLog,
 
   // Enable sending user PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
@@ -47,7 +55,7 @@ Sentry.init({
 
   // Keeps OAuth codes and session ids out of span URLs now that spans record
   // one per sampled request. See the constant's doc comment.
-  beforeSendSpan: redactSensitiveSpanUrls,
+  beforeSendSpan: (span) => redactWebOriginSpan(redactSensitiveSpanUrls(span)),
 });
 
 // Join key between a Railway HTTP log line and a Sentry event. Registered as a

--- a/scripts/cloudflare-origin-apply.test.ts
+++ b/scripts/cloudflare-origin-apply.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { applyOriginRule, originRule, planOriginRule } from './cloudflare-origin-apply';
+const secret = 'a'.repeat(64);
+afterEach(() => vi.unstubAllGlobals());
+
+describe('origin header transform', () => {
+  it('overwrites a client header only on www', () => {
+    const rule = originRule(secret);
+    expect(rule.expression).toBe('(http.host eq "www.boardsesh.com")');
+    expect(rule.action_parameters?.headers?.['x-boardsesh-origin-verify']).toEqual({ operation: 'set', value: secret });
+  });
+  it('preserves foreign rules and reports no credentials in a rotation plan', () => {
+    const rules = [
+      { id: 'foreign', description: 'other transform' },
+      { ...originRule('b'.repeat(64)), id: 'owned' },
+    ];
+    expect(planOriginRule(rules, secret)).toEqual({ action: 'update', id: 'owned' });
+    expect(rules[0]).toEqual({ id: 'foreign', description: 'other transform' });
+  });
+  it('is idempotent', () => {
+    expect(planOriginRule([{ ...originRule(secret), id: 'owned' }], secret).action).toBe('none');
+  });
+  it('rejects another rule owning the same header', () => {
+    expect(() =>
+      planOriginRule(
+        [{ action_parameters: { headers: { 'X-Boardsesh-Origin-Verify': { operation: 'remove' } } } }],
+        secret,
+      ),
+    ).toThrow('Another rule');
+  });
+  it('rejects weak or malformed secrets', () => {
+    expect(() => originRule('short')).toThrow('32 random bytes');
+  });
+  it('never prints a secret echoed by an API failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ secret }), { status: 403 })));
+    await expect(
+      applyOriginRule({ CLOUDFLARE_API_TOKEN: 'token', WEB_ORIGIN_VERIFY_SECRET: secret }, true),
+    ).rejects.toThrow('HTTP 403');
+  });
+  it('dry run never writes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+    expect(await applyOriginRule({ CLOUDFLARE_API_TOKEN: 'token', WEB_ORIGIN_VERIFY_SECRET: secret }, false)).toBe(
+      'Dry run: create origin header rule',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1].method).toBe('GET');
+  });
+});
+
+it('updates only the owned rule and verifies it without replacing the ruleset', async () => {
+  const foreign = { id: 'foreign', description: 'unrelated transform' };
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce(
+      Response.json({
+        success: true,
+        result: { id: 'ruleset', rules: [foreign, { ...originRule('b'.repeat(64)), id: 'owned' }] },
+      }),
+    )
+    .mockResolvedValueOnce(Response.json({ success: true, result: {} }))
+    .mockResolvedValueOnce(
+      Response.json({
+        success: true,
+        result: { id: 'ruleset', rules: [foreign, { ...originRule(secret), id: 'owned' }] },
+      }),
+    );
+  vi.stubGlobal('fetch', fetchMock);
+  expect(await applyOriginRule({ CLOUDFLARE_API_TOKEN: 'token', WEB_ORIGIN_VERIFY_SECRET: secret }, true)).toBe(
+    'Applied and verified origin header rule',
+  );
+  expect(fetchMock.mock.calls[1][0]).toContain('/rulesets/ruleset/rules/owned');
+  expect(fetchMock.mock.calls[1][1].method).toBe('PATCH');
+  expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual(originRule(secret));
+});
+
+it('withholds malformed API response bodies', async () => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(`invalid ${secret}`)));
+  await expect(
+    applyOriginRule({ CLOUDFLARE_API_TOKEN: 'token', WEB_ORIGIN_VERIFY_SECRET: secret }, true),
+  ).rejects.toThrow('invalid JSON; response withheld');
+});

--- a/scripts/cloudflare-origin-apply.ts
+++ b/scripts/cloudflare-origin-apply.ts
@@ -55,7 +55,7 @@ export function planOriginRule(
   return { action: matches ? 'none' : 'update', id: current.id };
 }
 
-export async function applyOriginRule(env: NodeJS.ProcessEnv, apply: boolean): Promise<string> {
+export async function applyOriginRule(env: Record<string, string | undefined>, apply: boolean): Promise<string> {
   const token = env.CLOUDFLARE_API_TOKEN;
   const secret = env.WEB_ORIGIN_VERIFY_SECRET ?? '';
   const desired = originRule(secret);

--- a/scripts/cloudflare-origin-apply.ts
+++ b/scripts/cloudflare-origin-apply.ts
@@ -1,0 +1,112 @@
+/// <reference types="node" />
+import { pathToFileURL } from 'node:url';
+
+const ZONE_ID = '2ffcc52b2e8c604fd85b9faa8efc18bf';
+const PHASE = 'http_request_late_transform';
+const MARKER = 'boardsesh:verify-web-origin (managed by scripts/cloudflare-origin-apply.ts)';
+const HEADER = 'x-boardsesh-origin-verify';
+
+type TransformRule = {
+  id?: string;
+  description?: string;
+  action?: string;
+  expression?: string;
+  enabled?: boolean;
+  action_parameters?: { headers?: Record<string, { operation: string; value?: string }> };
+};
+type Ruleset = { id: string; rules?: TransformRule[] };
+
+export function originRule(secret: string): TransformRule {
+  if (!/^[a-f0-9]{64}$/.test(secret)) throw new Error('Origin secret must be 32 random bytes encoded as hex');
+  return {
+    description: MARKER,
+    expression: '(http.host eq "www.boardsesh.com")',
+    action: 'rewrite',
+    enabled: true,
+    action_parameters: { headers: { [HEADER]: { operation: 'set', value: secret } } },
+  };
+}
+
+/** Reports only action/ID, never current or desired header values. */
+export function planOriginRule(
+  rules: TransformRule[],
+  secret: string,
+): { action: 'create' | 'update' | 'none'; id?: string } {
+  const desired = originRule(secret);
+  const owned = rules.filter((rule) => rule.description === MARKER);
+  if (owned.length > 1) throw new Error('Duplicate managed origin rules require review');
+  if (
+    rules.some(
+      (rule) =>
+        rule.description !== MARKER &&
+        Object.keys(rule.action_parameters?.headers ?? {}).some((header) => header.toLowerCase() === HEADER),
+    )
+  ) {
+    throw new Error('Another rule modifies the origin header; resolve ownership before applying');
+  }
+  const current = owned[0];
+  if (!current) return { action: 'create' };
+  if (!current.id) throw new Error('Managed origin rule is missing its ID');
+  const matches =
+    current.action === desired.action &&
+    current.expression === desired.expression &&
+    current.enabled === true &&
+    JSON.stringify(current.action_parameters) === JSON.stringify(desired.action_parameters);
+  return { action: matches ? 'none' : 'update', id: current.id };
+}
+
+export async function applyOriginRule(env: NodeJS.ProcessEnv, apply: boolean): Promise<string> {
+  const token = env.CLOUDFLARE_API_TOKEN;
+  const secret = env.WEB_ORIGIN_VERIFY_SECRET ?? '';
+  const desired = originRule(secret);
+  if (!token) throw new Error('CLOUDFLARE_API_TOKEN is required');
+  async function api<Result>(path: string, method = 'GET', body?: unknown): Promise<Result | null> {
+    let response: Response;
+    try {
+      response = await fetch(`https://api.cloudflare.com/client/v4/zones/${ZONE_ID}${path}`, {
+        method,
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch {
+      throw new Error('Cloudflare origin-rule request failed; response details withheld');
+    }
+    if (method === 'GET' && response.status === 404) return null;
+    // Never print API bodies: they can echo the secret-bearing rule.
+    if (!response.ok)
+      throw new Error(`Cloudflare origin-rule request failed (HTTP ${response.status}); response withheld`);
+    let payload: { success: boolean; result: Result };
+    try {
+      payload = (await response.json()) as { success: boolean; result: Result };
+    } catch {
+      throw new Error('Cloudflare origin-rule response was invalid JSON; response withheld');
+    }
+    if (!payload.success) throw new Error('Cloudflare origin-rule API returned failure; response withheld');
+    return payload.result;
+  }
+  const current = await api<Ruleset>(`/rulesets/phases/${PHASE}/entrypoint`);
+  const plan = planOriginRule(current?.rules ?? [], secret);
+  if (!apply || plan.action === 'none') return `${apply ? 'Apply' : 'Dry run'}: ${plan.action} origin header rule`;
+  if (!current) {
+    await api('/rulesets', 'POST', { name: 'Boardsesh request headers', kind: 'zone', phase: PHASE, rules: [desired] });
+  } else if (plan.action === 'create') {
+    await api(`/rulesets/${current.id}/rules`, 'POST', desired);
+  } else {
+    await api(`/rulesets/${current.id}/rules/${plan.id}`, 'PATCH', desired);
+  }
+  const verified = await api<Ruleset>(`/rulesets/phases/${PHASE}/entrypoint`);
+  if (!verified || planOriginRule(verified.rules ?? [], secret).action !== 'none')
+    throw new Error('Origin header read-back verification failed');
+  return 'Applied and verified origin header rule';
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  applyOriginRule(process.env, process.argv.includes('--apply'))
+    .then(console.log)
+    .catch((error: unknown) => {
+      // Only our sanitized errors are emitted. Never stringify request objects.
+      console.error(error instanceof Error ? error.message : 'Origin rule failed');
+      process.exitCode = 1;
+    });
+}

--- a/scripts/production-smoke.test.ts
+++ b/scripts/production-smoke.test.ts
@@ -1,7 +1,8 @@
 /// <reference types="node" />
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
+  fetchOnce,
   FIXTURE_PATHS,
   WWW_CHECKS,
   finalVerdict,
@@ -587,5 +588,40 @@ describe('parseBaseUrl', () => {
   it('rejects a malformed --base rather than failing three retries deep', () => {
     expect(() => parseBaseUrl(['--base', 'www.boardsesh.com'])).toThrow(/not a valid URL/);
     expect(() => parseBaseUrl(['--base', 'not a url at all'])).toThrow(/not a valid URL/);
+  });
+});
+
+describe('authenticated direct-origin smoke transport', () => {
+  it('forwards the secret on same-origin redirects', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 307, headers: { location: '/destination' } }))
+      .mockResolvedValueOnce(new Response('ok'));
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      await fetchOnce('https://origin.up.railway.app/start', 1000, 'secret');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[1][1].headers['X-Boardsesh-Origin-Verify']).toBe('secret');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+  it('never follows a cross-origin redirect carrying the secret', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 302, headers: { location: 'https://other.example/' } }));
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      await expect(fetchOnce('https://origin.up.railway.app/start', 1000, 'secret')).rejects.toThrow(
+        'left the requested origin',
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+  it('rejects sending the secret to a public or insecure base URL', async () => {
+    await expect(fetchOnce('https://www.boardsesh.com/', 1000, 'secret')).rejects.toThrow('HTTPS Railway origin');
+    await expect(fetchOnce('http://origin.up.railway.app/', 1000, 'secret')).rejects.toThrow('HTTPS Railway origin');
   });
 });

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -617,21 +617,42 @@ function resolvePath(check: SmokeCheck, env: NodeJS.ProcessEnv): string | null {
   return buildPath ? buildPath(fixtureValue) : null;
 }
 
-async function fetchOnce(url: string, timeoutMs: number): Promise<SmokeResponse> {
+export async function fetchOnce(url: string, timeoutMs: number, originSecret?: string): Promise<SmokeResponse> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetch(url, {
-      signal: controller.signal,
-      redirect: 'follow',
-      headers: {
-        // Identify the smoke in access logs, and ask for the uncached answer —
-        // a CDN hit would happily serve the *previous* deploy's HTML and mask
-        // exactly the regression this exists to catch.
-        'User-Agent': 'boardsesh-production-smoke/1.0',
-        'Cache-Control': 'no-cache',
-      },
-    });
+    const initialUrl = new URL(url);
+    const headersForOrigin: Record<string, string> = {
+      // Identify the smoke in access logs, and ask for the uncached answer —
+      // a CDN hit would happily serve the *previous* deploy's HTML and mask
+      // exactly the regression this exists to catch.
+      'User-Agent': 'boardsesh-production-smoke/1.0',
+      'Cache-Control': 'no-cache',
+    };
+    if (originSecret) {
+      if (initialUrl.protocol !== 'https:' || !initialUrl.hostname.endsWith('.up.railway.app')) {
+        throw new Error('Origin verification secret requires an HTTPS Railway origin');
+      }
+      headersForOrigin['X-Boardsesh-Origin-Verify'] = originSecret;
+    }
+    let currentUrl = initialUrl;
+    let response: Response;
+    for (let redirects = 0; ; redirects++) {
+      response = await fetch(currentUrl.toString(), {
+        signal: controller.signal,
+        redirect: 'manual',
+        headers: headersForOrigin,
+      });
+      const location = response.headers.get('location');
+      if (![301, 302, 303, 307, 308].includes(response.status) || !location) break;
+      await response.body?.cancel();
+      if (redirects >= 5) throw new Error('Too many smoke redirects');
+      const destination = new URL(location, currentUrl);
+      if (destination.origin !== initialUrl.origin || destination.username || destination.password) {
+        throw new Error('Smoke redirect left the requested origin');
+      }
+      currentUrl = destination;
+    }
     const headers: Record<string, string> = {};
     response.headers.forEach((value, name) => {
       headers[name.toLowerCase()] = value;
@@ -641,8 +662,8 @@ async function fetchOnce(url: string, timeoutMs: number): Promise<SmokeResponse>
       contentType: response.headers.get('content-type') ?? '',
       body: await response.text(),
       headers,
-      // `redirect: 'follow'` above means this can differ from `url`.
-      url: response.url || url,
+      // Same-origin redirects may change the final path.
+      url: response.url || currentUrl.toString(),
     };
   } finally {
     clearTimeout(timer);
@@ -687,7 +708,7 @@ async function runCheck(check: SmokeCheck, baseUrl: string, env: NodeJS.ProcessE
   for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
     let detail: string;
     try {
-      const response = await fetchOnce(url, check.timeoutMs ?? REQUEST_TIMEOUT_MS);
+      const response = await fetchOnce(url, check.timeoutMs ?? REQUEST_TIMEOUT_MS, env.WEB_ORIGIN_VERIFY_SECRET);
       const failure =
         originFailure(response, baseUrl) ??
         check.assert(response, {


### PR DESCRIPTION
## Summary
The public Railway web hostname lets crawlers bypass Cloudflare and trigger rendering directly. Add staged origin verification across all routes, stripping the secret before downstream handlers and external rewrites. Only GET/HEAD `/api/health` is exempt when enabled.

Add a narrowly scoped, manually dispatched Cloudflare request-header rule and authenticated normal/rollback deployment smokes. Redirects cannot carry the secret to another origin. Server and edge Sentry hooks redact the incoming credential before error, transaction, span and structured-log export. The flag stays disabled until the stripping middleware, secret and Cloudflare header are deployed in that order; the runbook includes rollback and rotation.

Validation: full repository typecheck, full lint (0 errors) and 238 focused plus 25 telemetry tests passed, including POST-body preservation, previously excluded routes, missing/wrong secrets, header stripping and Cloudflare ownership/error redaction.

The origin and crawler branches also merge cleanly; all 378 combined tests passed.

## Release Notes
none

## Test plan
1. Open Boardsesh → homepage loads.
2. Open a shared climb → climb details appear.
3. Sign in → your account appears.

## Risk
Risk: 3/5 — incorrect activation could block www; default-disabled staging and rollback are documented.
