### PR TITLE
fix(db): recover postgres connections after transaction disconnects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1148,7 +1148,22 @@ jobs:
         run: |
           mkdir -p packages/backend/test-results
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            vp test run --project backend --changed "origin/$BASE_REF" \
+            # A change to the dependency graph itself has no module-graph edge
+            # to any spec, so `--changed` selects nothing that exercises it.
+            # #5299 patched the postgres driver every backend test runs
+            # against and this job still picked only the one new spec --
+            # ~4,500 tests never touched the patched driver. Drop the filter
+            # when the install inputs move. A shallow fetch can leave no merge
+            # base; `|| true` then keeps today's filtered behaviour.
+            selection="--changed origin/$BASE_REF"
+            changed_files=$(git diff --name-only "origin/$BASE_REF"...HEAD || true)
+            if printf '%s\n' "$changed_files" |
+              grep -qE '^(pnpm-workspace\.yaml|pnpm-lock\.yaml|patches/|packages/[^/]+/patches/)'; then
+              echo "::notice title=Full backend suite::install inputs changed; running the whole backend project, not --changed"
+              selection=""
+            fi
+            # shellcheck disable=SC2086 # $selection is an intentionally split flag pair
+            vp test run --project backend $selection \
               --shard=${{ matrix.shard }}/${{ matrix.total }} \
               --reporter=verbose --reporter=github-actions \
               --reporter=junit --outputFile.junit=./packages/backend/test-results/junit-backend-${{ matrix.shard }}.xml

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -25,6 +25,7 @@ COPY manifests/package.json manifests/pnpm-lock.yaml manifests/pnpm-workspace.ya
 # Patch files referenced by pnpm-workspace.yaml must be present before the
 # fetch: pnpm resolves patch hashes from the lockfile and needs the files.
 COPY manifests/patches ./patches
+COPY manifests/packages/db/patches ./packages/db/patches
 
 # --- the NETWORK layer -------------------------------------------------------
 # `pnpm fetch` populates the store from the LOCKFILE ALONE, so this layer's

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -348,11 +348,16 @@ WORKDIR /ci-seed/manifests
 # lockfile is unchanged (measured: the manifest changed on 88 of the last 180
 # days). Do not add a `source/` COPY here to "match" the other Dockerfiles --
 # a job brings its own source via `actions/checkout`.
+#
+# `manifests/packages` lands BEFORE the fetch here (the sibling Dockerfiles put
+# it after, to keep their fetch layer keyed on the lockfile alone), so it
+# already carries the patch files a patchedDependencies entry points at inside
+# a workspace package -- e.g. packages/db/patches/postgres@3.4.9.patch. No
+# extra COPY for those; only the root `patches/` needs its own line.
 COPY --chown=runner:runner \
      manifests/package.json manifests/pnpm-lock.yaml manifests/pnpm-workspace.yaml ./
 COPY --chown=runner:runner manifests/packages ./packages
 COPY --chown=runner:runner manifests/patches ./patches
-COPY --chown=runner:runner manifests/packages/db/patches ./packages/db/patches
 
 # `pnpm fetch` (not a full install) populates the content-addressable store
 # from the lockfile alone, without needing a real workspace checkout --

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -352,6 +352,7 @@ COPY --chown=runner:runner \
      manifests/package.json manifests/pnpm-lock.yaml manifests/pnpm-workspace.yaml ./
 COPY --chown=runner:runner manifests/packages ./packages
 COPY --chown=runner:runner manifests/patches ./patches
+COPY --chown=runner:runner manifests/packages/db/patches ./packages/db/patches
 
 # `pnpm fetch` (not a full install) populates the content-addressable store
 # from the lockfile alone, without needing a real workspace checkout --

--- a/Dockerfile.sync
+++ b/Dockerfile.sync
@@ -32,6 +32,7 @@ COPY manifests/package.json manifests/pnpm-lock.yaml manifests/pnpm-workspace.ya
 # Patch files referenced by pnpm-workspace.yaml must be present before the
 # fetch: pnpm resolves patch hashes from the lockfile and needs the files.
 COPY manifests/patches ./patches
+COPY manifests/packages/db/patches ./packages/db/patches
 
 # --- the NETWORK layer -------------------------------------------------------
 # `pnpm fetch` populates the store from the LOCKFILE ALONE, so this layer's

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -27,6 +27,7 @@ COPY manifests/package.json manifests/pnpm-lock.yaml manifests/pnpm-workspace.ya
 # Patch files referenced by pnpm-workspace.yaml must be present before the
 # fetch: pnpm resolves patch hashes from the lockfile and needs the files.
 COPY manifests/patches ./patches
+COPY manifests/packages/db/patches ./packages/db/patches
 
 # --- the NETWORK layer -------------------------------------------------------
 # `pnpm fetch` populates the store from the LOCKFILE ALONE, so this layer's

--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -57,8 +57,10 @@ The workspace patches and pins `postgres@3.4.9` until an upstream release passes
 the backend disconnect/recovery regressions. Both Node entry points (ESM and
 CommonJS) receive the patch. It lives in `packages/db/patches`, outside the root
 `patches` directory that mobile hashes into its native runtime fingerprint.
-The backend, web, sync, and CI Dockerfiles copy it before fetching dependencies;
-the deployment-input guard checks every configured patch directory.
+The backend, web, and sync Dockerfiles copy it before fetching dependencies;
+the deployment-input guard checks every configured patch directory. `Dockerfile.ci`
+needs no extra line — it copies all of `manifests/packages` before `pnpm fetch`,
+so a patch stored inside a workspace package rides along.
 
 A socket closing during a transaction can reject its query, then trigger the
 driver's automatic rollback after `closed()` has nulled the socket. That small

--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -51,6 +51,45 @@ about which statements "look idempotent".
   Wrapping a sequence would re-run the earlier statements when a later one
   fails to connect.
 
