### PR TITLE
fix(mobile): preserve Android BLE disconnect errors

### DIFF
--- a/.github/workflows/android-pr-rn.yml
+++ b/.github/workflows/android-pr-rn.yml
@@ -100,19 +100,20 @@ jobs:
 
       - uses: ./.github/actions/android-rn-setup
 
-      - name: Run local-module unit tests (Robolectric/JUnit)
+      - name: Run native-module unit tests (Robolectric/JUnit)
         working-directory: packages/mobile/android
         # Robolectric/JUnit tests for local Expo modules that ship them:
         # live-activity (session-presence lifecycle + foreground-service retry),
         # memory-trim (Glide trim-level policy) and board-renderer (overlay
-        # cache-dir recovery). The gradle project path for an Expo local module
+        # cache-dir recovery), plus patched ble-plx disconnect diagnostics.
+        # The gradle project path for an Expo local module
         # is autolinking-derived, so discover it rather than hardcode.
         run: |
           set -euo pipefail
-          # One entry per local module that ships Kotlin unit tests. Adding a
+          # One entry per module that ships native unit tests. Adding a
           # module here is the only change needed — each name is discovered
           # and must resolve to exactly one Gradle project.
-          TESTED_MODULES=(live-activity memory-trim board-renderer)
+          TESTED_MODULES=(live-activity memory-trim board-renderer react-native-ble-plx)
           ALL_PROJECTS=$(./gradlew --no-daemon -q projects)
           for MODULE in "${TESTED_MODULES[@]}"; do
             mapfile -t PROJECTS < <(printf '%s\n' "$ALL_PROJECTS" | sed -n "s/.*Project '\(:[^']*${MODULE}[^']*\)'.*/\1/p")

