### PR TITLE
fix(web): restore password-reset emails

### DIFF
--- a/docs/production-deploy.md
+++ b/docs/production-deploy.md
@@ -347,9 +347,11 @@ The flip PR must not merge until every one of these is checked:
 1. Web-only secrets are pasted onto the `boardsesh-web` Railway service, with
    Vercel's exact values where continuity depends on it: `NEXTAUTH_SECRET` and
    `CRON_SECRET`, plus `GOOGLE_CLIENT_SECRET`, `APPLE_ID`, `APPLE_SECRET`,
-   `IRON_SESSION_PASSWORD`, `EMAIL_VERIFICATION_ENABLED`, and
-   `BOARDSESH_EXPO_WEB_ORIGIN`. Check by hitting `/api/auth/providers` on the
-   Railway origin and confirming it lists both `apple` and `google`.
+   `IRON_SESSION_PASSWORD`, `EMAIL_VERIFICATION_ENABLED`, `SMTP_USER`,
+   `SMTP_PASSWORD`, and `BOARDSESH_EXPO_WEB_ORIGIN`. `SMTP_HOST` defaults to
+   `smtp.fastmail.com`; `EMAIL_FROM` defaults to `SMTP_USER`. Check by hitting
+   `/api/auth/providers` on the Railway origin and confirming it lists both
+   `apple` and `google`.
 2. #5027, the apex → www redirect, is merged and applied. Verify with
    `curl -sI https://boardsesh.com/x?y=1`: it must answer 301 to
    `https://www.boardsesh.com/x?y=1` with a `cf-ray` header.

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -1,7 +1,7 @@
-# Railway (OTA project config-as-code)
+# Railway config assertions
 
-Config-as-code for the Railway project that runs the self-hosted xprem OTA server
-(`updates.boardsesh.com`). It is the same three-file shape as
+Config assertions for the Railway project that runs the public web service and the
+self-hosted xprem OTA server (`updates.boardsesh.com`). It is the same three-file shape as
 [cloudflare.md](./cloudflare.md): typed desired state, a pure diff, and one script
 that does all the I/O.
 
@@ -22,11 +22,14 @@ it. A second `--apply` with nothing to do is a no-op.
 
 ## What it manages
 