+## Socket disconnects and transaction cleanup (#5299)
+
+The workspace patches and pins `postgres@3.4.9` until an upstream release passes
+the backend disconnect/recovery regressions. Both Node entry points (ESM and
+CommonJS) receive the patch. It lives in `packages/db/patches`, outside the root
+`patches` directory that mobile hashes into its native runtime fingerprint.
+The backend, web, sync, and CI Dockerfiles copy it before fetching dependencies;
+the deployment-input guard checks every configured patch directory.
+
+A socket closing during a transaction can reject its query, then trigger the
+driver's automatic rollback after `closed()` has nulled the socket. That small
+write schedules `nextWrite` on the immediate queue, where the null dereference
+escapes the query promise and kills the backend. No application Postgres
+`onclose` hook is involved in the reproduced path.
+
+[Upstream PR #1168](https://github.com/porsager/postgres/pull/1168) guards that
+write. The guard alone prevented the crash in our reproduction but left a
+rollback in the connection's query state, hanging subsequent pool queries.
+Our patch also records failure for the transaction's lifetime, rejects its
+queued and later statements (including automatic rollback/commit), and clears
+the write buffer and immediate handle on close/termination. Closing also clears
+the failed connection's result/error state so a server FATAL response cannot
+reject the first query on a replacement socket. A transaction
+callback resuming after pool reconnection still fails against its original
+transaction; it cannot write through the replacement connection.
+
+The existing connect retry policy is unchanged. An interrupted transaction
+fails; its statements are never replayed. Ordinary application errors still
+roll back normally, including savepoints. Sentry retains its normal fatal-error
+handling; there is no process-level exception suppression.
+
+`postgres-disconnect.test.ts` runs isolated Node processes against both installed
+entry points, using controlled socket closes and termination of the test's own
+live PostgreSQL connection. It checks query settlement, repeated pool reuse,
+fresh transactions, delayed callbacks, and startup write-timer recovery. Keep
+these tests when upgrading; remove the override and patch only when the new
+release passes them. After deployment, check BOARDSESH-GH and replica restarts,
+and confirm `/health/db` recovers after database availability returns.
+
 ## Budgets
 
 Defaults, both overridable by env:

--- a/packages/backend/src/__tests__/helpers/postgres-disconnect-process.ts
+++ b/packages/backend/src/__tests__/helpers/postgres-disconnect-process.ts
@@ -1,0 +1,227 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { Duplex } from 'node:stream';
+import type postgresTypes from 'postgres';
+
+// Run in a child process: the original bug throws on the immediate queue,
+// outside the query promise. A parent timeout also detects a silently wedged pool.
+const [entryPoint, scenario] = process.argv.slice(2);
+const postgres: typeof postgresTypes =
+  entryPoint === 'cjs' ? createRequire(import.meta.url)('postgres') : (await import('postgres')).default;
+
+function frame(type: string, payload = Buffer.alloc(0)): Buffer {
+  const header = Buffer.alloc(5);
+  header.write(type);
+  header.writeInt32BE(payload.length + 4, 1);
+  return Buffer.concat([header, payload]);
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+async function simulatedDisconnect(): Promise<void> {
+  const statements: { socket: number; statement: string }[] = [];
+  const sockets: DatabaseSocket[] = [];
+  const failedStatementsSettled = deferred();
+  const resumeTransaction = deferred();
+  const delayedStatementSettled = deferred();
+  let didDisconnect = false;
+
+  class DatabaseSocket extends Duplex {
+    readonly socketNumber = sockets.length + 1;
+    private started = false;
+    private closing = false;
+    private parsedStatement = '';
+    private transactionState = 'I';
+
+    constructor() {
+      super();
+      sockets.push(this);
+      // This immediate precedes the driver's buffered startup write. Closing
+      // must reset its timer as well as cancel it, or reconnect never flushes.
+      if (scenario === 'startup' && this.socketNumber === 1) setImmediate(() => this.destroy());
+    }
+
+    override _read(): void {}
+
+    private respond(frames: Buffer[]): void {
+      setImmediate(() => {
+        if (!this.destroyed && !this.closing) this.push(Buffer.concat(frames));
+      });
+    }
+
+    private ready(): Buffer {
+      return frame('Z', Buffer.from(this.transactionState));
+    }
+
+    private executeStatement(statement: string): Buffer[] {
+      statements.push({ socket: this.socketNumber, statement });
+      if (statement === 'select disconnect' && !didDisconnect) {
+        didDisconnect = this.closing = true;
+        if (scenario === 'fatal') {
+          this.push(frame('E', Buffer.from('SFATAL\0C57P01\0Mterminating connection\0\0')));
+        }
+        setImmediate(() =>
+          this.destroy(
+            scenario === 'error' ? Object.assign(new Error('socket reset'), { code: 'ECONNRESET' }) : undefined,
+          ),
+        );
+        return [];
+      }
+      if (statement.startsWith('begin')) this.transactionState = 'T';
+      if (statement === 'commit' || statement === 'rollback') this.transactionState = 'I';
+      const command = statement.startsWith('select') ? 'SELECT 1' : statement.trim().toUpperCase();
+      return [frame('C', Buffer.from(`${command}\0`))];
+    }
+
+    override _write(bytes: Buffer, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+      if (!this.started) {
+        this.started = true;
+        this.respond([this.ready()]);
+        callback();
+        return;
+      }
+      const responses: Buffer[] = [];
+      // A batch may contain several complete simple/extended protocol frames.
+      for (let offset = 0; offset < bytes.length && !this.closing;) {
+        const type = String.fromCharCode(bytes[offset]);
+        const size = bytes.readInt32BE(offset + 1);
+        const payload = bytes.subarray(offset + 5, offset + size + 1);
+        offset += size + 1;
+        if (type === 'Q') {
+          responses.push(...this.executeStatement(payload.toString('utf8', 0, payload.length - 1)), this.ready());
+        } else if (type === 'P') {
+          const nameEnd = payload.indexOf(0);
+          this.parsedStatement = payload.toString('utf8', nameEnd + 1, payload.indexOf(0, nameEnd + 1));
+          responses.push(frame('1'));
+        } else if (type === 'D') {
+          responses.push(frame('n'));
+        } else if (type === 'B') {
+          responses.push(frame('2'));
+        } else if (type === 'E') {
+          responses.push(...this.executeStatement(this.parsedStatement));
+        } else if (type === 'S') {
+          responses.push(this.ready());
+        } else if (type === 'X') {
+          this.destroy();
+        } else {
+          assert.fail(`Unexpected protocol frame: ${type}`);
+        }
+      }
+      if (responses.length) this.respond(responses);
+      callback();
+    }
+  }
+
+  // These two driver-supported test controls are absent from its public types.
+  const poolOptions = {
+    max: 1,
+    max_pipeline: 1,
+    fetch_types: false,
+    prepare: false,
+    idle_timeout: 0,
+    max_lifetime: 0,
+    backoff: () => 0,
+    socket: () => new DatabaseSocket(),
+  };
+  const pool = postgres('postgres://test:test@localhost/test', poolOptions);
+  try {
+    if (scenario === 'startup') {
+      await pool.unsafe('select startup_recovered');
+      assert.equal(sockets.length, 2);
+      assert.equal(statements.filter(({ statement }) => statement === 'select startup_recovered').length, 1);
+    } else {
+      const transaction = pool.begin(async (sql) => {
+        const outcomes = await Promise.allSettled([
+          sql.unsafe('select disconnect'),
+          sql.unsafe('select pipelined'),
+          sql.unsafe('select queued'),
+        ]);
+        assert.ok(outcomes.every((outcome) => outcome.status === 'rejected'));
+        failedStatementsSettled.resolve();
+        if (scenario === 'delayed') {
+          await resumeTransaction.promise;
+          await assert.rejects(sql.unsafe('select stale_transaction'), { code: 'CONNECTION_CLOSED' });
+          delayedStatementSettled.resolve();
+        } else {
+          throw new Error('transaction must roll back');
+        }
+      });
+      await assert.rejects(transaction, { code: 'CONNECTION_CLOSED' });
+      await failedStatementsSettled.promise;
+      // Let automatic rollback and its deferred write run before recovery.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    for (let index = 0; index < 3; index++) await pool.unsafe(`select recovered_${index}`);
+    if (scenario === 'delayed') {
+      resumeTransaction.resolve();
+      await delayedStatementSettled.promise;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    await pool.begin(async (sql) => {
+      await sql.unsafe('select fresh_transaction');
+    });
+    assert.ok(statements.some(({ statement }) => statement === 'commit'));
+    assert.ok(
+      !statements.some(({ socket, statement }) => socket > 1 && /disconnect|pipelined|queued|stale/.test(statement)),
+    );
+    if (scenario !== 'startup') assert.ok(!statements.some(({ statement }) => statement === 'rollback'));
+    for (let index = 0; index < 3; index++) {
+      assert.equal(statements.filter(({ statement }) => statement === `select recovered_${index}`).length, 1);
+    }
+  } finally {
+    resumeTransaction.resolve();
+    await pool.end({ timeout: 0 });
+    for (const socket of sockets) socket.destroy();
+  }
+}
+
+async function realDisconnect(): Promise<void> {
+  const pool = postgres(process.env.DATABASE_URL!, { max: 1, prepare: false, backoff: () => 0 });
+  const admin = postgres(process.env.DATABASE_URL!, { max: 1, prepare: false });
+  try {
+    await assert.rejects(
+      pool.begin(async (sql) => {
+        const [{ pid }] = await sql<{ pid: number }[]>`select pg_backend_pid() as pid`;
+        // Only terminate this test's connection, never the database service.
+        await admin`select pg_terminate_backend(${pid})`;
+        await sql`select 1`;
+      }),
+    );
+    for (let index = 0; index < 3; index++) {
+      assert.equal((await pool`select 42 as answer`)[0].answer, 42);
+    }
+    await pool.begin(async (sql) => {
+      assert.equal((await sql`select 43 as answer`)[0].answer, 43);
+      await assert.rejects(
+        sql.savepoint(async (savepoint) => {
+          await savepoint`select 1`;
+          throw new Error('savepoint rollback');
+        }),
+        /savepoint rollback/,
+      );
+      assert.equal((await sql`select 44 as answer`)[0].answer, 44);
+    });
+    await assert.rejects(
+      pool.begin(async (sql) => {
+        await sql`select 1`;
+        throw new Error('ordinary rollback');
+      }),
+      /ordinary rollback/,
+    );
+    assert.equal((await pool`select 45 as answer`)[0].answer, 45);
+  } finally {
+    await pool.end({ timeout: 0 });
+    await admin.end({ timeout: 0 });
+  }
+}
+
+if (scenario === 'live') await realDisconnect();
+else await simulatedDisconnect();
+process.stdout.write('disconnect recovery verified\n');

--- a/packages/backend/src/__tests__/postgres-disconnect.test.ts
+++ b/packages/backend/src/__tests__/postgres-disconnect.test.ts
@@ -1,0 +1,27 @@
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vite-plus/test';
+import { getWorkerDatabaseUrl } from './worker-db';
+
+const executeFile = promisify(execFile);
+const fixturePath = fileURLToPath(new URL('./helpers/postgres-disconnect-process.ts', import.meta.url));
+
+describe.each(['esm', 'cjs'])('postgres disconnect recovery (%s)', (entryPoint) => {
+  it.each(['clean', 'error', 'fatal', 'startup', 'delayed', 'live'])(
+    'survives %s disconnects and reuses the pool without replaying statements',
+    async (scenario) => {
+      const { stdout, stderr } = await executeFile(
+        process.execPath,
+        ['--import', 'tsx', fixturePath, entryPoint, scenario],
+        {
+          env: { ...process.env, DATABASE_URL: getWorkerDatabaseUrl() },
+          timeout: 15_000,
+        },
+      );
+      expect(stdout).toContain('disconnect recovery verified');
+      expect(stderr).toBe('');
+    },
+    20_000,
+  );
+});

--- a/packages/backend/src/__tests__/postgres-disconnect.test.ts
+++ b/packages/backend/src/__tests__/postgres-disconnect.test.ts
@@ -20,7 +20,14 @@ describe.each(['esm', 'cjs'])('postgres disconnect recovery (%s)', (entryPoint) 
         },
       );
       expect(stdout).toContain('disconnect recovery verified');
-      expect(stderr).toBe('');
+      // Name the #5299 crash rather than demanding an empty stderr, which any
+      // future Node or tsx deprecation warning would break. Against the stock
+      // 3.4.9 driver the `live` scenario prints exactly this, thrown from
+      // `process.processImmediate` where no query promise can catch it; the
+      // simulated scenarios instead wedge the pool, which `executeFile` already
+      // surfaces as a non-zero exit before these assertions run.
+      expect(stderr).not.toContain("Cannot read properties of null (reading 'write')");
+      expect(stderr).not.toMatch(/\bTypeError\b/);
     },
     20_000,
   );

--- a/packages/db/patches/postgres@3.4.9.patch
+++ b/packages/db/patches/postgres@3.4.9.patch
@@ -1,0 +1,144 @@
+--- a/src/connection.js
++++ b/src/connection.js
+@@ -252,7 +252,7 @@
+   }
+ 
+   function nextWrite(fn) {
+-    const x = socket.write(chunk, fn)
++    const x = socket && chunk && socket.write(chunk, fn)
+     nextWriteTimer !== null && clearImmediate(nextWriteTimer)
+     chunk = nextWriteTimer = null
+     return x
+@@ -425,6 +425,7 @@
+       error(Errors.connection('CONNECTION_DESTROYED', options))
+ 
+     clearImmediate(nextWriteTimer)
++    chunk = nextWriteTimer = null
+     if (socket) {
+       socket.removeListener('data', data)
+       socket.removeListener('connect', connected)
+@@ -438,6 +439,7 @@
+     remaining = 0
+     incomings = null
+     clearImmediate(nextWriteTimer)
++    chunk = nextWriteTimer = null
+     socket.removeListener('data', data)
+     socket.removeListener('connect', connected)
+     idleTimer.cancel()
+@@ -451,6 +453,9 @@
+       return reconnect()
+ 
+     !hadError && (query || sent.length) && error(Errors.connection('CONNECTION_CLOSED', options, socket))
++    // A replacement socket must not inherit a failed result or fatal error.
++    query = results = errorResponse = null
++    result = new Result()
+     closedTime = performance.now()
+     hadError && options.shared.retries++
+     delay = (typeof backoff === 'function' ? backoff(options.shared.retries) : backoff) * 1000
+--- a/src/index.js
++++ b/src/index.js
+@@ -236,13 +236,21 @@
+     const queries = Queue()
+     let savepoints = 0
+       , connection
++      , connectionError = null
+       , prepare = null
+ 
+     try {
+       await sql.unsafe('begin ' + options.replace(/[^a-z ]/ig, ''), [], { onexecute }).execute()
+       return await Promise.race([
+         scope(connection, fn),
+-        new Promise((_, reject) => connection.onclose = reject)
++        new Promise((_, reject) => connection.onclose = error => {
++          // A transaction cannot use this connection again, even after the
++          // pool reconnects it. Settle statements waiting in its own queue.
++          connectionError = error
++          while (queries.length)
++            queries.shift().reject(error)
++          reject(error)
++        })
+       ])
+     } catch (error) {
+       throw error
+@@ -290,6 +298,9 @@
+ 
+       function handler(q) {
+         q.catch(e => uncaughtError || (uncaughtError = e))
++        // Includes automatic rollback and callbacks resuming after close.
++        if (connectionError)
++          return q.reject(connectionError)
+         c.queue === full
+           ? queries.push(q)
+           : c.execute(q) || move(c, full)
+--- a/cjs/src/connection.js
++++ b/cjs/src/connection.js
+@@ -252,7 +252,7 @@
+   }
+ 
+   function nextWrite(fn) {
+-    const x = socket.write(chunk, fn)
++    const x = socket && chunk && socket.write(chunk, fn)
+     nextWriteTimer !== null && clearImmediate(nextWriteTimer)
+     chunk = nextWriteTimer = null
+     return x
+@@ -425,6 +425,7 @@
+       error(Errors.connection('CONNECTION_DESTROYED', options))
+ 
+     clearImmediate(nextWriteTimer)
++    chunk = nextWriteTimer = null
+     if (socket) {
+       socket.removeListener('data', data)
+       socket.removeListener('connect', connected)
+@@ -438,6 +439,7 @@
+     remaining = 0
+     incomings = null
+     clearImmediate(nextWriteTimer)
++    chunk = nextWriteTimer = null
+     socket.removeListener('data', data)
+     socket.removeListener('connect', connected)
+     idleTimer.cancel()
+@@ -451,6 +453,9 @@
+       return reconnect()
+ 
+     !hadError && (query || sent.length) && error(Errors.connection('CONNECTION_CLOSED', options, socket))
++    // A replacement socket must not inherit a failed result or fatal error.
++    query = results = errorResponse = null
++    result = new Result()
+     closedTime = performance.now()
+     hadError && options.shared.retries++
+     delay = (typeof backoff === 'function' ? backoff(options.shared.retries) : backoff) * 1000
+--- a/cjs/src/index.js
++++ b/cjs/src/index.js
+@@ -236,13 +236,21 @@
+     const queries = Queue()
+     let savepoints = 0
+       , connection
++      , connectionError = null
+       , prepare = null
+ 
+     try {
+       await sql.unsafe('begin ' + options.replace(/[^a-z ]/ig, ''), [], { onexecute }).execute()
+       return await Promise.race([
+         scope(connection, fn),
+-        new Promise((_, reject) => connection.onclose = reject)
++        new Promise((_, reject) => connection.onclose = error => {
++          // A transaction cannot use this connection again, even after the
++          // pool reconnects it. Settle statements waiting in its own queue.
++          connectionError = error
++          while (queries.length)
++            queries.shift().reject(error)
++          reject(error)
++        })
+       ])
+     } catch (error) {
+       throw error
+@@ -290,6 +298,9 @@
+ 
+       function handler(q) {
+         q.catch(e => uncaughtError || (uncaughtError = e))
++        // Includes automatic rollback and callbacks resuming after close.
++        if (connectionError)
++          return q.reject(connectionError)
+         c.queue === full
+           ? queries.push(q)
+           : c.execute(q) || move(c, full)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  postgres: 3.4.9
   react-native-screens: 4.26.2
 
 patchedDependencies:
@@ -13,6 +14,7 @@ patchedDependencies:
   expo-dev-launcher@57.0.16: ba11bf1ad99f2bed1d9c959e8e68d1fe44e76bed157286850cde1dd5fc342d56
   expo-image@57.0.3: 68cfa579530a19eff0353bb5b9c0ea543980992877a93a69d832471f6ef91f60
   expo-updates@57.0.19: 67f24f95aa789e95b632312352bca97ddc9fd5264328d4c85a8fcc929f96f50a
+  postgres@3.4.9: cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8
   react-native-ble-plx@3.5.1: 243c7040f835074cd999a8719675046d66acf9fe2e88948c40d11d8133f181c4
   react-native-screens@4.26.2: 6b77eaedcf3b2210551b4099df209748d8135cff58ee4d89c3b20d8e6d2cf246
 
@@ -73,8 +75,8 @@ importers:
         specifier: ~7.0.2001
         version: 7.0.2001
       postgres:
-        specifier: ^3.4.9
-        version: 3.4.9
+        specifier: 3.4.9
+        version: 3.4.9(patch_hash=cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8)
       semver:
         specifier: ^7.8.5
         version: 7.8.5
@@ -140,10 +142,10 @@ importers:
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9(patch_hash=cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8))
       postgres:
-        specifier: ^3.4.9
-        version: 3.4.9
+        specifier: 3.4.9
+        version: 3.4.9(patch_hash=cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8)
       tsx:
         specifier: ^4.23.1
         version: 4.23.12
@@ -258,7 +260,7 @@ importers:
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9(patch_hash=cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8))
       graphql:
         specifier: ^16.14.2
         version: 16.14.2
@@ -330,8 +332,8 @@ importers:
         specifier: ^0.31.10
         version: 0.31.10
       postgres:
-        specifier: ^3.4.9
-        version: 3.4.9
+        specifier: 3.4.9
+        version: 3.4.9(patch_hash=cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8)
       typescript:
         specifier: ~7.0.2
         version: 7.0.2
@@ -391,13 +393,13 @@ importers:
         version: link:../sync-runtime
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9(patch_hash=cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8))
       next-auth:
         specifier: ^4.24.15
         version: 4.24.15(next@16.3.2(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(nodemailer@9.0.5)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       postgres:
-        specifier: ^3.4.9
-        version: 3.4.9
+        specifier: 3.4.9
+        version: 3.4.9(patch_hash=cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8)
       uuid:
         specifier: ^14.0.1
         version: 14.0.2
@@ -452,13 +454,13 @@ importers:
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9(patch_hash=cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8))
       jose:
         specifier: ^6.2.6
         version: 6.2.10
       postgres:
-        specifier: ^3.4.9
-        version: 3.4.9
+        specifier: 3.4.9
+        version: 3.4.9(patch_hash=cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8)
       tsx:
         specifier: ^4.23.1
         version: 4.23.12
@@ -486,7 +488,7 @@ importers:
         version: link:../shared-schema
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9(patch_hash=cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8))
     devDependencies:
       '@types/node':
         specifier: ^25.9.5
@@ -883,7 +885,7 @@ importers:
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9(patch_hash=cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8))
     devDependencies:
       '@types/node':
         specifier: ^25.9.5
@@ -1701,7 +1703,7 @@ importers:
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9(patch_hash=cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8))
       emoji-mart:
         specifier: ^5.6.0
         version: 5.6.0
@@ -7471,7 +7473,7 @@ packages:
       kysely: '*'
       mysql2: '>=2'
       pg: '>=8'
-      postgres: '>=3'
+      postgres: 3.4.9
       prisma: '*'
       sql.js: '>=1'
       sqlite3: '>=5'
@@ -18129,13 +18131,13 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.23.12
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(expo-sqlite@57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8))(pg@8.23.0)(postgres@3.4.9(patch_hash=cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8)):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.23.1
       expo-sqlite: 57.0.2(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
       pg: 8.23.0
-      postgres: 3.4.9
+      postgres: 3.4.9(patch_hash=cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8)
 
   dset@3.1.4: {}
 
@@ -20774,7 +20776,7 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
-  postgres@3.4.9: {}
+  postgres@3.4.9(patch_hash=cc5ffa34588bf5dddc62453336cff1d96554d55969995042e368f24147ff75c8): {}
 
   posthog-js-lite@4.10.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,9 +41,12 @@ enableGlobalVirtualStore: false
 virtualStoreDirMaxLength: 120
 
 overrides:
+  # Remove only when an upstream release passes the disconnect/recovery tests (#5299).
+  postgres: 3.4.9
   react-native-screens: 4.26.2
 
 patchedDependencies:
+  'postgres@3.4.9': packages/db/patches/postgres@3.4.9.patch
   'react-native-ble-plx@3.5.1': patches/react-native-ble-plx@3.5.1.patch
   '@expo/fingerprint@0.20.11': patches/@expo__fingerprint@0.20.11.patch
   '@expo/ui@57.0.14': patches/@expo__ui@57.0.14.patch

--- a/scripts/__tests__/mobile-patches-check.test.ts
+++ b/scripts/__tests__/mobile-patches-check.test.ts
@@ -864,6 +864,48 @@ describe('checkPatchInventory', () => {
     expect(errors[0]).toContain('4.25.2');
   });
 
+  const serverKey = 'postgres@3.4.9';
+  const serverPath = 'packages/db/patches/postgres@3.4.9.patch';
+
+  it('accepts the explicitly registered server patch outside native fingerprint inputs', () => {
+    expect(
+      checkPatchInventory({
+        ...base,
+        patchedDependencies: { ...base.patchedDependencies, [serverKey]: serverPath },
+        serverPatchPaths: [serverPath],
+      }),
+    ).toEqual([]);
+  });
+
+  it('rejects a missing server patch', () => {
+    expect(
+      checkPatchInventory({
+        ...base,
+        patchedDependencies: { ...base.patchedDependencies, [serverKey]: serverPath },
+      }),
+    ).toEqual([expect.stringContaining('server patch ' + serverPath + ' is missing')]);
+  });
+
+  it('rejects moving a server patch into native fingerprint inputs', () => {
+    expect(
+      checkPatchInventory({
+        ...base,
+        patchedDependencies: { ...base.patchedDependencies, [serverKey]: `patches/${serverKey}.patch` },
+        patchFilenames: [...base.patchFilenames, `${serverKey}.patch`],
+      }),
+    ).toEqual([expect.stringContaining('server patch must stay at'), expect.stringContaining('orphaned')]);
+  });
+
+  it('rejects moving a native patch outside the fingerprinted directory', () => {
+    expect(
+      checkPatchInventory({
+        ...base,
+        patchedDependencies: { [TABS_KEY]: `packages/db/patches/${TABS_KEY}.patch` },
+        serverPatchPaths: [`packages/db/patches/${TABS_KEY}.patch`],
+      }),
+    ).toEqual([expect.stringContaining('not in patches/')]);
+  });
+
   it('fails when a newly patched package has no rule and no allowlist entry', () => {
     const errors = checkPatchInventory({
       ...base,

--- a/scripts/check-service-deploy-inputs.mjs
+++ b/scripts/check-service-deploy-inputs.mjs
@@ -104,9 +104,9 @@ function requireDockerContextFile(failures, repoRoot, dockerfilePath) {
 
   // patchedDependencies are resolved during install, so the patch files must be
   // copied into the install layer or `pnpm install --frozen-lockfile` fails.
-  if (Object.keys(getPatchedDependencies(repoRoot)).length > 0) {
-    requiredPreInstallCopies.push('COPY manifests/patches ./patches');
-  }
+  const patchDirectories = [...new Set(Object.values(getPatchedDependencies(repoRoot)).map(posix.dirname))];
+  const patchCopies = patchDirectories.map((directory) => `COPY manifests/${directory} ./${directory}`);
+  requiredPreInstallCopies.push(...patchCopies);
 
   for (const copyLine of requiredPreInstallCopies) {
     const copyIndex = indexOfInstruction(dockerfileContents, copyLine);
@@ -141,7 +141,7 @@ function requireDockerContextFile(failures, repoRoot, dockerfilePath) {
           'otherwise the fetch layer keys on all 49 workspace manifests and one version bump re-downloads everything',
       );
     }
-    for (const preFetchCopy of [manifestRootCopy, 'COPY manifests/patches ./patches']) {
+    for (const preFetchCopy of [manifestRootCopy, ...patchCopies]) {
       const preFetchIndex = indexOfInstruction(dockerfileContents, preFetchCopy);
       if (preFetchIndex !== -1 && preFetchIndex > fetchIndex) {
         failures.push(`${dockerfilePath}: ${preFetchCopy} must appear before \`pnpm fetch\``);
@@ -188,7 +188,10 @@ function requireDockerContextFile(failures, repoRoot, dockerfilePath) {
 function verifyGeneratedContext(failures, repoRoot, serviceName, outputRoot) {
   const outputDir = join(outputRoot, serviceName);
   const result = createServiceDockerContext({ serviceName, repoRoot, outputDir });
-  const expectedManifestPaths = getWorkspacePackageJsonPaths(repoRoot);
+  const expectedManifestPaths = [
+    ...getWorkspacePackageJsonPaths(repoRoot),
+    ...Object.values(getPatchedDependencies(repoRoot)).filter((patchPath) => patchPath.startsWith('packages/')),
+  ];
   const actualManifestPaths = listFiles(join(result.outputDir, 'manifests', 'packages')).map((filePath) =>
     posix.join('packages', filePath),
   );

--- a/scripts/check-service-deploy-inputs.test.mjs
+++ b/scripts/check-service-deploy-inputs.test.mjs
@@ -557,6 +557,35 @@ void test('rejects source package COPY instructions before pnpm install', () => 
   });
 });
 
+void test('copies server-only patches outside mobile fingerprint inputs before fetch', () => {
+  withFixtureRepo((repoRoot) => {
+    const patchPath = 'packages/db/patches/postgres@3.4.9.patch';
+    writeWorkspaceYaml(repoRoot, { patchedDependencies: { 'postgres@3.4.9': patchPath } });
+    writeFixtureFile(repoRoot, patchPath, 'diff\n');
+    const patchCopy = 'COPY manifests/packages/db/patches ./packages/db/patches';
+    assert.match(
+      createServiceDeployInputFailures({ repoRoot }).join('\n'),
+      /missing COPY manifests\/packages\/db\/patches/,
+    );
+
+    for (const dockerfile of ['Dockerfile.backend', 'Dockerfile.web', 'Dockerfile.sync']) {
+      writeFixtureFile(repoRoot, dockerfile, dockerfileLines([patchCopy]));
+    }
+    assert.deepEqual(createServiceDeployInputFailures({ repoRoot }), []);
+
+    // Copying all package manifests after fetch is too late for this patch.
+    writeFixtureFile(
+      repoRoot,
+      'Dockerfile.backend',
+      dockerfileLines().replace(
+        'COPY manifests/packages ./packages',
+        `${patchCopy}\nCOPY manifests/packages ./packages`,
+      ),
+    );
+    assert.match(createServiceDeployInputFailures({ repoRoot }).join('\n'), /patches must appear before `pnpm fetch`/);
+  });
+});
+
 void test('does not mistake a comment naming the install command for the install itself', () => {
   withFixtureRepo((repoRoot) => {
     writeWorkspaceYaml(repoRoot, { patchedDependencies: { 'left-pad@1.0.0': 'patches/left-pad@1.0.0.patch' } });

--- a/scripts/mobile-patches-check.ts
+++ b/scripts/mobile-patches-check.ts
@@ -52,7 +52,7 @@
  */
 
 import { createRequire } from 'node:module';
-import { readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { resolve, dirname, basename } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parse as parseYaml } from 'yaml';
@@ -307,6 +307,13 @@ export const UNGUARDED_PATCHES: Readonly<Record<string, string>> = {
     'dev-client-only — it never ships in a store binary.',
 };
 
+/** Server-only patches stay outside patches/, which is a native fingerprint input.
+ * Postgres is guarded by the backend's ESM/CJS disconnect regression tests.
+ */
+export const SERVER_PATCHES: Readonly<Record<string, string>> = {
+  'postgres@3.4.9': 'packages/db/patches/postgres@3.4.9.patch',
+};
+
 /**
  * Strip `//` line comments and block comments from Objective-C++ source.
  *
@@ -381,6 +388,8 @@ export interface PatchInventoryInput {
   patchedDependencies: Record<string, string>;
   /** Filenames present in patches/ (basenames, not paths). */
   patchFilenames: readonly string[];
+  /** Existing repo-relative server patch paths; only SERVER_PATCHES may use these. */
+  serverPatchPaths?: readonly string[];
   /** `patchedKey` of every entry in {@link RULES}. */
   guardedKeys: readonly string[];
   /** Keys deliberately left unguarded, mapped to the reason. */
@@ -402,9 +411,18 @@ export function checkPatchInventory(input: PatchInventoryInput): string[] {
   const guarded = new Set(input.guardedKeys);
 
   for (const [patchedKey, patchPath] of Object.entries(input.patchedDependencies)) {
+    if (Object.prototype.hasOwnProperty.call(SERVER_PATCHES, patchedKey)) {
+      const expectedPath = SERVER_PATCHES[patchedKey];
+      if (patchPath !== expectedPath) {
+        errors.push(`${patchedKey}: server patch must stay at ${expectedPath}, outside native fingerprint inputs.`);
+      } else if (!input.serverPatchPaths?.includes(patchPath)) {
+        errors.push(`${patchedKey}: server patch ${patchPath} is missing.`);
+      }
+      continue;
+    }
     const filename = basename(patchPath);
     referenced.add(filename);
-    if (!present.has(filename)) {
+    if (patchPath !== `patches/${filename}` || !present.has(filename)) {
       errors.push(
         `${patchedKey}: "patchedDependencies" points at ${patchPath}, but that file is not in patches/. ` +
           `pnpm cannot apply a patch it can't read — restore the file or drop the key.`,
@@ -609,6 +627,7 @@ export function main(): number {
   const inventoryErrors = checkPatchInventory({
     patchedDependencies,
     patchFilenames,
+    serverPatchPaths: Object.values(SERVER_PATCHES).filter((patchPath) => existsSync(resolve(repoRoot, patchPath))),
     guardedKeys: RULES.map((rule) => rule.patchedKey),
     allowUnguarded: UNGUARDED_PATCHES,
   });


### PR DESCRIPTION
## Summary

Closes #5299.

**The crash.** When a Postgres socket drops mid-transaction, postgres.js 3.4.9 rejects the in-flight query and then issues the transaction's automatic `rollback`. By then `closed()` has nulled `socket`, but the rollback's bytes sit in `chunk` and the flush is deferred to `nextWrite()` on the immediate queue, where `socket.write(chunk, fn)` dereferences null (`src/connection.js:254`). The `TypeError` is thrown from `process.processImmediate`, outside every query promise, so no application `catch` can reach it and the process exits. Three backend replicas died inside the same second on 2026-09-07.

**The fix** is `packages/db/patches/postgres@3.4.9.patch`, applied to both entry points the runtime can load (`src/` for ESM, `cjs/src/` for CommonJS):

- Guard the deferred write (upstream porsager/postgres#1168). On its own this stops the crash and leaves the pool wedged.
- Null `chunk` and `nextWriteTimer` in `terminate()` and `closed()`. `write()` only schedules a flush while `nextWriteTimer === null` (`connection.js:250`), so a timer handle surviving the close blocks every later write on the replacement socket. That is the wedge.
- Clear `query` / `results` / `errorResponse` and mint a fresh `Result` in `closed()`, placed after the `error(...)` call so pending rejections still fire. Without it a server FATAL belonging to the dead connection rejects the first query on the replacement socket.
- Latch `connectionError` in `index.js` so `scope()`'s catch cannot send `rollback` down a dead connection, and statements still queued on the failed transaction reject instead of hanging.

The pin (`overrides: postgres: 3.4.9`) and the patch come out together when an upstream release passes `postgres-disconnect.test.ts`. The patch lives under `packages/db/patches`, not the root `patches/`, because the root directory is hashed into the mobile native runtime fingerprint.

### The patch actually reproduces #5299

Reverting the four hunks inside `node_modules` and running the fixture directly, once per entry point and scenario:

| driver | `live` (real socket, `pg_terminate_backend`) | five simulated scenarios × ESM/CJS |
| --- | --- | --- |
| patched | `disconnect recovery verified` | 10 / 10 verified |
| stock 3.4.9 | CJS: `TypeError: Cannot read properties of null (reading 'write')` at `Immediate.nextWrite (cjs/src/connection.js:255:22)`, `at process.processImmediate`. ESM: uncaught `PostgresError: terminating connection due to administrator command` (57P01) | 0 / 10 verified — every run wedges (`unsettled top-level await`, exit 13) |

That CJS line is the Sentry signature from the issue, byte for byte.

`postgres-disconnect.test.ts:23` no longer asserts `stderr` is empty — any future Node or tsx deprecation warning would have broken it. It now asserts the crash is absent: no `TypeError`, and none of `Cannot read properties of null (reading 'write')`. The table above is what makes those assertions non-vacuous rather than decorative; the simulated scenarios fail earlier still, on `executeFile` rejecting the wedged child's non-zero exit.

### The coverage gap this PR started with

`test-backend` ran for 81 seconds on the previous revision. `ci.yml` filters that job with `vp test run --project backend --changed origin/$BASE_REF`, and neither `pnpm-workspace.yaml` nor a patch file has a module-graph edge to any spec — so the only backend file Vitest selected was the new test, and roughly 4,500 backend tests never executed against the patched driver. A driver patch is the one change where "run what the diff touches" means "run everything".

This revision drops the `--changed` filter when the install inputs move (`pnpm-workspace.yaml`, `pnpm-lock.yaml`, `patches/**`, `packages/*/patches/**`) — eight lines inside the existing step, no new job. The job already runs for those paths through the `rootCi` filter, and pnpm rewrites a patch's hash into `pnpm-lock.yaml` on every patch edit, so the gate cannot be dodged by touching a `.patch` alone. **This PR's own `test-backend` run is therefore the full backend project, and it is the authoritative number for the change.**

`Dockerfile.backend` / `.web` / `.sync` copy the new patch directory before `pnpm fetch`, and the deployment-input guard now derives the required `COPY` lines from every configured patch directory instead of hardcoding `patches/`. `Dockerfile.ci` no longer carries a line of its own: it copies all of `manifests/packages` before its fetch (the siblings deliberately copy it after, to keep the fetch layer keyed on the lockfile), so a patch inside a workspace package already rides along. Verified by generating the `ci` context and finding `manifests/packages/db/patches/postgres@3.4.9.patch` in it; `ci-image-workflow.test.ts` already pins that ordering.

### Evidence

**CI, this revision, full backend project:** `Test Files 323 passed (323)`, `Tests 4696 passed (4696)`, 301s. The job log carries the notice `install inputs changed; running the whole backend project, not --changed`, and the job went from 81s to 6m23s. Every backend test now demonstrably ran against the patched driver, and all of them pass.

`vp run test:db` (Node's runner, `packages/db`): **704 tests, 690 pass, 0 fail, 14 skipped**.

The full backend project was also run three times on the shared dev box; none of the three is a number worth quoting, and the CI run above supersedes them. The box sat at load average 38-141 on 18 cores and `/home` hit 100% mid-run:

- 18 workers: `Test Files 267 passed | 54 failed (321)`, `Tests 4135 passed | 37 failed | 485 skipped (4657)`.
- 8 workers: `Test Files 106 passed | 215 failed (321)`, `Tests 2147 passed | 27 failed | 2489 skipped (4663)`.

The failure set moved between runs and every suite-level failure was a `beforeAll` casualty in `src/__tests__/setup.ts` -- `Hook timed out in 60000ms`, `out of shared memory` on `TRUNCATE ... CASCADE`, `write CONNECT_TIMEOUT localhost:5433`, `deadlock detected`, `database boardsesh_backend_test_wN does not exist` -- across files unrelated to this diff. CI passing all 323 files, including every one of those, confirms the reading.

### The two socket-hangup failures the previous body left unnamed

Both live in `packages/backend/src/__tests__/graphql-resolvers.test.ts`:

1. **`GraphQL Resolver Input Validation > Angle Validation > should accept negative angle -5 (Aurora boards support negative tilt) without an angle error`** — resolves `climb(...)` at angle `-5` and asserts the query completes, i.e. that `-5` is not rejected as out of range.
2. **`GraphQL Resolver Input Validation > Search Climbs Validation > should accept valid pageSize`** — runs `searchClimbs` with `pageSize: 50` and asserts `searchClimbs` and `searchClimbs.hasMore` come back defined.

They are exactly the two of that file's nine tests that call the `execute()` helper. The other seven go through `expectError()`, whose `error:` handler calls `resolve()` — "connection errors are also acceptable" — so a dead socket passes them silently. That is why a whole-file transport failure surfaces as precisely two failures.

The cause is a fixed port, not the driver: the file binds `TEST_PORT = 8084`. On the dev box used here, ports 8081, 8082 and 8083 were held by Expo Metro dev servers that had been running 18–22 hours in three unrelated worktrees, and Expo claims the next free port in that range. `integration.test.ts` binds the fixed port 8082 and failed all 22 of its tests in every single run for the same reason. When 8084 happened to be free, `graphql-resolvers.test.ts` passed in full. Nothing in this diff touches the WebSocket transport, and CI ran that file green here as part of all 323 backend files. Both failures reproduce on any checkout — `main` included — whenever something else owns 8084; neither was reproduced against a separate `main` working tree, so that part is mechanism plus CI, not a side-by-side run.

## Release Notes

none

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 4/5 — shared database transaction cleanup; interrupted writes must never replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