--- a/docs/ui/12-bluetooth.md
+++ b/docs/ui/12-bluetooth.md
@@ -119,6 +119,8 @@ Long-pressing the lightbulb opens the `LightControlDrawer` (`light-control-drawe
 
 **Unexpected disconnect (`handleDisconnection` callback):**
 
+- Android's pinned `react-native-ble-plx` patch preserves native disconnect errors independently of the already-resolved connect promise. Connection status codes (including 8: timeout and 19: peer termination) reach `disconnectAndroidCode`; genuine ATT operation errors keep their original mapping. Deliberate cancellation and unavailable platform statuses remain unclassified. The patch also preserves setup/MTU timeout errors and safely serializes quoted error descriptions. This requires a new native Android build; older binaries still report null errors. See #5279, whose intermittent disconnect cause remains unconfirmed.
+
 - Fires when native iOS or ble-plx reports a link drop, or when a write failure tears down the connection.
 - Consumes only when both adapter identity and generation match, so duplicate or stale callbacks cannot end a replacement link.
 - Fires analytics with `reason: 'unexpected'`, `disconnectTrigger: 'link_drop'`, the available platform-specific `disconnect*` fields, and the same `connectionDurationSec` lifetime property. Platform fields and `disconnectCategory` are absent from deliberate disconnects.

--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -1176,6 +1176,30 @@ describe('RNBleAdapter', () => {
       );
     });
 
+    it.each([8, 19, 133])('forwards patched Android disconnect status %s', async (androidErrorCode) => {
+      const adapter = setupConnectableAdapter(
+        'moonboard',
+        'dev-disc-android',
+        vi.fn().mockResolvedValue([{ uuid: 'uart-write-uuid' }]),
+      );
+      await adapter.requestAndConnect();
+      const callback = vi.fn();
+      adapter.onDisconnect(callback);
+      const handler = mockBleManager.onDeviceDisconnected.mock.calls.at(-1)?.[1] as
+        | ((error: unknown, device: unknown) => void)
+        | undefined;
+      handler?.({ errorCode: 201, androidErrorCode, iosErrorCode: null, reason: 'Link dropped' }, null);
+      expect(callback).toHaveBeenCalledOnce();
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'ble-plx',
+          bleErrorCode: 201,
+          androidErrorCode,
+          description: 'Link dropped',
+        }),
+      );
+    });
+
     it('forwards a clean (null-error) ble-plx drop as a source-only BleDisconnectInfo', async () => {
       const adapter = setupConnectableAdapter(
         'aurora',

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -1351,6 +1351,42 @@ describe('BluetoothProvider wall-confirm integration', () => {
       });
     });
 
+    it.each([
+      [8, 'link_timeout'],
+      [19, 'peer_terminated'],
+      [133, 'unknown'],
+    ] as const)('reports Android status %s to PostHog as %s', (androidErrorCode, category) => {
+      renderProvider(createElement(BluetoothProbe));
+      analytics.track.mockClear();
+      bluetooth.options?.onConnectionEnded?.({
+        reason: 'unexpected',
+        disconnectTrigger: 'link_drop',
+        connectionDurationSec: 30,
+        boardName: 'moonboard',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1',
+        inSession: false,
+        disconnectInfo: {
+          source: 'ble-plx',
+          androidErrorCode,
+          bleErrorCode: 201,
+          description: 'Link dropped',
+        },
+      });
+      expect(analytics.track).toHaveBeenCalledWith(
+        'Bluetooth Disconnected',
+        expect.objectContaining({
+          disconnectSource: 'ble-plx',
+          disconnectAndroidCode: androidErrorCode,
+          disconnectBleCode: 201,
+          disconnectCategory: category,
+          disconnectReason: 'Link dropped',
+          connectionDurationSec: 30,
+        }),
+      );
+    });
+
     it('uses old-board attribution for a deliberate config switch and omits transport fields', () => {
       presence.boardId = 222;
       renderProvider(createElement(BluetoothProbe));

--- a/patches/react-native-ble-plx@3.5.1.patch
+++ b/patches/react-native-ble-plx@3.5.1.patch
@@ -1,0 +1,347 @@
+diff --git a/android/build.gradle b/android/build.gradle
+--- a/android/build.gradle
++++ b/android/build.gradle
+@@ -67,6 +67,10 @@
+     }
+   }
+ 
++  testOptions {
++    unitTests.returnDefaultValues = true
++  }
++
+   lintOptions {
+     disable "GradleCompatible"
+   }
+@@ -89,6 +93,9 @@
+   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
+   //noinspection GradleDynamicVersion
+   implementation "com.facebook.react:react-native:+"
++  testImplementation 'junit:junit:4.13.2'
++  testImplementation 'org.mockito:mockito-core:5.14.2'
++  testImplementation 'org.json:json:20240303'
+   implementation 'io.reactivex.rxjava2:rxjava:2.2.17'
+   implementation "com.polidea.rxandroidble2:rxandroidble:1.17.2"
+ }
+diff --git a/android/src/main/java/com/bleplx/BlePlxModule.java b/android/src/main/java/com/bleplx/BlePlxModule.java
+--- a/android/src/main/java/com/bleplx/BlePlxModule.java
++++ b/android/src/main/java/com/bleplx/BlePlxModule.java
+@@ -11,6 +11,7 @@
+ import com.bleplx.adapter.Descriptor;
+ import com.bleplx.adapter.Device;
+ import com.bleplx.adapter.OnErrorCallback;
++import com.bleplx.adapter.OnConnectionStateChangeCallback;
+ import com.bleplx.adapter.OnEventCallback;
+ import com.bleplx.adapter.OnSuccessCallback;
+ import com.bleplx.adapter.RefreshGattMoment;
+@@ -407,12 +408,16 @@
+           safePromise.resolve(deviceConverter.toJSObject(data));
+         }
+       },
+-      new OnEventCallback<ConnectionState>() {
+-        @Override
+-        public void onEvent(ConnectionState connectionState) {
++      new OnConnectionStateChangeCallback() {
++        @Override
++        public void onEvent(ConnectionState connectionState, @Nullable BleError disconnectError) {
+           if (connectionState == ConnectionState.DISCONNECTED) {
+             WritableArray event = Arguments.createArray();
+-            event.pushNull();
++            if (disconnectError == null) {
++              event.pushNull();
++            } else {
++              event.pushString(errorConverter.toJs(disconnectError));
++            }
+             WritableMap device = Arguments.createMap();
+             device.putString("id", deviceId);
+             event.pushMap(device);
+diff --git a/android/src/main/java/com/bleplx/adapter/BleAdapter.java b/android/src/main/java/com/bleplx/adapter/BleAdapter.java
+--- a/android/src/main/java/com/bleplx/adapter/BleAdapter.java
++++ b/android/src/main/java/com/bleplx/adapter/BleAdapter.java
+@@ -68,7 +68,7 @@
+     String deviceIdentifier,
+     ConnectionOptions connectionOptions,
+     OnSuccessCallback<Device> onSuccessCallback,
+-    OnEventCallback<ConnectionState> onConnectionStateChangedCallback,
++    OnConnectionStateChangeCallback onConnectionStateChangedCallback,
+     OnErrorCallback onErrorCallback);
+ 
+   void cancelDeviceConnection(
+diff --git a/android/src/main/java/com/bleplx/adapter/BleModule.java b/android/src/main/java/com/bleplx/adapter/BleModule.java
+--- a/android/src/main/java/com/bleplx/adapter/BleModule.java
++++ b/android/src/main/java/com/bleplx/adapter/BleModule.java
+@@ -47,6 +47,7 @@
+ 
+ import java.util.ArrayList;
+ import java.util.HashMap;
++import java.util.concurrent.atomic.AtomicReference;
+ import java.util.List;
+ import java.util.UUID;
+ import java.util.concurrent.TimeUnit;
+@@ -393,7 +394,7 @@
+   public void connectToDevice(String deviceIdentifier,
+                               ConnectionOptions connectionOptions,
+                               OnSuccessCallback<Device> onSuccessCallback,
+-                              OnEventCallback<ConnectionState> onConnectionStateChangedCallback,
++                              OnConnectionStateChangeCallback onConnectionStateChangedCallback,
+                               OnErrorCallback onErrorCallback) {
+     if (rxBleClient == null) {
+       onErrorCallback.onError(new BleError(BleErrorCode.BluetoothManagerDestroyed, "BleManager not created when tried to connect to device", null));
+@@ -1233,19 +1234,14 @@
+                                    final Long timeout,
+                                    final int connectionPriority,
+                                    final OnSuccessCallback<Device> onSuccessCallback,
+-                                   final OnEventCallback<ConnectionState> onConnectionStateChangedCallback,
++                                   final OnConnectionStateChangeCallback onConnectionStateChangedCallback,
+                                    final OnErrorCallback onErrorCallback) {
+ 
+     final SafeExecutor<Device> safeExecutor = new SafeExecutor<>(onSuccessCallback, onErrorCallback);
+ 
+     Observable<RxBleConnection> connect = device
+       .establishConnection(autoConnect)
+-      .doOnSubscribe(disposable -> onConnectionStateChangedCallback.onEvent(ConnectionState.CONNECTING))
+-      .doFinally(() -> {
+-        safeExecutor.error(BleErrorUtils.cancelled());
+-        onDeviceDisconnected(device);
+-        onConnectionStateChangedCallback.onEvent(ConnectionState.DISCONNECTED);
+-      });
++      .doOnSubscribe(disposable -> onConnectionStateChangedCallback.onEvent(ConnectionState.CONNECTING, null));
+ 
+     if (refreshGattMoment == RefreshGattMoment.ON_CONNECTED) {
+       connect = connect.flatMap(rxBleConnection -> rxBleConnection
+@@ -1276,10 +1272,20 @@
+     }
+ 
+ 
++    // boardsesh/boardsesh#5279: SafeExecutor is consumed by connect success.
++    // Capture the terminal error before cleanup disposes the subscription, and
++    // finalize AFTER all connection operators so MTU/timeout failures survive too.
++    final AtomicReference<BleError> disconnectError = new AtomicReference<>();
+     final Disposable subscription = connect
++      .doOnError(error -> disconnectError.set(errorConverter.toError(error)))
++      .doFinally(() -> {
++        safeExecutor.error(BleErrorUtils.cancelled());
++        onDeviceDisconnected(device);
++        onConnectionStateChangedCallback.onEvent(ConnectionState.DISCONNECTED, disconnectError.get());
++      })
+       .subscribe(rxBleConnection -> {
+         Device localDevice = rxBleDeviceToDeviceMapper.map(device, rxBleConnection);
+-        onConnectionStateChangedCallback.onEvent(ConnectionState.CONNECTED);
++        onConnectionStateChangedCallback.onEvent(ConnectionState.CONNECTED, null);
+         cleanServicesAndCharacteristicsForDevice(localDevice);
+         connectedDevices.put(device.getMacAddress(), localDevice);
+         activeConnections.put(device.getMacAddress(), rxBleConnection);
+diff --git a/android/src/main/java/com/bleplx/adapter/OnConnectionStateChangeCallback.java b/android/src/main/java/com/bleplx/adapter/OnConnectionStateChangeCallback.java
+new file mode 100644
+--- /dev/null
++++ b/android/src/main/java/com/bleplx/adapter/OnConnectionStateChangeCallback.java
+@@ -0,0 +1,9 @@
++package com.bleplx.adapter;
++
++import androidx.annotation.Nullable;
++import com.bleplx.adapter.errors.BleError;
++
++/** Connection errors travel with the terminal event, independently of the connect promise. */
++public interface OnConnectionStateChangeCallback {
++  void onEvent(ConnectionState state, @Nullable BleError error);
++}
+diff --git a/android/src/main/java/com/bleplx/converter/BleErrorToJsObjectConverter.java b/android/src/main/java/com/bleplx/converter/BleErrorToJsObjectConverter.java
+--- a/android/src/main/java/com/bleplx/converter/BleErrorToJsObjectConverter.java
++++ b/android/src/main/java/com/bleplx/converter/BleErrorToJsObjectConverter.java
+@@ -1,6 +1,8 @@
+ package com.bleplx.converter;
+ 
+ import com.bleplx.adapter.errors.BleError;
++import com.bleplx.adapter.errors.BleErrorCode;
++import org.json.JSONObject;
+ import com.facebook.react.bridge.Arguments;
+ import com.facebook.react.bridge.ReadableArray;
+ import com.facebook.react.bridge.WritableArray;
+@@ -15,7 +17,9 @@
+   }
+ 
+   public String toJs(BleError error) {
+-    WritableArray array = Arguments.createArray();
++    // Disconnect status is a connection/HCI code, even when below 0x80.
++    // ATT status retains the upstream mapping for characteristic operations.
++    boolean isDisconnect = error.errorCode == BleErrorCode.DeviceDisconnected;
+     StringBuilder stringBuilder = new StringBuilder();
+     stringBuilder.append("{");
+ 
+@@ -23,7 +27,7 @@
+     stringBuilder.append(error.errorCode.code);
+ 
+     stringBuilder.append(",\"attErrorCode\":");
+-    if (error.androidCode == null || error.androidCode >= 0x80 || error.androidCode < 0) {
++    if (isDisconnect || error.androidCode == null || error.androidCode >= 0x80 || error.androidCode < 0) {
+       stringBuilder.append("null");
+     } else {
+       stringBuilder.append(error.androidCode.intValue());
+@@ -32,7 +36,7 @@
+     stringBuilder.append(",\"iosErrorCode\": null");
+ 
+     stringBuilder.append(",\"androidErrorCode\":");
+-    if (error.androidCode == null || error.androidCode < 0x80) {
++    if (error.androidCode == null || error.androidCode < 0 || (!isDisconnect && error.androidCode < 0x80)) {
+       stringBuilder.append("null");
+     } else {
+       stringBuilder.append(error.androidCode.intValue());
+@@ -57,9 +61,7 @@
+     if (value == null) {
+       stringBuilder.append("null");
+     } else {
+-      stringBuilder.append("\"");
+-      stringBuilder.append(value);
+-      stringBuilder.append("\"");
++      stringBuilder.append(JSONObject.quote(value));
+     }
+   }
+ }
+diff --git a/android/src/test/java/com/bleplx/adapter/DisconnectDiagnosticsTest.java b/android/src/test/java/com/bleplx/adapter/DisconnectDiagnosticsTest.java
+new file mode 100644
+--- /dev/null
++++ b/android/src/test/java/com/bleplx/adapter/DisconnectDiagnosticsTest.java
+@@ -0,0 +1,144 @@
++package com.bleplx.adapter;
++
++import static org.junit.Assert.*;
++import static org.mockito.Mockito.*;
++
++import android.bluetooth.BluetoothManager;
++import android.content.Context;
++import com.bleplx.adapter.errors.BleError;
++import com.bleplx.adapter.errors.BleErrorCode;
++import com.bleplx.converter.BleErrorToJsObjectConverter;
++import com.polidea.rxandroidble2.RxBleClient;
++import com.polidea.rxandroidble2.RxBleConnection;
++import com.polidea.rxandroidble2.RxBleDevice;
++import com.polidea.rxandroidble2.exceptions.BleDisconnectedException;
++import io.reactivex.Single;
++import io.reactivex.subjects.PublishSubject;
++import java.lang.reflect.Field;
++import java.util.ArrayList;
++import java.util.List;
++import java.util.concurrent.CountDownLatch;
++import java.util.concurrent.TimeUnit;
++import org.json.JSONObject;
++import org.junit.Before;
++import org.junit.Test;
++
++public class DisconnectDiagnosticsTest {
++  private static final String ADDRESS = "01:02:03:04:05:06";
++  private BleModule module;
++  private RxBleDevice device;
++  private RxBleConnection connection;
++  private PublishSubject<RxBleConnection> link;
++  private final List<BleError> disconnects = new ArrayList<>();
++  private final List<BleError> failures = new ArrayList<>();
++  private final List<Device> successes = new ArrayList<>();
++  private final CountDownLatch disconnected = new CountDownLatch(1);
++
++  @Before public void setUp() throws Exception {
++    Context context = mock(Context.class);
++    when(context.getSystemService(Context.BLUETOOTH_SERVICE)).thenReturn(mock(BluetoothManager.class));
++    module = new BleModule(context);
++    RxBleClient client = mock(RxBleClient.class);
++    Field clientField = BleModule.class.getDeclaredField("rxBleClient");
++    clientField.setAccessible(true);
++    clientField.set(module, client);
++    device = mock(RxBleDevice.class);
++    connection = mock(RxBleConnection.class);
++    when(client.getBleDevice(ADDRESS)).thenReturn(device);
++    when(device.getMacAddress()).thenReturn(ADDRESS);
++    when(device.getName()).thenReturn("MoonBoard");
++    when(connection.getMtu()).thenReturn(23);
++    link = PublishSubject.create();
++    when(device.establishConnection(false)).thenAnswer(invocation -> link);
++  }
++
++  private void connect(int mtu, Long timeout) {
++    module.connectToDevice(ADDRESS, new ConnectionOptions(false, mtu, null, timeout, 0),
++      successes::add, (state, error) -> {
++        if (state == ConnectionState.DISCONNECTED) {
++          disconnects.add(error);
++          disconnected.countDown();
++        }
++      }, failures::add);
++  }
++
++  @Test public void preservesDropAfterConnectSuccessAndEmitsOnce() {
++    connect(0, null);
++    link.onNext(connection);
++    link.onError(new BleDisconnectedException(ADDRESS, 8));
++    assertEquals(1, successes.size());
++    assertTrue(failures.isEmpty());
++    assertEquals(1, disconnects.size());
++    assertEquals(BleErrorCode.DeviceDisconnected, disconnects.get(0).errorCode);
++    assertEquals(Integer.valueOf(8), disconnects.get(0).androidCode);
++  }
++
++  @Test public void deliberateDisconnectStaysNullAndReconnectHasNoStaleError() {
++    connect(0, null);
++    link.onNext(connection);
++    link.onError(new BleDisconnectedException(ADDRESS, 19));
++    assertEquals(Integer.valueOf(19), disconnects.get(0).androidCode);
++    link = PublishSubject.create();
++    connect(0, null);
++    link.onNext(connection);
++    module.cancelDeviceConnection(ADDRESS, ignored -> {}, failures::add);
++    assertEquals(2, disconnects.size());
++    assertNull(disconnects.get(1));
++    assertTrue(failures.isEmpty());
++  }
++
++  @Test public void connectionFailureStillRejectsAndCarriesTerminalError() {
++    connect(0, null);
++    link.onError(new BleDisconnectedException(ADDRESS, 133));
++    assertTrue(successes.isEmpty());
++    assertEquals(1, failures.size());
++    assertEquals(1, disconnects.size());
++    assertEquals(Integer.valueOf(133), disconnects.get(0).androidCode);
++  }
++
++  @Test public void downstreamMtuFailureSurvivesUpstreamDisposal() {
++    when(connection.requestMtu(247)).thenReturn(Single.error(new IllegalStateException("MTU failed")));
++    connect(247, null);
++    link.onNext(connection);
++    assertTrue(successes.isEmpty());
++    assertEquals(1, failures.size());
++    assertEquals(1, disconnects.size());
++    assertNotNull(disconnects.get(0));
++    assertTrue(disconnects.get(0).reason.contains("MTU failed"));
++  }
++
++  @Test public void connectionTimeoutCarriesErrorInsteadOfCancellation() throws Exception {
++    connect(0, 10L);
++    assertTrue(disconnected.await(5, TimeUnit.SECONDS));
++    assertEquals(1, failures.size());
++    assertEquals(1, disconnects.size());
++    assertEquals(BleErrorCode.OperationTimedOut, disconnects.get(0).errorCode);
++  }
++
++  @Test public void serializesConnectionStatusesAsAndroidNotAtt() throws Exception {
++    for (int status : new int[] {0, 8, 19, 22, 133}) {
++      JSONObject payload = new JSONObject(new BleErrorToJsObjectConverter().toJs(
++        new BleError(BleErrorCode.DeviceDisconnected, "link dropped", status)));
++      assertEquals(status, payload.getInt("androidErrorCode"));
++      assertTrue(payload.isNull("attErrorCode"));
++    }
++  }
++
++  @Test public void missingAndNegativeConnectionStatusesStayUnknown() throws Exception {
++    for (Integer status : new Integer[] {null, -1}) {
++      JSONObject payload = new JSONObject(new BleErrorToJsObjectConverter().toJs(
++        new BleError(BleErrorCode.DeviceDisconnected, "no status", status)));
++      assertTrue(payload.isNull("androidErrorCode"));
++      assertTrue(payload.isNull("attErrorCode"));
++    }
++  }
++
++  @Test public void attOperationsKeepTheirExistingMappingAndReasonsAreValidJson() throws Exception {
++    String reason = "write \"failed\"\npath\\device";
++    JSONObject payload = new JSONObject(new BleErrorToJsObjectConverter().toJs(
++      new BleError(BleErrorCode.CharacteristicWriteFailed, reason, 8)));
++    assertEquals(8, payload.getInt("attErrorCode"));
++    assertTrue(payload.isNull("androidErrorCode"));
++    assertEquals(reason, payload.getString("reason"));
++  }
++}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ patchedDependencies:
   expo-dev-launcher@57.0.16: ba11bf1ad99f2bed1d9c959e8e68d1fe44e76bed157286850cde1dd5fc342d56
   expo-image@57.0.3: 68cfa579530a19eff0353bb5b9c0ea543980992877a93a69d832471f6ef91f60
   expo-updates@57.0.19: 67f24f95aa789e95b632312352bca97ddc9fd5264328d4c85a8fcc929f96f50a
+  react-native-ble-plx@3.5.1: 243c7040f835074cd999a8719675046d66acf9fe2e88948c40d11d8133f181c4
   react-native-screens@4.26.2: 6b77eaedcf3b2210551b4099df209748d8135cff58ee4d89c3b20d8e6d2cf246
 
 importers:
@@ -765,7 +766,7 @@ importers:
         version: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)
       react-native-ble-plx:
         specifier: 3.5.1
-        version: 3.5.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+        version: 3.5.1(patch_hash=243c7040f835074cd999a8719675046d66acf9fe2e88948c40d11d8133f181c4)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       react-native-edge-to-edge:
         specifier: 1.8.1
         version: 1.8.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -21030,7 +21031,7 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  react-native-ble-plx@3.5.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
+  react-native-ble-plx@3.5.1(patch_hash=243c7040f835074cd999a8719675046d66acf9fe2e88948c40d11d8133f181c4)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,6 +44,7 @@ overrides:
   react-native-screens: 4.26.2
 
 patchedDependencies:
+  'react-native-ble-plx@3.5.1': patches/react-native-ble-plx@3.5.1.patch
   '@expo/fingerprint@0.20.11': patches/@expo__fingerprint@0.20.11.patch
   '@expo/ui@57.0.14': patches/@expo__ui@57.0.14.patch
   'expo-dev-launcher@57.0.16': patches/expo-dev-launcher@57.0.16.patch

--- a/scripts/mobile-patches-check.ts
+++ b/scripts/mobile-patches-check.ts
@@ -102,6 +102,29 @@ export interface PatchRule {
  */
 export const RULES: readonly PatchRule[] = [
   {
+    package: 'react-native-ble-plx',
+    file: 'android/src/main/java/com/bleplx/adapter/BleModule.java',
+    sentinels: ['AtomicReference<BleError> disconnectError', 'ConnectionState.DISCONNECTED, disconnectError.get()'],
+    orderedSentinels: ['disconnectError.set(errorConverter.toError(error))', '.doFinally(() -> {'],
+    patchedKey: 'react-native-ble-plx@3.5.1',
+  },
+  {
+    package: 'react-native-ble-plx',
+    file: 'android/src/main/java/com/bleplx/BlePlxModule.java',
+    sentinels: ['OnConnectionStateChangeCallback', 'event.pushString(errorConverter.toJs(disconnectError))'],
+    patchedKey: 'react-native-ble-plx@3.5.1',
+  },
+  {
+    package: 'react-native-ble-plx',
+    file: 'android/src/main/java/com/bleplx/converter/BleErrorToJsObjectConverter.java',
+    sentinels: [
+      'error.errorCode == BleErrorCode.DeviceDisconnected',
+      '!isDisconnect && error.androidCode < 0x80',
+      'JSONObject.quote(value)',
+    ],
+    patchedKey: 'react-native-ble-plx@3.5.1',
+  },
+  {
     package: '@expo/fingerprint',
     file: 'build/utils/Path.js',
     sentinels: ['normalizeIsolatedStoreModulePath', 'ISOLATED_STORE_MODULE_ROOT_REGEX'],


### PR DESCRIPTION
## Summary

Android disconnect events from `react-native-ble-plx` always carried a null error after connecting, hiding the reason for the dropped link in #5279. Patch the pinned library to preserve the native terminal error through cleanup and send it with the existing JavaScript disconnect event. Connection status codes such as timeout (8) and peer termination (19) now reach the existing PostHog diagnostics instead of being misclassified as ATT errors.

Deliberate cancellation remains null, reconnects cannot inherit an earlier error, and setup/MTU failures retain their original error. Error descriptions are safely JSON-escaped. This improves diagnosis; the intermittent disconnect cause in #5279 remains unconfirmed.

Requires a new Android binary; an OTA update cannot apply this native patch. No physical-board test has been performed here.

Validation: 9,172 mobile tests, 8 native Android regression tests, 55 patch-guard tests, mobile typechecking, both iOS/Android bundles, formatting/lint, and patch-install checks pass. The Android PR workflow now runs the library's native tests. iOS simulator checks were skipped on Linux.

Two independent Astra reviews approved commit `737b244f8` with no actionable findings. One reviewed RxJava lifecycle ordering, cancellation, reconnects, and error propagation, and independently reran 108 focused mobile tests successfully. The other reviewed native/JavaScript serialization, PostHog classification, patch/lock consistency, and CI integration, and independently passed the patch guard (11 rules, 7 patch files).

The automated Claude review check is blocked by the account's weekly usage limit (resets September 12 at 07:00 UTC); it produced no review findings.

Fresh-checkout CI's full repository typecheck passes. The local full check did not complete because of temporary-disk capacity and relocation-related build paths; scoped mobile checks passed locally before relocation.

## Release Notes

none

- [x] No release note needed (internal / technical change)

## Test plan

1. New Android build: connect a board → lightbulb turns on.
2. Light a climb → the selected holds illuminate.
3. Disconnect → lightbulb turns off.
4. Reconnect, then switch controller off → lightbulb turns off.

## Risk

Risk: 5/5 — native BLE lifecycle reporting changes; requires a new Android build.
