### PR TITLE
feat(mobile): add MoonBoard hold-above toggle to Settings

### DIFF
--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -6,7 +6,9 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { GradeDisplayFormat } from '@boardsesh/play-view';
 import type { ThemeOverride } from '@boardsesh/key-value-storage';
 import { SUPPORTED_LOCALES, LOCALE_LABELS } from '@boardsesh/i18n';
+import { isMoonboardBoardName } from '@boardsesh/board-config';
 import { useTheme } from '../../../src/providers/theme-provider';
+import { useOptionalBluetoothContext } from '../../../src/providers/bluetooth-provider';
 import { useLocalePreference } from '../../../src/providers/i18n-provider';
 import { resolveLanguage, type LocaleOverride } from '../../../src/lib/i18n/locale-preference';
 import { openExternalUrl } from '../../../src/lib/open-url';
@@ -118,6 +120,16 @@ export default function MoreScreen() {
   const [lightOnSwipe, setLightOnSwipe] = useSetting('lightOnSwipe');
   const [lightOnClimbTap, setLightOnClimbTap] = useSetting('lightOnClimbTap');
   const autoDisconnectTimeoutLabels = useAutoDisconnectTimeoutLabels();
+  // MoonBoard "V2" additional-LED feature — same setting + toggle handler as the
+  // BLE control sheet (BleControlSheetHost), so it's reachable without opening a
+  // live connection. Only shown for a MoonBoard, same gate as that sheet.
+  const bluetooth = useOptionalBluetoothContext();
+  const showMoonboardLightAdjacentHolds = isMoonboardBoardName(bluetooth?.boardName);
+  const handleToggleMoonboardLightAdjacentHolds = (next: boolean) => {
+    hapticSelection();
+    bluetooth?.setMoonboardLightAdjacentHolds(next);
+    bluetooth?.reassertWall();
+  };
   const { enableBoardsOffline } = useBoardDownloads();
   const { data: myBoardsConnection } = useMyBoards(undefined, { enabled: offlineEnabled && !!profile });
   // Memoized so the empty-while-loading fallback keeps a stable identity — the
@@ -660,6 +672,18 @@ export default function MoreScreen() {
           setLightOnClimbTap(next);
         },
       },
+      ...(showMoonboardLightAdjacentHolds
+        ? [
+            {
+              kind: 'toggle' as const,
+              key: 'moonboardLightAdjacentHolds',
+              label: t('lightControl.lightAdjacentHolds'),
+              subtitle: t('lightControl.lightAdjacentHoldsHelp'),
+              value: bluetooth?.moonboardLightAdjacentHolds ?? false,
+              onValueChange: handleToggleMoonboardLightAdjacentHolds,
+            },
+          ]
+        : []),
     ],
   });
 


### PR DESCRIPTION
## Summary

The "light the hold above" MoonBoard feature (additional-LED support) only lived in the live Bluetooth control sheet, so a climber had to be actively connected to discover or toggle it. This adds the same toggle to the Settings screen's "Board lighting" section, next to the existing "Light problems on swipe" / "Light problems when tapping the list" rows.

- Reuses the existing persisted setting (`moonboardLightAdjacentHolds`) and its BLE send/reassert path — no new state, no BLE protocol changes.
- Reuses the existing copy (`common:lightControl.lightAdjacentHolds` / `lightAdjacentHoldsHelp`) already shown in the BLE sheet, so the two surfaces read consistently.
- Row only appears when the connected board is a MoonBoard (same gate `BleControlSheetHost` uses via `isMoonboardBoardName`).
- Toggling calls `setMoonboardLightAdjacentHolds` + `reassertWall()`, matching the BLE sheet's handler, so a live connection re-lights immediately.

Verified: `vp run typecheck:mobile`, `vp check`, `vp run test:mobile` (2 pre-existing unrelated failures in `logbook-tab-grouped.test.tsx`, confirmed present on `main` without this change), `vp run check:mobile-bundle`.

## Release Notes

- Find "Light the hold above" for MoonBoard in Settings → Board lighting, not just the Bluetooth menu

## Test plan

1. Connect a MoonBoard → Settings → Board lighting → new "Light the hold above" toggle appears.
2. Flip it on → wall re-lights with the dimmer neighbour LEDs.
3. Connect a Kilter/Tension board → toggle is hidden.

## Risk

Risk: 2/5 — additive Settings UI reusing an existing, already-shipped setting and BLE send path; no BLE protocol or native code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESKRXzVj6mNfhn8Aaz77Uk