-- **Services.** Asserts `boardsesh-ota-v3` exists; reports when the ClickHouse
-  service is missing. It never creates or deletes a service — see
+- **Services.** Asserts `boardsesh-ota-v3` and `boardsesh-web` exist; reports when
+  the ClickHouse service is missing. It never creates or deletes a service — see
   [Why services are not created](#why-services-are-not-created).
 - **Variables.** Asserts the declared variables are set and are not still an
-  unfilled `<placeholder>`.
+  unfilled `<placeholder>`. It also checks public safe-value rules without
+  printing live values: `boardsesh-web` needs SMTP credentials, `BOARDSESH_WEB`
+  must be absent or `1`, and `NEXTAUTH_URL` or `BASE_URL` must name the canonical
+  `https://www.boardsesh.com` origin.
 - **ClickHouse retention.** Asserts the TTLs on xprem's `observe_metrics` and
   `observe_logs` tables.
 

--- a/infra/railway/config.ts
+++ b/infra/railway/config.ts
@@ -38,6 +38,12 @@ export const OTA_SERVICE_NAME = 'boardsesh-ota-v3';
 /** The ClickHouse service backing xprem's Observe feature. */
 export const CLICKHOUSE_SERVICE_NAME = 'boardsesh-ota-clickhouse';
 
+/** The public www service. It is asserted here but never created by this tool. */
+export const WEB_SERVICE_NAME = 'boardsesh-web';
+
+/** The only public origin that can safely issue Boardsesh's cross-subdomain session cookies. */
+export const CANONICAL_WEB_ORIGIN = 'https://www.boardsesh.com';
+
 /**
  * Image for the ClickHouse service. Pinned to the version xprem itself tests
  * against — docker-compose.yml and .github/workflows/push.yml in the xprem repo
@@ -109,10 +115,27 @@ export interface RequiredEnvVar {
   reason: string;
 }
 
+/** A variable which may be absent, but must use one of these safe values when present. */
+export interface OptionalConstrainedEnvVar {
+  name: string;
+  /** Public, non-secret values that are valid when the variable is present. */
+  allowedValues: readonly string[];
+  reason: string;
+}
+
+/** At least one variable in the group must contain the public expected value. */
+export interface RequiredOneOfEnvVars {
+  names: readonly string[];
+  expectedValue: string;
+  reason: string;
+}
+
 export interface ServiceDesired {
   name: string;
   management: ServiceManagement;
   requiredVars: RequiredEnvVar[];
+  optionalConstrainedVars?: OptionalConstrainedEnvVar[];
+  requiredOneOfVars?: RequiredOneOfEnvVars[];
   /** Only meaningful for a report-only service we describe but do not create. */
   expected?: {
     image: string;
@@ -239,6 +262,35 @@ export const desiredRailwayState: RailwayDesiredState = {
         image: CLICKHOUSE_IMAGE,
         volumeMountPath: CLICKHOUSE_VOLUME_MOUNT_PATH,
       },
+    },
+    {
+      name: WEB_SERVICE_NAME,
+      management: 'assert-only',
+      requiredVars: [
+        {
+          name: 'SMTP_USER',
+          reason: 'Required to send password-reset and verification emails for credential accounts.',
+        },
+        {
+          name: 'SMTP_PASSWORD',
+          reason: 'Required to authenticate the SMTP transport for credential-account emails.',
+        },
+      ],
+      optionalConstrainedVars: [
+        {
+          name: 'BOARDSESH_WEB',
+          allowedValues: ['1'],
+          reason: 'The Docker image enables the www-to-app auth bridge; any other dashboard override disables it.',
+        },
+      ],
+      requiredOneOfVars: [
+        {
+          names: ['NEXTAUTH_URL', 'BASE_URL'],
+          expectedValue: CANONICAL_WEB_ORIGIN,
+          reason:
+            'At least one canonical origin is required for secure cross-subdomain session cookies and email links.',
+        },
+      ],
     },
   ],
   clickhouseRetention: CLICKHOUSE_RETENTION,

--- a/infra/railway/plan.ts
+++ b/infra/railway/plan.ts
@@ -13,9 +13,9 @@
 //      left alone, the way the Cloudflare tool preserves foreign rules verbatim.
 //   2. Never overwrite a value that is already set and not a placeholder. Only
 //      `absent` and `placeholder` are drift this tool will fix.
-//   3. Never surface a secret value. Variables are reduced to a three-state
-//      classification before they reach a PlannedChange, so no code path can print
-//      a DSN or a token.
+//   3. Never surface a secret value. Variable values are inspected only to
+//      classify them or compare them to public configured values; no live value
+//      reaches a PlannedChange.
 
 import {
   PLACEHOLDER_PATTERN,
@@ -175,6 +175,43 @@ export function diffServiceVars(desired: ServiceDesired, live: LiveState, option
       // Convergeable only when the caller actually supplied a value. Without one
       // this is a report, not a fix — the tool never invents a secret.
       blocked: !supplied,
+    });
+  }
+
+  for (const constrained of desired.optionalConstrainedVars ?? []) {
+    const rawValue = serviceVars[constrained.name];
+    const state = classifyVar(rawValue);
+    if (state === 'absent') continue;
+
+    const normalizedValue = rawValue?.trim();
+    if (normalizedValue && constrained.allowedValues.includes(normalizedValue)) continue;
+
+    const allowedValues = constrained.allowedValues.map((allowedValue) => `"${allowedValue}"`).join(' or ');
+    changes.push({
+      resource: 'env-var',
+      summary: `${desired.name}: ${constrained.name} must be absent or ${allowedValues}`,
+      detail:
+        `${constrained.reason}\n` +
+        `The variable is ${state === 'placeholder' ? 'an unfilled placeholder' : 'set to an unsupported value'}. ` +
+        `Remove it or set it to ${allowedValues}.`,
+      target: { serviceName: desired.name, varName: constrained.name },
+      blocked: true,
+    });
+  }
+
+  for (const requirement of desired.requiredOneOfVars ?? []) {
+    const matchesExpectedValue = requirement.names.some(
+      (name) => serviceVars[name]?.trim() === requirement.expectedValue,
+    );
+    if (matchesExpectedValue) continue;
+
+    changes.push({
+      resource: 'env-var',
+      summary: `${desired.name}: one of ${requirement.names.join(' or ')} must equal ${requirement.expectedValue}`,
+      detail:
+        `${requirement.reason}\n` +
+        `Set at least one listed variable to ${requirement.expectedValue}; the live value is not printed.`,
+      blocked: true,
     });
   }
 

