### PR TITLE
fix(sync): handle schema additions and refresh cached climb fields

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -261,7 +261,8 @@ replay. Partial fresh downloads persist their coverage with each page; reaching 
 does not count as backfilling its missing prefix. Scope removal clears the refresh keys with its other
 metadata, while forced sign-out that retains board catalogs retains refresh progress too.
 
-When adding a synced reference field, append its SQLite migration and bump that table's `refreshRevision`
+When adding a synced reference field, add it to the table's cumulative `refreshColumns` list,
+append its SQLite migration and bump that table's `refreshRevision`
 (or start at 1). Keep export/resolver columns and migration parity tests green. No schema-version bump is
 needed for refresh bookkeeping itself: it lives in the existing `sync_meta` table.
 

--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -230,6 +230,41 @@ layout artifact but intentionally outside the enabled size.
   artifact hits exactly that stale path: it rejects the artifact and crawls the scope page by page until the
   next export rebuilds it at v5.
 
+### Compatible additions and missing columns
+
+Extra incoming columns are expected while server exports and installed apps run different versions.
+Both snapshot and paged imports skip them using the client column allowlist. The mobile adapter records
+an informational breadcrumb once per origin/table/column per launch, including client and artifact
+versions when available; these additions do not create Sentry issues. Reporter failures cannot stop sync.
+
+Before reconciliation or any imported row writes, climbs, stats, and grades artifacts must contain every
+configured client column, and those columns must exist locally too. Missing columns raise
+`SnapshotSchemaCompatibilityError`, classified as `artifact-invalid` by the existing retry/fallback flow.
+This prevents NULL-filled fields from being stranded behind an advanced checkpoint. Schema metadata must
+contain positive integer versions consistent across the tables in each artifact.
+
+### Refreshing fields skipped by older apps
+
+`TABLE_CONFIGS.board_climbs.refreshRevision = 1` schedules a one-time replay for existing enabled catalogs.
+It covers `is_hidden` values an older app skipped even when the server row never changes again. Existing
+catalogs replay conservatively; there is no data wipe and their downloaded-state markers remain valid.
+
+Refreshes run after ordinary sync on a confirmed unmetered connection. They reuse 500-row pages with a
+separate cursor in `schema-refresh:<table>:<scope>` (`revision`, `mode`, `complete`, `updatedAt`, `syncSeq`).
+Normal deltas retain their own cursor and keep running on metered links. Refresh rows and progress commit
+together; older refresh rows cannot overwrite newer cached rows. A disconnect, backgrounding, or metered
+connection pauses the replay until the next eligible sync. Completion advances the ordinary cursor only
+if the replay is newer. Malformed or nonadvancing pages cannot mark the replay complete.
+
+Current snapshots and full fresh paged downloads stamp the revision as covered, so they do not immediately
+replay. Partial fresh downloads persist their coverage with each page; reaching the end of a legacy delta
+does not count as backfilling its missing prefix. Scope removal clears the refresh keys with its other
+metadata, while forced sign-out that retains board catalogs retains refresh progress too.
+
+When adding a synced reference field, append its SQLite migration and bump that table's `refreshRevision`
+(or start at 1). Keep export/resolver columns and migration parity tests green. No schema-version bump is
+needed for refresh bookkeeping itself: it lives in the existing `sync_meta` table.
+
 ### The two artifact sizes in a manifest entry
 
 A manifest entry carries the artifact's size twice, and the two diverge once `--gzip` ships:

--- a/docs/climb-moderation.md
+++ b/docs/climb-moderation.md
@@ -142,8 +142,10 @@ enum, `proposal_on_your_climb` to `notification_type`, and `is_hidden` / `hidden
 `board_climbs.is_hidden` ships to the on-device SQLite mirror as schema **v5**
 (`packages/shared/offline-sync/src/db/migrations.ts`), stored as a nullable INTEGER because it arrives
 by `ALTER TABLE` on existing databases rather than in the v1 `CREATE`. Local queries therefore read it
-as `COALESCE(c.is_hidden, 0) = 0`, so rows pulled before the column existed behave as visible until the
-next delta refreshes them.
+as `COALESCE(c.is_hidden, 0) = 0`, so rows pulled before the column existed behave as visible until
+refreshed. Ordinary deltas only revisit changed rows: a resumable, unmetered catalog refresh now fills
+flags skipped by older clients even when those rows never change again. Cached climbs remain usable
+during that refresh; see [catalog refresh](board-snapshots.md#refreshing-fields-skipped-by-older-apps).
 
 A v5 client meeting a v4 board snapshot rejects the artifact (`SnapshotSchemaStaleError`) and crawls
 the scope page by page instead — one night of slower first downloads until the nightly export rebuilds

--- a/docs/sync-table-manifest.md
+++ b/docs/sync-table-manifest.md
@@ -26,7 +26,8 @@ into `primaryKeyColumns`-many parts. So resolver output, local DDL, and table-co
 ## Casing & types
 
 Schema changes must cover already-downloaded rows as well as DDL: when adding a reference-data field,
-bump the table's `refreshRevision` in `table-config.ts` so old checkpoints cannot skip its backfill.
+bump the table's `refreshRevision` and add the field to its cumulative `refreshColumns` list in
+`table-config.ts` so old checkpoints cannot skip its backfill or certify an incomplete response.
 See [snapshot compatibility and catalog refresh](board-snapshots.md#refreshing-fields-skipped-by-older-apps).
 The client tolerates additive columns from newer producers; tests enforce exact column/PK parity for the
 current migration, configuration, resolver, and export contracts.

--- a/docs/sync-table-manifest.md
+++ b/docs/sync-table-manifest.md
@@ -25,6 +25,12 @@ into `primaryKeyColumns`-many parts. So resolver output, local DDL, and table-co
 
 ## Casing & types
 
+Schema changes must cover already-downloaded rows as well as DDL: when adding a reference-data field,
+bump the table's `refreshRevision` in `table-config.ts` so old checkpoints cannot skip its backfill.
+See [snapshot compatibility and catalog refresh](board-snapshots.md#refreshing-fields-skipped-by-older-apps).
+The client tolerates additive columns from newer producers; tests enforce exact column/PK parity for the
+current migration, configuration, resolver, and export contracts.
+
 - **All JSON keys and SQLite columns are `snake_case`** (identical to Postgres column names). Resolvers must
   emit snake_case (raw SQL select or explicit mapping) — NOT drizzle's camelCase JS fields.
 - SQLite types: `TEXT`, `INTEGER`, `REAL`. Booleans → `INTEGER` 0/1 (the upsert maps JS booleans). Timestamps → `TEXT`

--- a/packages/backend/src/__tests__/snapshot-export-golden.test.ts
+++ b/packages/backend/src/__tests__/snapshot-export-golden.test.ts
@@ -61,6 +61,13 @@ function ctx(): ConnectionContext {
 type EmptyPage = { documents: never[]; cursor: SyncCursorInput; hasMore: false };
 type ResolverResponse = Record<string, unknown>;
 
+function assertDocumentColumns(document: unknown, columns: readonly string[]): void {
+  if (typeof document !== 'object' || document === null || Array.isArray(document)) {
+    throw new Error('Sync resolver must emit an object document');
+  }
+  expect(Object.keys(document).sort()).toEqual([...columns].sort());
+}
+
 // A graphqlFetch that routes the two board queries to the REAL resolvers (against
 // the seeded Postgres) and serves an empty page for every other sync query and
 // deletions — exactly the shape pullSync expects, so the full client upsert path
@@ -75,13 +82,19 @@ async function graphqlFetch<T>(query: string, variables?: Record<string, unknown
   // Check stats before climbs: 'syncClimbStats' does not contain the substring
   // 'syncClimbs' (capital S after 'syncClimb'), so ordering is unambiguous.
   if (query.includes('syncClimbStats')) {
-    return { syncClimbStats: await syncQueries.syncClimbStats(undefined, resolverArgs, ctx()) } as T;
+    const result = await syncQueries.syncClimbStats(undefined, resolverArgs, ctx());
+    for (const document of result.documents) assertDocumentColumns(document, STATS_COLUMNS);
+    return { syncClimbStats: result } as T;
   }
   if (query.includes('syncClimbGrades')) {
-    return { syncClimbGrades: await syncQueries.syncClimbGrades(undefined, resolverArgs, ctx()) } as T;
+    const result = await syncQueries.syncClimbGrades(undefined, resolverArgs, ctx());
+    for (const document of result.documents) assertDocumentColumns(document, GRADES_COLUMNS);
+    return { syncClimbGrades: result } as T;
   }
   if (query.includes('syncClimbs')) {
-    return { syncClimbs: await syncQueries.syncClimbs(undefined, resolverArgs, ctx()) } as T;
+    const result = await syncQueries.syncClimbs(undefined, resolverArgs, ctx());
+    for (const document of result.documents) assertDocumentColumns(document, CLIMB_COLUMNS);
+    return { syncClimbs: result } as T;
   }
   const fieldMatch = query.match(/\{\s*\n?\s*(sync[A-Za-z]+)\(/);
   const fieldName = fieldMatch ? fieldMatch[1] : 'unknown';
@@ -99,6 +112,7 @@ async function insertClimb(values: {
   description?: string | null;
   isDraft?: boolean;
   isListed?: boolean | null;
+  isHidden?: boolean;
   compatibleSizeIds: number[];
   requiredSetIds?: number[] | null;
   characteristics?: string[] | null;
@@ -111,12 +125,12 @@ async function insertClimb(values: {
   const characteristics = values.characteristics == null ? null : `{${values.characteristics.join(',')}}`;
   await db.execute(sql`
     INSERT INTO board_climbs
