### PR TITLE
fix(mobile): stop the floating PR picker interrupting climb search

### DIFF
--- a/.github/workflows/mobile-ota-preview-prompt.yml
+++ b/.github/workflows/mobile-ota-preview-prompt.yml
@@ -187,7 +187,7 @@ jobs:
               '',
               `Any older \`${branch}\` revision was removed. A maintainer with repository write access can ` +
                 `comment **\`/ota-preview\`** to publish this fork's current revision. Then select it from ` +
-                `xprem's blue branch marker.`,
+                `**More → Previews → Test a PR preview** in Boardsesh.`,
               '',
               '<sub>Re-comment `/ota-preview` after new pushes to refresh the preview. A native change ' +
                 'needs a TestFlight/Play build instead.</sub>',

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -1,8 +1,8 @@
 name: Mobile OTA Preview (Per-PR Branch)
 
 # Publishes a PR's JS bundle to its own self-hosted OTA branch `pr-<number>` so
-# anyone on a compatible store / TestFlight binary can load it through xprem's
-# official branch picker. The native config keeps the `production` channel fixed;
+# anyone on a compatible store / TestFlight binary can load it through Test a PR
+# preview in More or the user drawer. Native config keeps the `production` channel fixed;
 # `pr-<number>` is only the eoas upload branch. See docs/mobile-ota-updates.md.
 #
 # ─── SECURITY — READ BEFORE EDITING ──────────────────────────────────────────────
@@ -761,8 +761,9 @@ jobs:
             }
             const howto = anyPublished
               ? ['',
-                 `In Boardsesh, tap xprem's blue branch marker, then select **\`${branch}\`**. ` +
-                   `Reset in the same panel when you are done.`,
+                 `In Boardsesh, open **More → Previews → Test a PR preview** (also in the user drawer), ` +
+                   `then select **\`${branch}\`**. When done, open the test plan under **More → Previews** ` +
+                   `and choose **Leave preview**.`,
                  '<sub>The server may take up to 15 seconds to refresh the branch list after publishing.</sub>',
                  '']
               : [''];

--- a/docs/crowdsourced-qa-mobile.md
+++ b/docs/crowdsourced-qa-mobile.md
@@ -15,12 +15,10 @@ author, risk (`Risk: N/5` from the PR body) and how fresh the branch is, plus ch
 verdict they already filed, and a branch the server refused because it crashed here. Tapping one
 surfs onto it and reloads.
 
-The row stays put when that list is empty, and that is the point. The screen is the only surface
-that can SAY *"Previews are switched off"* or *"Nothing to test right now"* — xprem's blue edge
-marker renders nothing at all in exactly those cases, so while this was tester-only, "no button" and
-"no previews" were indistinguishable from the outside and reports read as "the preview option is
-gone". Hiding it now needs a real reason: a binary that cannot surf, where the row would offer
-something the app genuinely cannot do.
+The row stays put when that list is empty: the screen explains *"Previews are switched off"*
+or *"Nothing to test right now"*. It is hidden only on a binary that cannot surf.
+The floating xprem marker and its light-only sheet were removed for #5287; preview selection
+uses these themed menu destinations. The app still uses xprem's branch API through `qa-surf.ts`.
 
 **The cold-start prompt is still tester-only.** A user whose profile has `isTester` gets one prompt
 per cold start without asking for it — the pick list on production, or on a `pr-<n>` bundle the
@@ -142,7 +140,7 @@ menu entry does not consult `isTester` at all, so it is unaffected — only the 
 **Nothing prompts before xprem's migration settles.** A surfing-capable binary's first launch clears
 a retired channel override and calls `Updates.reloadAsync()`. `app/_layout.tsx` publishes that state
 through `src/lib/ota-branch-surfing-state.ts`; the gate waits for `ready` so it never pushes a route
-the reload throws away. `ready` also covers the store's pre-launch state — `OtaBranchControlCenter`
+the reload throws away. `ready` also covers the store's pre-launch state — `OtaBranchSurfingInitializer`
 is the LAST root sibling, so its publishing effect runs after the gate's — which is why
 `decideQaGate` waits on `surfingReady` alone rather than on `surfingBuild && !surfingReady`. Reading
 an unpublished store as "this build cannot surf" would resolve to `none`, and the gate marks the

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -73,7 +73,7 @@ run `eoas doctor`.
 ### Standing rules
 
 - **Never drop `expo-app-id`, `expo-channel-name`, or `xprem-branch`.** Self-hosted clients bake all