--- a/packages/web/app/api/auth/register/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/register/__tests__/route.test.ts
@@ -21,6 +21,11 @@ vi.mock('@boardsesh/email', () => ({
   sendVerificationEmail: (...args: unknown[]) => mockSendVerificationEmail(...args),
 }));
 
+const mockCaptureException = vi.fn();
+vi.mock('@sentry/nextjs', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
 vi.mock('bcryptjs', () => ({
   hash: async () => 'hashed-password',
 }));
@@ -109,5 +114,16 @@ describe('POST /api/auth/register', () => {
       if (savedBaseUrl === undefined) delete process.env.BASE_URL;
       else process.env.BASE_URL = savedBaseUrl;
     }
+  });
+
+  it('reports a verification-email failure to Sentry while returning the account response', async () => {
+    const smtpError = new Error('smtp failed');
+    mockSendVerificationEmail.mockRejectedValueOnce(smtpError);
+
+    const response = await POST(createRequest({ email: 'test@example.com', password: 'password123' }));
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({ emailSent: false, requiresVerification: true });
+    expect(mockCaptureException).toHaveBeenCalledWith(smtpError, expect.objectContaining({ tags: expect.anything() }));
   });
 });

--- a/packages/web/app/api/auth/register/route.ts
+++ b/packages/web/app/api/auth/register/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
 import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
 import { hash } from 'bcryptjs';
@@ -122,6 +123,9 @@ export async function POST(request: NextRequest) {
         emailSent = true;
       } catch (emailError) {
         console.error('Failed to send verification email:', emailError);
+        Sentry.captureException(emailError, {
+          tags: { area: 'auth', flow: 'register', phase: 'send-email' },
+        });
         // User is created, they can use resend functionality
       }
 

--- a/packages/web/app/api/auth/resend-verification/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/resend-verification/__tests__/route.test.ts
@@ -15,6 +15,11 @@ vi.mock('@boardsesh/email', () => ({
   sendVerificationEmail: (...args: unknown[]) => mockSendVerificationEmail(...args),
 }));
 
+const mockCaptureException = vi.fn();
+vi.mock('@sentry/nextjs', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
 const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
 const mockValues = vi.fn().mockResolvedValue(undefined);
 const mockUserSelect = vi.fn();
@@ -91,5 +96,15 @@ describe('POST /api/auth/resend-verification', () => {
     } finally {
       if (savedBaseUrl !== undefined) process.env.BASE_URL = savedBaseUrl;
     }
+  });
+
+  it('reports a verification-email failure to Sentry', async () => {
+    const smtpError = new Error('smtp failed');
+    mockSendVerificationEmail.mockRejectedValueOnce(smtpError);
+
+    const response = await POST(createRequest({ email: 'test@example.com' }));
+
+    expect(response.status).toBe(500);
+    expect(mockCaptureException).toHaveBeenCalledWith(smtpError, expect.objectContaining({ tags: expect.anything() }));
   });
 });

--- a/packages/web/app/api/auth/resend-verification/route.ts
+++ b/packages/web/app/api/auth/resend-verification/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
 import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
 import { eq } from 'drizzle-orm';
