### PR TITLE
fix(mobile): restore image uploads on native and browser apps

### DIFF
--- a/docs/user-media-storage.md
+++ b/docs/user-media-storage.md
@@ -90,6 +90,24 @@ vp exec tsx packages/backend/src/scripts/backfill-image-variants.ts --prefix bet
 
 The backfill creates only missing variants and skips existing objects. It does not change beta links or refetch Instagram/TikTok posts. Re-run the dry run to confirm no variants remain, then check the affected public URLs; cached CDN 404s may need time to expire.
 
+### App multipart uploads
+
+Avatars, bug-report screenshots and PR QA screenshots use the mobile app's
+`appendUploadImage` adapter. Native release bundles pin React Native's fetch with
+`EXPO_PUBLIC_USE_RN_FETCH=1` because Expo fetch can crash Hermes (see
+`docs/mobile-ota-updates.md`). RN multipart parts must carry a readable `uri`,
+plus `name` and `type`. A `bytes()`-only descriptor sends an empty file part.
+
+The native adapter also exposes a non-enumerable `bytes()` reader for Expo fetch
+in development. RN's serializer spreads only the URI and metadata into the
+native bridge; Expo reads the original entry's method. Both paths can replay the
+form after authentication refresh. Keep the fetch pin in place.
+
+The browser adapter reads picker/manipulator `blob:` or `data:` URLs without
+backend credentials and appends a real Blob with an explicit filename. Both
+adapters reject missing or empty images, and leave the multipart boundary to
+fetch. The backend rejects empty avatar and screenshot parts before storage.
+
 ### Feedback screenshots
 
 `POST /api/feedback-screenshots` takes one authenticated image per request and returns `{ key }`. There is no `/static/` route for these: the only readers are a GitHub comment and the admin dashboard, and both get a `media.boardsesh.com` URL directly. The key it mints — `feedback-screenshots/<uuid>.<ext>` — rides on a QA verdict (`submitQaVerdict`) or a bug report (`submitAppFeedback`), and the backend turns it back into a `media.boardsesh.com` URL when it writes the PR comment or the GitHub issue. See `docs/crowdsourced-qa.md`.

--- a/packages/backend/src/__tests__/avatar-upload-s3.test.ts
+++ b/packages/backend/src/__tests__/avatar-upload-s3.test.ts
@@ -102,6 +102,28 @@ describe('avatar upload S3 path (write-first, clean-after)', () => {
     }
   });
 