-  three in `updates.requestHeaders`; xprem's official picker overrides only `xprem-branch`.
+  three in `updates.requestHeaders`; xprem's branch API overrides only `xprem-branch`.
 - **Move the `eoas` pin first, the V3 server image second — never the other way round.** A CLI that
   trails the server can 404 on app-scoped routes. Re-verify after every bump (above).
 - **Dashboard creds are production-release creds.** `/dashboard` mints API keys, exports the cert,
@@ -90,7 +90,7 @@ run `eoas doctor`.
 | Publish        | `vp run mobile:publish` (→ `eas update`) | auto on push to `main` (`mobile-ota-production.yml`); manual: publish one platform, then immediately run `mobile:upload-sourcemaps` (→ `eoas publish` + Sentry Debug ID upload) |
 
 A third path rides the **same self-hosted server**: per-PR `pr-<number>` branches that let any user
-validate a specific PR on a compatible store/TestFlight build via xprem's official branch picker —
+validate a specific PR on a compatible store/TestFlight build via **Test a PR preview** —
 see [Per-PR preview branches](#per-pr-preview-branches-self-hosted) below.
 
 The split is decided in `packages/mobile/app.config.ts` (`resolveUpdatesConfig`): when
@@ -310,7 +310,7 @@ client requesting an unmapped channel gets `No branch mapping found`. Mapping is
 
 - **Production** is mapped once, by hand, in the dashboard — nothing on `main` remaps it.
 - **Per-PR previews are branches, not channels.** The production channel enables xprem Branch
-  Surfing with the narrow pattern `pr-*`; the official `@xprem/control-center` sends
+  Surfing with the narrow pattern `pr-*`; the branch API in `@xprem/control-center` sends
   `xprem-branch: pr-N`. No per-PR channel or mapping is created.
 - **Branch Surfing is ON** for `production` with the pattern `pr-*` (enabled 2026-09-01, once native
   builds carrying the picker and the baked `xprem-branch` header had reached testers — that ordering
@@ -1085,24 +1085,21 @@ EXPO_UPDATES_URL=https://example.test/manifest vp exec expo prebuild
    `packages/mobile/src/...` source lines, their Debug IDs match the uploaded OTA maps, and the
    events' native release/dist still identify the installed store binaries rather than the OTA.
 
-## Official branch picker
+## PR preview picker
 
-Production/TestFlight builds follow xprem's
-[official Branch Surfing integration](https://mercure-technologies.gitbook.io/xprem/concepts/branch-surfing)
-and mount `ControlCenter` from `@xprem/control-center@3.1.2`. Xprem probes
-`/branch_lists` once per JS session and renders its built-in blue edge marker only when Branch
-Surfing is enabled for the production channel and a compatible branch exists. It is available to
-every app user and shows xprem's raw branch names such as `pr-4613`.
+Production/TestFlight builds use xprem's
+[Branch Surfing API](https://mercure-technologies.gitbook.io/xprem/concepts/branch-surfing)
+through the `qa-surf.ts` adapter, which retains the config and surf modules from
+`@xprem/control-center@3.1.2`. The app does not mount the package's `ControlCenter` UI.
+Its floating edge target and light-only sheet were removed for #5287 after reports of
+the sheet opening while closing climb search.
 
-The marker is not the only entry point, and treating it as one was a mistake worth recording: it
-renders **nothing at all** when surfing is off or no branch matches this binary, so "the marker is
-missing" and "there is nothing to test" look identical from a tester's side of the screen. Every
-user now also gets Boardsesh's own **Test a PR preview** row — in the user drawer and under
-**Previews** on the More tab — which opens a screen that *says* which of the two it is
-("Previews are switched off", "Nothing to test right now"). The row is hidden only on a binary that
-cannot surf at all, where it would offer something the app genuinely cannot do.
+Every user on a surfing-capable binary gets Boardsesh's **Test a PR preview** row in the
+user drawer and under **Previews** on the More tab. Both open the themed preview screen,
+which lists compatible PR branches and explains "Previews are switched off" or "Nothing
+to test right now" when appropriate. The row is hidden only on a binary that cannot surf.
 
-On top of both, a user whose profile has `isTester` is *prompted* without asking: on every cold
+A user whose profile has `isTester` is also *prompted* without asking: on every cold
 start the app either offers a PR preview list (title, risk, how fresh) or, if they are already on a
 `pr-<n>` bundle, shows that PR's `## Test plan`. Finishing sends an approve/decline verdict back to
 the PR and clears the branch pin. Anyone signed in can file such a verdict from the screens above;
@@ -1124,16 +1121,18 @@ manifest signing remain enforced by expo-updates.
 Old builds may have a native `expo-channel-name` override and a best-effort AsyncStorage mirror under
 `dev_ota_channel_override`. On the first launch in the fingerprint cohort carrying the required
 Branch Surfing headers, Boardsesh clears the native override unconditionally, removes the mirror, persists a
-dedicated migration-complete marker, and reloads before mounting `ControlCenter`. The marker matters:
+dedicated migration-complete marker, and reloads before publishing QA readiness. The root's
+`OtaBranchSurfingInitializer` renders nothing and keeps this migration independent of preview UI.
+The marker matters:
 the mirror can be absent even when the native override exists, while later launches must preserve
-xprem's own selected branch. A failed read/clear/write leaves the picker disabled and retries later.
+xprem's own selected branch. A failed read/clear/write leaves QA readiness false and retries on a later launch.
 EAS preview builds skip this migration; their separate tester-only `BranchSwitcherScreen` remains
 available under More → Preview Build.
 
 The retired custom channel switcher, GraphQL GitHub proxy, preview route, and web QR page were
 removed. The Android `/preview` intent filter remains only as a compatibility ingress, so existing
 `/preview/pr-N` links still land safely on What's New, including after login; branch selection happens
-only through xprem's marker. Sentry crash tools now live at More → Development → Sentry
+through **Test a PR preview** in More or the user drawer. Sentry crash tools now live at More → Development → Sentry
 Diagnostics for tester accounts.
 
 Telemetry keeps `ota_channel=production` and reads the selected branch from
@@ -1143,7 +1142,7 @@ in PostHog/Sentry. Diagnostic eligibility uses the same manifest field.
 ## Per-PR preview branches (self-hosted)
 
 Every PR with React Native changes can publish its JS bundle to its own self-hosted branch
-`pr-<number>`, which any user can switch to on a compatible store/TestFlight build via the official picker
+`pr-<number>`, which any user can switch to on a compatible store/TestFlight build via the preview picker
 above — no per-tester build. Workflow: `.github/workflows/mobile-ota-preview.yml` (sweep:
 `mobile-ota-preview-sweep.yml`).
 

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -298,7 +298,7 @@ export default function MoreScreen() {
   // "Force server unreachable" switch below is available to everyone who passes
   // this gate, in every build, so the old "…and at least one tool applies"
   // conjunct would only ever have hidden a section that has a row.
-  // Store-build previews now use xprem's everyone-facing blue edge marker, so
+  // Store-build previews have their own everyone-facing Previews section, so
   // the retired OTA channel switcher is no longer listed here.
   const showDevSection = __DEV__ || Boolean(profile?.isTester) || isAdmin;
 

--- a/packages/mobile/app/+native-intent.ts
+++ b/packages/mobile/app/+native-intent.ts
@@ -24,7 +24,7 @@ export function redirectSystemPath({ path, initial }: { path: string; initial: b
   }
   // The retired custom OTA picker emitted /preview/pr-N links in PR comments.
   // New builds no longer have that route; land those durable links on What's
-  // New while xprem's official edge marker remains the picker entry point.
+  // New. Preview selection is available from More and the user drawer.
   if (isLegacyPreviewLink(path)) {
     return '/changelog';
   }

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -31,7 +31,6 @@ import * as Updates from 'expo-updates';
 import { SystemBars } from 'react-native-edge-to-edge';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { BottomSheetModalProvider } from '@expo/ui/community/bottom-sheet';
-import { ControlCenter } from '@xprem/control-center';
 import { ObserveRoot } from 'expo-observe';
 import Constants from 'expo-constants';
 import { QueryProvider } from '../src/providers/query-provider';
@@ -139,7 +138,7 @@ function buildStaticFeatureFlags(): FeatureFlags | undefined {
 
 const STATIC_FEATURE_FLAGS = buildStaticFeatureFlags();
 
-function OtaBranchControlCenter() {
+function OtaBranchSurfingInitializer() {
   // Fingerprint-bound required headers distinguish Branch Surfing-capable
   // binaries from EAS previews. Updates.channel cannot do that: a legacy
   // persisted override changes the value exposed for this launch.
@@ -169,7 +168,7 @@ function OtaBranchControlCenter() {
       .then((preparation) => {
         // A cleared native override requires a new JS runtime before xprem reads
         // Updates.channel. reloadAsync normally never returns to this tree; if it
-        // does, keep the picker disabled rather than mounting against stale data.
+        // does, keep readiness false rather than publishing stale state.
         if (!cancelled && preparation === 'ready') setMigrationComplete(true);
       })
       .catch((error: unknown) => {
@@ -189,7 +188,7 @@ function OtaBranchControlCenter() {
     setOtaBranchSurfingState({ surfingBuild: branchSurfingBuild, ready: migrationComplete });
   }, [branchSurfingBuild, migrationComplete]);
 
-  return branchSurfingBuild && migrationComplete ? <ControlCenter /> : null;
+  return null;
 }
 
 const errorStyles = StyleSheet.create({
@@ -882,12 +881,11 @@ function RootLayout() {
           </QueryProvider>
         </I18nProvider>
       </AnalyticsProvider>
-      {/* Final sibling by design, matching xprem's documented composition. RN
-          paints later siblings above earlier ones; placing the ControlCenter
-          here keeps its absolute edge marker above the full-screen app tree.
-          A one-time migration clears retired Boardsesh channel overrides and
-          reloads before this component becomes eligible to mount. */}
-      <OtaBranchControlCenter />
+      {/* Initialize preview eligibility without mounting xprem's floating picker:
+          its edge touch target can intercept climb-search interactions (#5287).
+          The QA screens use xprem's branch APIs directly and wait for this
+          initializer's one-time migration before prompting. */}
+      <OtaBranchSurfingInitializer />
     </GestureHandlerRootView>
   );
 }

--- a/packages/mobile/src/lib/__tests__/native-intent.test.ts
+++ b/packages/mobile/src/lib/__tests__/native-intent.test.ts
@@ -71,15 +71,15 @@ describe('redirectSystemPath', () => {
   });
 
   // Existing OTA-preview PR comments outlive the retired custom preview route.
-  // New builds land each old link on What's New while xprem's official edge
-  // marker remains the picker entry point.
+  // New builds land each old link on What's New. Preview selection is available
+  // from More and the user drawer.
   it.each([
     'com.boardsesh.app://preview/pr-1234',
     'com.boardsesh.app:///preview/pr-1234',
     '/preview/pr-1234',
     'https://boardsesh.com/preview/pr-1234',
     'https://www.boardsesh.com/preview/pr-1234',
-  ])('lands the legacy preview link on the official picker entry point: %s', (path) => {
+  ])("lands the legacy preview link on What's New: %s", (path) => {
     getShareExtensionKeyMock.mockReturnValue('SHAREKEY');
     expect(redirectSystemPath({ path, initial: true })).toBe('/changelog');
   });

--- a/packages/mobile/src/lib/apply-channel-override.ts
+++ b/packages/mobile/src/lib/apply-channel-override.ts
@@ -18,7 +18,7 @@ import { OTA_APP_ID } from './ota-app-id';
 // and reverts to the build-time headers.
 //
 // Used by the separate EAS preview-build branch switcher. Production self-hosted
-// previews use xprem's ControlCenter and override `xprem-branch` instead.
+// previews use xprem's branch API and override `xprem-branch` instead.
 export function applyChannelOverride(channel: string | null): void {
   Updates.setUpdateRequestHeadersOverride(
     channel === null ? null : { 'expo-app-id': OTA_APP_ID, 'expo-channel-name': channel },

--- a/packages/mobile/src/lib/legacy-ota-channel-migration.ts
+++ b/packages/mobile/src/lib/legacy-ota-channel-migration.ts
@@ -41,14 +41,14 @@ type OtaBranchSurfingPreparationDependencies = {
 export type OtaBranchSurfingPreparation = 'skipped' | 'ready' | 'reloading';
 
 /**
- * Clear Boardsesh's retired channel override exactly once before xprem mounts.
+ * Clear Boardsesh's retired channel override exactly once before QA is ready.
  *
  * The old AsyncStorage mirror was best-effort, so its absence does not prove the
  * native override is absent. A dedicated completion marker lets the first new
  * build clear native state unconditionally, while preserving xprem's own branch
  * override on every later launch. Changing the native headers requires a reload:
- * Updates.channel is a module constant for the current JS runtime and xprem reads
- * it when the ControlCenter mounts.
+ * Updates.channel is a module constant for the current JS runtime and xprem's
+ * branch API reads it when resolving the config for a preview action.
  */
 export async function prepareOtaBranchSurfing({
   branchSurfingBuild,

--- a/packages/mobile/src/lib/ota-branch-surfing-state.ts
+++ b/packages/mobile/src/lib/ota-branch-surfing-state.ts
@@ -1,7 +1,7 @@
 import { useSyncExternalStore } from 'react';
 
 /**
- * What the root layout's `OtaBranchControlCenter` already knows about this
+ * What the root layout's `OtaBranchSurfingInitializer` already knows about this
  * binary's ability to surf OTA branches, published so surfaces outside that
  * subtree (the QA launch gate, the user drawer) can read it without redoing the
  * work or, worse, racing it.

--- a/packages/mobile/src/lib/qa/use-qa-menu.ts
+++ b/packages/mobile/src/lib/qa/use-qa-menu.ts
@@ -12,8 +12,8 @@ import { readRunningPrNumber } from './qa-surf';
  * `show` is the binary's capability alone. Every signed-in user gets the entry
  * point: the picker is the one surface that can SAY why there is nothing to load
  * ("Previews are switched off", "Nothing to test right now"), and hiding it left
- * everyone but a tester with only xprem's edge marker — which renders nothing at
- * all in exactly those cases, so "no marker" and "no previews" looked identical.
+ * everyone but a tester with only xprem's former edge marker, which rendered
+ * nothing in those cases, so "no marker" and "no previews" looked identical.
  * A build that cannot surf still hides it: there the row would offer something
  * the binary genuinely cannot do.
  *

--- a/packages/mobile/src/providers/deep-link-provider.tsx
+++ b/packages/mobile/src/providers/deep-link-provider.tsx
@@ -182,8 +182,7 @@ export function DeepLinkProvider({ children }: { children: ReactNode }) {
 
   // Preserve retired /preview/pr-N links through the auth gate. The original
   // route no longer exists, so replay the safe What's New destination after
-  // login; xprem's official edge marker is globally available there when the
-  // server allows Branch Surfing.
+  // login. Preview selection is available from More and the user drawer.
   useEffect(() => {
     if (!isAuthenticated) return;
     let cancelled = false;


### PR DESCRIPTION
## Summary

Closing climb search could bring up xprem's light-only PR picker, especially after switching apps. Remove its floating edge control and sheet; preview testing remains available through Boardsesh's themed More and user-drawer screens.

Keep the root preview initializer, legacy override migration, readiness publication, and xprem branch APIs. Native configuration and dependencies are unchanged. Update the OTA/QA documentation, generated preview instructions, and stale entry-point comments.

Closes #5287.

Validation: after rebasing onto current main, `vp check`, `vp run typecheck`, and all 9,192 mobile tests (852 files) passed. The 31 workflow tests and iOS/Android production bundle checks passed. The pre-commit hook passed. The iOS simulator build and log check passed before the rebase; this worktree's Metro bundle reached the sign-in screen and a screenshot was captured. The dev server loaded the issue QA notes. The PR changes no native configuration or dependencies; it was rebased to pick up main's newly landed native fingerprint.

The search/app-switch reproduction and actual preview switching still need a signed-in compatible store/TestFlight build, because development builds already disable the floating picker. Automated Claude review could not run because its account reached the weekly limit (resets September 12 at 07:00 UTC); it produced no code findings.

## Release Notes

Close climb search without a PR preview sheet popping up.

## Test plan

1. Climbs → open search and type; matching climbs appear.
2. Switch apps and return; your search is still visible.
3. Close search; the climb list stays visible without a preview sheet.
4. More → Previews → Test plan; the plan matches your theme.
5. User drawer → Test plan; the same plan opens.

## Risk

Risk: 2/5 — removes duplicate preview UI; preview initialization and switching stay intact.