@@ -88,12 +89,24 @@ export async function POST(request: NextRequest) {
     // without the build arg. `??` keeps an empty string and every link in this
     // email would lose its origin; falling back to the request origin is right.
     const baseUrl = process.env.BASE_URL?.trim() || request.nextUrl.origin;
-    await sendVerificationEmail(email, token, baseUrl);
+    try {
+      await sendVerificationEmail(email, token, baseUrl);
+    } catch (emailError) {
+      console.error('Failed to resend verification email:', emailError);
+      Sentry.captureException(emailError, {
+        tags: { area: 'auth', flow: 'resend-verification', phase: 'send-email' },
+      });
+      await consistentDelay(startTime);
+      return NextResponse.json({ error: 'Failed to send verification email' }, { status: 500 });
+    }
 
     await consistentDelay(startTime);
     return NextResponse.json({ message: genericMessage }, { status: 200 });
   } catch (error) {
     console.error('Resend verification error:', error);
+    Sentry.captureException(error, {
+      tags: { area: 'auth', flow: 'resend-verification', phase: 'request' },
+    });
     await consistentDelay(startTime);
     return NextResponse.json({ error: 'Failed to send verification email' }, { status: 500 });
   }

--- a/scripts/railway-apply.test.ts
+++ b/scripts/railway-apply.test.ts
@@ -7,8 +7,10 @@ import {
   CLICKHOUSE_VOLUME_NAME,
   CLICKHOUSE_VOLUME_USAGE_LIMIT_PERCENT,
   CLICKHOUSE_SERVICE_NAME,
+  CANONICAL_WEB_ORIGIN,
   OTA_SERVICE_NAME,
   PLACEHOLDER_PATTERN,
+  WEB_SERVICE_NAME,
   desiredRailwayState,
 } from '../infra/railway/config';
 import {
@@ -35,13 +37,33 @@ import {
 
 const NO_SUPPLIED = { suppliedVars: new Set<string>() };
 
+const WEB_SYNC_VARIABLES = {
+  SMTP_USER: 'mailer@boardsesh.com',
+  SMTP_PASSWORD: 'test-password',
+  BOARDSESH_WEB: '1',
+  BASE_URL: CANONICAL_WEB_ORIGIN,
+};
+
+function withWebSyncVariables(variables: Record<string, string>): Record<string, string> {
+  return { ...WEB_SYNC_VARIABLES, ...variables };
+}
+
 function liveState(overrides: Partial<LiveState> = {}): LiveState {
   return {
     services: [
       { id: 'svc-ota', name: OTA_SERVICE_NAME },
       { id: 'svc-ch', name: CLICKHOUSE_SERVICE_NAME },
+      { id: 'svc-web', name: WEB_SERVICE_NAME },
     ],
-    variables: { [OTA_SERVICE_NAME]: { CLICKHOUSE_URL: 'clickhouse://u:p@host:9000/expo_observe' } },
+    variables: {
+      [OTA_SERVICE_NAME]: { CLICKHOUSE_URL: 'clickhouse://u:p@host:9000/expo_observe' },
+      [WEB_SERVICE_NAME]: {
+        SMTP_USER: 'mailer@boardsesh.com',
+        SMTP_PASSWORD: 'test-password',
+        BOARDSESH_WEB: '1',
+        BASE_URL: CANONICAL_WEB_ORIGIN,
+      },
+    },
     // 853 MiB of 50 GiB — the real reading when the volume was provisioned.
     clickhouseVolume: { usedMb: 853, capacityMb: 50000 },
     clickhouseTtl: Object.fromEntries(
@@ -99,6 +121,9 @@ describe('diffService', () => {
 
 describe('diffServiceVars', () => {
   const otaService = desiredRailwayState.services[0];
+  const webService = desiredRailwayState.services.find((service) => service.name === WEB_SERVICE_NAME);
+
+  if (!webService) throw new Error('Expected the web service assertion.');
 
   it('is silent when the variable is set', () => {
     expect(diffServiceVars(otaService, liveState(), NO_SUPPLIED)).toEqual([]);
@@ -137,6 +162,78 @@ describe('diffServiceVars', () => {
     const [change] = diffServiceVars(otaService, live, NO_SUPPLIED);
     expect(JSON.stringify(change)).not.toContain('hunter2');
   });
+
+  it('reports missing web SMTP credentials', () => {
+    const live = liveState({
+      variables: {
+        ...liveState().variables,
+        [WEB_SERVICE_NAME]: { BOARDSESH_WEB: '1', BASE_URL: CANONICAL_WEB_ORIGIN },
+      },
+    });
+
+    const changes = diffServiceVars(webService, live, NO_SUPPLIED);
+    expect(changes.map((change) => change.summary)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('SMTP_USER is absent'),
+        expect.stringContaining('SMTP_PASSWORD is absent'),
+      ]),
+    );
+  });
+
+  it('allows an absent BOARDSESH_WEB override', () => {
+    const live = liveState({
+      variables: {
+        ...liveState().variables,
+        [WEB_SERVICE_NAME]: {
+          SMTP_USER: 'mailer@boardsesh.com',
+          SMTP_PASSWORD: 'test-password',
+          BASE_URL: CANONICAL_WEB_ORIGIN,
+        },
+      },
+    });
+
+    expect(diffServiceVars(webService, live, NO_SUPPLIED)).toEqual([]);
+  });
+
+  it('reports a non-one BOARDSESH_WEB override without printing it', () => {
+    const wrongValue = 'turn-off-the-auth-bridge';
+    const live = liveState({
+      variables: {
+        ...liveState().variables,
+        [WEB_SERVICE_NAME]: { ...liveState().variables[WEB_SERVICE_NAME], BOARDSESH_WEB: wrongValue },
+      },
+    });
+
+    const changes = diffServiceVars(webService, live, NO_SUPPLIED);
+    expect(JSON.stringify(changes)).not.toContain(wrongValue);
+    expect(changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ summary: expect.stringContaining('BOARDSESH_WEB must be absent or "1"') }),
+      ]),
+    );
+  });
+
+  it('requires a canonical NEXTAUTH_URL or BASE_URL without printing the live URL', () => {
+    const wrongValue = 'https://attacker.example';
+    const live = liveState({
+      variables: {
+        ...liveState().variables,
+        [WEB_SERVICE_NAME]: {
+          ...liveState().variables[WEB_SERVICE_NAME],
+          NEXTAUTH_URL: wrongValue,
+          BASE_URL: wrongValue,
+        },
+      },
+    });
+
+    const changes = diffServiceVars(webService, live, NO_SUPPLIED);
+    expect(JSON.stringify(changes)).not.toContain(wrongValue);
+    expect(changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ summary: expect.stringContaining('NEXTAUTH_URL or BASE_URL') }),
+      ]),
+    );
+  });
 });
 
 describe('diffTableRetention', () => {
@@ -172,7 +269,7 @@ describe('buildPlan', () => {
     const live = liveState({ services: [], variables: {} });
     const plan = buildPlan(desiredRailwayState, live, NO_SUPPLIED);
     expect(plan.filter((change) => change.resource === 'env-var')).toEqual([]);
-    expect(plan.filter((change) => change.resource === 'service')).toHaveLength(2);
+    expect(plan.filter((change) => change.resource === 'service')).toHaveLength(3);
   });
 
   it('reports missing TTLs', () => {
@@ -276,7 +373,7 @@ describe('main', () => {
       }
 
       const data = body.query.includes('variables(')
-        ? { variables }
+        ? { variables: withWebSyncVariables(variables) }
         : {
             project: {
               name: 'boardsesh-ota',
@@ -285,6 +382,7 @@ describe('main', () => {
                 edges: [
                   { node: { id: 'svc-ota', name: OTA_SERVICE_NAME } },
                   { node: { id: 'svc-ch', name: CLICKHOUSE_SERVICE_NAME } },
+                  { node: { id: 'svc-web', name: WEB_SERVICE_NAME } },
                 ],
               },
             },
@@ -416,6 +514,7 @@ describe('Railway authentication', () => {
         edges: [
           { node: { id: 'svc-ota', name: OTA_SERVICE_NAME } },
           { node: { id: 'svc-ch', name: CLICKHOUSE_SERVICE_NAME } },
+          { node: { id: 'svc-web', name: WEB_SERVICE_NAME } },
         ],
       },
     },
@@ -472,7 +571,7 @@ describe('Railway authentication', () => {
       const data = query.includes('volumes {')
         ? VOLUMES_DATA
         : query.includes('variables(')
-          ? { variables: { CLICKHOUSE_URL: 'clickhouse://x/y' } }
+          ? { variables: withWebSyncVariables({ CLICKHOUSE_URL: 'clickhouse://x/y' }) }
           : PROJECT_DATA;
       return new Response(JSON.stringify({ data }), { status: 200 });
     }) as typeof globalThis.fetch;
@@ -716,7 +815,7 @@ describe('apply mode', () => {
         );
       }
       if (body.query.includes('variables(')) {
-        return new Response(JSON.stringify({ data: { variables } }), { status: 200 });
+        return new Response(JSON.stringify({ data: { variables: withWebSyncVariables(variables) } }), { status: 200 });
       }
       return new Response(
         JSON.stringify({
@@ -728,6 +827,7 @@ describe('apply mode', () => {
                 edges: [
                   { node: { id: 'svc-ota', name: OTA_SERVICE_NAME } },
                   { node: { id: 'svc-ch', name: CLICKHOUSE_SERVICE_NAME } },
+                  { node: { id: 'svc-web', name: WEB_SERVICE_NAME } },
                 ],
               },
             },

--- a/scripts/railway-apply.ts
+++ b/scripts/railway-apply.ts
@@ -11,10 +11,10 @@
  *     service is missing. Services are NEVER created or deleted by this tool — see
  *     CREATION_IS_NOT_AUTOMATED in infra/railway/config.ts for why.
  *   - Variables: asserts the declared variables are set and are not still an
- *     unfilled `<placeholder>`. A variable is only WRITTEN when the caller supplies
- *     its value as `RAILWAY_VAR_<NAME>` in this process's own environment; without
- *     one, drift is reported and left alone. A value that is already set is never
- *     overwritten.
+ *     unfilled `<placeholder>`, plus any public value constraints. A variable is
+ *     only WRITTEN when the caller supplies its value as `RAILWAY_VAR_<NAME>` in
+ *     this process's own environment; without one, drift is reported and left
+ *     alone. A value that is already set is never overwritten.
  *   - ClickHouse retention: asserts the TTLs on xprem's Observe tables. Skipped
  *     (not failed) when no CLICKHOUSE_URL is available to this process, matching how
  *     scripts/mobile-ota-health-check.ts skips without a PostHog key.
@@ -265,8 +265,9 @@ async function fetchProject(token: string, projectId: string, environmentName: s
 /**
  * Read the variables for every service we declare.
  *
- * Only declared services are queried: this tool has no reason to pull the secrets
- * of the Postgres service or anything else sharing the project.
+ * Only declared services with variable assertions are queried: this tool has no
+ * reason to pull the secrets of the Postgres service or anything else sharing the
+ * project.
  */
 async function fetchVariables(
   token: string,
@@ -279,7 +280,11 @@ async function fetchVariables(
 
   for (const declared of desired.services) {
     const live = services.find((service) => service.name === declared.name);
-    if (!live || declared.requiredVars.length === 0) continue;
+    const hasVariableAssertions =
+      declared.requiredVars.length > 0 ||
+      (declared.optionalConstrainedVars?.length ?? 0) > 0 ||
+      (declared.requiredOneOfVars?.length ?? 0) > 0;
+    if (!live || !hasVariableAssertions) continue;
     const data = await railwayRequest<{ variables: Record<string, string> }>(token, VARIABLES_QUERY, {
       projectId,
       environmentId,


### PR DESCRIPTION
## Summary

Closes #5289.

Restores the `boardsesh-web` SMTP credentials from the Boardsesh 1Password vault and redeploys the live service. The Railway drift check now asserts those credentials, protects the web auth-origin settings, and never reports live values. Registration and resend-verification email failures now reach Sentry.

Validation: targeted auth and Railway tests pass (80 tests); `vp check`, web typecheck/build, and Railway-script typecheck pass. The full workspace typecheck was attempted but unrelated parallel tasks were killed locally with exit 137 under memory pressure.

## Release Notes

- Get password-reset and verification emails when you need them.

## Test plan

1. Open Forgot password and submit a credential-account email.
2. Open reset link, choose password, then sign in.
3. Create credential account and receive verification email.
4. Resend verification and receive a fresh email.

## Risk

Risk: 4/5 — production auth-email configuration and recovery flows.