-      (uuid, board_type, layout_id, setter_id, name, description, is_draft, is_listed,
+      (uuid, board_type, layout_id, setter_id, name, description, is_draft, is_listed, is_hidden,
        compatible_size_ids, required_set_ids, characteristics, frames, updated_at)
     VALUES
       (${values.uuid}, ${BOARD_TYPE}, ${LAYOUT_ID}, ${values.setterId ?? null},
        ${values.name ?? null}, ${values.description ?? null}, ${values.isDraft ?? false},
-       ${values.isListed ?? true}, ${compatible}::int[], ${requiredSetIds}::int[],
+       ${values.isListed ?? true}, ${values.isHidden ?? false}, ${compatible}::int[], ${requiredSetIds}::int[],
        ${characteristics}::text[], ${values.frames ?? null}, ${values.updatedAt}::timestamp)
   `);
 }
@@ -336,6 +350,7 @@ describe('board-snapshot export ↔ live pull parity', () => {
     await insertClimb({
       uuid: 'c1',
       name: 'Crimp Master',
+      isHidden: true,
       description: 'a real description',
       isDraft: false,
       isListed: true,
@@ -432,6 +447,8 @@ describe('board-snapshot export ↔ live pull parity', () => {
     const c1 = artifactClimbs.find((row) => row.uuid === 'c1')!;
     expect(c1.is_draft).toBe(0);
     expect(c1.is_listed).toBe(1);
+    expect(c1.is_hidden).toBe(1);
+    expect(artifactClimbs.find((row) => row.uuid === 'c2')?.is_hidden).toBe(0);
     expect(c1.compatible_size_ids).toBe(JSON.stringify([5, 6]));
     expect(c1.characteristics).toBe(JSON.stringify(['crimpy', 'powerful']));
     expect(c1.updated_at).toBe('2026-05-01T00:00:00Z');

--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -119,8 +119,10 @@ vi.mock('../../lib/connectivity/connectivity-store', () => ({
 }));
 
 const reportHandledError = vi.fn();
+const addErrorBreadcrumb = vi.fn();
 vi.mock('../../lib/error-reporting', () => ({
   reportHandledError: (...args: unknown[]) => reportHandledError(...args),
+  addErrorBreadcrumb: (...args: unknown[]) => addErrorBreadcrumb(...args),
 }));
 
 const trackMock = vi.fn();
@@ -502,17 +504,24 @@ describe('scheduler trigger bindings', () => {
     expect(onlineManagerSetOnline).not.toHaveBeenCalled();
   });
 
-  it('binds schema-drift telemetry to Sentry with the offline-sync tags', () => {
+  it('records compatible columns as breadcrumbs without creating an issue', () => {
     const { options } = startAndGetTriggers();
-    options.onSchemaDrift?.({ tableName: 'boardsesh_ticks', column: 'shiny_new_column' });
-
-    expect(reportHandledError).toHaveBeenCalledWith(
-      expect.objectContaining({ message: expect.stringContaining('shiny_new_column') }),
+    const drift = {
+      tableName: 'boardsesh_ticks',
+      column: 'shiny_new_column',
+      origin: 'pull' as const,
+      direction: 'extra-source-column' as const,
+      clientSchemaVersion: 5,
+    };
+    options.onSchemaDrift?.(drift);
+    expect(addErrorBreadcrumb).toHaveBeenCalledWith(
       expect.objectContaining({
-        tags: { source: 'offline-sync', kind: 'schema-drift' },
-        extra: { tableName: 'boardsesh_ticks', column: 'shiny_new_column' },
+        category: 'offline-sync.schema-compatibility',
+        level: 'info',
+        data: drift,
       }),
     );
+    expect(reportHandledError).not.toHaveBeenCalled();
   });
 });
 
@@ -1540,8 +1549,15 @@ describe('triggerSync / pullSync bindings', () => {
     await pullSync(db, queryClient, graphqlFetch, { onSchemaDrift: customDrift });
 
     const options = pullSyncCore.mock.calls[0][3] as SyncOptions;
-    options.onSchemaDrift?.({ tableName: 't', column: 'c' });
-    expect(customDrift).toHaveBeenCalledWith({ tableName: 't', column: 'c' });
+    const drift = {
+      tableName: 't',
+      column: 'c',
+      origin: 'pull' as const,
+      direction: 'extra-source-column' as const,
+      clientSchemaVersion: 5,
+    };
+    options.onSchemaDrift?.(drift);
+    expect(customDrift).toHaveBeenCalledWith(drift);
     expect(reportHandledError).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -59,7 +59,7 @@ import {
   refreshDeviceState,
   subscribeConnectivity as subscribeConnectivityStore,
 } from '../lib/connectivity/connectivity-store';
-import { reportHandledError } from '../lib/error-reporting';
+import { reportHandledError, addErrorBreadcrumb } from '../lib/error-reporting';
 import { isOfflineEngineEnabled } from '../lib/offline-engine';
 import { takeDownloadTrigger } from '../settings';
 import { track } from '../lib/analytics';
@@ -165,10 +165,12 @@ const reportMutationDeadLettered: MutationDeadLetterReporter = ({
   });
 };
 
-const reportSchemaDrift: SchemaDriftReporter = ({ tableName, column }) => {
-  reportHandledError(new Error(`Sync document for ${tableName} contains unknown column: ${column}`), {
-    tags: { source: 'offline-sync', kind: 'schema-drift' },
-    extra: { tableName, column },
+const reportSchemaDrift: SchemaDriftReporter = (drift) => {
+  addErrorBreadcrumb({
+    category: 'offline-sync.schema-compatibility',
+    message: 'Ignored compatible extra sync column',
+    level: 'info',
+    data: drift,
   });
 };
 

--- a/packages/shared/offline-sync/src/db/__tests__/migrations.test.ts
+++ b/packages/shared/offline-sync/src/db/__tests__/migrations.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 
 import { runMigrations, MIGRATIONS, LATEST_SCHEMA_VERSION } from '../migrations';
 import { SCHEMA_STATEMENTS } from '../schema';
+import { TABLE_CONFIGS } from '../../sync/table-config';
 import { createTestDatabase, listTables, primaryKeyColumns, tableColumns } from '../../testing/sqlite-test-db';
 
 // The set of tables migration 1 must create (the sync manifest's per-table list
@@ -58,6 +59,31 @@ async function rollBackAlterColumnsAbove(
 }
 
 describe('runMigrations', () => {
+  it.each([0, 4])('matches every sync column and primary key after upgrading schema v%i', async (version) => {
+    const database = createTestDatabase();
+    try {
+      if (version > 0) {
+        for (const migration of MIGRATIONS.filter((entry) => entry.version <= version)) {
+          for (const statement of migration.statements) await database.execAsync(statement);
+        }
+        await database.execAsync(`CREATE TABLE schema_version (id INTEGER PRIMARY KEY, version INTEGER NOT NULL);
+          INSERT INTO schema_version VALUES (1, ${version});
+          INSERT INTO board_climbs (uuid, board_type, layout_id) VALUES ('keep', 'tension', 10);`);
+      }
+      await runMigrations(database);
+      for (const [tableName, config] of Object.entries(TABLE_CONFIGS)) {
+        expect(new Set(await tableColumns(database, tableName)), tableName).toEqual(new Set(config.localColumns));
+        expect(await primaryKeyColumns(database, tableName), tableName).toEqual(config.primaryKeyColumns);
+      }
+      if (version > 0)
+        expect(
+          await database.getFirstAsync("SELECT uuid, is_hidden FROM board_climbs WHERE uuid = 'keep'"),
+        ).toMatchObject({ uuid: 'keep', is_hidden: null });
+    } finally {
+      database.close();
+    }
+  });
+
   it('creates every expected table on a fresh database', async () => {
     const db = createTestDatabase();
 

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -253,6 +253,7 @@ export type {
 export { vacuumDatabase, measureReclaimableBytes } from './db/vacuum';
 export { SCHEMA_STATEMENTS } from './db/schema';
 export { runMigrations, MIGRATIONS, LATEST_SCHEMA_VERSION } from './db/migrations';
+export { SnapshotSchemaCompatibilityError, type SchemaDriftReport } from './sync/schema-compatibility';
 export type { Migration } from './db/migrations';
 export {
   OFFLINE_DB_BUSY_TIMEOUT_MS,

--- a/packages/shared/offline-sync/src/sync/__tests__/bootstrap-failure-reason.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/bootstrap-failure-reason.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { classifySnapshotBootstrapFailure } from '../bootstrap-failure-reason';
+import { SnapshotSchemaCompatibilityError } from '../schema-compatibility';
 import {
   SnapshotWipedError,
   SnapshotSchemaStaleError,
@@ -17,6 +18,11 @@ import {
 
 describe('classifySnapshotBootstrapFailure', () => {
   it('names the engine error classes', () => {
+    expect(
+      classifySnapshotBootstrapFailure(
+        new SnapshotSchemaCompatibilityError('board_climbs', 'missing-source-column', ['is_hidden'], 5),
+      ),
+    ).toBe('artifact-invalid');
     expect(classifySnapshotBootstrapFailure(new SnapshotWipedError())).toBe('aborted-wipe');
     expect(classifySnapshotBootstrapFailure(new SnapshotSchemaStaleError(3))).toBe('schema-stale');
     expect(classifySnapshotBootstrapFailure(new SnapshotPermanentMissError('still gzipped'))).toBe('permanent-miss');

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client-upsert.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client-upsert.test.ts
@@ -222,7 +222,12 @@ describe('upsertDocuments batching (via pullSync)', () => {
 
     const driftCalls = onSchemaDrift.mock.calls.filter(([drift]) => drift.column === 'made_up_column_xyz');
     expect(driftCalls).toHaveLength(1);
-    expect(driftCalls[0][0]).toEqual({ tableName: 'boardsesh_ticks', column: 'made_up_column_xyz' });
+    expect(driftCalls[0][0]).toMatchObject({
+      tableName: 'boardsesh_ticks',
+      column: 'made_up_column_xyz',
+      origin: 'pull',
+      direction: 'extra-source-column',
+    });
 
     // The unknown column never reaches the SQL — only allowlisted columns do.
     const insertCalls = sqlCalls.filter((call) => call.sql.includes('INSERT OR REPLACE INTO boardsesh_ticks'));

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
@@ -512,7 +512,15 @@ describe('sync layer — real-DDL integration', () => {
         comment: 'second',
         updated_at: '2024-05-02T00:00:00Z',
       };
-      await pullSync(db, queryClient, makeSingleTableFetch({ queryName: 'syncTicks', documents: [secondVersion] }));
+      await pullSync(
+        db,
+        queryClient,
+        makeSingleTableFetch({
+          queryName: 'syncTicks',
+          documents: [secondVersion],
+          cursor: { updatedAt: DEFAULT_CURSOR.updatedAt, syncSeq: '2' },
+        }),
+      );
 
       const rows = await db.getAllAsync<Record<string, unknown>>('SELECT * FROM boardsesh_ticks WHERE uuid = ?', [
         'tick-dup',
@@ -1063,7 +1071,7 @@ describe('sync layer — real-DDL integration', () => {
       await pullSync(db, queryClient, makeCoverageFetch([{ uuid: 'fresh-tick', status: 'send' }]).fetch);
 
       const onCoverageReset = vi.fn();
-      const second = makeCoverageFetch([{ uuid: 'fresh-tick', status: 'send' }]);
+      const second = makeCoverageFetch([]);
       await pullSync(db, queryClient, second.fetch, { onCoverageReset });
 
       expect(onCoverageReset).not.toHaveBeenCalled();

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { OfflineDatabase, QueryInvalidator } from '../../database';
 
-vi.mock('../checkpoints', () => ({
+vi.mock('../checkpoints', async () => ({
+  ...(await vi.importActual<typeof import('../checkpoints')>('../checkpoints')),
   getCheckpoint: vi.fn().mockResolvedValue(null),
   setCheckpoint: vi.fn().mockResolvedValue(undefined),
   getCheckpointKey: vi.fn((tableName: string, boardType?: string) =>
@@ -15,7 +16,6 @@ vi.mock('../checkpoints', () => ({
   ensureScopeDownloadStartedAt: vi.fn(async (_db: unknown, _scopeKey: string, nowMs: number) => nowMs),
   SCOPE_DOWNLOAD_START_MAX_AGE_MS: 24 * 60 * 60 * 1000,
   rewindDeletionsCheckpoint: vi.fn().mockResolvedValue(undefined),
-  compareCheckpoints: vi.fn().mockReturnValue(0),
   DELETIONS_CHECKPOINT_KEY: 'checkpoint:deletions',
   SCOPE_COMPLETE_PREFIX: 'scope-complete:',
 }));

--- a/packages/shared/offline-sync/src/sync/__tests__/purge-abandoned-download.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/purge-abandoned-download.test.ts
@@ -38,7 +38,7 @@ import { ensureMutationQueueTable } from '../../mutation-queue/schema';
 import { beginScopePurge, __resetDrainerStateForTests } from '../../mutation-queue/drainer';
 import { __resetDownloadTerminalRegistryForTests } from '../download-terminal-registry';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
-import { SCHEMA_STATEMENTS } from '../../db/schema';
+import { MIGRATIONS } from '../../db/migrations';
 import type { OfflineBoardScope } from '../../offline-board-key';
 import type { SnapshotManifest, SnapshotManifestEntry } from '../snapshot-manifest';
 
@@ -63,7 +63,7 @@ const WATERMARK = { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '20' };
 function buildArtifact(filePath: string): void {
   const artifact = new DatabaseSync(filePath);
   try {
-    for (const statement of SCHEMA_STATEMENTS) artifact.exec(statement);
+    for (const migration of MIGRATIONS) for (const statement of migration.statements) artifact.exec(statement);
     artifact.exec(SNAPSHOT_META_DDL);
     artifact
       .prepare(

--- a/packages/shared/offline-sync/src/sync/__tests__/schema-refresh.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/schema-refresh.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runMigrations } from '../../db/migrations';
+import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
+import { pullSync } from '../pull-client';
+import { TABLE_CONFIGS } from '../table-config';
+import { getCheckpoint, setCheckpoint, markScopeDownloadComplete, isScopeDownloadComplete } from '../checkpoints';
+import {
+  getSchemaRefreshState,
+  schemaRefreshKey,
+  writeSchemaRefreshState,
+  REFRESH_START_CURSOR,
+} from '../schema-refresh';
+import {
+  __resetDrainerStateForTests,
+  beginScopePurge,
+  setBackgrounded,
+  setSigningOut,
+} from '../../mutation-queue/drainer';
+import { removeBoardScopeData } from '../scope-teardown';
+import type { SyncCheckpoint } from '../checkpoints';
+import type { GraphQLFetch } from '../../mutation-queue/handlers';
+
+const SCOPE = 'tension:10:8';
+const HEAD = { updatedAt: '2026-09-07T22:00:00.000Z', syncSeq: '200' };
+const OLD = { updatedAt: '2026-09-06T00:00:00.000Z', syncSeq: '10' };
+let directory: string;
+let db: TestSqliteDb;
+let unmetered: boolean;
+const queryClient = { invalidateQueries: vi.fn() };
+
+function climb(uuid: string, sequence = 10) {
+  return {
+    uuid,
+    board_type: 'tension',
+    layout_id: 10,
+    compatible_size_ids: [8],
+    name: uuid,
+    is_hidden: true,
+    is_draft: false,
+    is_listed: true,
+    updated_at: OLD.updatedAt,
+    sync_seq: sequence,
+  };
+}
+
+function source(documents = [climb('hidden')], onPage?: (cursor: SyncCheckpoint | undefined) => void) {
+  const fetch = vi.fn(async <T>(query: string, variables?: Record<string, unknown>): Promise<T> => {
+    if (query.includes('syncDeletions')) return { syncDeletions: { deletions: [], cursor: HEAD, hasMore: false } } as T;
+    if (query.includes('syncClimbs(')) {
+      const cursor = variables?.cursor as SyncCheckpoint | undefined;
+      onPage?.(cursor);
+      const remaining = documents.filter(
+        (document) =>
+          !cursor ||
+          document.updated_at > cursor.updatedAt ||
+          (document.updated_at === cursor.updatedAt && document.sync_seq > Number(cursor.syncSeq)),
+      );
+      const page = remaining.slice(0, 1);
+      const last = page[0];
+      return {
+        syncClimbs: {
+          documents: page,
+          hasMore: remaining.length > 1,
+          cursor: last
+            ? { updatedAt: last.updated_at, syncSeq: String(last.sync_seq) }
+            : (cursor ?? REFRESH_START_CURSOR),
+        },
+      } as T;
+    }
+    const config = Object.values(TABLE_CONFIGS).find((entry) => query.includes(`${entry.queryName}(`));
+    if (!config) throw new Error('Unexpected query');
+    return { [config.queryName]: { documents: [], cursor: HEAD, hasMore: false } } as T;
+  });
+  return fetch as typeof fetch & GraphQLFetch;
+}
+
+async function sync(fetch: GraphQLFetch = source()) {
+  await pullSync(db, queryClient, fetch, { enabledBoards: [SCOPE], isOnUnmeteredNetwork: () => unmetered });
+}
+
+async function seedLegacy() {
+  await db.runAsync(
+    `INSERT INTO board_climbs
+    (uuid, board_type, layout_id, compatible_size_ids, is_hidden, updated_at, sync_seq)
+    VALUES ('hidden', 'tension', 10, '[8]', NULL, ?, 10)`,
+    [OLD.updatedAt],
+  );
+  await setCheckpoint(db, `checkpoint:board_climbs:${SCOPE}`, HEAD);
+  await markScopeDownloadComplete(db, SCOPE);
+}
+
+async function hiddenFlag() {
+  return (
+    await db.getFirstAsync<{ is_hidden: number | null }>("SELECT is_hidden FROM board_climbs WHERE uuid = 'hidden'")
+  )?.is_hidden;
+}
+
+beforeEach(async () => {
+  directory = mkdtempSync(join(tmpdir(), 'schema-refresh-'));
+  db = createTestDatabase(join(directory, 'main.db'));
+  await runMigrations(db);
+  __resetDrainerStateForTests();
+  unmetered = true;
+  queryClient.invalidateQueries.mockClear();
+});
+
+afterEach(() => {
+  __resetDrainerStateForTests();
+  db.close();
+  rmSync(directory, { recursive: true, force: true });
+});
+
+describe('reference schema refresh', () => {
+  it('fills skipped flags behind an existing checkpoint exactly once, without regressing ordinary sync', async () => {
+    await seedLegacy();
+    const fetch = source();
+    await sync(fetch);
+    expect(await hiddenFlag()).toBe(1);
+    expect(await getCheckpoint(db, `checkpoint:board_climbs:${SCOPE}`)).toEqual(HEAD);
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toMatchObject({ revision: 1, complete: true });
+    expect(await isScopeDownloadComplete(db, SCOPE)).toBe(true);
+    await sync(fetch);
+    const climbCalls = fetch.mock.calls.filter(([query]) => query.includes('syncClimbs('));
+    expect(climbCalls).toHaveLength(3); // delta + refresh, then delta only
+  });
+
+  it('keeps ordinary deltas and cached climbs usable on metered connections', async () => {
+    await seedLegacy();
+    unmetered = false;
+    const fetch = source();
+    await sync(fetch);
+    expect(fetch.mock.calls.filter(([query]) => query.includes('syncClimbs('))).toHaveLength(1);
+    expect(await hiddenFlag()).toBeNull();
+    expect(await isScopeDownloadComplete(db, SCOPE)).toBe(true);
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toBeNull();
+    unmetered = true;
+    await sync();
+    expect(await hiddenFlag()).toBe(1);
+  });
+
+  it('resumes a committed refresh page after restart and network deferral', async () => {
+    await seedLegacy();
+    const documents = [climb('hidden'), climb('second', 11)];
+    await sync(
+      source(documents, (cursor) => {
+        if (cursor?.syncSeq === '0') unmetered = false;
+      }),
+    );
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toMatchObject({ complete: false, syncSeq: '10' });
+    expect(queryClient.invalidateQueries).toHaveBeenCalled();
+    db.close();
+    db = createTestDatabase(join(directory, 'main.db'));
+    await sync(source(documents));
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toMatchObject({ complete: false, syncSeq: '10' });
+    unmetered = true;
+    const fetch = source(documents);
+    await sync(fetch);
+    const cursors = fetch.mock.calls
+      .filter(([query]) => query.includes('syncClimbs('))
+      .map(([, variables]) => variables?.cursor);
+    expect(cursors).toEqual([HEAD, expect.objectContaining(OLD)]);
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toMatchObject({ complete: true, syncSeq: '11' });
+  });
+
+  it('does not replay a fresh full paged download', async () => {
+    const fetch = source();
+    await sync(fetch);
+    expect(fetch.mock.calls.filter(([query]) => query.includes('syncClimbs('))).toHaveLength(1);
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toMatchObject({ complete: true, mode: 'download' });
+  });
+
+  it('finishes an interrupted fresh download without replaying its prefix', async () => {
+    const documents = [climb('hidden'), climb('second', 11)];
+    const original = db.withExclusiveTransactionAsync.bind(db);
+    let interrupt = true;
+    vi.spyOn(db, 'withExclusiveTransactionAsync').mockImplementation(async (task) => {
+      await original(task);
+      if (interrupt && (await getSchemaRefreshState(db, 'board_climbs', SCOPE))?.syncSeq === '10') {
+        interrupt = false;
+        setBackgrounded(true);
+      }
+    });
+    await sync(source(documents));
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toMatchObject({ mode: 'download', complete: false });
+    setBackgrounded(false);
+    const fetch = source(documents);
+    await sync(fetch);
+    expect(fetch.mock.calls.filter(([query]) => query.includes('syncClimbs('))).toHaveLength(1);
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toMatchObject({ complete: true });
+  });
+
+  it.each(['background', 'signout', 'purge'] as const)(
+    'discards a refresh page interrupted by %s',
+    async (interruption) => {
+      await seedLegacy();
+      let release: (() => void) | undefined;
+      await sync(
+        source(undefined, (cursor) => {
+          if (cursor?.syncSeq !== '0') return;
+          if (interruption === 'background') setBackgrounded(true);
+          if (interruption === 'signout') setSigningOut(true);
+          if (interruption === 'purge') release = beginScopePurge('tension:10');
+        }),
+      );
+      release?.();
+      expect(await hiddenFlag()).toBeNull();
+      expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toBeNull();
+    },
+  );
+
+  it('preserves a newer local row when the refresh sees an older server page', async () => {
+    await seedLegacy();
+    await db.runAsync("UPDATE board_climbs SET is_hidden = 0, updated_at = ?, sync_seq = 200 WHERE uuid = 'hidden'", [
+      HEAD.updatedAt,
+    ]);
+    await sync();
+    expect(await hiddenFlag()).toBe(0);
+  });
+
+  it('removes refresh state with a scope and leaves sibling state alone', async () => {
+    await seedLegacy();
+    await sync();
+    await writeSchemaRefreshState(db, 'board_climbs', 'tension:11:8', {
+      ...OLD,
+      revision: 1,
+      complete: false,
+      mode: 'refresh',
+    });
+    await removeBoardScopeData({
+      db,
+      scope: { boardType: 'tension', layoutId: 10, sizeId: 8 },
+      scopeKey: SCOPE,
+      retainedScopes: [],
+    });
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toBeNull();
+    expect(await getSchemaRefreshState(db, 'board_climbs', 'tension:11:8')).not.toBeNull();
+  });
+
+  it.each(['empty', 'stalled', 'invalid'] as const)('never completes or advances a malformed %s page', async (kind) => {
+    await seedLegacy();
+    const normal = source();
+    const fetch = async <T>(query: string, variables?: Record<string, unknown>): Promise<T> => {
+      if (query.includes('syncClimbs(') && (variables?.cursor as SyncCheckpoint)?.syncSeq === '0') {
+        return {
+          syncClimbs: {
+            documents: kind === 'empty' ? [] : [climb('hidden')],
+            hasMore: true,
+            cursor: kind === 'invalid' ? { updatedAt: 'bad', syncSeq: 'bad' } : REFRESH_START_CURSOR,
+          },
+        } as T;
+      }
+      return normal(query, variables) as Promise<T>;
+    };
+    await expect(sync(fetch)).rejects.toThrow(/Sync returned/);
+    expect(await hiddenFlag()).toBeNull();
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toBeNull();
+    expect(await getCheckpoint(db, `checkpoint:board_climbs:${SCOPE}`)).toEqual(HEAD);
+  });
+
+  it('recovers a corrupt persisted refresh marker', async () => {
+    await seedLegacy();
+    await db.runAsync('INSERT INTO sync_meta (key, value) VALUES (?, ?)', [
+      schemaRefreshKey('board_climbs', SCOPE),
+      '{bad',
+    ]);
+    await sync();
+    expect(await hiddenFlag()).toBe(1);
+  });
+});

--- a/packages/shared/offline-sync/src/sync/__tests__/schema-refresh.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/schema-refresh.test.ts
@@ -6,7 +6,13 @@ import { runMigrations } from '../../db/migrations';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
 import { pullSync } from '../pull-client';
 import { TABLE_CONFIGS } from '../table-config';
-import { getCheckpoint, setCheckpoint, markScopeDownloadComplete, isScopeDownloadComplete } from '../checkpoints';
+import {
+  compareCheckpoints,
+  getCheckpoint,
+  setCheckpoint,
+  markScopeDownloadComplete,
+  isScopeDownloadComplete,
+} from '../checkpoints';
 import {
   getSchemaRefreshState,
   schemaRefreshKey,
@@ -55,8 +61,7 @@ function source(documents = [climb('hidden')], onPage?: (cursor: SyncCheckpoint 
       const remaining = documents.filter(
         (document) =>
           !cursor ||
-          document.updated_at > cursor.updatedAt ||
-          (document.updated_at === cursor.updatedAt && document.sync_seq > Number(cursor.syncSeq)),
+          compareCheckpoints({ updatedAt: document.updated_at, syncSeq: String(document.sync_seq) }, cursor) > 0,
       );
       const page = remaining.slice(0, 1);
       const last = page[0];
@@ -114,6 +119,110 @@ afterEach(() => {
 });
 
 describe('reference schema refresh', () => {
+  it('accepts increasing microseconds even when the sequence decreases', async () => {
+    const first = { ...climb('hidden', 200), updated_at: '2026-09-06T00:00:00.000100Z' };
+    const second = { ...climb('second', 10), updated_at: '2026-09-06T00:00:00.000900Z' };
+    await sync(source([first, second]));
+    expect(await getCheckpoint(db, `checkpoint:board_climbs:${SCOPE}`)).toEqual({
+      updatedAt: second.updated_at,
+      syncSeq: '10',
+    });
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toMatchObject({ complete: true });
+  });
+
+  it.each([
+    ['2026-09-06T00:00:00.5Z', '2026-09-06T00:00:00Z', 0],
+    ['2026-09-06T00:00:00Z', '2026-09-06T00:00:00.5Z', 1],
+    ['2026-09-06T00:00:00.500000Z', '2026-09-06T00:00:00.5Z', 1],
+    ['2026-09-06T00:00:00.000900Z', '2026-09-06T00:00:00.000100Z', 0],
+  ])('orders refresh timestamps %s versus %s precisely', async (localTimestamp, sourceTimestamp, expectedFlag) => {
+    await seedLegacy();
+    await db.runAsync("UPDATE board_climbs SET is_hidden = 0, updated_at = ? WHERE uuid = 'hidden'", [localTimestamp]);
+    await sync(source([{ ...climb('hidden'), updated_at: sourceTimestamp }]));
+    expect(await hiddenFlag()).toBe(expectedFlag);
+  });
+
+  it.each([false, true])('refuses missing refresh fields, including mixed pages (%s)', async (mixed) => {
+    await seedLegacy();
+    const normal = source();
+    const malformed = async <T>(query: string, variables?: Record<string, unknown>): Promise<T> => {
+      if (query.includes('syncClimbs(') && (variables?.cursor as SyncCheckpoint)?.syncSeq === '0') {
+        const incomplete: Record<string, unknown> = { ...climb('hidden') };
+        delete incomplete.is_hidden;
+        return {
+          syncClimbs: {
+            documents: mixed ? [climb('second', 11), incomplete] : [incomplete],
+            hasMore: false,
+            cursor: { ...OLD, syncSeq: mixed ? '11' : '10' },
+          },
+        } as T;
+      }
+      return normal(query, variables) as Promise<T>;
+    };
+    await expect(sync(malformed)).rejects.toThrow('missing columns: is_hidden');
+    expect(await hiddenFlag()).toBeNull();
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toBeNull();
+    expect(await getCheckpoint(db, `checkpoint:board_climbs:${SCOPE}`)).toEqual(HEAD);
+    await sync();
+    expect(await hiddenFlag()).toBe(1);
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toMatchObject({ complete: true });
+  });
+
+  it('does not stamp full-download coverage after a page omits a refresh field', async () => {
+    unmetered = false;
+    const normal = source([climb('hidden'), climb('second', 11)]);
+    const incomplete = async <T>(query: string, variables?: Record<string, unknown>): Promise<T> => {
+      const result = await normal<Record<string, { documents: Record<string, unknown>[] }>>(query, variables);
+      for (const document of result.syncClimbs?.documents ?? []) {
+        if (document.uuid === 'second') delete document.is_hidden;
+      }
+      return result as T;
+    };
+    await sync(incomplete);
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toBeNull();
+    expect(await isScopeDownloadComplete(db, SCOPE)).toBe(true);
+    unmetered = true;
+    await sync(source([climb('hidden'), climb('second', 11)]));
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toMatchObject({ complete: true });
+  });
+
+  it('invalidates committed pages when a later fetch fails, even with an empty-tail retry', async () => {
+    await seedLegacy();
+    const normal = source([climb('hidden'), climb('second', 11)]);
+    const fails = async <T>(query: string, variables?: Record<string, unknown>): Promise<T> => {
+      if (query.includes('syncClimbs(') && (variables?.cursor as SyncCheckpoint)?.syncSeq === '10') {
+        throw new Error('second page unavailable');
+      }
+      return normal(query, variables) as Promise<T>;
+    };
+    await expect(sync(fails)).rejects.toThrow('second page unavailable');
+    expect(await hiddenFlag()).toBe(1);
+    expect(queryClient.invalidateQueries).toHaveBeenCalled();
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toMatchObject({ complete: false, syncSeq: '10' });
+    await sync(source());
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toMatchObject({ complete: true });
+  });
+
+  it('reopens completed coverage when a later ordinary delta omits the field', async () => {
+    await seedLegacy();
+    await sync();
+    const newer = { ...climb('hidden', 201), updated_at: '2026-09-08T00:00:00Z' };
+    const normal = source([{ ...newer }]);
+    const incomplete = async <T>(query: string, variables?: Record<string, unknown>): Promise<T> => {
+      const result = await normal<Record<string, { documents: Record<string, unknown>[] }>>(query, variables);
+      for (const document of result.syncClimbs?.documents ?? []) delete document.is_hidden;
+      return result as T;
+    };
+    unmetered = false;
+    await sync(incomplete);
+    expect(await hiddenFlag()).toBeNull();
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toBeNull();
+    unmetered = true;
+    await sync(source([newer]));
+    expect(await hiddenFlag()).toBe(1);
+    expect(await getSchemaRefreshState(db, 'board_climbs', SCOPE)).toMatchObject({ complete: true });
+  });
+
   it('fills skipped flags behind an existing checkpoint exactly once, without regressing ordinary sync', async () => {
     await seedLegacy();
     const fetch = source();

--- a/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.integration.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.integration.test.ts
@@ -74,7 +74,7 @@ function createFetch(climbsCursors: unknown[]): GraphqlFetchMock {
       climbsCursors.push(variables?.cursor);
       return {
         syncClimbs: {
-          documents: [CLIMB_DOC],
+          documents: variables?.cursor ? [] : [CLIMB_DOC],
           cursor: { updatedAt: CLIMB_DOC.updated_at, syncSeq: '10' },
           hasMore: false,
         },

--- a/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/scope-teardown.test.ts
@@ -221,6 +221,10 @@ describe('removeBoardScopeData — markers', () => {
   async function seedMarkers(scopeKey: string): Promise<void> {
     for (const table of BOARD_DATA_TABLES) {
       await setCheckpoint(db, `checkpoint:${table}:${scopeKey}`, { updatedAt: '2026-06-01T00:00:00Z', syncSeq: '9' });
+      await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+        `schema-refresh:${table}:${scopeKey}`,
+        JSON.stringify({ revision: 1, complete: true }),
+      ]);
     }
     await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
       `scope-complete:${scopeKey}`,
@@ -314,7 +318,7 @@ describe('removeBoardScopeData — markers', () => {
   // what "a scope's downloaded state" consists of. Adding a marker here should mean
   // deliberately updating this list (and `seedMarkers` above, which proves the
   // teardown actually clears each one), not nudging a magic number.
-  it('is exactly the scope’s checkpoints plus its nine markers', async () => {
+  it('includes exactly the scope checkpoints, refresh state, and lifecycle markers', async () => {
     const keys = scopeSyncMetaKeys('kilter:1:5');
 
     expect(new Set(keys)).toEqual(
@@ -322,6 +326,9 @@ describe('removeBoardScopeData — markers', () => {
         'checkpoint:board_climbs:kilter:1:5',
         'checkpoint:board_climb_stats:kilter:1:5',
         'checkpoint:board_climb_grades:kilter:1:5',
+        'schema-refresh:board_climbs:kilter:1:5',
+        'schema-refresh:board_climb_stats:kilter:1:5',
+        'schema-refresh:board_climb_grades:kilter:1:5',
         'scope-complete:kilter:1:5',
         // Its Started twin: leaving this behind would drop a re-added board out
         // of the download funnel forever (issue #4316).

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -55,7 +55,6 @@ import {
   __resetDrainerStateForTests,
 } from '../../mutation-queue/drainer';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
-import { SCHEMA_STATEMENTS } from '../../db/schema';
 import type { OfflineBoardScope } from '../../offline-board-key';
 import {
   SNAPSHOT_MANIFEST_FORMAT_VERSION,
@@ -123,7 +122,7 @@ function buildArtifact(spec: ArtifactSpec): void {
       db.exec(spec.climbsDdl ?? '');
       db.exec(spec.statsDdl ?? '');
     } else {
-      for (const statement of SCHEMA_STATEMENTS) db.exec(statement);
+      for (const migration of MIGRATIONS) for (const statement of migration.statements) db.exec(statement);
     }
     db.exec(SNAPSHOT_META_DDL);
 
@@ -666,10 +665,9 @@ describe('bootstrapScopeFromSnapshot', () => {
     expect(climbs.map((row) => row.uuid)).toEqual(['fresh-row']);
   });
 
-  it('tolerates schema drift in both directions and reports it to telemetry', async () => {
+  it('rejects missing expected columns without importing or advancing checkpoints', async () => {
     const filePath = join(workDir, 'drift.db');
-    // Seed has an extra column (extra_seed, ignored) and is missing one the live
-    // table has (setter_username → NULL-filled). Stats table is the standard one.
+    // A partial schema must be rejected even when its metadata claims to be current.
     buildArtifact({
       filePath,
       climbs: [],
@@ -700,17 +698,67 @@ describe('bootstrapScopeFromSnapshot', () => {
     const onSchemaDrift = vi.fn();
     await expect(
       bootstrapScopeFromSnapshot({ db, scope: SCOPE_KILTER_5, scopeKey: 'kilter:1:5', filePath, onSchemaDrift }),
-    ).resolves.toBeDefined();
+    ).rejects.toMatchObject({ name: 'SnapshotSchemaCompatibilityError', direction: 'missing-source-column' });
 
     const row = await db.getFirstAsync<{ uuid: string; setter_username: string | null }>(
       'SELECT uuid, setter_username FROM board_climbs WHERE uuid = ?',
       ['d1'],
     );
-    expect(row?.uuid).toBe('d1');
-    expect(row?.setter_username).toBeNull(); // main-only column, NULL-filled
-    const driftColumns = onSchemaDrift.mock.calls.map(([drift]) => (drift as { column: string }).column);
-    expect(driftColumns).toContain('extra_seed'); // seed-only → dropped
-    expect(driftColumns).toContain('setter_username'); // main-only → NULL-filled
+    expect(row).toBeNull();
+    expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toBeNull();
+    expect(onSchemaDrift).not.toHaveBeenCalled();
+  });
+
+  it.each(['local', 'source'] as const)(
+    'rejects a missing %s column before reconciling cached climbs',
+    async (side) => {
+      const filePath = join(workDir, `missing-${side}.db`);
+      buildArtifact({
+        filePath,
+        climbs: [],
+        stats: [],
+        climbsWatermark: CLIMBS_WATERMARK,
+        statsWatermark: STATS_WATERMARK,
+      });
+      await db.runAsync(
+        "INSERT INTO board_climbs (uuid, board_type, layout_id, compatible_size_ids, updated_at, sync_seq) VALUES ('keep', 'kilter', 1, '[5]', '1970-01-01T00:00:00.000Z', 0)",
+      );
+      if (side === 'local') await db.execAsync('ALTER TABLE board_climbs DROP COLUMN is_hidden');
+      else {
+        const artifact = new DatabaseSync(filePath);
+        artifact.exec('ALTER TABLE board_climbs DROP COLUMN is_hidden');
+        artifact.close();
+      }
+      await expect(
+        bootstrapScopeFromSnapshot({ db, filePath, scope: SCOPE_KILTER_5, scopeKey: 'kilter:1:5' }),
+      ).rejects.toMatchObject({
+        name: 'SnapshotSchemaCompatibilityError',
+        direction: `missing-${side}-column`,
+        columns: ['is_hidden'],
+      });
+      expect(await db.getFirstAsync("SELECT uuid FROM board_climbs WHERE uuid = 'keep'")).not.toBeNull();
+      expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toBeNull();
+    },
+  );
+
+  it.each(['invalid', 'inconsistent'] as const)('rejects %s schema metadata before importing', async (kind) => {
+    const filePath = join(workDir, `schema-${kind}.db`);
+    buildArtifact({
+      filePath,
+      climbs: [],
+      stats: [],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const artifact = new DatabaseSync(filePath);
+    artifact
+      .prepare("UPDATE snapshot_meta SET schema_version = ? WHERE table_name = 'board_climb_stats'")
+      .run(kind === 'invalid' ? 'banana' : LATEST_SCHEMA_VERSION + 1);
+    artifact.close();
+    await expect(
+      bootstrapScopeFromSnapshot({ db, filePath, scope: SCOPE_KILTER_5, scopeKey: 'kilter:1:5' }),
+    ).rejects.toMatchObject({ name: 'SnapshotSchemaCompatibilityError', direction: 'invalid-version' });
+    expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toBeNull();
   });
 
   it('throws (no rows, no checkpoints) on a corrupt/garbage artifact', async () => {

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-forward-compatibility.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-forward-compatibility.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Reproduce the shipped v4 client contract against a v5 producer, without adding
+// a production option that could bypass schema verification.
+vi.mock('../../db/migrations', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../db/migrations')>();
+  return { ...original, LATEST_SCHEMA_VERSION: 4 };
+});
+vi.mock('../table-config', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../table-config')>();
+  return {
+    ...original,
+    TABLE_CONFIGS: {
+      ...original.TABLE_CONFIGS,
+      board_climbs: {
+        ...original.TABLE_CONFIGS.board_climbs,
+        refreshRevision: undefined,
+        localColumns: original.TABLE_CONFIGS.board_climbs.localColumns.filter((column) => column !== 'is_hidden'),
+      },
+    },
+  };
+});
+
+import { MIGRATIONS, runMigrations } from '../../db/migrations';
+import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
+import { bootstrapScopeFromSnapshot } from '../snapshot-bootstrap';
+import { getCheckpoint } from '../checkpoints';
+import { __resetDrainerStateForTests } from '../../mutation-queue/drainer';
+
+let directory: string;
+let db: TestSqliteDb;
+let filePath: string;
+beforeEach(async () => {
+  __resetDrainerStateForTests();
+  directory = mkdtempSync(join(tmpdir(), 'snapshot-forward-compat-'));
+  db = createTestDatabase(join(directory, 'main.db'));
+  await runMigrations(db);
+  await db.execAsync('ALTER TABLE board_climbs DROP COLUMN is_hidden; UPDATE schema_version SET version = 4');
+  filePath = join(directory, 'artifact.db');
+  const artifact = new DatabaseSync(filePath);
+  try {
+    for (const migration of MIGRATIONS) for (const statement of migration.statements) artifact.exec(statement);
+    artifact.exec(`
+      ALTER TABLE board_climbs ADD COLUMN future_column TEXT;
+      INSERT INTO board_climbs (uuid, board_type, layout_id, compatible_size_ids, is_hidden, updated_at, sync_seq)
+        VALUES ('hidden', 'tension', 10, '[8]', 1, '2026-09-07T22:00:00.000Z', 10);
+      CREATE TABLE snapshot_meta (table_name TEXT PRIMARY KEY, watermark_updated_at TEXT,
+        watermark_sync_seq TEXT, row_count INTEGER, built_at TEXT, schema_version INTEGER, format_version INTEGER);
+      INSERT INTO snapshot_meta VALUES
+        ('board_climbs', '2026-09-07T22:00:00.000Z', '10', 1, '2026-09-07T22:30:00.000Z', 5, 1),
+        ('board_climb_stats', '1970-01-01T00:00:00.000Z', '0', 0, '2026-09-07T22:30:00.000Z', 5, 1);
+    `);
+  } finally {
+    artifact.close();
+  }
+});
+afterEach(() => {
+  db.close();
+  rmSync(directory, { recursive: true, force: true });
+});
+
+it('imports a newer Tension artifact, reports additions once, and survives a throwing reporter', async () => {
+  const reporter = vi.fn(() => {
+    throw new Error('telemetry unavailable');
+  });
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    await bootstrapScopeFromSnapshot({
+      db,
+      filePath,
+      scope: { boardType: 'tension', layoutId: 10, sizeId: 8 },
+      scopeKey: 'tension:10:8',
+      onSchemaDrift: reporter,
+    });
+  }
+  expect(await db.getFirstAsync("SELECT uuid FROM board_climbs WHERE uuid = 'hidden'")).toMatchObject({
+    uuid: 'hidden',
+  });
+  expect(await getCheckpoint(db, 'checkpoint:board_climbs:tension:10:8')).toMatchObject({ syncSeq: '10' });
+  expect(reporter).toHaveBeenCalledTimes(2);
+  expect(reporter).toHaveBeenCalledWith({
+    tableName: 'board_climbs',
+    column: 'is_hidden',
+    origin: 'snapshot',
+    direction: 'extra-source-column',
+    clientSchemaVersion: 4,
+    artifactSchemaVersion: 5,
+  });
+});

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-import-batching.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-import-batching.test.ts
@@ -35,7 +35,7 @@ import { beginScopePurge, __resetDrainerStateForTests } from '../../mutation-que
 import { configureMainConnection } from '../../db/pragmas';
 import { isDatabaseLockedError } from '../../db/lock-errors';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
-import { SCHEMA_STATEMENTS } from '../../db/schema';
+import { MIGRATIONS } from '../../db/migrations';
 import { climbsScopeFilter } from '../board-scope-sql';
 import type { OfflineBoardScope } from '../../offline-board-key';
 import type { OfflineDatabase, QueryInvalidator } from '../../database';
@@ -105,7 +105,7 @@ function twoLayoutArtifact(): ArtifactShape {
 function buildArtifact(filePath: string, shape: ArtifactShape): void {
   const artifact = new DatabaseSync(filePath);
   try {
-    for (const statement of SCHEMA_STATEMENTS) artifact.exec(statement);
+    for (const migration of MIGRATIONS) for (const statement of migration.statements) artifact.exec(statement);
     artifact.exec(SNAPSHOT_META_DDL);
     const insertClimb = artifact.prepare(
       `INSERT OR REPLACE INTO board_climbs
@@ -355,7 +355,7 @@ describe('stats keyset query plan', () => {
 
     const planDb = new DatabaseSync(':memory:');
     try {
-      for (const statement of SCHEMA_STATEMENTS) planDb.exec(statement);
+      for (const migration of MIGRATIONS) for (const statement of migration.statements) planDb.exec(statement);
       planDb.exec(`ATTACH DATABASE '${artifactPath}' AS bs_snapshot`);
       planDb.exec('CREATE TEMP TABLE bs_import_climbs (uuid TEXT PRIMARY KEY)');
       const bindCount = (statsInsert as string).split('?').length - 1;
@@ -380,6 +380,7 @@ describe('batch accounting', () => {
   it('reports the scoped row count, a finite batch count and a measured lock hold', async () => {
     const { db } = await freshClientDb('accounting');
     const batchProgress: Array<{ rowsImported: number; batches: number }> = [];
+    const startedAt = Date.now();
     const result = await bootstrapScopeFromSnapshot({
       db,
       scope: KILTER_SCOPE,
@@ -388,6 +389,7 @@ describe('batch accounting', () => {
       batchRows: 3,
       onBatch: (progress) => batchProgress.push({ ...progress }),
     });
+    const elapsedMs = Date.now() - startedAt;
 
     // Rows, not batches: a keyset range over the artifact's stats PK walks
     // ARTIFACT rows, so ceil(scopedStats / B) is NOT the batch count.
@@ -403,8 +405,8 @@ describe('batch accounting', () => {
     );
     expect(batchProgress[batchProgress.length - 1].rowsImported).toBe(42);
 
-    // The timings are all real numbers, and the batch loop cannot be shorter
-    // than the longest hold inside it.
+    // Lock timing includes reconciliation and the final checkpoint commit, not
+    // just row batches. Only the whole import bounds every exclusive hold.
     for (const timing of [
       result.importVerifyMs,
       result.importReconcileMs,
@@ -414,7 +416,7 @@ describe('batch accounting', () => {
       expect(Number.isFinite(timing)).toBe(true);
       expect(timing).toBeGreaterThanOrEqual(0);
     }
-    expect(result.importRowsMs).toBeGreaterThanOrEqual(result.importLockMaxMs);
+    expect(elapsedMs).toBeGreaterThanOrEqual(result.importLockMaxMs);
   });
 
   // Dropping the `applyBulkImportPragmas` call would pass every other test in

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-import-batching.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-import-batching.test.ts
@@ -791,12 +791,12 @@ describe('a lost lock race is not a bad artifact', () => {
     } as typeof db.execAsync);
 
     const WAIT_MS = 40;
-    // Real wall time, ignoring the requested rung: the ladder's 250ms would make
-    // the case slow for no extra signal. Yields rather than a timer so the SQLite
-    // double's microtask ordering is untouched.
+    // Advance only the injected lock wait. Real wall time also counts CPU
+    // contention from parallel suites, making the phase assertions flaky.
+    let clockMs = Date.now();
+    vi.spyOn(Date, 'now').mockImplementation(() => clockMs);
     const sleep = async (): Promise<void> => {
-      const until = Date.now() + WAIT_MS;
-      while (Date.now() < until) await Promise.resolve();
+      clockMs += WAIT_MS;
     };
 
     const result = await bootstrapScopeFromSnapshot({

--- a/packages/shared/offline-sync/src/sync/bootstrap-failure-reason.ts
+++ b/packages/shared/offline-sync/src/sync/bootstrap-failure-reason.ts
@@ -102,6 +102,7 @@ export function classifySnapshotBootstrapFailure(cause: unknown): SnapshotBootst
   const name = cause instanceof Error ? cause.name : null;
   if (name === 'SnapshotWipedError') return 'aborted-wipe';
   if (name === 'SnapshotSchemaStaleError') return 'schema-stale';
+  if (name === 'SnapshotSchemaCompatibilityError') return 'artifact-invalid';
   if (name === 'SnapshotWatermarkRegressionError') return 'watermark-regression';
   if (name === 'SnapshotPermanentMissError') return 'permanent-miss';
   if (name === 'SnapshotArtifactTruncatedError') return 'artifact-truncated';

--- a/packages/shared/offline-sync/src/sync/checkpoints.ts
+++ b/packages/shared/offline-sync/src/sync/checkpoints.ts
@@ -25,7 +25,7 @@ export const DELETIONS_CHECKPOINT_KEY = 'checkpoint:deletions';
 /**
  * Order two checkpoints on the composite keyset `(updatedAt, syncSeq)`, the same
  * ordering the sync resolvers page on. `updatedAt` is compared as an instant
- * (Date.parse) rather than lexically — ISO strings with mixed sub-second
+ * rather than lexically, preserving PostgreSQL microseconds — mixed sub-second
  * precision (`…00Z` vs `…00.5Z`) misorder under a raw string compare. `syncSeq`
  * is a decimal string that can exceed Number's safe range, so it is compared via
  * BigInt (a raw string compare would rank `'9'` above `'10'`). Returns <0 when
@@ -39,6 +39,14 @@ export function compareCheckpoints(a: SyncCheckpoint, b: SyncCheckpoint): number
   const bTime = Date.parse(b.updatedAt);
   if (Number.isFinite(aTime) && Number.isFinite(bTime) && aTime !== bTime) {
     return aTime < bTime ? -1 : 1;
+  }
+  if (Number.isFinite(aTime) && Number.isFinite(bTime)) {
+    // Date.parse truncates below milliseconds. Compare the remaining digits
+    // before sync_seq, which need not increase across different timestamps.
+    const remainder = (timestamp: string) => (/\.(\d+)/.exec(timestamp)?.[1] ?? '').padEnd(6, '0').slice(3, 6);
+    const aRemainder = remainder(a.updatedAt);
+    const bRemainder = remainder(b.updatedAt);
+    if (aRemainder !== bRemainder) return aRemainder < bRemainder ? -1 : 1;
   }
   const aSeq = toSeqBigInt(a.syncSeq);
   const bSeq = toSeqBigInt(b.syncSeq);

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -3,6 +3,7 @@ import type { SyncCursorInput, SyncResult, SyncDeletionsResult } from '../types'
 import { TABLE_CONFIGS, USER_DATA_TABLES, BOARD_DATA_TABLES } from './table-config';
 import {
   getCheckpoint,
+  compareCheckpoints,
   setCheckpoint,
   getCheckpointKey,
   markScopeDownloadComplete,
@@ -16,6 +17,7 @@ import {
 import { markUserDataComplete } from './local-user-owner';
 import {
   getSchemaRefreshState,
+  schemaRefreshKey,
   markSchemaRefreshComplete,
   writeSchemaRefreshState,
   REFRESH_START_CURSOR,
@@ -663,10 +665,17 @@ function buildMultiRowInsertSql(
     .filter((column) => !primaryKeyColumns.includes(column))
     .map((column) => `${column} = excluded.${column}`)
     .join(', ');
+  // Sync/export timestamps are UTC ISO text, but PostgreSQL omits trailing
+  // fractional zeroes. Pad the fraction so TEXT ordering preserves microseconds.
+  const timestampKey = (column: string) =>
+    `(substr(${column}, 1, 19) || '.' || CASE WHEN substr(${column}, 20, 1) = '.'
+      THEN substr(substr(${column}, 21, length(${column}) - 21) || '000000', 1, 6)
+      ELSE '000000' END)`;
   return `INSERT INTO ${tableName} (${columnList}) VALUES ${valuesClause}
     ON CONFLICT (${primaryKeyColumns.join(', ')}) DO UPDATE SET ${assignments}
     WHERE ${tableName}.${cursorColumn} IS NULL
-       OR (excluded.${cursorColumn}, excluded.sync_seq) >= (${tableName}.${cursorColumn}, ${tableName}.sync_seq)`;
+       OR (${timestampKey(`excluded.${cursorColumn}`)}, excluded.sync_seq)
+          >= (${timestampKey(`${tableName}.${cursorColumn}`)}, ${tableName}.sync_seq)`;
 }
 
 async function upsertDocuments(
@@ -761,11 +770,7 @@ function assertSyncPageProgress(result: SyncResult, cursor: SyncCursorInput | un
     throw new Error('Sync returned an invalid cursor');
   }
   if (cursor?.updatedAt && cursor.syncSeq) {
-    const previousTime = Date.parse(cursor.updatedAt);
-    if (
-      timestamp < previousTime ||
-      (timestamp === previousTime && BigInt(result.cursor.syncSeq) <= BigInt(cursor.syncSeq))
-    ) {
+    if (compareCheckpoints(result.cursor, { updatedAt: cursor.updatedAt, syncSeq: cursor.syncSeq }) <= 0) {
       throw new Error('Sync returned a nonadvancing cursor');
     }
   }
@@ -798,7 +803,7 @@ async function syncTable(
   const revision = boardScope ? config.refreshRevision : undefined;
   const previousRefresh =
     revision && boardScope ? await getSchemaRefreshState(db, tableName, boardScope.scopeKey) : null;
-  const fullDownload =
+  let fullDownload =
     !refresh &&
     (!checkpoint ||
       (previousRefresh?.revision === revision && previousRefresh?.mode === 'download' && !previousRefresh.complete));
@@ -818,9 +823,6 @@ async function syncTable(
   let totalProcessed = 0;
   let completedAtTail = false;
   const finish = (reachedTail: boolean) => {
-    if (totalProcessed > 0) {
-      for (const key of config.invalidateKeys) queryClient.invalidateQueries({ queryKey: key });
-    }
     return { reachedTail, rowsProcessed: totalProcessed, resumedFromCheckpoint };
   };
 
@@ -837,83 +839,106 @@ async function syncTable(
   // table happened to be mid-flight (see `cycleAborted` in pullSync).
 
   let hasMore = true;
-  while (hasMore) {
-    // Sign-out is wiping local data: stop before this page writes the old
-    // user's rows back (mirrors the drainer's guard).
-    if (!canWrite() || (refresh && !(await refresh.shouldContinue())) || !canWrite()) return finish(false);
-    const variables: Record<string, unknown> = { cursor, limit: PAGE_LIMIT };
-    if (config.isPerBoard && boardScope) {
-      variables.boardType = boardScope.boardType;
-      variables.layoutId = boardScope.layoutId;
-      variables.sizeId = boardScope.sizeId;
+  try {
+    while (hasMore) {
+      // Sign-out is wiping local data: stop before this page writes the old
+      // user's rows back (mirrors the drainer's guard).
+      if (!canWrite() || (refresh && !(await refresh.shouldContinue())) || !canWrite()) return finish(false);
+      const variables: Record<string, unknown> = { cursor, limit: PAGE_LIMIT };
+      if (config.isPerBoard && boardScope) {
+        variables.boardType = boardScope.boardType;
+        variables.layoutId = boardScope.layoutId;
+        variables.sizeId = boardScope.sizeId;
+      }
+
+      const response = await graphqlFetch<Record<string, SyncResult>>(query, variables);
+      const result = response[config.queryName];
+
+      // Re-check after the await: the wipe (or this scope's purge) may have
+      // started AND fully completed while this page was on the wire. This is the
+      // check that discards an in-flight page.
+      if (isSigningOut() || hasPurgeLanded(purgeToken, purgeKey) || isBackgrounded()) return finish(false);
+
+      assertSyncPageProgress(result, cursor);
+      if (result.documents.length === 0) break;
+      const missingRefreshColumns = (config.refreshColumns ?? []).filter((column) =>
+        result.documents.some((document) => !Object.prototype.hasOwnProperty.call(document, column)),
+      );
+      if (refresh && missingRefreshColumns.length > 0) {
+        throw new Error(`Sync refresh for ${tableName} is missing columns: ${missingRefreshColumns.join(', ')}`);
+      }
+      // A later ordinary delta can also erase a previously repaired field.
+      // Invalidate coverage even when this catalog already completed a refresh.
+      const clearDownloadCoverage = !refresh && missingRefreshColumns.length > 0;
+      if (clearDownloadCoverage) fullDownload = false;
+
+      const committed = await upsertDocuments(db, tableName, result.documents, config.localColumns, onSchemaDrift, {
+        canWrite,
+        preserveNewerRows: !!refresh,
+        afterUpsert: async (transaction) => {
+          if (!refresh) await setCheckpoint(transaction, checkpointKey, result.cursor);
+          if (clearDownloadCoverage && boardScope) {
+            await transaction.runAsync('DELETE FROM sync_meta WHERE key = ?', [
+              schemaRefreshKey(tableName, boardScope.scopeKey),
+            ]);
+          }
+          if (revision && boardScope && (refresh || fullDownload)) {
+            if (!result.hasMore) {
+              await markSchemaRefreshComplete(
+                transaction,
+                tableName,
+                boardScope.scopeKey,
+                result.cursor,
+                refresh ? 'refresh' : 'download',
+              );
+              completedAtTail = true;
+            } else {
+              await writeSchemaRefreshState(transaction, tableName, boardScope.scopeKey, {
+                ...result.cursor,
+                revision,
+                complete: false,
+                mode: refresh ? 'refresh' : 'download',
+              });
+            }
+          }
+        },
+      });
+      if (!committed) return finish(false);
+      lastCursor = result.cursor;
+
+      totalProcessed += result.documents.length;
+      onProgress?.(totalProcessed);
+
+      cursor = { updatedAt: result.cursor.updatedAt, syncSeq: result.cursor.syncSeq };
+      hasMore = result.hasMore;
     }
 
-    const response = await graphqlFetch<Record<string, SyncResult>>(query, variables);
-    const result = response[config.queryName];
+    if (revision && boardScope && (refresh || fullDownload) && !completedAtTail) {
+      let completed = false;
+      await db.withExclusiveTransactionAsync(async (transaction) => {
+        await applyBusyTimeout(transaction);
+        if (!canWrite()) return;
+        await markSchemaRefreshComplete(
+          transaction,
+          tableName,
+          boardScope.scopeKey,
+          lastCursor,
+          refresh ? 'refresh' : 'download',
+        );
+        completed = true;
+      });
+      if (!completed) return finish(false);
+    }
 
-    // Re-check after the await: the wipe (or this scope's purge) may have
-    // started AND fully completed while this page was on the wire. This is the
-    // check that discards an in-flight page.
-    if (isSigningOut() || hasPurgeLanded(purgeToken, purgeKey) || isBackgrounded()) return finish(false);
-
-    assertSyncPageProgress(result, cursor);
-    if (result.documents.length === 0) break;
-
-    const committed = await upsertDocuments(db, tableName, result.documents, config.localColumns, onSchemaDrift, {
-      canWrite,
-      preserveNewerRows: !!refresh,
-      afterUpsert: async (transaction) => {
-        if (!refresh) await setCheckpoint(transaction, checkpointKey, result.cursor);
-        if (revision && boardScope && (refresh || fullDownload)) {
-          if (!result.hasMore) {
-            await markSchemaRefreshComplete(
-              transaction,
-              tableName,
-              boardScope.scopeKey,
-              result.cursor,
-              refresh ? 'refresh' : 'download',
-            );
-            completedAtTail = true;
-          } else {
-            await writeSchemaRefreshState(transaction, tableName, boardScope.scopeKey, {
-              ...result.cursor,
-              revision,
-              complete: false,
-              mode: refresh ? 'refresh' : 'download',
-            });
-          }
-        }
-      },
-    });
-    if (!committed) return finish(false);
-    lastCursor = result.cursor;
-
-    totalProcessed += result.documents.length;
-    onProgress?.(totalProcessed);
-
-    cursor = { updatedAt: result.cursor.updatedAt, syncSeq: result.cursor.syncSeq };
-    hasMore = result.hasMore;
+    // Completion requires a terminal page; malformed empty/nonadvancing pages throw.
+    return finish(true);
+  } finally {
+    // A later fetch/validation/write can fail after earlier pages committed.
+    // Those changes must become visible even if the next retry has no rows.
+    if (totalProcessed > 0) {
+      for (const key of config.invalidateKeys) queryClient.invalidateQueries({ queryKey: key });
+    }
   }
-
-  if (revision && boardScope && (refresh || fullDownload) && !completedAtTail) {
-    let completed = false;
-    await db.withExclusiveTransactionAsync(async (transaction) => {
-      await applyBusyTimeout(transaction);
-      if (!canWrite()) return;
-      await markSchemaRefreshComplete(
-        transaction,
-        tableName,
-        boardScope.scopeKey,
-        lastCursor,
-        refresh ? 'refresh' : 'download',
-      );
-      completed = true;
-    });
-    if (!completed) return finish(false);
-  }
-
-  // Completion requires a terminal page; malformed empty/nonadvancing pages throw.
-  return finish(true);
 }
 
 async function processDeletions(

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -1,4 +1,4 @@
-import type { OfflineDatabase, QueryInvalidator, SqlValue } from '../database';
+import type { OfflineDatabase, QueryInvalidator, SqlExecutor, SqlValue } from '../database';
 import type { SyncCursorInput, SyncResult, SyncDeletionsResult } from '../types';
 import { TABLE_CONFIGS, USER_DATA_TABLES, BOARD_DATA_TABLES } from './table-config';
 import {
@@ -14,6 +14,14 @@ import {
   DELETIONS_CHECKPOINT_KEY,
 } from './checkpoints';
 import { markUserDataComplete } from './local-user-owner';
+import {
+  getSchemaRefreshState,
+  markSchemaRefreshComplete,
+  writeSchemaRefreshState,
+  REFRESH_START_CURSOR,
+  type SchemaRefreshState,
+} from './schema-refresh';
+import type { SyncCheckpoint } from './checkpoints';
 import {
   bootstrapScopeFromSnapshot,
   bootstrapScopeGradesFromSnapshot,
@@ -97,11 +105,11 @@ import {
 } from '../offline-board-key';
 
 /**
- * Telemetry hook for schema drift: a sync document carried a column the local
- * allowlist doesn't know. The app adapter reports it (mobile → Sentry, tags
- * source: 'offline-sync', kind: 'schema-drift'); tests and headless callers omit it.
+ * Compatible additions are observational breadcrumbs, not failures. Missing
+ * expected snapshot columns are rejected separately before rows can be changed.
  */
-export type SchemaDriftReporter = (drift: { tableName: string; column: string }) => void;
+export type { SchemaDriftReporter } from './schema-compatibility';
+import { reportExtraColumn, type SchemaDriftReporter } from './schema-compatibility';
 
 /**
  * What a report site inside the bootstrap phase supplies. `reason` and `aborted`
@@ -541,8 +549,8 @@ export type SyncOptions = {
   /** Telemetry for a scope getting back onto the snapshot path (issue #4313). */
   onBootstrapPathRecovered?: BootstrapPathRecoveredReporter;
   /**
-   * Whether the device is on an unmetered link. Consulted for ONE decision: the
-   * automatic heal of a partly-crawled scope, which is a ~100 MB download the
+   * Whether the device is on an unmetered link. Consulted for automatic schema
+   * refreshes and the heal of a partly-crawled scope, which is a ~100 MB download the
    * user did not ask for today. A fresh bootstrap (they just enabled the board,
    * behind a size-disclosing confirm) and a user-requested retry both ignore it.
    *
@@ -551,7 +559,8 @@ export type SyncOptions = {
    * not fired yet on a cold launch, and answer "unmetered" for the very first
    * cycle — the one that starts a ~100 MB heal over cellular.
    *
-   * DEFAULTS TO `() => true`, so web and every existing caller are unchanged.
+   * Snapshot healing defaults to true for legacy callers. Automatic schema
+   * refreshes require an affirmative probe; absent means defer the extra traffic.
    */
   isOnUnmeteredNetwork?: () => boolean | Promise<boolean>;
   /**
@@ -568,10 +577,6 @@ export type SyncOptions = {
 type BoardScope = OfflineBoardScope & { scopeKey: string };
 
 const PAGE_LIMIT = 500;
-
-// One schema-drift report per (table, column) per app launch — a 500-row page
-// must not emit 500 identical telemetry events.
-const reportedUnknownSyncColumns = new Set<string>();
 
 function buildSyncQuery(queryName: string, isPerBoard: boolean): string {
   // Per-board pulls carry the board type plus optional layout/size scope so a
@@ -643,11 +648,25 @@ export function multiRowChunkSize(columnCount: number): number {
   return Math.max(1, Math.floor(SQLITE_MAX_BIND_VARIABLES / columnCount));
 }
 
-function buildMultiRowInsertSql(tableName: string, columns: readonly string[], rowCount: number): string {
+function buildMultiRowInsertSql(
+  tableName: string,
+  columns: readonly string[],
+  rowCount: number,
+  preserveNewerRows = false,
+): string {
   const columnList = columns.join(', ');
   const rowPlaceholder = `(${columns.map(() => '?').join(', ')})`;
   const valuesClause = Array.from({ length: rowCount }, () => rowPlaceholder).join(', ');
-  return `INSERT OR REPLACE INTO ${tableName} (${columnList}) VALUES ${valuesClause}`;
+  if (!preserveNewerRows) return `INSERT OR REPLACE INTO ${tableName} (${columnList}) VALUES ${valuesClause}`;
+  const { primaryKeyColumns, cursorColumn } = TABLE_CONFIGS[tableName];
+  const assignments = columns
+    .filter((column) => !primaryKeyColumns.includes(column))
+    .map((column) => `${column} = excluded.${column}`)
+    .join(', ');
+  return `INSERT INTO ${tableName} (${columnList}) VALUES ${valuesClause}
+    ON CONFLICT (${primaryKeyColumns.join(', ')}) DO UPDATE SET ${assignments}
+    WHERE ${tableName}.${cursorColumn} IS NULL
+       OR (excluded.${cursorColumn}, excluded.sync_seq) >= (${tableName}.${cursorColumn}, ${tableName}.sync_seq)`;
 }
 
 async function upsertDocuments(
@@ -656,8 +675,13 @@ async function upsertDocuments(
   documents: Record<string, unknown>[],
   allowedColumns: readonly string[],
   onSchemaDrift?: SchemaDriftReporter,
-): Promise<void> {
-  if (documents.length === 0) return;
+  page?: {
+    canWrite: () => boolean;
+    afterUpsert: (transaction: SqlExecutor) => Promise<void>;
+    preserveNewerRows: boolean;
+  },
+): Promise<boolean> {
+  if (documents.length === 0) return true;
 
   // Unknown columns are SKIPPED, not fatal: the backend deploys before OTA
   // clients update, so a newly-added server column must not brick every older
@@ -669,10 +693,7 @@ async function upsertDocuments(
   for (const document of documents) {
     const unknownColumns = Object.keys(document).filter((column) => !allowedColumnSet.has(column));
     for (const unknownColumn of unknownColumns) {
-      const driftKey = `${tableName}.${unknownColumn}`;
-      if (reportedUnknownSyncColumns.has(driftKey)) continue;
-      reportedUnknownSyncColumns.add(driftKey);
-      onSchemaDrift?.({ tableName, column: unknownColumn });
+      reportExtraColumn(onSchemaDrift, { origin: 'pull', tableName, column: unknownColumn });
     }
   }
 
@@ -698,7 +719,7 @@ async function upsertDocuments(
   const sqlForRowCount = (rowCount: number): string => {
     let sql = sqlByRowCount.get(rowCount);
     if (!sql) {
-      sql = buildMultiRowInsertSql(tableName, columns, rowCount);
+      sql = buildMultiRowInsertSql(tableName, columns, rowCount, page?.preserveNewerRows);
       sqlByRowCount.set(rowCount, sql);
     }
     return sql;
@@ -708,10 +729,12 @@ async function upsertDocuments(
   // thousands of pages, and a per-50-row transaction multiplied every page's
   // commit overhead by 10 while giving the drainer no meaningful extra window —
   // it can interleave between pages either way.
+  let committed = false;
   await db.withExclusiveTransactionAsync(async (transaction) => {
     // This page's insert runs on its own connection (busy_timeout defaults to 0);
     // wait for a held lock instead of losing the whole page to an instant SQLITE_BUSY.
     await applyBusyTimeout(transaction);
+    if (page && !page.canWrite()) return;
     for (let chunkStart = 0; chunkStart < documents.length; chunkStart += chunkSize) {
       const chunk = documents.slice(chunkStart, chunkStart + chunkSize);
       const values: SqlValue[] = [];
@@ -722,7 +745,30 @@ async function upsertDocuments(
       }
       await transaction.runAsync(sqlForRowCount(chunk.length), values);
     }
+    await page?.afterUpsert(transaction);
+    committed = true;
   });
+  return committed;
+}
+
+function assertSyncPageProgress(result: SyncResult, cursor: SyncCursorInput | undefined): void {
+  if (result.documents.length === 0) {
+    if (result.hasMore) throw new Error('Sync returned an empty page with hasMore=true');
+    return;
+  }
+  const timestamp = Date.parse(result.cursor.updatedAt);
+  if (!Number.isFinite(timestamp) || !/^\d+$/.test(result.cursor.syncSeq)) {
+    throw new Error('Sync returned an invalid cursor');
+  }
+  if (cursor?.updatedAt && cursor.syncSeq) {
+    const previousTime = Date.parse(cursor.updatedAt);
+    if (
+      timestamp < previousTime ||
+      (timestamp === previousTime && BigInt(result.cursor.syncSeq) <= BigInt(cursor.syncSeq))
+    ) {
+      throw new Error('Sync returned a nonadvancing cursor');
+    }
+  }
 }
 
 async function syncTable(
@@ -735,6 +781,7 @@ async function syncTable(
   boardScope?: BoardScope,
   onProgress?: (documentsProcessed: number) => void,
   onSchemaDrift?: SchemaDriftReporter,
+  refresh?: { state: SchemaRefreshState; shouldContinue: () => Promise<boolean> },
 ): Promise<{ reachedTail: boolean; rowsProcessed: number; resumedFromCheckpoint: boolean }> {
   const config = TABLE_CONFIGS[tableName];
   if (!config) throw new Error(`No sync config for table: ${tableName}`);
@@ -747,7 +794,16 @@ async function syncTable(
   const purgeKey = boardScope ? purgeNamespaceKey(boardScope) : undefined;
 
   const checkpointKey = getCheckpointKey(tableName, boardScope?.scopeKey);
-  const checkpoint = await getCheckpoint(db, checkpointKey);
+  const checkpoint = refresh?.state ?? (await getCheckpoint(db, checkpointKey));
+  const revision = boardScope ? config.refreshRevision : undefined;
+  const previousRefresh =
+    revision && boardScope ? await getSchemaRefreshState(db, tableName, boardScope.scopeKey) : null;
+  const fullDownload =
+    !refresh &&
+    (!checkpoint ||
+      (previousRefresh?.revision === revision && previousRefresh?.mode === 'download' && !previousRefresh.complete));
+  const canWrite = (): boolean => !isSigningOut() && !hasPurgeLanded(purgeToken, purgeKey) && !isBackgrounded();
+  let lastCursor: SyncCheckpoint = checkpoint ?? REFRESH_START_CURSOR;
   // Whether some earlier call already advanced this cursor, so the caller can
   // tell "these are all the rows" from "these are the tail of a crawl someone
   // else started" (issue #4393). Sound because `setCheckpoint` below only runs
@@ -760,6 +816,13 @@ async function syncTable(
     ? { updatedAt: checkpoint.updatedAt, syncSeq: checkpoint.syncSeq }
     : undefined;
   let totalProcessed = 0;
+  let completedAtTail = false;
+  const finish = (reachedTail: boolean) => {
+    if (totalProcessed > 0) {
+      for (const key of config.invalidateKeys) queryClient.invalidateQueries({ queryKey: key });
+    }
+    return { reachedTail, rowsProcessed: totalProcessed, resumedFromCheckpoint };
+  };
 
   // The signing-out boolean is only true for the milliseconds the wipe takes;
   // a page fetch in flight across that window sees `false` on both sides and
@@ -777,8 +840,7 @@ async function syncTable(
   while (hasMore) {
     // Sign-out is wiping local data: stop before this page writes the old
     // user's rows back (mirrors the drainer's guard).
-    if (isSigningOut() || hasPurgeLanded(purgeToken, purgeKey) || isBackgrounded())
-      return { reachedTail: false, rowsProcessed: totalProcessed, resumedFromCheckpoint };
+    if (!canWrite() || (refresh && !(await refresh.shouldContinue())) || !canWrite()) return finish(false);
     const variables: Record<string, unknown> = { cursor, limit: PAGE_LIMIT };
     if (config.isPerBoard && boardScope) {
       variables.boardType = boardScope.boardType;
@@ -792,15 +854,39 @@ async function syncTable(
     // Re-check after the await: the wipe (or this scope's purge) may have
     // started AND fully completed while this page was on the wire. This is the
     // check that discards an in-flight page.
-    if (isSigningOut() || hasPurgeLanded(purgeToken, purgeKey) || isBackgrounded())
-      return { reachedTail: false, rowsProcessed: totalProcessed, resumedFromCheckpoint };
+    if (isSigningOut() || hasPurgeLanded(purgeToken, purgeKey) || isBackgrounded()) return finish(false);
 
-    // An empty page would not advance the cursor; if the backend ever returns
-    // documents:[] with hasMore:true we'd spin forever. Stop here (I2).
+    assertSyncPageProgress(result, cursor);
     if (result.documents.length === 0) break;
 
-    await upsertDocuments(db, tableName, result.documents, config.localColumns, onSchemaDrift);
-    await setCheckpoint(db, checkpointKey, result.cursor);
+    const committed = await upsertDocuments(db, tableName, result.documents, config.localColumns, onSchemaDrift, {
+      canWrite,
+      preserveNewerRows: !!refresh,
+      afterUpsert: async (transaction) => {
+        if (!refresh) await setCheckpoint(transaction, checkpointKey, result.cursor);
+        if (revision && boardScope && (refresh || fullDownload)) {
+          if (!result.hasMore) {
+            await markSchemaRefreshComplete(
+              transaction,
+              tableName,
+              boardScope.scopeKey,
+              result.cursor,
+              refresh ? 'refresh' : 'download',
+            );
+            completedAtTail = true;
+          } else {
+            await writeSchemaRefreshState(transaction, tableName, boardScope.scopeKey, {
+              ...result.cursor,
+              revision,
+              complete: false,
+              mode: refresh ? 'refresh' : 'download',
+            });
+          }
+        }
+      },
+    });
+    if (!committed) return finish(false);
+    lastCursor = result.cursor;
 
     totalProcessed += result.documents.length;
     onProgress?.(totalProcessed);
@@ -809,19 +895,25 @@ async function syncTable(
     hasMore = result.hasMore;
   }
 
-  // Only bust caches when this table actually changed. Sync runs on every
-  // foreground + reconnect, and an unconditional invalidation here refetches
-  // every active climb/logbook/playlist query over the network even when zero
-  // rows moved (matching processDeletions, which only invalidates on arrivals).
-  if (totalProcessed > 0) {
-    for (const key of config.invalidateKeys) {
-      queryClient.invalidateQueries({ queryKey: key });
-    }
+  if (revision && boardScope && (refresh || fullDownload) && !completedAtTail) {
+    let completed = false;
+    await db.withExclusiveTransactionAsync(async (transaction) => {
+      await applyBusyTimeout(transaction);
+      if (!canWrite()) return;
+      await markSchemaRefreshComplete(
+        transaction,
+        tableName,
+        boardScope.scopeKey,
+        lastCursor,
+        refresh ? 'refresh' : 'download',
+      );
+      completed = true;
+    });
+    if (!completed) return finish(false);
   }
 
-  // Both loop exits here mean the server has nothing more for this cursor:
-  // hasMore === false, or an empty page (the tail). Aborts return early above.
-  return { reachedTail: true, rowsProcessed: totalProcessed, resumedFromCheckpoint };
+  // Completion requires a terminal page; malformed empty/nonadvancing pages throw.
+  return finish(true);
 }
 
 async function processDeletions(
@@ -3041,6 +3133,40 @@ export async function pullSync(
         ...timings,
         phases,
       });
+    }
+  }
+
+  // Ordinary deltas retain priority and their own checkpoint, including on cellular.
+  // Only already-complete catalogs need this conservative replay after an upgrade.
+  for (const boardScope of boardScopes) {
+    if (cycleAborted()) return reportInterruptedCycle();
+    if (scopePurged(boardScope) || !(await isScopeDownloadComplete(db, boardScope.scopeKey))) continue;
+    for (const tableName of BOARD_DATA_TABLES) {
+      const revision = TABLE_CONFIGS[tableName].refreshRevision;
+      if (!revision) continue;
+      const state = await getSchemaRefreshState(db, tableName, boardScope.scopeKey);
+      if (state && state.revision >= revision && state.complete) continue;
+      if (cycleAborted() || scopePurged(boardScope)) break;
+      const shouldContinue = async (): Promise<boolean> =>
+        !cycleAborted() && !scopePurged(boardScope) && (await (options?.isOnUnmeteredNetwork?.() ?? false));
+      if (!(await shouldContinue())) continue;
+      await syncTable(
+        db,
+        queryClient,
+        graphqlFetch,
+        tableName,
+        purgeToken,
+        boardScope,
+        undefined,
+        options?.onSchemaDrift,
+        {
+          state:
+            state?.revision === revision
+              ? state
+              : { ...REFRESH_START_CURSOR, revision, complete: false, mode: 'refresh' },
+          shouldContinue,
+        },
+      );
     }
   }
 

--- a/packages/shared/offline-sync/src/sync/schema-compatibility.ts
+++ b/packages/shared/offline-sync/src/sync/schema-compatibility.ts
@@ -1,0 +1,43 @@
+import { LATEST_SCHEMA_VERSION } from '../db/migrations';
+
+export type SchemaDriftReport = {
+  tableName: string;
+  column: string;
+  origin: 'snapshot' | 'pull';
+  direction: 'extra-source-column';
+  clientSchemaVersion: number;
+  artifactSchemaVersion?: number;
+};
+
+export type SchemaDriftReporter = (drift: SchemaDriftReport) => void;
+
+const reportedColumns = new Set<string>();
+
+/** Additive columns are compatible across independently deployed clients/servers. */
+export function reportExtraColumn(
+  reporter: SchemaDriftReporter | undefined,
+  report: Omit<SchemaDriftReport, 'direction' | 'clientSchemaVersion'>,
+): void {
+  if (!reporter) return;
+  const key = `${report.origin}:${report.tableName}:${report.column}`;
+  if (reportedColumns.has(key)) return;
+  reportedColumns.add(key);
+  try {
+    reporter({ ...report, direction: 'extra-source-column', clientSchemaVersion: LATEST_SCHEMA_VERSION });
+  } catch {
+    // Observational callbacks must never turn a compatible import into a failure.
+  }
+}
+
+export class SnapshotSchemaCompatibilityError extends Error {
+  constructor(
+    readonly tableName: string,
+    readonly direction: 'missing-local-column' | 'missing-source-column' | 'invalid-version',
+    readonly columns: readonly string[],
+    readonly artifactSchemaVersion: unknown,
+    readonly clientSchemaVersion = LATEST_SCHEMA_VERSION,
+  ) {
+    super(`snapshot bootstrap: incompatible schema for ${tableName}: ${direction} ${columns.join(', ')}`);
+    this.name = 'SnapshotSchemaCompatibilityError';
+  }
+}

--- a/packages/shared/offline-sync/src/sync/schema-refresh.ts
+++ b/packages/shared/offline-sync/src/sync/schema-refresh.ts
@@ -1,0 +1,82 @@
+import type { SqlExecutor } from '../database';
+import { TABLE_CONFIGS } from './table-config';
+import { compareCheckpoints, getCheckpoint, getCheckpointKey, setCheckpoint, type SyncCheckpoint } from './checkpoints';
+
+export const SCHEMA_REFRESH_PREFIX = 'schema-refresh:';
+export const REFRESH_START_CURSOR: SyncCheckpoint = { updatedAt: '1970-01-01T00:00:00.000Z', syncSeq: '0' };
+
+export type SchemaRefreshState = SyncCheckpoint & {
+  revision: number;
+  complete: boolean;
+  /** A new full download already covers the prefix; an old delta does not. */
+  mode: 'download' | 'refresh';
+};
+
+export function schemaRefreshKey(tableName: string, scopeKey: string): string {
+  return `${SCHEMA_REFRESH_PREFIX}${tableName}:${scopeKey}`;
+}
+
+export async function getSchemaRefreshState(
+  db: SqlExecutor,
+  tableName: string,
+  scopeKey: string,
+): Promise<SchemaRefreshState | null> {
+  const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [
+    schemaRefreshKey(tableName, scopeKey),
+  ]);
+  if (!row) return null;
+  try {
+    const state: unknown = JSON.parse(row.value);
+    if (typeof state !== 'object' || state === null) return null;
+    if (
+      !('revision' in state) ||
+      !Number.isSafeInteger(state.revision) ||
+      !('complete' in state) ||
+      typeof state.complete !== 'boolean' ||
+      !('mode' in state) ||
+      (state.mode !== 'download' && state.mode !== 'refresh') ||
+      !('updatedAt' in state) ||
+      typeof state.updatedAt !== 'string' ||
+      !Number.isFinite(Date.parse(state.updatedAt)) ||
+      !('syncSeq' in state) ||
+      typeof state.syncSeq !== 'string' ||
+      !/^\d+$/.test(state.syncSeq)
+    )
+      return null;
+    return state as SchemaRefreshState;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeSchemaRefreshState(
+  db: SqlExecutor,
+  tableName: string,
+  scopeKey: string,
+  state: SchemaRefreshState,
+): Promise<void> {
+  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+    schemaRefreshKey(tableName, scopeKey),
+    JSON.stringify(state),
+  ]);
+}
+
+/** Called in the same transaction as a complete snapshot/full-download checkpoint. */
+export async function markSchemaRefreshComplete(
+  db: SqlExecutor,
+  tableName: string,
+  scopeKey: string,
+  cursor: SyncCheckpoint,
+  mode: SchemaRefreshState['mode'] = 'download',
+): Promise<void> {
+  const revision = TABLE_CONFIGS[tableName].refreshRevision;
+  if (!revision) return;
+  // Refreshes use a separate cursor so ordinary deltas continue on cellular.
+  // Completing a refresh must never regress a checkpoint advanced by those deltas.
+  if (mode === 'refresh') {
+    const key = getCheckpointKey(tableName, scopeKey);
+    const current = await getCheckpoint(db, key);
+    if (!current || compareCheckpoints(cursor, current) > 0) await setCheckpoint(db, key, cursor);
+  }
+  await writeSchemaRefreshState(db, tableName, scopeKey, { ...cursor, revision, complete: true, mode });
+}

--- a/packages/shared/offline-sync/src/sync/scope-teardown.ts
+++ b/packages/shared/offline-sync/src/sync/scope-teardown.ts
@@ -61,6 +61,7 @@ import {
   BOOTSTRAP_RETRY_PREFIX,
 } from './bootstrap-retry';
 import { BOARD_DATA_TABLES } from './table-config';
+import { schemaRefreshKey } from './schema-refresh';
 
 /** One scope's measured footprint. `estimatedBytes` is an apportionment — see getScopeUsage. */
 export type ScopeUsage = {
@@ -95,6 +96,7 @@ export type ScopeTeardownResult = {
 export function scopeSyncMetaKeys(scopeKey: string): string[] {
   return [
     ...BOARD_DATA_TABLES.map((tableName) => getCheckpointKey(tableName, scopeKey)),
+    ...BOARD_DATA_TABLES.map((tableName) => schemaRefreshKey(tableName, scopeKey)),
     `${SCOPE_COMPLETE_PREFIX}${scopeKey}`,
     // Its Started twin (issue #4316). Both must die with the rows: leaving the
     // Started marker behind would silently drop a re-added board out of the

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -24,6 +24,8 @@ import type { SnapshotGradesArtifact, SnapshotManifestEntry, SnapshotTableName }
 import { SNAPSHOT_MANIFEST_FORMAT_VERSION } from './snapshot-manifest';
 import { climbsScopeFilter, isSizeScopedBoard } from './board-scope-sql';
 import { TABLE_CONFIGS } from './table-config';
+import { reportExtraColumn, SnapshotSchemaCompatibilityError } from './schema-compatibility';
+import { markSchemaRefreshComplete } from './schema-refresh';
 import {
   compareCheckpoints,
   getCheckpointKey,
@@ -717,29 +719,38 @@ async function tableColumns(db: SqlExecutor, tableName: string, schema: string):
 }
 
 /**
- * The columns present in BOTH the live table and the artifact's copy of it, in
- * live (main) order. A snapshot built at a different client schema than the live
- * DB is tolerated: a column only in the artifact is dropped from the copy (its
- * data is skipped); a column only in main is left out of the SELECT and thus
- * NULL-filled. Both directions are reported as drift telemetry.
+ * Import the client's configured columns. Extra source columns are compatible;
+ * missing expected columns would leave permanent holes behind the stamped cursor.
  */
 async function sharedColumns(
   db: SqlExecutor,
   tableName: string,
   onSchemaDrift: SchemaDriftReporter | undefined,
+  artifactSchemaVersion: number,
   alias: string = SNAPSHOT_ALIAS,
 ): Promise<string[]> {
   const mainColumns = await tableColumns(db, tableName, 'main');
   const snapshotColumns = await tableColumns(db, tableName, alias);
   const mainSet = new Set(mainColumns);
   const snapshotSet = new Set(snapshotColumns);
+  const expectedColumns = TABLE_CONFIGS[tableName].localColumns;
+  for (const [direction, available] of [
+    ['missing-local-column', mainSet],
+    ['missing-source-column', snapshotSet],
+  ] as const) {
+    const missing = expectedColumns.filter((column) => !available.has(column));
+    if (missing.length > 0) {
+      throw new SnapshotSchemaCompatibilityError(tableName, direction, missing, artifactSchemaVersion);
+    }
+  }
+  const expectedSet = new Set(expectedColumns);
   for (const column of snapshotColumns) {
-    if (!mainSet.has(column)) onSchemaDrift?.({ tableName, column });
+    if (!expectedSet.has(column)) {
+      reportExtraColumn(onSchemaDrift, { origin: 'snapshot', tableName, column, artifactSchemaVersion });
+    }
   }
-  for (const column of mainColumns) {
-    if (!snapshotSet.has(column)) onSchemaDrift?.({ tableName, column });
-  }
-  return mainColumns.filter((column) => snapshotSet.has(column));
+  assertSafeColumns(expectedColumns);
+  return [...expectedColumns];
 }
 
 // --- Import SQL ---------------------------------------------------------------
@@ -968,11 +979,11 @@ async function beginExclusiveWithRetry(db: SqlExecutor, sleep: (ms: number) => P
 async function importScopeBatched(
   txn: SqlExecutor,
   scope: OfflineBoardScope,
-  onSchemaDrift: SchemaDriftReporter | undefined,
+  columns: Record<SnapshotTableName, string[]>,
   options: SnapshotImportBatchOptions,
 ): Promise<{ climbsImported: number; statsImported: number; batches: number }> {
-  const climbColumns = await sharedColumns(txn, 'board_climbs', onSchemaDrift);
-  const statsColumns = await sharedColumns(txn, 'board_climb_stats', onSchemaDrift);
+  const climbColumns = columns.board_climbs;
+  const statsColumns = columns.board_climb_stats;
   assertSafeColumns(climbColumns);
   assertSafeColumns(statsColumns);
   if (climbColumns.length === 0) throw new Error('snapshot bootstrap: no shared board_climbs columns');
@@ -1087,6 +1098,7 @@ const DELETIONS_SNAPSHOT_META_TABLE = 'sync_deletions';
 
 type VerifiedSnapshotMeta = {
   builtAt: string;
+  schemaVersion: number;
   /**
    * Optional for backwards compatibility. Artifacts published before this
    * metadata row shipped fall back to the older scoped-row watermark rewind.
@@ -1197,6 +1209,7 @@ async function verifySnapshotMeta(
   tables: readonly string[] = SNAPSHOT_TABLES,
 ): Promise<VerifiedSnapshotMeta> {
   let artifactBuiltAt: string | null = null;
+  let schemaVersion: number | null = null;
   for (const tableName of tables) {
     const meta = await db.getFirstAsync<SnapshotMetaRow>(
       `SELECT table_name, watermark_updated_at, watermark_sync_seq, row_count, built_at, schema_version, format_version
@@ -1204,6 +1217,14 @@ async function verifySnapshotMeta(
       [tableName],
     );
     if (!meta) throw new Error(`snapshot bootstrap: snapshot_meta missing row for ${tableName}`);
+    if (
+      !Number.isSafeInteger(meta.schema_version) ||
+      meta.schema_version < 1 ||
+      (schemaVersion !== null && schemaVersion !== meta.schema_version)
+    ) {
+      throw new SnapshotSchemaCompatibilityError(tableName, 'invalid-version', [], meta.schema_version);
+    }
+    schemaVersion = meta.schema_version;
     if (meta.format_version !== SNAPSHOT_MANIFEST_FORMAT_VERSION) {
       throw new Error(
         `snapshot bootstrap: format_version ${meta.format_version} != ${SNAPSHOT_MANIFEST_FORMAT_VERSION} for ${tableName}`,
@@ -1231,9 +1252,11 @@ async function verifySnapshotMeta(
     }
   }
 
-  if (!artifactBuiltAt) throw new Error('snapshot bootstrap: snapshot_meta did not contain a built_at');
+  if (!artifactBuiltAt || schemaVersion === null)
+    throw new Error('snapshot bootstrap: snapshot_meta did not contain a built_at');
   return {
     builtAt: artifactBuiltAt,
+    schemaVersion,
     deletionsReplayFrom: await readDeletionsReplayFrom(db, alias, artifactBuiltAt),
   };
 }
@@ -1341,6 +1364,7 @@ export async function bootstrapScopeFromSnapshot(params: {
   const purgeKey = purgeNamespaceKey(scope);
 
   let watermarks: Record<SnapshotTableName, SyncCheckpoint> | null = null;
+  let columns: Record<SnapshotTableName, string[]>;
   let deletionsReplayFrom: SyncCheckpoint | null = null;
   let imported = { climbsImported: 0, statsImported: 0, batches: 0 };
   let importVerifyMs = 0;
@@ -1373,6 +1397,10 @@ export async function bootstrapScopeFromSnapshot(params: {
         }
 
         const snapshotMeta = await verifySnapshotMeta(txn);
+        columns = {
+          board_climbs: await sharedColumns(txn, 'board_climbs', onSchemaDrift, snapshotMeta.schemaVersion),
+          board_climb_stats: await sharedColumns(txn, 'board_climb_stats', onSchemaDrift, snapshotMeta.schemaVersion),
+        };
         deletionsReplayFrom = snapshotMeta.deletionsReplayFrom;
         watermarks = await scopedWatermarks(txn, scope);
 
@@ -1466,7 +1494,7 @@ export async function bootstrapScopeFromSnapshot(params: {
 
         const rowsStartedAt = Date.now();
         const waitBeforeRows = importLockWaitMs;
-        imported = await importScopeBatched(txn, scope, onSchemaDrift, { batchRows, runExclusive, onBatch });
+        imported = await importScopeBatched(txn, scope, columns, { batchRows, runExclusive, onBatch });
         importRowsMs = Date.now() - rowsStartedAt - (importLockWaitMs - waitBeforeRows);
 
         // CHECKPOINTS LAST, in their own transaction, after every row batch has
@@ -1475,6 +1503,8 @@ export async function bootstrapScopeFromSnapshot(params: {
         // unrecoverable (see this function's docblock and scope-teardown.ts).
         await runExclusive(async () => {
           await setCheckpoint(txn, getCheckpointKey('board_climbs', scopeKey), stampedWatermarks.board_climbs);
+          await markSchemaRefreshComplete(txn, 'board_climbs', scopeKey, stampedWatermarks.board_climbs);
+          await markSchemaRefreshComplete(txn, 'board_climb_stats', scopeKey, stampedWatermarks.board_climb_stats);
           await setCheckpoint(
             txn,
             getCheckpointKey('board_climb_stats', scopeKey),
@@ -1631,6 +1661,7 @@ export async function bootstrapScopeGradesFromSnapshot(params: {
   let rowsImported = 0;
   let gradesVerifyMs = 0;
   let gradesLockMs = 0;
+  let gradeColumns: string[];
   try {
     await db.withExclusiveTransactionAsync(async (txn) => {
       await txn.execAsync('COMMIT');
@@ -1648,7 +1679,8 @@ export async function bootstrapScopeGradesFromSnapshot(params: {
         // Verified against the ONE-ELEMENT grades list. The client's
         // whole-layout SNAPSHOT_TABLES is untouched, which is what keeps this
         // change invisible to every pre-change artifact still on the CDN.
-        await verifySnapshotMeta(txn, GRADES_ALIAS, GRADES_SNAPSHOT_TABLES);
+        const snapshotMeta = await verifySnapshotMeta(txn, GRADES_ALIAS, GRADES_SNAPSHOT_TABLES);
+        gradeColumns = await sharedColumns(txn, GRADES_TABLE, onSchemaDrift, snapshotMeta.schemaVersion, GRADES_ALIAS);
 
         if (isSigningOut() || hasPurgeLanded(startToken, purgeKey)) throw new SnapshotWipedError();
 
@@ -1676,7 +1708,6 @@ export async function bootstrapScopeGradesFromSnapshot(params: {
       // still open.
       try {
         const lockHeldFrom = Date.now();
-        const gradeColumns = await sharedColumns(txn, GRADES_TABLE, onSchemaDrift, GRADES_ALIAS);
         assertSafeColumns(gradeColumns);
         if (gradeColumns.length === 0)
           throw new Error('snapshot grades bootstrap: no shared board_climb_grades columns');
@@ -1719,6 +1750,7 @@ export async function bootstrapScopeGradesFromSnapshot(params: {
         if (isSigningOut() || hasPurgeLanded(startToken, purgeKey)) throw new SnapshotWipedError();
 
         await setCheckpoint(txn, getCheckpointKey(GRADES_TABLE, scopeKey), watermark);
+        await markSchemaRefreshComplete(txn, GRADES_TABLE, scopeKey, watermark);
         // COMMIT here rather than leaving it for the wrapper, so gradesLockMs
         // covers the whole hold, then hand the wrapper an empty transaction.
         await txn.execAsync('COMMIT');

--- a/packages/shared/offline-sync/src/sync/sync-scheduler.ts
+++ b/packages/shared/offline-sync/src/sync/sync-scheduler.ts
@@ -85,8 +85,8 @@ export type SchedulerOptions = {
   /** Threaded through to pullSync's SyncOptions — see BootstrapPathRecoveredInfo. */
   onBootstrapPathRecovered?: BootstrapPathRecoveredReporter;
   /**
-   * Threaded through to pullSync's SyncOptions. Only the automatic heal of a
-   * partly-crawled scope consults it (issue #4313).
+   * Threaded through to pullSync's SyncOptions for automatic catalog refreshes
+   * and healing partly-crawled scopes.
    */
   isOnUnmeteredNetwork?: () => boolean | Promise<boolean>;
 };

--- a/packages/shared/offline-sync/src/sync/table-config.ts
+++ b/packages/shared/offline-sync/src/sync/table-config.ts
@@ -13,6 +13,8 @@ export type TableSyncConfig = {
   invalidateKeys: InvalidateKeys;
   primaryKeyColumns: string[];
   localColumns: readonly string[];
+  /** Bump when existing reference rows need newly synced fields backfilled. */
+  refreshRevision?: number;
   /**
    * The timestamp half of this table's `(timestamp, sync_seq)` keyset cursor —
    * whatever the resolver passes as `updatedAtColumn` in
@@ -121,6 +123,7 @@ const TABLE_SYNC_DEFINITIONS: Record<string, TableSyncDefinition> = {
     localColumns: ['playlist_uuid', 'follower_id', 'created_at', 'updated_at'],
   },
   board_climbs: {
+    refreshRevision: 1,
     queryName: 'syncClimbs',
     cursorColumn: UPDATED_AT_CURSOR,
     operationKey: 'SYNC_CLIMBS',

--- a/packages/shared/offline-sync/src/sync/table-config.ts
+++ b/packages/shared/offline-sync/src/sync/table-config.ts
@@ -15,6 +15,8 @@ export type TableSyncConfig = {
   localColumns: readonly string[];
   /** Bump when existing reference rows need newly synced fields backfilled. */
   refreshRevision?: number;
+  /** Cumulative fields that must be present before coverage can be stamped. */
+  refreshColumns?: readonly string[];
   /**
    * The timestamp half of this table's `(timestamp, sync_seq)` keyset cursor —
    * whatever the resolver passes as `updatedAtColumn` in
@@ -124,6 +126,7 @@ const TABLE_SYNC_DEFINITIONS: Record<string, TableSyncDefinition> = {
   },
   board_climbs: {
     refreshRevision: 1,
+    refreshColumns: ['is_hidden'],
     queryName: 'syncClimbs',
     cursorColumn: UPDATED_AT_CURSOR,
     operationKey: 'SYNC_CLIMBS',


### PR DESCRIPTION
## Summary

Fixes Sentry issue **7716227969**. An older OTA can legitimately import a newer snapshot containing `is_hidden`; compatible additions were incorrectly reported as handled exceptions. Cached rows could also remain behind the checkpoint without ever receiving the newly introduced field.

- Record compatible extra columns as deduplicated, non-throwing breadcrumbs with client/artifact context.
- Reject missing required snapshot columns and invalid schema metadata before reconciliation, row writes, or checkpoint changes; retain the existing bounded fallback.
- Refresh existing reference catalogs once per field revision on unmetered connections. Persist a separate page cursor, prioritize ordinary deltas, preserve newer rows, and resume safely after backgrounding or network changes.
- Stamp refresh coverage on new full downloads and snapshots; remove refresh markers with their scope.
- Add old-client/new-snapshot, migration/config/export parity, cached-field recovery, interruption, and cursor regression tests.

Author verification: 812 shared offline-sync tests, 9,141 mobile tests, and 27 focused backend tests passed. Full uncached typecheck, repository check, pre-commit hooks, and iOS/Android bundle checks passed. iOS native build and simulator launch succeeded; screenshot inspected. The simulator wrapper remained attached to Metro after launch and was interrupted; a separate 30-second simulator log check completed without crash output. Signed-in device download/upgrade QA remains manual.

Review follow-up: an independent code-review subagent found four issues and one related edge case; all five are fixed, and its final pass found no remaining actionable findings. Timestamp comparisons now preserve microseconds and mixed fractional precision; missing fields cannot certify refresh coverage; ordinary incomplete deltas reopen coverage; failed later pages still invalidate committed changes.

Follow-up validation: 822 shared tests passed with two workers and a 15-second timeout (the default five-second SQLite contention cases timed out under parallel load); 9,141 mobile tests, full uncached typecheck, scoped lint/format, and pre-commit checks passed.

## Release Notes

Keep downloaded climbs up to date after app updates.

## Test plan

1. Signed in → My Boards → enable offline → download completes.
2. Turn on airplane mode → open a climb → holds appear.
3. Reconnect Wi-Fi → reopen app → downloaded climbs remain available.
4. Background during download → reopen → progress resumes.

## Risk

Risk: 4/5 — changes offline imports, checkpoint writes, and catalog refreshes.