+  it('rejects an empty upload before writing variants or deleting existing objects', async () => {
+    validateTokenMock.mockResolvedValue({ userId: USER_ID });
+    isS3ConfiguredMock.mockReturnValue(true);
+    const { baseUrl, server } = await startAvatarServer();
+    try {
+      const form = new FormData();
+      form.append('userId', USER_ID);
+      form.append('avatar', new Blob([], { type: 'image/jpeg' }), 'avatar.jpg');
+      const response = await fetch(`${baseUrl}/api/avatars`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer avatar-token' },
+        body: form,
+      });
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: 'Uploaded file is empty' });
+      expect(uploadToS3Mock).not.toHaveBeenCalled();
+      expect(deleteUserAvatarsFromS3Mock).not.toHaveBeenCalled();
+    } finally {
+      await closeServer(server);
+    }
+  });
+
   it('never deletes the existing avatar when the S3 upload fails', async () => {
     validateTokenMock.mockResolvedValue({ userId: USER_ID });
     isS3ConfiguredMock.mockReturnValue(true);

--- a/packages/backend/src/__tests__/avatar-upload.test.ts
+++ b/packages/backend/src/__tests__/avatar-upload.test.ts
@@ -131,6 +131,30 @@ describe('avatar upload routes', () => {
     }
   });
 
+  it.each(['image/jpeg', 'image/png'])(
+    'rejects an empty %s replacement and preserves the existing avatar',
+    async (mimeType) => {
+      validateTokenMock.mockResolvedValue({ userId: USER_ID });
+      const { baseUrl, server } = await startAvatarServer();
+      try {
+        const savedResponse = await uploadAvatar(baseUrl, new Blob([JPEG_BYTES], { type: 'image/jpeg' }), 'avatar.jpg');
+        expect(savedResponse.status).toBe(200);
+        const { avatarUrl } = (await savedResponse.json()) as { avatarUrl: string };
+        const emptyResponse = await uploadAvatar(baseUrl, new Blob([], { type: mimeType }), 'empty.jpg');
+        expect(emptyResponse.status).toBe(400);
+        expect(await emptyResponse.json()).toEqual({ error: 'Uploaded file is empty' });
+        const preserved = await fetch(`${baseUrl}${avatarUrl}`);
+        expect(preserved.status).toBe(200);
+        expect(Buffer.from(await preserved.arrayBuffer())).toEqual(JPEG_BYTES);
+        expect((await readdir(getAvatarsDir())).filter((filename) => filename.startsWith(USER_ID))).toEqual([
+          `${USER_ID}.jpg`,
+        ]);
+      } finally {
+        await closeServer(server);
+      }
+    },
+  );
+
   it('concurrent cross-extension uploads leave exactly one avatar (never zero)', async () => {
     validateTokenMock.mockResolvedValue({ userId: USER_ID });
     const { baseUrl, server } = await startAvatarServer();

--- a/packages/backend/src/handlers/avatars.ts
+++ b/packages/backend/src/handlers/avatars.ts
@@ -257,6 +257,13 @@ export async function handleAvatarUpload(req: IncomingMessage, res: ServerRespon
         return;
       }
 
+      if (fileBuffer.length === 0) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Uploaded file is empty' }));
+        resolve();
+        return;
+      }
+
       // Capture the narrowed values so the serialized closure below keeps
       // their non-null types.
       const uploadBuffer = fileBuffer;

--- a/packages/mobile/src/lib/__tests__/auth-interceptor.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-interceptor.test.ts
@@ -293,6 +293,32 @@ describe('recoverAuthRejection', () => {
 // ── authenticatedFetch ───────────────────────────────────────────────────
 
 describe('authenticatedFetch', () => {
+  it('replays the complete multipart body after refreshing a rejected token', async () => {
+    const imageBytes = Uint8Array.from([0xff, 0xd8, 0xff, 0xdb, 0xff, 0xd9]);
+    const form = new FormData();
+    form.append('avatar', new Blob([imageBytes], { type: 'image/jpeg' }), 'avatar.jpg');
+    form.append('userId', 'climber-id');
+    const uploadHeaders: string[] = [];
+    mockGetAuthToken.mockResolvedValueOnce('old-jwt').mockResolvedValueOnce('new-jwt');
+    mockFetch.mockImplementation(async (url: string, options: RequestInit) => {
+      if (url.endsWith('/auth/native/refresh')) {
+        return Response.json({ jwt: 'new-jwt', refreshToken: 'new-refresh', expiresAt: '2099-01-01T00:00:00Z' });
+      }
+      const request = new Request(url, options);
+      uploadHeaders.push(request.headers.get('Authorization')!);
+      const decoded = await request.formData();
+      const image = decoded.getAll('avatar')[0] as unknown as File;
+      expect(image.name).toBe('avatar.jpg');
+      expect(image.type).toBe('image/jpeg');
+      expect(new Uint8Array(await image.arrayBuffer())).toEqual(imageBytes);
+      expect(decoded.getAll('userId')[0]).toBe('climber-id');
+      return Response.json({}, { status: uploadHeaders.length === 1 ? 401 : 200 });
+    });
+    const response = await authenticatedFetch('https://ws.example.com/api/avatars', { method: 'POST', body: form });
+    expect(response.status).toBe(200);
+    expect(uploadHeaders).toEqual(['Bearer old-jwt', 'Bearer new-jwt']);
+  });
+
   it('retries with new token on 401 even when token is not expiring', async () => {
     // Token is NOT expiring — the 401 path should bypass the expiry check
     mockIsTokenExpiringSoon.mockResolvedValue(false);

--- a/packages/mobile/src/lib/__tests__/avatar-upload.test.ts
+++ b/packages/mobile/src/lib/__tests__/avatar-upload.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { NativeFormData, type NativeUploadFormData } from '../../../test/native-upload-runtime';
 
 // Fixed backend origin so the relative→absolute logic is deterministic and
 // independent of EXPO_PUBLIC_BACKEND_URL.
@@ -18,6 +19,8 @@ vi.mock('../auth-interceptor', () => ({
 const fileBytes = new Uint8Array([1, 2, 3]);
 vi.mock('expo-file-system', () => ({
   File: class {
+    exists = true;
+    size = 3;
     uri: string;
     constructor(uri: string) {
       this.uri = uri;
@@ -28,22 +31,7 @@ vi.mock('expo-file-system', () => ({
   },
 }));
 
-// A minimal FormData that records appended parts as-is (Node's undici FormData
-// stringifies non-Blob values, which would hide the part object we need to
-// inspect — the whole point of this regression test).
-class RecordingFormData {
-  parts: [string, unknown][] = [];
-  append(name: string, value: unknown) {
-    this.parts.push([name, value]);
-  }
-  get(name: string) {
-    return this.parts.find(([key]) => key === name)?.[1];
-  }
-  has(name: string) {
-    return this.parts.some(([key]) => key === name);
-  }
-}
-vi.stubGlobal('FormData', RecordingFormData);
+afterEach(() => vi.unstubAllGlobals());
 
 import { absolutizeAvatarUrl, uploadAvatar } from '../avatar-upload';
 
@@ -56,6 +44,7 @@ function jsonResponse(body: unknown, ok = true): Response {
 }
 
 beforeEach(() => {
+  vi.stubGlobal('FormData', NativeFormData);
   vi.clearAllMocks();
 });
 
@@ -71,7 +60,7 @@ describe('absolutizeAvatarUrl', () => {
 });
 
 describe('uploadAvatar', () => {
-  it('POSTs an Expo-fetch-compatible multipart part and returns a cache-busted absolute URL', async () => {
+  it('POSTs an multipart file readable by RN and Expo fetch and returns a cache-busted absolute URL', async () => {
     mockAuthenticatedFetch.mockResolvedValue(jsonResponse({ success: true, avatarUrl: '/static/avatars/me.jpg' }));
 
     const result = await uploadAvatar(file, userId);
@@ -86,13 +75,12 @@ describe('uploadAvatar', () => {
     // No explicit Content-Type — the fetch layer sets the multipart boundary.
     expect(options.headers).toBeUndefined();
 
-    const body = options.body as unknown as RecordingFormData;
+    const body = options.body as unknown as NativeUploadFormData;
     expect(body.get('userId')).toBe(userId);
 
-    // The regression: the avatar part must expose `bytes()` + name/type, NOT the
-    // legacy `{ uri }` descriptor that Expo's fetch rejects.
+    // Release builds use RN fetch; its serializer must retain the file URI.
     const avatarPart = body.get('avatar') as { name: string; type: string; bytes: () => Promise<Uint8Array> };
-    expect(avatarPart).not.toHaveProperty('uri');
+    expect(body.getParts()[0].uri).toBe(file.uri);
     expect(avatarPart.name).toBe('avatar.jpg');
     expect(avatarPart.type).toBe('image/jpeg');
     expect(typeof avatarPart.bytes).toBe('function');

--- a/packages/mobile/src/lib/__tests__/upload-image.test.ts
+++ b/packages/mobile/src/lib/__tests__/upload-image.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, statSync } from 'node:fs';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { NativeFormData, convertFormDataAsync } from '../../../test/native-upload-runtime';
+
+const readBytes = vi.hoisted(() => vi.fn());
+vi.mock('expo-file-system', () => ({
+  File: class {
+    constructor(readonly uri: string) {}
+    get exists() {
+      return existsSync(new URL(this.uri));
+    }
+    get size() {
+      return statSync(new URL(this.uri)).size;
+    }
+    bytes() {
+      return readBytes(this.uri);
+    }
+  },
+}));
+
+import { appendUploadImage } from '../upload-image';
+
+const JPEG_BYTES = Uint8Array.from([0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0x0d, 0x0a, 0xff, 0xd9]);
+let fixtureDirectory: string;
+let imageUri: string;
+
+beforeEach(async () => {
+  fixtureDirectory = await mkdtemp(join(tmpdir(), 'boardsesh-upload-'));
+  imageUri = pathToFileURL(join(fixtureDirectory, 'picked image.jpg')).href;
+  await writeFile(new URL(imageUri), JPEG_BYTES);
+  readBytes.mockReset().mockImplementation((uri: string) => readFile(new URL(uri)));
+  vi.stubGlobal('FormData', NativeFormData);
+});
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await rm(fixtureDirectory, { recursive: true, force: true });
+});
+
+describe('native image multipart encoding', () => {
+  it.each(['avatar', 'screenshot'])(
+    'gives RN a readable %s file without sending functions to native',
+    async (fieldName) => {
+      const form = new NativeFormData();
+      await appendUploadImage(form, fieldName, { uri: imageUri, name: 'picked.jpg', type: 'image/jpeg' });
+      const [part] = form.getParts();
+      expect(part).toEqual({
+        uri: imageUri,
+        name: 'picked.jpg',
+        type: 'image/jpeg',
+        fieldName,
+        headers: {
+          'content-disposition': `form-data; name="${fieldName}"; filename="picked.jpg"`,
+          'content-type': 'image/jpeg',
+        },
+      });
+      // The native bridge reads the URI, rather than invoking a JS bytes callback.
+      expect(readBytes).not.toHaveBeenCalled();
+      expect(new Uint8Array(await readFile(new URL(part.uri!)))).toEqual(JPEG_BYTES);
+    },
+  );
+
+  it('encodes complete bytes and metadata with the Expo multipart encoder, including replay', async () => {
+    const form = new NativeFormData();
+    await appendUploadImage(form, 'avatar', { uri: imageUri, name: 'avatar.jpg', type: 'image/jpeg' });
+    form.append('userId', 'climber-id');
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const { body, boundary } = await convertFormDataAsync(form);
+      const encodedRequest = new Request('https://example.com/upload', {
+        method: 'POST',
+        headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
+        body: new Uint8Array(body).buffer,
+      });
+      const decoded = await encodedRequest.formData();
+      const image = decoded.getAll('avatar')[0] as unknown as File;
+      expect(image.name).toBe('avatar.jpg');
+      expect(image.type).toBe('image/jpeg');
+      expect(new Uint8Array(await image.arrayBuffer())).toEqual(JPEG_BYTES);
+      expect(decoded.getAll('userId')[0]).toBe('climber-id');
+    }
+  });
+
+  it.each(['missing', 'empty'])('rejects a %s file before appending a part', async (kind) => {
+    if (kind === 'missing') await rm(new URL(imageUri));
+    else await writeFile(new URL(imageUri), new Uint8Array());
+    const form = new NativeFormData();
+    await expect(
+      appendUploadImage(form, 'screenshot', { uri: imageUri, name: 'shot.jpg', type: 'image/jpeg' }),
+    ).rejects.toThrow(kind === 'missing' ? 'Selected image is unavailable' : 'Selected image is empty');
+    expect(form.getParts()).toEqual([]);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/upload-image.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/upload-image.web.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { appendUploadImage } from '../upload-image.web';
+
+vi.mock('../upload-image', () => import('../upload-image.web'));
+vi.mock('../env', () => ({ BACKEND_URL: 'https://ws.example.com' }));
+const authenticatedFetchMock = vi.hoisted(() => vi.fn());
+vi.mock('../auth-interceptor', () => ({ authenticatedFetch: authenticatedFetchMock }));
+
+import { uploadAvatar } from '../avatar-upload';
+import { clearScreenshotUploadCache, uploadFeedbackScreenshots } from '../feedback/screenshot-upload';
+
+const JPEG_BYTES = Uint8Array.from([0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0xff, 0xd9]);
+const objectUrls: string[] = [];
+const browserFetch = globalThis.fetch;
+
+beforeEach(() => {
+  authenticatedFetchMock.mockReset();
+  clearScreenshotUploadCache();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  for (const uri of objectUrls.splice(0)) URL.revokeObjectURL(uri);
+});
+
+function imageUri(kind: string): string {
+  if (kind === 'data') return `data:image/jpeg;base64,${Buffer.from(JPEG_BYTES).toString('base64')}`;
+  const uri = URL.createObjectURL(new Blob([JPEG_BYTES], { type: 'image/jpeg' }));
+  objectUrls.push(uri);
+  return uri;
+}
+
+describe('browser uploads', () => {
+  it.each(['blob', 'data'])('serializes a %s image as a real file with unchanged bytes', async (kind) => {
+    const uri = imageUri(kind);
+    const sourceFetch = vi.fn(browserFetch);
+    vi.stubGlobal('fetch', sourceFetch);
+    const form = new FormData();
+    await appendUploadImage(form, 'screenshot', { uri, name: 'screenshot.jpg', type: 'image/jpeg' });
+    const request = new Request('https://example.com/upload', { method: 'POST', body: form });
+    expect(request.headers.get('content-type')).toContain('multipart/form-data; boundary=');
+    const decoded = await request.formData();
+    const image = decoded.getAll('screenshot')[0] as unknown as File;
+    expect(image.name).toBe('screenshot.jpg');
+    expect(image.type).toBe('image/jpeg');
+    expect(new Uint8Array(await image.arrayBuffer())).toEqual(JPEG_BYTES);
+    expect(sourceFetch).toHaveBeenCalledExactlyOnceWith(uri);
+  });
+
+  it.each(['avatar', 'screenshots'])('sends complete %s through the shared uploader', async (flow) => {
+    authenticatedFetchMock.mockImplementation(async (url: string, options: RequestInit) => {
+      const decoded = await new Request(url, options).formData();
+      const fieldName = flow === 'avatar' ? 'avatar' : 'screenshot';
+      const image = decoded.getAll(fieldName)[0] as unknown as File;
+      expect(new Uint8Array(await image.arrayBuffer())).toEqual(JPEG_BYTES);
+      if (flow === 'avatar') expect(decoded.getAll('userId')[0]).toBe('climber-id');
+      return Response.json(
+        flow === 'avatar' ? { avatarUrl: '/static/avatars/climber-id.jpg' } : { key: 'feedback-screenshots/shot.jpg' },
+      );
+    });
+    const uri = imageUri('blob');
+    if (flow === 'avatar') await expect(uploadAvatar({ uri }, 'climber-id')).resolves.toContain('/static/avatars/');
+    else await expect(uploadFeedbackScreenshots([uri])).resolves.toEqual(['feedback-screenshots/shot.jpg']);
+    expect(authenticatedFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an empty image without contacting the backend', async () => {
+    await expect(uploadAvatar({ uri: 'data:image/jpeg;base64,' }, 'climber-id')).rejects.toThrow(
+      'Selected image is empty',
+    );
+    expect(authenticatedFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unavailable image without contacting the backend', async () => {
+    const uri = imageUri('blob');
+    URL.revokeObjectURL(uri);
+    await expect(uploadFeedbackScreenshots([uri])).rejects.toThrow();
+    expect(authenticatedFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsuccessful source response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+    await expect(uploadAvatar({ uri: 'blob:missing' }, 'climber-id')).rejects.toThrow('Selected image is unavailable');
+    expect(authenticatedFetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/avatar-upload.ts
+++ b/packages/mobile/src/lib/avatar-upload.ts
@@ -1,4 +1,4 @@
-import { File } from 'expo-file-system';
+import { appendUploadImage } from './upload-image';
 import { authenticatedFetch } from './auth-interceptor';
 import { BACKEND_URL } from './env';
 
@@ -47,22 +47,12 @@ function withCacheBuster(url: string): string {
  * added by the fetch layer, and `authenticatedFetch` only touches `Authorization`.
  */
 export async function uploadAvatar(file: AvatarUploadFile, userId: string): Promise<string> {
-  const localFile = new File(file.uri);
-
   const formData = new FormData();
-  // Expo's global `fetch` (WinterCG) rejects React Native's legacy
-  // `{ uri, name, type }` FormData file descriptor with "Unsupported FormDataPart
-  // implementation": its multipart encoder only accepts a string, a Blob, or an
-  // object exposing `bytes()`. Hand it the file's bytes plus an explicit
-  // name/type so the part carries a `filename` (busboy treats it as a file, not a
-  // field) and the correct `Content-Type`. Cast through `unknown` because the DOM
-  // `FormData` types only know `Blob`.
-  const avatarPart = {
+  await appendUploadImage(formData, 'avatar', {
+    uri: file.uri,
     name: file.name ?? 'avatar.jpg',
     type: file.type ?? 'image/jpeg',
-    bytes: () => localFile.bytes(),
-  };
-  formData.append('avatar', avatarPart as unknown as Blob);
+  });
   formData.append('userId', userId);
 
   const response = await authenticatedFetch(AVATAR_ENDPOINT, {

--- a/packages/mobile/src/lib/feedback/__tests__/screenshot-upload.test.ts
+++ b/packages/mobile/src/lib/feedback/__tests__/screenshot-upload.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { NativeFormData, type NativeUploadFormData } from '../../../../test/native-upload-runtime';
 
 // Fixed backend origin so the endpoint URL is deterministic and independent of
 // EXPO_PUBLIC_BACKEND_URL.
@@ -17,6 +18,8 @@ vi.mock('../../auth-interceptor', () => ({
 // per-URI payload in Node (the payload identifies which file a part carries).
 vi.mock('expo-file-system', () => ({
   File: class {
+    exists = true;
+    size = 3;
     uri: string;
     constructor(uri: string) {
       this.uri = uri;
@@ -27,22 +30,7 @@ vi.mock('expo-file-system', () => ({
   },
 }));
 
-// A minimal FormData that records appended parts as-is (Node's undici FormData
-// stringifies non-Blob values, which would hide the part object we need to
-// inspect — the whole point of this regression test).
-class RecordingFormData {
-  parts: [string, unknown][] = [];
-  append(name: string, value: unknown) {
-    this.parts.push([name, value]);
-  }
-  get(name: string) {
-    return this.parts.find(([key]) => key === name)?.[1];
-  }
-  has(name: string) {
-    return this.parts.some(([key]) => key === name);
-  }
-}
-vi.stubGlobal('FormData', RecordingFormData);
+afterEach(() => vi.unstubAllGlobals());
 
 import { clearScreenshotUploadCache, uploadFeedbackScreenshot, uploadFeedbackScreenshots } from '../screenshot-upload';
 
@@ -53,6 +41,7 @@ function jsonResponse(body: unknown, ok = true): Response {
 }
 
 beforeEach(() => {
+  vi.stubGlobal('FormData', NativeFormData);
   vi.clearAllMocks();
   // The uploaded-key cache is module state that outlives a single call — it is
   // what stops a retry re-uploading shots that already landed. Without a reset
@@ -62,7 +51,7 @@ beforeEach(() => {
 });
 
 describe('uploadFeedbackScreenshot', () => {
-  it('POSTs an Expo-fetch-compatible multipart part and returns the storage key', async () => {
+  it('POSTs an multipart file readable by RN and Expo fetch and returns the storage key', async () => {
     mockAuthenticatedFetch.mockResolvedValue(
       jsonResponse({ success: true, key: 'feedback-screenshots/abc.jpg', url: 'https://cdn/abc.jpg' }),
     );
@@ -76,11 +65,10 @@ describe('uploadFeedbackScreenshot', () => {
     // No explicit Content-Type — the fetch layer sets the multipart boundary.
     expect(options.headers).toBeUndefined();
 
-    const body = options.body as unknown as RecordingFormData;
-    // The regression: the part must expose `bytes()` + name/type, NOT the legacy
-    // `{ uri }` descriptor that Expo's fetch rejects.
+    const body = options.body as unknown as NativeUploadFormData;
+    // Release builds use RN fetch; its serializer must retain the file URI.
     const part = body.get('screenshot') as { name: string; type: string; bytes: () => Promise<Uint8Array> };
-    expect(part).not.toHaveProperty('uri');
+    expect(body.getParts()[0].uri).toBe('file:///tmp/shot.jpg');
     expect(part.name).toBe('screenshot.jpg');
     expect(part.type).toBe('image/jpeg');
     expect(typeof part.bytes).toBe('function');
@@ -109,7 +97,7 @@ describe('uploadFeedbackScreenshots', () => {
     };
     let call = 0;
     mockAuthenticatedFetch.mockImplementation(async (_url: string, options: RequestInit) => {
-      const body = options.body as unknown as RecordingFormData;
+      const body = options.body as unknown as NativeUploadFormData;
       const part = body.get('screenshot') as { bytes: () => Promise<Uint8Array> };
       const uri = new TextDecoder().decode(await part.bytes());
       // First request resolves last.
@@ -134,6 +122,21 @@ describe('uploadFeedbackScreenshots', () => {
     await expect(uploadFeedbackScreenshots(['file:///a.jpg', 'file:///b.gif'])).rejects.toThrow(
       'Unsupported file type',
     );
+  });
+
+  it('retries only missing screenshots and keeps the original order', async () => {
+    mockAuthenticatedFetch
+      .mockResolvedValueOnce(jsonResponse({ key: 'feedback-screenshots/a.jpg' }))
+      .mockResolvedValueOnce(jsonResponse({ error: 'Upload interrupted' }, false));
+    await expect(uploadFeedbackScreenshots(['file:///a.jpg', 'file:///b.jpg'])).rejects.toThrow('Upload interrupted');
+    mockAuthenticatedFetch.mockClear().mockResolvedValue(jsonResponse({ key: 'feedback-screenshots/b.jpg' }));
+    await expect(uploadFeedbackScreenshots(['file:///a.jpg', 'file:///b.jpg'])).resolves.toEqual([
+      'feedback-screenshots/a.jpg',
+      'feedback-screenshots/b.jpg',
+    ]);
+    expect(mockAuthenticatedFetch).toHaveBeenCalledTimes(1);
+    const [, options] = mockAuthenticatedFetch.mock.calls[0] as [string, RequestInit];
+    expect((options.body as NativeUploadFormData).getParts()[0].uri).toBe('file:///b.jpg');
   });
 
   it('makes no request at all for an empty list', async () => {

--- a/packages/mobile/src/lib/feedback/screenshot-upload.ts
+++ b/packages/mobile/src/lib/feedback/screenshot-upload.ts
@@ -1,4 +1,4 @@
-import { File } from 'expo-file-system';
+import { appendUploadImage } from '../upload-image';
 import { FEEDBACK_SCREENSHOT_MAX_COUNT } from '@boardsesh/shared-schema';
 import { authenticatedFetch } from '../auth-interceptor';
 import { BACKEND_URL } from '../env';
@@ -16,22 +16,12 @@ const SCREENSHOT_ENDPOINT = `${BACKEND_URL}/api/feedback-screenshots`;
  * the fetch layer, and `authenticatedFetch` only touches `Authorization`.
  */
 export async function uploadFeedbackScreenshot(uri: string): Promise<string> {
-  const localFile = new File(uri);
-
   const formData = new FormData();
-  // Expo's global `fetch` (WinterCG) rejects React Native's legacy
-  // `{ uri, name, type }` FormData file descriptor with "Unsupported FormDataPart
-  // implementation": its multipart encoder only accepts a string, a Blob, or an
-  // object exposing `bytes()`. Hand it the file's bytes plus an explicit
-  // name/type so the part carries a `filename` (busboy treats it as a file, not a
-  // field) and the correct `Content-Type`. Cast through `unknown` because the DOM
-  // `FormData` types only know `Blob`.
-  const screenshotPart = {
+  await appendUploadImage(formData, 'screenshot', {
+    uri,
     name: 'screenshot.jpg',
     type: 'image/jpeg',
-    bytes: () => localFile.bytes(),
-  };
-  formData.append('screenshot', screenshotPart as unknown as Blob);
+  });
 
   const response = await authenticatedFetch(SCREENSHOT_ENDPOINT, {
     method: 'POST',

--- a/packages/mobile/src/lib/upload-image.ts
+++ b/packages/mobile/src/lib/upload-image.ts
@@ -1,0 +1,17 @@
+import { File } from 'expo-file-system';
+import type { UploadImage } from './upload-image.types';
+
+/** Append a replayable file for both RN fetch (release) and Expo fetch (development). */
+export async function appendUploadImage(formData: FormData, fieldName: string, image: UploadImage): Promise<void> {
+  const localFile = new File(image.uri);
+  if (!localFile.exists) throw new Error('Selected image is unavailable');
+  if (localFile.size === 0) throw new Error('Selected image is empty');
+
+  const imagePart = { uri: localFile.uri, name: image.name, type: image.type };
+  // RN's getParts() spreads this descriptor before handing it to native code.
+  // Keep Expo's reader non-enumerable so only uri/name/type cross that bridge.
+  // Expo's encoder reads bytes() directly from the original FormData entry.
+  Object.defineProperty(imagePart, 'bytes', { value: () => localFile.bytes() });
+  // DOM types omit RN's URI descriptor; the runtime supports it.
+  formData.append(fieldName, imagePart as unknown as Blob);
+}

--- a/packages/mobile/src/lib/upload-image.types.ts
+++ b/packages/mobile/src/lib/upload-image.types.ts
@@ -1,0 +1,6 @@
+/** A compressed image ready to become a multipart file. */
+export type UploadImage = {
+  uri: string;
+  name: string;
+  type: string;
+};

--- a/packages/mobile/src/lib/upload-image.web.ts
+++ b/packages/mobile/src/lib/upload-image.web.ts
@@ -1,0 +1,11 @@
+import type { UploadImage } from './upload-image.types';
+
+/** Browser picker/manipulator URIs refer to blobs, not native filesystem files. */
+export async function appendUploadImage(formData: FormData, fieldName: string, image: UploadImage): Promise<void> {
+  // Read the local blob/data URL without attaching backend credentials.
+  const response = await fetch(image.uri);
+  if (!response.ok) throw new Error('Selected image is unavailable');
+  const imageBlob = await response.blob();
+  if (imageBlob.size === 0) throw new Error('Selected image is empty');
+  formData.append(fieldName, imageBlob.slice(0, imageBlob.size, image.type), image.name);
+}

--- a/packages/mobile/test/native-upload-runtime.ts
+++ b/packages/mobile/test/native-upload-runtime.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { runInNewContext } from 'node:vm';
+
+// Load the installed SDK serializers, including RN's Flow source, without
+// initializing native modules. Babel is already part of RN's build toolchain.
+// A recording FormData mock missed the original zero-byte upload regression.
+const testRequire = createRequire(import.meta.url);
+const nativeRequire = createRequire(testRequire.resolve('react-native/package.json'));
+const babel = nativeRequire('@babel/core') as {
+  transformSync(source: string, options: Record<string, unknown>): { code?: string | null } | null;
+};
+const nativePreset = nativeRequire.resolve('@react-native/babel-preset');
+
+function loadSdkModule<Exports>(filename: string): Exports {
+  const transformed = babel.transformSync(readFileSync(filename, 'utf8'), {
+    filename,
+    configFile: false,
+    babelrc: false,
+    presets: [nativePreset],
+  });
+  if (!transformed?.code) throw new Error(`Could not transform SDK serializer: ${filename}`);
+  const sdkModule = { exports: {} };
+  const sourceRequire = createRequire(filename);
+  runInNewContext(transformed.code, {
+    module: sdkModule,
+    exports: sdkModule.exports,
+    Blob,
+    TextEncoder,
+    Uint8Array,
+    require: (specifier: string): unknown =>
+      specifier.startsWith('.') ? loadSdkModule(sourceRequire.resolve(`${specifier}.ts`)) : sourceRequire(specifier),
+  });
+  return sdkModule.exports as Exports;
+}
+
+export type NativeUploadPart = {
+  uri?: string;
+  string?: string;
+  fieldName: string;
+  headers: Record<string, string>;
+};
+export type NativeUploadFormData = FormData & { getParts(): NativeUploadPart[] };
+
+const { default: ReactNativeFormData } = loadSdkModule<{ default: new () => NativeUploadFormData }>(
+  testRequire.resolve('react-native/Libraries/Network/FormData'),
+);
+const { installFormDataPatch } = loadSdkModule<{
+  installFormDataPatch: (constructor: typeof ReactNativeFormData) => typeof ReactNativeFormData;
+}>(testRequire.resolve('expo/src/winter/FormData.ts'));
+
+export const NativeFormData = installFormDataPatch(ReactNativeFormData);
+export const { convertFormDataAsync } = loadSdkModule<{
+  convertFormDataAsync: (form: FormData, boundary?: string) => Promise<{ body: Uint8Array; boundary: string }>;
+}>(testRequire.resolve('expo/src/winter/fetch/convertFormData.ts'));


### PR DESCRIPTION
## Summary

Bug-report screenshots, PR QA screenshots, and avatars were sent as empty files in release builds. Those builds intentionally use React Native fetch (`EXPO_PUBLIC_USE_RN_FETCH=1`), but the uploaders supplied an Expo-only `bytes()` descriptor without the file URI RN needs. This matches Sentry issue **7715212228** and its 258-byte screenshot request.

Both uploaders now share a platform adapter: native requests carry a readable URI, filename, and MIME type; browser requests carry a real Blob. A non-enumerable bytes reader retains Expo development compatibility without passing a function across the RN bridge. Missing or empty images fail before upload, and the avatar endpoint rejects empty files before replacing existing storage.

Regression tests exercise the installed RN and Expo serializers, browser multipart bytes, authentication refresh/replay, screenshot retry ordering, and preservation of existing avatars. The release fetch pin and native dependencies/configuration remain unchanged.

Validation: all 848 mobile test files / 9,141 tests pass; all 20 affected backend HTTP tests pass; `vp check` reports no errors; workspace and mobile typechecks pass; iOS and Android release-mode bundles pass; pre-commit and commit-message hooks pass. The browser bundle check passes, including the exported shell and WASM assets. CI lint, typecheck, test shards, and mobile bundles also pass. CI confirms unchanged iOS/Android fingerprints and compatibility with existing builds. The automated Claude review could not run because its weekly account limit is exhausted (resets September 12 at 07:00 UTC), so this PR remains draft pending review. Physical iPhone/Android and browser UI QA remains required; iOS simulator checks are unavailable on this Linux host.

## Release Notes

Attach screenshots to bug reports and PR feedback, and update your profile photo again.

## Test plan

1. Sign in → Edit profile → save photo → avatar changes.
2. Report a bug → attach screenshot → submit → GitHub shows image.
3. Finish testing → attach screenshot → submit → PR comment shows image.
4. Reopen your profile → the new avatar still appears.
5. Browser app → repeat image uploads → images appear.

## Risk

Risk: 4/5 — changes authenticated image uploads and protects existing avatar writes.
