### PR TITLE
feat(mobile): mirror climbs from Live Activity and Android notification

### DIFF
--- a/docs/live-activity-board-control.md
+++ b/docs/live-activity-board-control.md
@@ -23,10 +23,39 @@ The **React Native layer** (`packages/mobile/src/lib/ble/`) owns BLE for the Exp
 
 **What's still missing for full lock-screen board control:**
 
-1. Widget can only do prev/next -- no add, remove, reorder, or mirror mutations from lock screen
+1. Widget has no add, remove, or reorder controls from the lock screen
 2. Rust board renderer has no Swift/iOS bindings -- only targets WASM today
 3. MoonBoard remains on the existing Capacitor BLE path; the native background BLE path currently targets Aurora boards only
 4. Cross-device repaint when _another_ user navigates: if your phone is suspended, your board stays stale until you unlock the phone. Tracked in issue #2174 (presence/ack design) and ultimately solved by the planned WS-enabled board controller.
+
+## Mirroring from the Lock Screen and Android notification
+
+On supported layouts (Tension except layout 11, Decoy, and Woods), the BLE holder
+sees a Mirror climb button in the iOS Lock Screen / expanded Dynamic Island and
+the Android foreground notification. The button becomes Unmirror climb when the
+current queue slot is mirrored. Previous, Next, and the lightbulb remain available.
+Android uses a custom notification-content button to preserve all three action slots.
+
+Mirroring is an absolute, server-confirmed update to the current queue slot.
+iOS calls `POST /api/widget/mirror` with its registered bearer token, session ID,
+queue-item UUID, and desired orientation. Android forwards the same identity and
+orientation to the existing GraphQL mutation. Requests for an old current slot are
+rejected. A failed/offline request leaves the climb unchanged; retrying cannot
+flip twice. The active-session in-app button uses the same shared mutation.
+Solo climbs and previews retain their local mirror controls.
+
+The backend publishes `ClimbMirrored` and includes orientation and queue-item UUID
+in APNs content. iOS persists a confirmation receipt until JS applies that sequence
+or a newer authoritative snapshot. Reopening the app replays the receipt through
+the queue sync gate. Native queue snapshots reject older sequences; a fresh socket
+subscription can rebaseline after a server sequence reset. Queue sequence metadata
+travels with the rendered JS state so older renders cannot overwrite native mirror
+confirmations. ActivityKit updates read the latest committed snapshot before publishing,
+and BLE rechecks ownership and receipt freshness immediately before writing.
+
+Deploy the additive backend schema/endpoint before shipping new native iOS and
+Android builds. Old binaries omit the new optional fields and keep existing controls.
+An OTA update alone cannot install these native buttons or App Intents.
 
 ## Connection ownership (lightbulb + Previous/Next)
 

--- a/docs/live-activity-board-control.md
+++ b/docs/live-activity-board-control.md
@@ -47,11 +47,15 @@ Solo climbs and previews retain their local mirror controls.
 The backend publishes `ClimbMirrored` and includes orientation and queue-item UUID
 in APNs content. iOS persists a confirmation receipt until JS applies that sequence
 or a newer authoritative snapshot. Reopening the app replays the receipt through
-the queue sync gate. Native queue snapshots reject older sequences; a fresh socket
+the queue sync gate. If JS has no sequence baseline yet, it fetches the complete
+queue before acknowledging the receipt. Mirror deltas update their exact queue
+slot even when optimistic navigation already selected another climb. Native queue
+snapshots reject older sequences; a fresh socket
 subscription can rebaseline after a server sequence reset. Queue sequence metadata
 travels with the rendered JS state so older renders cannot overwrite native mirror
 confirmations. ActivityKit updates read the latest committed snapshot before publishing,
 and BLE rechecks ownership and receipt freshness immediately before writing.
+Woods reflects its per-size native LED map using the same row geometry as JS.
 
 Deploy the additive backend schema/endpoint before shipping new native iOS and
 Android builds. Old binaries omit the new optional fields and keep existing controls.

--- a/packages/backend/src/__tests__/queue-mirror.test.ts
+++ b/packages/backend/src/__tests__/queue-mirror.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClimbQueueItem } from '@boardsesh/shared-schema';
+import type { QueueState } from '../services/room-manager/types';
+import { VersionConflictError } from '../services/room-manager/types';
+
+const mocks = vi.hoisted(() => ({ read: vi.fn(), write: vi.fn(), publish: vi.fn() }));
+vi.mock('../services/room-manager', async () => ({
+  VersionConflictError: (await import('../services/room-manager/types')).VersionConflictError,
+  roomManager: { getQueueState: mocks.read, updateQueueState: mocks.write },
+}));
+vi.mock('../pubsub/index', () => ({ pubsub: { publishQueueEvent: mocks.publish } }));
+import { mirrorSessionClimb, MirrorTargetChangedError } from '../services/queue-mirror';
+
+function snapshot(uuid = 'slot-1', mirrored = false): QueueState {
+  const item = { uuid, climb: { uuid: 'climb-1', mirrored } } as unknown as ClimbQueueItem;
+  return {
+    queue: [item],
+    currentClimbQueueItem: item,
+    sequence: 4,
+    version: 4,
+    stateHash: 'before',
+    stateHashOrdered: 'before-v2',
+  };
+}
+
+describe('confirmed session mirroring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.read.mockResolvedValue(snapshot());
+    mocks.write.mockResolvedValue({ sequence: 5, stateHash: 'after', stateHashOrdered: 'after-v2' });
+  });
+
+  it('updates the current slot and queue together and broadcasts the absolute orientation', async () => {
+    const result = await mirrorSessionClimb('session', true, 'slot-1');
+    expect(mocks.write).toHaveBeenCalledWith('session', [result?.item], result?.item, 4);
+    expect(result?.item.climb.mirrored).toBe(true);
+    expect(mocks.publish).toHaveBeenCalledWith(
+      'session',
+      expect.objectContaining({ __typename: 'ClimbMirrored', uuid: 'slot-1', mirrored: true, sequence: 5 }),
+    );
+  });
+
+  it('does not publish or advance sequence when the requested orientation already matches', async () => {
+    mocks.read.mockResolvedValue(snapshot('slot-1', true));
+    const result = await mirrorSessionClimb('session', true, 'slot-1');
+    expect(result?.event.sequence).toBe(4);
+    expect(mocks.write).not.toHaveBeenCalled();
+    expect(mocks.publish).not.toHaveBeenCalled();
+  });
+
+  it('rechecks the target after a version conflict instead of mirroring the next climb', async () => {
+    mocks.read.mockResolvedValueOnce(snapshot()).mockResolvedValueOnce(snapshot('slot-2'));
+    mocks.write.mockRejectedValueOnce(new VersionConflictError('session', 4));
+    await expect(mirrorSessionClimb('session', true, 'slot-1')).rejects.toBeInstanceOf(MirrorTargetChangedError);
+    expect(mocks.write).toHaveBeenCalledTimes(1);
+    expect(mocks.publish).not.toHaveBeenCalled();
+  });
+
+  it('preserves concurrent queue additions during retry', async () => {
+    const concurrent = snapshot();
+    concurrent.queue.push({ uuid: 'slot-2', climb: { uuid: 'other' } } as unknown as ClimbQueueItem);
+    concurrent.version = 5;
+    mocks.read.mockResolvedValueOnce(snapshot()).mockResolvedValueOnce(concurrent);
+    mocks.write
+      .mockRejectedValueOnce(new VersionConflictError('session', 4))
+      .mockResolvedValueOnce({ sequence: 6, stateHash: 'after', stateHashOrdered: 'after-v2' });
+    await mirrorSessionClimb('session', true, 'slot-1');
+    expect(mocks.write.mock.calls[1][1]).toHaveLength(2);
+    expect(mocks.write.mock.calls[1][3]).toBe(5);
+  });
+});

--- a/packages/backend/src/__tests__/widget-mirror.test.ts
+++ b/packages/backend/src/__tests__/widget-mirror.test.ts
@@ -1,0 +1,69 @@
+import { Readable } from 'node:stream';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+const mocks = vi.hoisted(() => ({ auth: vi.fn(), guard: vi.fn(), limit: vi.fn(), mirror: vi.fn() }));
+vi.mock('../handlers/widget-auth', () => ({ authenticateWidget: mocks.auth }));
+vi.mock('../handlers/widget-session-guard', () => ({ verifyWidgetSession: mocks.guard }));
+vi.mock('../handlers/widget-rate-limit', () => ({
+  checkWidgetRateLimit: mocks.limit,
+  ensureWidgetRateLimitPruner: vi.fn(),
+}));
+vi.mock('../handlers/cors', () => ({ applyCorsHeaders: () => true }));
+vi.mock('../services/queue-mirror', () => ({
+  mirrorSessionClimb: mocks.mirror,
+  MirrorTargetChangedError: class extends Error {},
+}));
+import { handleWidgetMirror } from '../handlers/widget-mirror';
+
+async function request(body: unknown) {
+  const req = Readable.from([JSON.stringify(body)]) as unknown as IncomingMessage;
+  req.method = 'POST';
+  req.headers = { authorization: 'Bearer registered' };
+  const response = { writeHead: vi.fn(), end: vi.fn() };
+  await handleWidgetMirror(req, response as unknown as ServerResponse);
+  return {
+    status: response.writeHead.mock.calls[0][0],
+    body: JSON.parse(response.end.mock.calls[0][0] as string) as Record<string, unknown>,
+  };
+}
+const body = { sessionId: 'session', queueItemUuid: 'slot', mirrored: true };
+describe('widget mirror endpoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.auth.mockResolvedValue({ kind: 'ok', userId: 'user' });
+    mocks.guard.mockResolvedValue({ ok: true, session: { boardPath: 'tension/1/1/1/40' } });
+    mocks.limit.mockReturnValue(true);
+    mocks.mirror.mockResolvedValue({
+      item: { uuid: 'slot' },
+      event: { sequence: 8, mirrored: true, stateHash: 'hash' },
+    });
+  });
+  it('returns a sequenced confirmation for the exact requested slot', async () => {
+    const response = await request(body);
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ sessionId: 'session', queueItemUuid: 'slot', mirrored: true, sequence: 8 });
+    expect(mocks.mirror).toHaveBeenCalledWith('session', true, 'slot');
+  });
+  it.each([
+    ['unknown token', { kind: 'unknown' }, 401],
+    ['wrong session', { kind: 'wrong-session' }, 410],
+    ['anonymous token', { kind: 'ok', userId: null }, 403],
+  ])('rejects %s before mutation', async (_name, auth, status) => {
+    mocks.auth.mockResolvedValue(auth);
+    expect((await request(body)).status).toBe(status);
+    expect(mocks.mirror).not.toHaveBeenCalled();
+  });
+  it('rejects ended sessions and unsupported boards', async () => {
+    mocks.guard.mockResolvedValueOnce({ ok: false, status: 410, error: 'Ended' });
+    expect((await request(body)).status).toBe(410);
+    mocks.guard.mockResolvedValueOnce({ ok: true, session: { boardPath: 'tension/11/1/1/40' } });
+    expect((await request(body)).status).toBe(409);
+    expect(mocks.mirror).not.toHaveBeenCalled();
+  });
+  it('rejects malformed or rate-limited requests', async () => {
+    expect((await request({ ...body, mirrored: 'true' })).status).toBe(400);
+    mocks.limit.mockReturnValue(false);
+    expect((await request(body)).status).toBe(429);
+    expect(mocks.mirror).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/graphql/resolvers/queue/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/queue/mutations.ts
@@ -1,6 +1,7 @@
 import type { ConnectionContext, ClimbQueueItem, QueueState } from '@boardsesh/shared-schema';
 import { roomManager, VersionConflictError } from '../../../services/room-manager';
 import { pubsub } from '../../../pubsub/index';
+import { mirrorSessionClimb } from '../../../services/queue-mirror';
 import { setCurrentClimbAndPublish } from '../../../services/queue-navigation';
 import {
   requireSessionWithReconnectGrace,
@@ -292,51 +293,17 @@ export const queueMutations = {
    * Toggle the mirrored state of the current climb
    * Updates both the current climb and the queue item if present
    */
-  mirrorCurrentClimb: async (_: unknown, { mirrored }: { mirrored: boolean }, ctx: ConnectionContext) => {
+  mirrorCurrentClimb: async (
+    _: unknown,
+    { mirrored, expectedQueueItemUuid }: { mirrored: boolean; expectedQueueItemUuid?: string | null },
+    ctx: ConnectionContext,
+  ) => {
     const startTime = performance.now();
     await applyRateLimit(ctx, RATE_LIMIT_SESSION, RATE_LIMIT_SESSION_OP);
     const sessionId = await requireSessionWithReconnectGrace(ctx);
-
-    const mirrorResult = await withQueueVersionRetry('mirrorCurrentClimb', sessionId, async (currentState) => {
-      // No current climb means there's nothing to mirror. Don't publish a
-      // no-op ClimbMirrored event — it clutters logs, occupies bus
-      // bandwidth, and (because sequence/stateHash don't advance) is fragile
-      // under co-sequencing with FullSync replay.
-      if (!currentState.currentClimbQueueItem) {
-        return null;
-      }
-
-      // Update the mirrored state
-      const currentClimb: ClimbQueueItem = {
-        ...currentState.currentClimbQueueItem,
-        climb: { ...currentState.currentClimbQueueItem.climb, mirrored },
-      };
-
-      // Also update in queue if present
-      const queue = currentState.queue.map((i) =>
-        i.uuid === currentClimb.uuid ? { ...i, climb: { ...i.climb, mirrored } } : i,
-      );
-
-      const updated = await roomManager.updateQueueState(sessionId, queue, currentClimb, currentState.version);
-      return { currentClimb, ...updated };
-    });
-
-    if (!mirrorResult) {
-      logMutationMetrics('mirrorCurrentClimb', performance.now() - startTime, sessionId);
-      return null;
-    }
-
-    pubsub.publishQueueEvent(sessionId, {
-      __typename: 'ClimbMirrored',
-      sequence: mirrorResult.sequence,
-      stateHash: mirrorResult.stateHash,
-      stateHashOrdered: mirrorResult.stateHashOrdered,
-      uuid: mirrorResult.currentClimb.uuid,
-      mirrored,
-    });
-
+    const result = await mirrorSessionClimb(sessionId, mirrored, expectedQueueItemUuid);
     logMutationMetrics('mirrorCurrentClimb', performance.now() - startTime, sessionId);
-    return mirrorResult.currentClimb;
+    return result?.item ?? null;
   },
 
   /**

--- a/packages/backend/src/handlers/widget-mirror.ts
+++ b/packages/backend/src/handlers/widget-mirror.ts
@@ -1,0 +1,59 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+import { boardSupportsMirroring, parseBoardPath } from '@boardsesh/board-config';
+import { z } from 'zod';
+import { applyCorsHeaders } from './cors';
+import { authenticateWidget } from './widget-auth';
+import { verifyWidgetSession } from './widget-session-guard';
+import { checkWidgetRateLimit, ensureWidgetRateLimitPruner } from './widget-rate-limit';
+import { mirrorSessionClimb, MirrorTargetChangedError } from '../services/queue-mirror';
+import { logger } from '../utils/logger';
+
+const mirrorBody = z.object({
+  sessionId: z.string().min(1),
+  queueItemUuid: z.string().min(1),
+  mirrored: z.boolean(),
+});
+
+/** Widget requests set an orientation on an exact queue slot, never on a moving index. */
+export async function handleWidgetMirror(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (!applyCorsHeaders(req, res)) return;
+  const reply = (status: number, body: unknown) => {
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(body));
+  };
+  if (req.method !== 'POST') return reply(405, { error: 'Method not allowed' });
+  let parsed: z.infer<typeof mirrorBody>;
+  try {
+    const chunks: Buffer[] = [];
+    let length = 0;
+    for await (const chunk of req) {
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string);
+      length += bytes.length;
+      if (length > 4096) return reply(413, { error: 'Request too large' });
+      chunks.push(bytes);
+    }
+    parsed = mirrorBody.parse(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+  } catch {
+    return reply(400, { error: 'Expected sessionId, queueItemUuid and mirrored' });
+  }
+  try {
+    const auth = await authenticateWidget(req.headers.authorization, parsed.sessionId);
+    if (auth.kind !== 'ok') return reply(auth.kind === 'wrong-session' ? 410 : 401, { error: 'Unauthorized' });
+    if (!auth.userId) return reply(403, { error: 'An authenticated participant is required' });
+    ensureWidgetRateLimitPruner();
+    if (!checkWidgetRateLimit(parsed.sessionId)) return reply(429, { error: 'Too many requests' });
+    const guard = await verifyWidgetSession(parsed.sessionId, auth.userId);
+    if (!guard.ok) return reply(guard.status, { error: guard.error });
+    const board = parseBoardPath(guard.session.boardPath);
+    if (!board || !boardSupportsMirroring(board.boardName, board.layoutId)) {
+      return reply(409, { error: 'This board does not support mirroring' });
+    }
+    const result = await mirrorSessionClimb(parsed.sessionId, parsed.mirrored, parsed.queueItemUuid);
+    if (!result) return reply(409, { error: 'No current climb' });
+    reply(200, { success: true, sessionId: parsed.sessionId, ...result.event, queueItemUuid: result.item.uuid });
+  } catch (error) {
+    if (error instanceof MirrorTargetChangedError) return reply(409, { error: error.message });
+    logger.error('[WidgetMirror] Request failed:', error);
+    reply(500, { error: 'Internal server error' });
+  }
+}

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -42,6 +42,7 @@ import {
   handleKilterCredentialsStart,
 } from './handlers/kilter-credentials-oauth';
 import { handleGymClaimVerify } from './handlers/gym-claims';
+import { handleWidgetMirror } from './handlers/widget-mirror';
 import { handleWidgetNavigate } from './handlers/widget-navigate';
 import { handleWidgetTakeControl } from './handlers/widget-take-control';
 import { handleSessionNavigate, handleSessionTakeControl } from './handlers/session-actions';
@@ -581,6 +582,10 @@ export async function startServer(): Promise<ServerResources> {
       }
 
       // Widget queue navigation endpoint (called by iOS lock-screen widget)
+      if (pathname === '/api/widget/mirror' && (req.method === 'POST' || req.method === 'OPTIONS')) {
+        await handleWidgetMirror(req, res);
+        return;
+      }
       if (pathname === '/api/widget/navigate' && (req.method === 'POST' || req.method === 'OPTIONS')) {
         await handleWidgetNavigate(req, res);
         return;

--- a/packages/backend/src/services/apns/content-state.ts
+++ b/packages/backend/src/services/apns/content-state.ts
@@ -31,5 +31,7 @@ export function buildContentStateFromQueueState(queueState: QueueState): LiveAct
     hasNext: currentIndex < queueState.queue.length - 1,
     hasPrevious: currentIndex > 0,
     climbUuid: currentItem.climb.uuid,
+    queueItemUuid: currentItem.uuid,
+    mirrored: currentItem.climb.mirrored === true,
   };
 }

--- a/packages/backend/src/services/apns/index.ts
+++ b/packages/backend/src/services/apns/index.ts
@@ -34,6 +34,8 @@ export interface LiveActivityContentState {
   hasNext: boolean;
   hasPrevious: boolean;
   climbUuid: string;
+  queueItemUuid?: string;
+  mirrored?: boolean;
   /**
    * Per-token board-connection state, derived from the board's current holder
    * (see board-connection.ts). OPTIONAL on the device: when omitted, iOS falls

--- a/packages/backend/src/services/queue-mirror.ts
+++ b/packages/backend/src/services/queue-mirror.ts
@@ -1,0 +1,37 @@
+import type { QueueEvent } from '@boardsesh/shared-schema';
+import { roomManager } from './room-manager';
+import { pubsub } from '../pubsub/index';
+import { withQueueVersionRetry } from '../graphql/resolvers/shared/queue-retry';
+
+export class MirrorTargetChangedError extends Error {
+  constructor() {
+    super('The current climb changed; refresh before mirroring');
+  }
+}
+
+/** An absolute, queue-slot-scoped write: retries must never toggle twice or flip a new head. */
+export async function mirrorSessionClimb(sessionId: string, mirrored: boolean, expectedQueueItemUuid?: string | null) {
+  const result = await withQueueVersionRetry('mirrorCurrentClimb', sessionId, async (currentState) => {
+    const currentItem = currentState.currentClimbQueueItem;
+    if (expectedQueueItemUuid && currentItem?.uuid !== expectedQueueItemUuid) throw new MirrorTargetChangedError();
+    if (!currentItem) return null;
+
+    const item = { ...currentItem, climb: { ...currentItem.climb, mirrored } };
+    const changed = !!currentItem.climb.mirrored !== mirrored;
+    const queue = currentState.queue.map((queuedItem) => (queuedItem.uuid === item.uuid ? item : queuedItem));
+    const snapshot = changed
+      ? await roomManager.updateQueueState(sessionId, queue, item, currentState.version)
+      : currentState;
+    const event: Extract<QueueEvent, { __typename: 'ClimbMirrored' }> = {
+      __typename: 'ClimbMirrored',
+      uuid: item.uuid,
+      mirrored,
+      sequence: snapshot.sequence,
+      stateHash: snapshot.stateHash,
+      stateHashOrdered: snapshot.stateHashOrdered,
+    };
+    return { item, event, changed };
+  });
+  if (result?.changed) pubsub.publishQueueEvent(sessionId, result.event);
+  return result;
+}

--- a/packages/board-constants/scripts/woods-led-maps-sources.ts
+++ b/packages/board-constants/scripts/woods-led-maps-sources.ts
@@ -14,6 +14,7 @@
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { WOODS_ROW_LENGTHS } from '../src/woods';
 
 export const WOODS_LED_MAP_SIZES = [
   { size: '8x10', file: 'light-map-8x10.json' },
@@ -108,15 +109,33 @@ ${json}
 
     private static let ledMaps: [String: [Int: Int]] = decode(ledMapsJSON)
 
+    // Generated from the same row geometry used by JS's hold mirroring.
+    private static let rowLengths: [String: [Int]] = [
+${WOODS_LED_MAP_SIZES.map(({ size }) => `        "${size}": [${WOODS_ROW_LENGTHS[size].join(', ')}]`).join(',\n')}
+    ]
+
     /// Woods size_id → dimension per WOODS_SIZES in
     /// packages/shared/board-config/src/woods-config.ts. Unknown sizes return
     /// nil so the caller can refuse the write instead of darkening the wall.
-    static func ledMap(forSizeId sizeId: Int) -> [Int: Int]? {
+    static func ledMap(forSizeId sizeId: Int, mirrored: Bool = false) -> [Int: Int]? {
+        let dimension: String
         switch sizeId {
-        case 1: return ledMaps["8x10"]
-        case 2: return ledMaps["12x12"]
+        case 1: dimension = "8x10"
+        case 2: dimension = "12x12"
         default: return nil
         }
+        guard let ledMap = ledMaps[dimension] else { return nil }
+        guard mirrored else { return ledMap }
+        guard let rows = rowLengths[dimension] else { return nil }
+        var reflected: [Int: Int] = [:]
+        var start = 0
+        for length in rows {
+            for column in 0..<length {
+                reflected[start + column] = ledMap[start + length - 1 - column]
+            }
+            start += length
+        }
+        return reflected
     }
 
     private static func decode(_ json: String) -> [String: [Int: Int]] {

--- a/packages/board-constants/src/woods.ts
+++ b/packages/board-constants/src/woods.ts
@@ -8,6 +8,14 @@ import { WOODS_HOLD_POSITIONS, WOODS_OCCUPIED_HOLD_IDS } from './generated/woods
 export { WOODS_LED_MAPS, WOODS_HOLD_POSITIONS, WOODS_OCCUPIED_HOLD_IDS };
 export type { WoodsBoardSize };
 
+// Shared row geometry for JS hold reflection and generated native LED maps.
+const repeat = (count: number, value: number): number[] => Array.from({ length: count }, () => value);
+
+export const WOODS_ROW_LENGTHS: Record<WoodsBoardSize, number[]> = {
+  '8x10': [...repeat(1, 11), ...repeat(21, 21), ...repeat(3, 11)],
+  '12x12': [...repeat(3, 17), ...repeat(23, 33), ...repeat(3, 17), ...repeat(1, 17), ...repeat(1, 16)],
+};
+
 // The Woods board advertises its name over the Nordic UART Service. Both the v1
 // ("Woods Board") and v2 ("Woods Board v2") controllers share this prefix and
 // speak the same LED command format, so one case-insensitive prefix matches both

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -20,6 +20,54 @@ final class LiveActivityWidgetTests: XCTestCase {
         super.tearDown()
     }
 
+    private func prepareMirror() {
+        defaults.set("session", forKey: SharedConstants.sessionIdKey)
+        defaults.set(true, forKey: SharedConstants.supportsMirroringKey)
+        SharedWidgetWallControlState.save(navigationAllowed: true, isPartySession: true, to: defaults)
+        SharedWidgetWallControlState.saveBoardConnection("connectedByMe", holderDisplayName: nil, to: defaults)
+        SharedQueueState.save(items: [makeQueueItem()], currentIndex: 0, to: defaults)
+    }
+
+    func testMirrorReceiptSurvivesReplayAndRejectsOldAcknowledgement() {
+        prepareMirror()
+        let receipt = SharedMirrorConfirmation(sessionId: "session", queueItemUuid: "queue-1", mirrored: true, sequence: 5, stateHash: "hash", stateHashOrdered: nil)
+        XCTAssertNotNil(SharedMirrorState.apply(receipt, in: defaults))
+        XCTAssertEqual(SharedQueueState.load(from: defaults).0.first?.mirrored, true)
+        XCTAssertEqual(SharedMirrorState.pending(in: defaults), receipt)
+        SharedMirrorState.acknowledge(sessionId: "other", sequence: 6, in: defaults)
+        SharedMirrorState.acknowledge(sessionId: "session", sequence: 4, in: defaults)
+        XCTAssertNotNil(SharedMirrorState.pending(in: defaults))
+        SharedMirrorState.acknowledge(sessionId: "session", sequence: 5, in: defaults)
+        XCTAssertNil(SharedMirrorState.pending(in: defaults))
+    }
+
+    func testOlderMirrorResponseCannotOverwriteNewerNativeState() {
+        prepareMirror()
+        XCTAssertTrue(SharedMirrorState.persist(items: [makeQueueItem(mirrored: false)], currentIndex: 0, sequence: 7, in: defaults))
+        let receipt = SharedMirrorConfirmation(sessionId: "session", queueItemUuid: "queue-1", mirrored: true, sequence: 6, stateHash: "hash", stateHashOrdered: nil)
+        XCTAssertNil(SharedMirrorState.apply(receipt, in: defaults))
+        XCTAssertEqual(SharedQueueState.load(from: defaults).0.first?.mirrored, false)
+    }
+
+    func testBufferedSocketSnapshotCannotUndoAcceptedMirror() {
+        prepareMirror()
+        let receipt = SharedMirrorConfirmation(sessionId: "session", queueItemUuid: "queue-1", mirrored: true, sequence: 6, stateHash: "hash", stateHashOrdered: nil)
+        XCTAssertNotNil(SharedMirrorState.apply(receipt, in: defaults))
+        XCTAssertFalse(SharedMirrorState.persist(items: [makeQueueItem()], currentIndex: 0, sequence: 5, in: defaults))
+        XCTAssertTrue(SharedMirrorState.isCurrent(receipt, in: defaults))
+        SharedWidgetWallControlState.saveBoardConnection("heldByPeer", holderDisplayName: "Crew", to: defaults)
+        XCTAssertFalse(SharedMirrorState.isCurrent(receipt, in: defaults))
+    }
+
+    func testFreshSubscriptionCanRebaselineAfterServerSequenceReset() {
+        prepareMirror()
+        XCTAssertTrue(SharedMirrorState.persist(items: [makeQueueItem(mirrored: true)], currentIndex: 0, sequence: 8, in: defaults))
+        XCTAssertFalse(SharedMirrorState.persist(items: [makeQueueItem()], currentIndex: 0, sequence: 2, subscriptionSequence: 7, in: defaults))
+        XCTAssertTrue(SharedMirrorState.persist(items: [makeQueueItem()], currentIndex: 0, sequence: 2, subscriptionSequence: 8, in: defaults))
+        XCTAssertEqual(SharedMirrorState.sequence(in: defaults), 2)
+        XCTAssertFalse(SharedQueueState.load(from: defaults).0[0].mirrored)
+    }
+
     private func makeQueueItem(
         uuid: String = "queue-1",
         climbUuid: String = "climb-1",

--- a/packages/mobile/ios-tests/WoodsBoardBleTests.swift
+++ b/packages/mobile/ios-tests/WoodsBoardBleTests.swift
@@ -268,13 +268,26 @@ final class WoodsBoardBleManagerTests: XCTestCase {
         XCTAssertEqual(reassembled(peripheral), "28,4,237,2,341,3,!")
     }
 
-    func testMirroredItemSendsRawFrames() {
-        // Woods mirroring is JS-side geometry; the manager must not route a
-        // mirrored item through BoardBleEncoding.mirroredFrames (no Woods rows
-        // in BoardPlacementData — it would refuse every climb).
+    func testMirroredItemReflectsThePerSizeLedMap() {
+        // 12x12 row 0 has 17 holds: location 0 reflects to location 16.
         let peripheral = displayWoods(frames: "p0r4", mirrored: true)
-        XCTAssertEqual(reassembled(peripheral), "28,4,!")
+        XCTAssertEqual(reassembled(peripheral), "\(ledMap(2)[16]!),4,!")
         XCTAssertEqual(peripheral.writtenChunks.first?.type, .withResponse)
+    }
+
+    func testMirrored8x10ItemUsesItsOwnRowGeometry() {
+        // 8x10 row 0 has 11 holds; the next row has 21.
+        let peripheral = displayWoods(frames: "p0r4p11r2", sizeId: 1, mirrored: true)
+        XCTAssertEqual(reassembled(peripheral), "\(ledMap(1)[10]!),4,\(ledMap(1)[31]!),2,!")
+    }
+
+    func testReflectedLedMapsPreserveEveryLed() {
+        for sizeId in [1, 2] {
+            let original = ledMap(sizeId)
+            let reflected = WoodsBoardData.ledMap(forSizeId: sizeId, mirrored: true)!
+            XCTAssertEqual(Set(original.keys), Set(reflected.keys))
+            XCTAssertEqual(Set(original.values), Set(reflected.values))
+        }
     }
 
     func testEmptyFramesItemClearsWithTheWoodsTerminatorNotAnAuroraPacket() {

--- a/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/BoardSessionActionReceiver.kt
+++ b/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/BoardSessionActionReceiver.kt
@@ -15,6 +15,12 @@ class BoardSessionActionReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         val correlationId = intent.getStringExtra(BoardSessionService.EXTRA_CORRELATION_ID) ?: ""
         when (intent.action) {
+            BoardSessionService.ACTION_MIRROR -> {
+                val sessionId = intent.getStringExtra(BoardSessionService.EXTRA_SESSION_ID) ?: return
+                val queueItemUuid = intent.getStringExtra(BoardSessionService.EXTRA_QUEUE_ITEM_UUID) ?: return
+                if (sessionId.isBlank() || queueItemUuid.isBlank() || !intent.hasExtra(BoardSessionService.EXTRA_MIRRORED)) return
+                SessionPresenceModule.dispatchMirror(sessionId, queueItemUuid, intent.getBooleanExtra(BoardSessionService.EXTRA_MIRRORED, false))
+            }
             BoardSessionService.ACTION_NAV_PREVIOUS ->
                 SessionPresenceModule.dispatchQueueNavigate(
                     "previous",

--- a/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/BoardSessionService.kt
+++ b/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/BoardSessionService.kt
@@ -7,6 +7,7 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
 import android.content.pm.ServiceInfo
+import android.graphics.Matrix
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
@@ -63,6 +64,13 @@ class BoardSessionService : Service() {
     private var reconnectLabel: String = "Connect to board"
     private var onWallTemplate: String = "{{name}} is on the wall"
 
+    private var sessionId: String = ""
+    private var queueItemUuid: String = ""
+    private var supportsMirroring: Boolean = false
+    private var mirrored: Boolean = false
+    private var mirrorLabel: String = "Mirror climb"
+    private var unmirrorLabel: String = "Unmirror climb"
+
     private var climbName: String? = null
     private var subtitle: String? = null
     private var hasNext: Boolean = false
@@ -113,6 +121,9 @@ class BoardSessionService : Service() {
                     channelNameLocalized = true
                 }
                 channelDescription = intent.getStringExtra(EXTRA_CHANNEL_DESC) ?: channelDescription
+                sessionId = intent.getStringExtra(EXTRA_SESSION_ID) ?: ""
+                mirrorLabel = intent.getStringExtra(EXTRA_MIRROR_LABEL) ?: mirrorLabel
+                unmirrorLabel = intent.getStringExtra(EXTRA_UNMIRROR_LABEL) ?: unmirrorLabel
                 contentTitleFallback = intent.getStringExtra(EXTRA_TITLE_FALLBACK) ?: contentTitleFallback
                 previousLabel = intent.getStringExtra(EXTRA_PREV_LABEL) ?: previousLabel
                 nextLabel = intent.getStringExtra(EXTRA_NEXT_LABEL) ?: nextLabel
@@ -123,20 +134,27 @@ class BoardSessionService : Service() {
                 holderDisplayName = intent.getStringExtra(EXTRA_HOLDER_NAME)
             }
             ACTION_UPDATE -> {
-                climbName = intent.getStringExtra(EXTRA_CLIMB_NAME) ?: climbName
-                subtitle = intent.getStringExtra(EXTRA_SUBTITLE) ?: subtitle
-                hasNext = intent.getBooleanExtra(EXTRA_HAS_NEXT, hasNext)
-                hasPrevious = intent.getBooleanExtra(EXTRA_HAS_PREVIOUS, hasPrevious)
-                currentIndex = intent.getIntExtra(EXTRA_CURRENT_INDEX, currentIndex)
-                totalClimbs = intent.getIntExtra(EXTRA_TOTAL_CLIMBS, totalClimbs)
-                boardConnection = intent.getStringExtra(EXTRA_BOARD_CONNECTION) ?: boardConnection
-                // Absent extra ⇒ no peer holder ⇒ clear (the controller only sends
-                // it for heldByPeer).
-                holderDisplayName = intent.getStringExtra(EXTRA_HOLDER_NAME)
-                // Absent overlay ⇒ render not ready yet; keep the last one so the
-                // thumbnail doesn't flicker out between updates.
-                intent.getStringExtra(EXTRA_OVERLAY_PATH)?.let { overlayPath = it }
-                intent.getStringArrayListExtra(EXTRA_BACKGROUND_PATHS)?.let { backgroundPaths = it }
+                val updateSessionId = intent.getStringExtra(EXTRA_SESSION_ID) ?: ""
+                if (sessionId.isEmpty() || updateSessionId == sessionId) {
+                    sessionId = updateSessionId
+                    queueItemUuid = intent.getStringExtra(EXTRA_QUEUE_ITEM_UUID) ?: ""
+                    supportsMirroring = intent.getBooleanExtra(EXTRA_SUPPORTS_MIRRORING, false)
+                    mirrored = intent.getBooleanExtra(EXTRA_MIRRORED, false)
+                    climbName = intent.getStringExtra(EXTRA_CLIMB_NAME) ?: climbName
+                    subtitle = intent.getStringExtra(EXTRA_SUBTITLE) ?: subtitle
+                    hasNext = intent.getBooleanExtra(EXTRA_HAS_NEXT, hasNext)
+                    hasPrevious = intent.getBooleanExtra(EXTRA_HAS_PREVIOUS, hasPrevious)
+                    currentIndex = intent.getIntExtra(EXTRA_CURRENT_INDEX, currentIndex)
+                    totalClimbs = intent.getIntExtra(EXTRA_TOTAL_CLIMBS, totalClimbs)
+                    boardConnection = intent.getStringExtra(EXTRA_BOARD_CONNECTION) ?: boardConnection
+                    // Absent extra ⇒ no peer holder ⇒ clear (the controller only sends
+                    // it for heldByPeer).
+                    holderDisplayName = intent.getStringExtra(EXTRA_HOLDER_NAME)
+                    // Absent overlay ⇒ render not ready yet; keep the last one so the
+                    // thumbnail doesn't flicker out between updates.
+                    intent.getStringExtra(EXTRA_OVERLAY_PATH)?.let { overlayPath = it }
+                    intent.getStringArrayListExtra(EXTRA_BACKGROUND_PATHS)?.let { backgroundPaths = it }
+                }
             }
         }
 
@@ -312,6 +330,12 @@ class BoardSessionService : Service() {
             views.setTextViewText(R.id.session_subtitle, collapsedSubtitle)
         }
 
+        val showMirror = supportsMirroring && sessionId.isNotEmpty() && queueItemUuid.isNotEmpty() &&
+            boardConnection == CONNECTION_CONNECTED_BY_ME
+        views.setViewVisibility(R.id.session_mirror, if (showMirror) android.view.View.VISIBLE else android.view.View.GONE)
+        views.setContentDescription(R.id.session_mirror, if (mirrored) unmirrorLabel else mirrorLabel)
+        views.setInt(R.id.session_mirror, "setImageAlpha", if (mirrored) 255 else 140)
+        if (showMirror) views.setOnClickPendingIntent(R.id.session_mirror, mirrorPendingIntent())
         val bitmap = currentBitmap()
         if (bitmap != null) {
             views.setImageViewBitmap(R.id.session_image, bitmap)
@@ -360,6 +384,16 @@ class BoardSessionService : Service() {
     // The lightbulb carries the current ownership so the receiver can choose
     // reassert (connectedByMe) vs reconnect; the notification is rebuilt on every
     // update, so the extra is always current.
+    private fun mirrorPendingIntent(): PendingIntent {
+        val intent = Intent(this, BoardSessionActionReceiver::class.java).apply {
+            action = ACTION_MIRROR
+            putExtra(EXTRA_SESSION_ID, sessionId)
+            putExtra(EXTRA_QUEUE_ITEM_UUID, queueItemUuid)
+            putExtra(EXTRA_MIRRORED, !mirrored)
+        }
+        return PendingIntent.getBroadcast(this, REQ_MIRROR, intent, pendingFlags())
+    }
+
     private fun bulbPendingIntent(): PendingIntent {
         val intent = Intent(this, BoardSessionActionReceiver::class.java).apply {
             action = ACTION_BULB
@@ -385,11 +419,13 @@ class BoardSessionService : Service() {
     // then re-fires once the bundled board layers are cached) would hit the cached
     // holds-only composite keyed by overlay alone and never re-render with the board
     // photo. The separator is a null char (never present in a file path).
-    private fun imageKey(overlay: String, backgrounds: List<String>): String =
-        if (backgrounds.isEmpty()) overlay else overlay + "\u0000" + backgrounds.joinToString("\u0000")
+    private fun imageKey(overlay: String, backgrounds: List<String>, mirrored: Boolean): String {
+        val base = if (backgrounds.isEmpty()) overlay else overlay + "\u0000" + backgrounds.joinToString("\u0000")
+        return if (mirrored) base + "\u0000mirrored" else base
+    }
 
     private fun currentBitmap(): Bitmap? =
-        overlayPath?.takeIf { it.isNotBlank() }?.let { bitmapCache.get(imageKey(it, backgroundPaths)) }
+        overlayPath?.takeIf { it.isNotBlank() }?.let { bitmapCache.get(imageKey(it, backgroundPaths, mirrored)) }
 
     // Composites the current climb's thumbnail off the main thread (after
     // promotion), then re-posts the notification with it. Never blocks
@@ -397,13 +433,14 @@ class BoardSessionService : Service() {
     private fun maybeComposeImage() {
         val overlay = overlayPath?.takeIf { it.isNotBlank() } ?: return
         val backgrounds = backgroundPaths
-        val key = imageKey(overlay, backgrounds)
+        val imageMirrored = mirrored
+        val key = imageKey(overlay, backgrounds, imageMirrored)
         currentImageKey = key
         if (bitmapCache.get(key) != null) return
         if (!inFlight.add(key)) return
         imageExecutor.execute {
             val bitmap = try {
-                imageComposer(overlay, backgrounds)
+                imageComposer(overlay, backgrounds)?.let { orientThumbnail(it, imageMirrored) }
             } catch (error: Throwable) {
                 // Throwable, not Exception: decoding/compositing large board PNGs can
                 // OutOfMemoryError on low-memory devices, which is an Error — catching
@@ -521,13 +558,27 @@ class BoardSessionService : Service() {
         // downscale ceiling. ~256 KB per thumbnail → ~8 entries at 2 MB.
         private const val BITMAP_CACHE_BYTES = 2 * 1024 * 1024
 
+        @VisibleForTesting
+        internal fun orientThumbnail(bitmap: Bitmap, mirrored: Boolean): Bitmap {
+            if (!mirrored) return bitmap
+            val transform = Matrix().apply { setScale(-1f, 1f) }
+            return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, transform, true)
+        }
+
         const val ACTION_START = "com.boardsesh.liveactivity.action.START"
         const val ACTION_UPDATE = "com.boardsesh.liveactivity.action.UPDATE"
         const val ACTION_STOP = "com.boardsesh.liveactivity.action.STOP"
         const val ACTION_NAV_PREVIOUS = "com.boardsesh.liveactivity.action.NAV_PREVIOUS"
         const val ACTION_NAV_NEXT = "com.boardsesh.liveactivity.action.NAV_NEXT"
+        const val ACTION_MIRROR = "com.boardsesh.liveactivity.action.MIRROR"
         const val ACTION_BULB = "com.boardsesh.liveactivity.action.BULB"
 
+        const val EXTRA_SESSION_ID = "sessionId"
+        const val EXTRA_QUEUE_ITEM_UUID = "queueItemUuid"
+        const val EXTRA_SUPPORTS_MIRRORING = "supportsMirroring"
+        const val EXTRA_MIRRORED = "mirrored"
+        const val EXTRA_MIRROR_LABEL = "mirrorLabel"
+        const val EXTRA_UNMIRROR_LABEL = "unmirrorLabel"
         const val EXTRA_CHANNEL_NAME = "channelName"
         const val EXTRA_CHANNEL_DESC = "channelDescription"
         const val EXTRA_TITLE_FALLBACK = "contentTitleFallback"
@@ -556,6 +607,7 @@ class BoardSessionService : Service() {
         private const val REQ_NEXT = 1
         private const val REQ_CONTENT = 2
         private const val REQ_BULB = 3
+        private const val REQ_MIRROR = 4
 
         // Process-static so a rapid stop/start keeps thumbnails warm (mirrors the
         // iOS ThumbnailFetcher's persistent cache intent) and so a single worker

--- a/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/SessionPresenceController.kt
+++ b/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/SessionPresenceController.kt
@@ -59,6 +59,9 @@ internal class SessionPresenceController(
         val strings = options?.androidNotification
         val intent = Intent(context, BoardSessionService::class.java).apply {
             action = BoardSessionService.ACTION_START
+            putExtra(BoardSessionService.EXTRA_SESSION_ID, options?.sessionId ?: "")
+            putExtra(BoardSessionService.EXTRA_MIRROR_LABEL, strings?.mirrorLabel ?: "Mirror climb")
+            putExtra(BoardSessionService.EXTRA_UNMIRROR_LABEL, strings?.unmirrorLabel ?: "Unmirror climb")
             putExtra(BoardSessionService.EXTRA_CHANNEL_NAME, strings?.channelName ?: "Active climbing session")
             putExtra(BoardSessionService.EXTRA_CHANNEL_DESC, strings?.channelDescription ?: "")
             putExtra(BoardSessionService.EXTRA_TITLE_FALLBACK, strings?.contentTitleFallback ?: "Climbing session")
@@ -95,6 +98,10 @@ internal class SessionPresenceController(
         }
         val intent = Intent(context, BoardSessionService::class.java).apply {
             action = BoardSessionService.ACTION_UPDATE
+            putExtra(BoardSessionService.EXTRA_SESSION_ID, options.sessionId)
+            putExtra(BoardSessionService.EXTRA_QUEUE_ITEM_UUID, options.queueItemUuid)
+            putExtra(BoardSessionService.EXTRA_SUPPORTS_MIRRORING, options.supportsMirroring)
+            putExtra(BoardSessionService.EXTRA_MIRRORED, options.mirrored)
             putExtra(BoardSessionService.EXTRA_CLIMB_NAME, options.climbName)
             putExtra(BoardSessionService.EXTRA_SUBTITLE, subtitle)
             putExtra(BoardSessionService.EXTRA_HAS_NEXT, options.hasNext)

--- a/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/SessionPresenceModule.kt
+++ b/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/SessionPresenceModule.kt
@@ -17,6 +17,8 @@ class AndroidNotificationStrings : Record {
     @Field var channelDescription: String = ""
     @Field var contentTitleFallback: String = "Climbing session"
     @Field var previousLabel: String = "Previous"
+    @Field var mirrorLabel: String = "Mirror climb"
+    @Field var unmirrorLabel: String = "Unmirror climb"
     @Field var nextLabel: String = "Next"
     @Field var relightLabel: String = "Relight wall"
     @Field var reconnectLabel: String = "Connect to board"
@@ -27,6 +29,7 @@ class AndroidNotificationStrings : Record {
 // visibility. iOS reads these via the App Group; on Android they ride the START
 // intent.
 class StartSessionOptions : Record {
+    @Field var sessionId: String = ""
     @Field var androidNotification: AndroidNotificationStrings? = null
     @Field var boardConnection: String = "connectedByMe"
     @Field var holderDisplayName: String? = null
@@ -39,6 +42,10 @@ class StartSessionOptions : Record {
 // `backgroundPaths` are the bundled board background layers under it; the service
 // composites them locally — no backend fetch.
 class SessionUpdateOptions : Record {
+    @Field var sessionId: String = ""
+    @Field var queueItemUuid: String = ""
+    @Field var supportsMirroring: Boolean = false
+    @Field var mirrored: Boolean = false
     @Field var climbName: String = ""
     @Field var climbDifficulty: String = ""
     @Field var angle: Int = 0
@@ -87,7 +94,8 @@ class SessionPresenceModule : Module() {
     override fun definition() = ModuleDefinition {
         Name("SessionPresence")
 
-        Events("queueNavigate", "boardControl")
+        Events("queueNavigate", "boardControl", "queueMirror")
+        Constants("supportsMirrorControl" to true)
 
         OnCreate { instance = WeakReference(this@SessionPresenceModule) }
         OnDestroy {
@@ -204,6 +212,13 @@ class SessionPresenceModule : Module() {
          * (connectedByMe) or "reconnect" otherwise; the JS bridge maps it to
          * bluetooth.reassertWall() / bluetooth.connect().
          */
+        fun dispatchMirror(sessionId: String, queueItemUuid: String, mirrored: Boolean) {
+            dispatch("queueMirror", mapOf(
+                "kind" to "request", "sessionId" to sessionId,
+                "queueItemUuid" to queueItemUuid, "mirrored" to mirrored,
+            ))
+        }
+
         fun dispatchBoardControl(action: String, correlationId: String) {
             dispatch(
                 "boardControl",

--- a/packages/mobile/modules/live-activity/android/src/main/res/drawable/ic_mirror.xml
+++ b/packages/mobile/modules/live-activity/android/src/main/res/drawable/ic_mirror.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="@color/session_accent">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M12,4V1L8,5l4,4V6c3.31,0 6,2.69 6,6 0,1.01 -0.25,1.97 -0.7,2.8l1.46,1.46C19.54,15.03 20,13.57 20,12c0,-4.42 -3.58,-8 -8,-8zM6,12c0,-1.01 0.25,-1.97 0.7,-2.8L5.24,7.74C4.46,8.97 4,10.43 4,12c0,4.42 3.58,8 8,8v3l4,-4 -4,-4v3c-3.31,0 -6,-2.69 -6,-6z" />
+</vector>

--- a/packages/mobile/modules/live-activity/android/src/main/res/layout/notification_session_collapsed.xml
+++ b/packages/mobile/modules/live-activity/android/src/main/res/layout/notification_session_collapsed.xml
@@ -46,4 +46,14 @@
             android:ellipsize="end"
             android:textAppearance="@style/TextAppearance.Compat.Notification.Info" />
     </LinearLayout>
+    <ImageButton
+        android:id="@+id/session_mirror"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="center_vertical"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:src="@drawable/ic_mirror"
+        android:padding="12dp"
+        android:visibility="gone"
+        tools:ignore="ContentDescription" />
 </LinearLayout>

--- a/packages/mobile/modules/live-activity/android/src/main/res/layout/notification_session_expanded.xml
+++ b/packages/mobile/modules/live-activity/android/src/main/res/layout/notification_session_expanded.xml
@@ -64,4 +64,14 @@
             android:visibility="gone"
             android:textAppearance="@style/TextAppearance.Compat.Notification.Info" />
     </LinearLayout>
+    <ImageButton
+        android:id="@+id/session_mirror"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="center_vertical"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:src="@drawable/ic_mirror"
+        android:padding="12dp"
+        android:visibility="gone"
+        tools:ignore="ContentDescription" />
 </LinearLayout>

--- a/packages/mobile/modules/live-activity/android/src/test/java/com/boardsesh/liveactivity/BoardSessionActionReceiverTest.kt
+++ b/packages/mobile/modules/live-activity/android/src/test/java/com/boardsesh/liveactivity/BoardSessionActionReceiverTest.kt
@@ -35,6 +35,7 @@ class BoardSessionActionReceiverTest {
     @Before
     fun setUp() {
         mockkObject(SessionPresenceModule.Companion)
+        every { SessionPresenceModule.dispatchMirror(any(), any(), any()) } just Runs
         every { SessionPresenceModule.dispatchBoardControl(any(), any()) } just Runs
         every { SessionPresenceModule.dispatchQueueNavigate(any(), any(), any()) } just Runs
     }
@@ -42,6 +43,23 @@ class BoardSessionActionReceiverTest {
     @After
     fun tearDown() {
         unmockkObject(SessionPresenceModule.Companion)
+    }
+
+    @Test
+    fun `mirror forwards an absolute orientation for the notification slot`() {
+        val intent = Intent(BoardSessionService.ACTION_MIRROR).apply {
+            putExtra(BoardSessionService.EXTRA_SESSION_ID, "session")
+            putExtra(BoardSessionService.EXTRA_QUEUE_ITEM_UUID, "slot")
+            putExtra(BoardSessionService.EXTRA_MIRRORED, true)
+        }
+        receiver.onReceive(context, intent)
+        verify(exactly = 1) { SessionPresenceModule.dispatchMirror("session", "slot", true) }
+    }
+
+    @Test
+    fun `mirror ignores incomplete notification intents`() {
+        receiver.onReceive(context, Intent(BoardSessionService.ACTION_MIRROR))
+        verify(exactly = 0) { SessionPresenceModule.dispatchMirror(any(), any(), any()) }
     }
 
     private fun bulbIntent(connection: String): Intent =

--- a/packages/mobile/modules/live-activity/android/src/test/java/com/boardsesh/liveactivity/BoardSessionServiceTest.kt
+++ b/packages/mobile/modules/live-activity/android/src/test/java/com/boardsesh/liveactivity/BoardSessionServiceTest.kt
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.GraphicsMode
 import org.robolectric.annotation.Config
 import java.util.concurrent.Executor
 
@@ -43,6 +44,50 @@ import java.util.concurrent.Executor
  */
 @RunWith(RobolectricTestRunner::class)
 class BoardSessionServiceTest {
+
+    @Test
+    @Config(sdk = [30])
+    @GraphicsMode(GraphicsMode.Mode.NATIVE)
+    fun `mirror flips thumbnail pixels and leaves source bitmap unchanged`() {
+        val bitmap = Bitmap.createBitmap(2, 1, Bitmap.Config.ARGB_8888)
+        bitmap.setPixel(0, 0, android.graphics.Color.RED)
+        bitmap.setPixel(1, 0, android.graphics.Color.BLUE)
+        val mirrored = BoardSessionService.orientThumbnail(bitmap, true)
+        assertEquals(android.graphics.Color.BLUE, mirrored.getPixel(0, 0))
+        assertEquals(android.graphics.Color.RED, mirrored.getPixel(1, 0))
+        assertEquals(android.graphics.Color.RED, bitmap.getPixel(0, 0))
+        assertSame(bitmap, BoardSessionService.orientThumbnail(bitmap, false))
+    }
+
+    @Test
+    @Config(sdk = [31])
+    fun `mirror content button requires supported board and ownership and retains navigation`() {
+        val captured = slot<Notification>()
+        every { ServiceCompat.startForeground(any(), any(), capture(captured), any()) } just Runs
+        val service = startService()
+        fun update(connection: String, supported: Boolean, mirrored: Boolean = false) {
+            service.onStartCommand(updateIntent(connection, hasPrevious = true, hasNext = true).apply {
+                putExtra(BoardSessionService.EXTRA_SESSION_ID, "session")
+                putExtra(BoardSessionService.EXTRA_QUEUE_ITEM_UUID, "queue-item")
+                putExtra(BoardSessionService.EXTRA_SUPPORTS_MIRRORING, supported)
+                putExtra(BoardSessionService.EXTRA_MIRRORED, mirrored)
+            }, 0, 2)
+        }
+        for (layout in listOf(R.layout.notification_session_collapsed, R.layout.notification_session_expanded)) {
+            update("connectedByMe", true, true)
+            val content = service.buildContentView(layout).apply(context, FrameLayout(context))
+            val button = content.findViewById<android.widget.ImageButton>(R.id.session_mirror)
+            assertEquals(android.view.View.VISIBLE, button.visibility)
+            assertEquals("Unmirror climb", button.contentDescription)
+            assertEquals(listOf("Previous", "Relight wall", "Next"), actionTitles(captured.captured))
+            update("heldByPeer", true)
+            assertEquals(android.view.View.GONE, service.buildContentView(layout)
+                .apply(context, FrameLayout(context)).findViewById<android.view.View>(R.id.session_mirror).visibility)
+            update("connectedByMe", false)
+            assertEquals(android.view.View.GONE, service.buildContentView(layout)
+                .apply(context, FrameLayout(context)).findViewById<android.view.View>(R.id.session_mirror).visibility)
+        }
+    }
 
     private val connectedDevice = ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
 

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -630,7 +630,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         items: [SharedQueueItem],
         currentIndex: Int,
         readyTimeout: TimeInterval,
-        drainTimeout: TimeInterval = 1.5
+        drainTimeout: TimeInterval = 1.5,
+        stillCurrent: @escaping @Sendable () -> Bool = { true }
     ) async -> Bool {
         await waitUntilReady(timeout: readyTimeout)
         let ready = runOnBleQueueSync { isReadyForWrite }
@@ -646,14 +647,16 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         return await displayCurrentItemAwaitingDrain(
             items: items,
             currentIndex: currentIndex,
-            drainTimeout: drainTimeout
+            drainTimeout: drainTimeout,
+            stillCurrent: stillCurrent
         )
     }
 
     private func displayCurrentItemAwaitingDrain(
         items: [SharedQueueItem],
         currentIndex: Int,
-        drainTimeout: TimeInterval
+        drainTimeout: TimeInterval,
+        stillCurrent: @escaping @Sendable () -> Bool = { true }
     ) async -> Bool {
         let displayOutcome = BoardBleDisplayWriteOutcome()
         // Both blocks enter the same serial queue in call order: the display
@@ -661,6 +664,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // waiter evaluates the global queue predicate.
         runOnBleQueue { [weak self] in
             guard let self else {
+                displayOutcome.settle(succeeded: false)
+                return
+            }
+            guard stillCurrent() else {
                 displayOutcome.settle(succeeded: false)
                 return
             }

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -1193,11 +1193,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // the plain-ASCII `led,role,…,!` format — BoardPlacementData has no
         // woods rows, so falling through to the Aurora path would refuse every
         // climb (and would let an empty-frames item write an *Aurora* clear
-        // packet to a Woods wall). Woods mirroring is JS-side geometry with no
-        // placement table here, and the JS send path dispatches raw frames for
-        // Woods too, so frames go out as-is.
+        // packet to a Woods wall). Reflect the per-size LED map for mirrored
+        // climbs using the same generated row geometry as the JS send path.
         if configuration.boardName == "woods" {
-            guard let ledMap = WoodsBoardData.ledMap(forSizeId: configuration.sizeId) else {
+            guard let ledMap = WoodsBoardData.ledMap(forSizeId: configuration.sizeId, mirrored: item.mirrored) else {
                 logger.error("No Woods LED table for size=\(configuration.sizeId, privacy: .public)")
                 completion?(false)
                 return

--- a/packages/mobile/modules/live-activity/ios/ClimbNavigationIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/ClimbNavigationIntent.swift
@@ -112,6 +112,9 @@ enum ClimbNavigationIntent {
             hasNext: newIndex < items.count - 1,
             hasPrevious: newIndex > 0,
             climbUuid: newItem.climbUuid,
+            queueItemUuid: newItem.uuid,
+            mirrored: newItem.mirrored,
+            supportsMirroring: defaults.bool(forKey: SharedConstants.supportsMirroringKey),
             // Prev/Next are only shown when this device drives the wall, so the
             // optimistic frame keeps the bulb lit + controls shown.
             boardConnection: "connectedByMe",

--- a/packages/mobile/modules/live-activity/ios/ClimbSessionAttributes.swift
+++ b/packages/mobile/modules/live-activity/ios/ClimbSessionAttributes.swift
@@ -12,6 +12,9 @@ struct ClimbSessionAttributes: ActivityAttributes {
         var hasNext: Bool
         var hasPrevious: Bool
         var climbUuid: String
+        var queueItemUuid: String? = nil
+        var mirrored: Bool? = nil
+        var supportsMirroring: Bool? = nil
         /// Who currently drives the board, from THIS device's point of view:
         /// "connectedByMe" | "heldByPeer" | "disconnected". Optional so an older
         /// binary decoding a newer push (or vice-versa) never fails to decode;

--- a/packages/mobile/modules/live-activity/ios/LiveActivityBleBridge.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityBleBridge.swift
@@ -20,14 +20,19 @@ enum LiveActivityBleBridge {
     /// the global write queue drained inside its existing timeout. This is
     /// diagnostic-only; failed or late writes keep their existing behavior.
     @discardableResult
-    static func writeBoardForIntent(items: [SharedQueueItem], currentIndex: Int) async -> Bool {
+    static func writeBoardForIntent(items: [SharedQueueItem], currentIndex: Int, mirrorReceipt: SharedMirrorConfirmation? = nil) async -> Bool {
         let task = BleIntentBackgroundTask()
         task.begin(name: "ble-display-intent")
         defer { task.end() }
         return await BoardBleManager.shared.displayCurrentItemAwaitingReady(
             items: items,
             currentIndex: currentIndex,
-            readyTimeout: 3.0
+            readyTimeout: 3.0,
+            stillCurrent: {
+                guard let mirrorReceipt else { return true }
+                guard let defaults = SharedConstants.sharedDefaults else { return false }
+                return SharedMirrorState.isCurrent(mirrorReceipt, in: defaults)
+            }
         )
     }
 

--- a/packages/mobile/modules/live-activity/ios/LiveActivityIntentDiagnostics.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityIntentDiagnostics.swift
@@ -5,6 +5,7 @@ import Foundation
 /// Fixed, non-identifying intent kinds. Keep this exhaustive with every
 /// `LiveActivityIntent` compiled into the main app and widget targets.
 enum LiveActivityIntentDiagnosticKind: String, Codable, CaseIterable {
+    case mirrorClimb
     case nextClimb
     case previousClimb
     case takeControl

--- a/packages/mobile/modules/live-activity/ios/LiveActivityManager.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityManager.swift
@@ -152,6 +152,17 @@ actor LiveActivityManager {
             return
         }
 
+        // Queued JS/socket work may resume after a newer mirror confirmation.
+        // Read the committed snapshot here, on the actor, immediately before publishing.
+        var state = state
+        if let defaults = SharedConstants.sharedDefaults {
+            guard activity.attributes.sessionId == defaults.string(forKey: SharedConstants.sessionIdKey) else { return }
+            let (items, index) = SharedQueueState.load(from: defaults)
+            if let latestState = Self.buildContentState(items: items, currentIndex: index) {
+                state = latestState
+            }
+        }
+
         // The ping timeout timer refreshes the stale date every 60s while
         // the native WebSocket is healthy, and each JS updateActivity call
         // also resets it. If all update paths fail for the stale interval,
@@ -305,6 +316,9 @@ actor LiveActivityManager {
             hasNext: currentIndex < items.count - 1,
             hasPrevious: currentIndex > 0,
             climbUuid: item.climbUuid,
+            queueItemUuid: item.uuid,
+            mirrored: item.mirrored,
+            supportsMirroring: SharedConstants.sharedDefaults?.bool(forKey: SharedConstants.supportsMirroringKey) ?? false,
             boardConnection: boardConnection,
             holderDisplayName: holderDisplayName
         )

--- a/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
@@ -77,7 +77,8 @@ public class LiveActivityModule: Module {
     public func definition() -> ModuleDefinition {
         Name("LiveActivity")
 
-        Events("queueNavigate")
+        Events("queueNavigate", "queueMirror")
+        Constants(["supportsMirrorControl": true])
 
         OnDestroy {
             self.stopDarwinObservation()
@@ -91,12 +92,21 @@ public class LiveActivityModule: Module {
                 self.hasListener = true
             }
             self.drainPendingEvents()
+            self.emitPendingMirror()
         }
 
         OnStopObserving {
             self.bufferQueue.sync {
                 self.hasListener = false
             }
+        }
+
+        AsyncFunction("getPendingMirror") { () -> [String: Any]? in
+            SharedConstants.sharedDefaults.flatMap { SharedMirrorState.pending(in: $0)?.eventBody }
+        }
+        AsyncFunction("acknowledgeMirror") { (sessionId: String, sequence: Int) in
+            guard let defaults = SharedConstants.sharedDefaults else { return }
+            SharedMirrorState.acknowledge(sessionId: sessionId, sequence: sequence, in: defaults)
         }
 
         AsyncFunction("isAvailable") { () -> [String: Any] in
@@ -331,9 +341,17 @@ public class LiveActivityModule: Module {
 
     @objc private func handleAppWillEnterForeground() {
         retryPendingRegistrationIfNeeded(trigger: "foreground")
+        emitPendingMirror()
+    }
+
+    private func emitPendingMirror() {
+        guard let defaults = SharedConstants.sharedDefaults,
+              let pending = SharedMirrorState.pending(in: defaults) else { return }
+        emitOrBuffer(name: "queueMirror", body: pending.eventBody)
     }
 
     private func handleQueueNavigateFromWidget() {
+        emitPendingMirror()
         guard let defaults = SharedConstants.sharedDefaults else { return }
 
         guard let action = defaults.string(forKey: SharedConstants.widgetNavigateActionKey) else {
@@ -659,6 +677,13 @@ public class LiveActivityModule: Module {
             components.fragment = nil
             return components.url?.absoluteString
         }()
+        let widgetMirrorUrl: String? = {
+            guard let graphqlUrl, var components = URLComponents(string: graphqlUrl) else { return nil }
+            components.path = "/api/widget/mirror"
+            components.query = nil
+            components.fragment = nil
+            return components.url?.absoluteString
+        }()
         let widgetTakeControlUrl: String? = {
             guard let graphqlUrl, var components = URLComponents(string: graphqlUrl) else { return nil }
             components.path = "/api/widget/take-control"
@@ -668,6 +693,12 @@ public class LiveActivityModule: Module {
         }()
 
         if let defaults = SharedConstants.sharedDefaults {
+            if defaults.string(forKey: SharedConstants.sessionIdKey) != sessionId {
+                defaults.removeObject(forKey: SharedConstants.pendingMirrorKey)
+                defaults.removeObject(forKey: SharedConstants.queueSequenceKey)
+            }
+            defaults.set(options.supportsMirroring, forKey: SharedConstants.supportsMirroringKey)
+            defaults.set(widgetMirrorUrl, forKey: SharedConstants.widgetMirrorUrlKey)
             defaults.set(sessionId, forKey: SharedConstants.sessionIdKey)
             defaults.set(serverUrl, forKey: SharedConstants.serverUrlKey)
             if let widgetNavigateUrl {
@@ -725,6 +756,7 @@ public class LiveActivityModule: Module {
 
         wsManager.onQueueStateChanged = { [weak self] items, currentIndex in
             guard let self else { return }
+            self.emitPendingMirror()
             guard let state = LiveActivityManager.buildContentState(
                 items: items,
                 currentIndex: currentIndex
@@ -828,6 +860,7 @@ public class LiveActivityModule: Module {
             defaults.removeObject(forKey: SharedConstants.currentIndexKey)
             defaults.removeObject(forKey: SharedConstants.sessionIdKey)
             defaults.removeObject(forKey: SharedConstants.pendingActionKey)
+            defaults.removeObject(forKey: SharedConstants.pendingMirrorKey)
             defaults.removeObject(forKey: SharedConstants.widgetNavigateUrlKey)
             defaults.removeObject(forKey: SharedConstants.widgetTakeControlUrlKey)
             defaults.removeObject(forKey: SharedConstants.authTokenKey)
@@ -854,6 +887,12 @@ public class LiveActivityModule: Module {
 
     private func updateActivity(options: UpdateActivityOptions) {
         guard #available(iOS 17.0, *) else { return }
+        guard acceptQueueUpdate(
+            sessionId: options.sessionId, sequence: options.queueSequence,
+            navigationAllowed: options.widgetNavigationAllowed, isPartySession: options.isPartySession,
+            boardConnection: options.boardConnection, holderDisplayName: options.holderDisplayName,
+            supportsMirroring: options.supportsMirroring
+        ) else { return }
 
         var wallControlChanged = false
         var renderModeChanged = false
@@ -889,7 +928,11 @@ public class LiveActivityModule: Module {
                     mirrored: item.mirrored
                 ))
             }
-            SharedQueueState.save(items: queueItems, currentIndex: options.currentIndex, to: defaults)
+            if let sequence = options.queueSequence {
+                guard SharedMirrorState.persist(items: queueItems, currentIndex: options.currentIndex, sequence: sequence, in: defaults) else { return }
+            } else {
+                SharedQueueState.save(items: queueItems, currentIndex: options.currentIndex, to: defaults)
+            }
             SharedWidgetWallControlState.save(
                 navigationAllowed: options.widgetNavigationAllowed,
                 isPartySession: options.isPartySession,
@@ -911,6 +954,9 @@ public class LiveActivityModule: Module {
             hasNext: options.hasNext,
             hasPrevious: options.hasPrevious,
             climbUuid: options.climbUuid,
+            queueItemUuid: options.queueItemUuid,
+            mirrored: options.mirrored,
+            supportsMirroring: options.supportsMirroring,
             boardConnection: options.boardConnection,
             holderDisplayName: options.holderDisplayName
         )
@@ -933,10 +979,41 @@ public class LiveActivityModule: Module {
         }
     }
 
+    /// Ownership always advances, even while an older JS queue waits for mirror reconciliation.
+    private func acceptQueueUpdate(
+        sessionId: String?, sequence: Int?, navigationAllowed: Bool, isPartySession: Bool,
+        boardConnection: String, holderDisplayName: String?, supportsMirroring: Bool
+    ) -> Bool {
+        guard let defaults = SharedConstants.sharedDefaults else { return true }
+        if let sessionId, sessionId != defaults.string(forKey: SharedConstants.sessionIdKey) { return false }
+        defaults.set(supportsMirroring, forKey: SharedConstants.supportsMirroringKey)
+        let receipt = SharedMirrorState.pending(in: defaults)
+        let stale = sequence.map { $0 < SharedMirrorState.sequence(in: defaults) } ?? (receipt != nil)
+        if stale {
+            SharedWidgetWallControlState.save(navigationAllowed: navigationAllowed, isPartySession: isPartySession, to: defaults)
+            SharedWidgetWallControlState.saveBoardConnection(boardConnection, holderDisplayName: holderDisplayName, to: defaults)
+            let (items, index) = SharedQueueState.load(from: defaults)
+            if let state = LiveActivityManager.buildContentState(items: items, currentIndex: index) {
+                enqueueLifecycleWork { await LiveActivityManager.shared.updateActivity(state: state) }
+            }
+            return false
+        }
+        if let receipt, let sequence {
+            SharedMirrorState.acknowledge(sessionId: receipt.sessionId, sequence: sequence, in: defaults)
+        }
+        return true
+    }
+
     // MARK: - updateActivityClimb (lightweight — no queue serialization)
 
     private func updateActivityClimb(options: UpdateActivityClimbOptions) {
         guard #available(iOS 17.0, *) else { return }
+        guard acceptQueueUpdate(
+            sessionId: options.sessionId, sequence: options.queueSequence,
+            navigationAllowed: options.widgetNavigationAllowed, isPartySession: options.isPartySession,
+            boardConnection: options.boardConnection, holderDisplayName: options.holderDisplayName,
+            supportsMirroring: options.supportsMirroring
+        ) else { return }
 
         var wallControlChanged = false
         var renderModeChanged = false
@@ -955,7 +1032,19 @@ public class LiveActivityModule: Module {
                 defaults.set(renderMode, forKey: SharedConstants.renderModeKey)
             }
 
-            SharedQueueState.saveCurrentIndex(options.currentIndex, to: defaults)
+            if let sequence = options.queueSequence {
+                let (items, _) = SharedQueueState.load(from: defaults)
+                let updatedItems = items.map { item in
+                    item.uuid == options.queueItemUuid ? SharedQueueItem(
+                        uuid: item.uuid, climbUuid: item.climbUuid, climbName: item.climbName,
+                        difficulty: item.difficulty, angle: item.angle, frames: item.frames,
+                        setterUsername: item.setterUsername, mirrored: options.mirrored
+                    ) : item
+                }
+                guard SharedMirrorState.persist(items: updatedItems, currentIndex: options.currentIndex, sequence: sequence, in: defaults) else { return }
+            } else {
+                SharedQueueState.saveCurrentIndex(options.currentIndex, to: defaults)
+            }
             SharedWidgetWallControlState.save(
                 navigationAllowed: options.widgetNavigationAllowed,
                 isPartySession: options.isPartySession,
@@ -977,6 +1066,9 @@ public class LiveActivityModule: Module {
             hasNext: options.hasNext,
             hasPrevious: options.hasPrevious,
             climbUuid: options.climbUuid,
+            queueItemUuid: options.queueItemUuid,
+            mirrored: options.mirrored,
+            supportsMirroring: options.supportsMirroring,
             boardConnection: options.boardConnection,
             holderDisplayName: options.holderDisplayName
         )
@@ -1011,6 +1103,7 @@ struct StartSessionOptions: Record {
     @Field var authToken: String?
     @Field var wsUrl: String?
     @Field var graphqlUrl: String?
+    @Field var supportsMirroring: Bool = false
     @Field var widgetNavigationAllowed: Bool = true
     @Field var isPartySession: Bool = false
     /// Board-connection state from THIS device's POV: "connectedByMe" |
@@ -1042,6 +1135,10 @@ struct UpdateActivityQueueItem: Record {
 }
 
 struct UpdateActivityOptions: Record {
+    @Field var sessionId: String?
+    @Field var queueSequence: Int?
+    @Field var queueItemUuid: String?
+    @Field var mirrored: Bool = false
     @Field var climbName: String = ""
     @Field var climbDifficulty: String = ""
     @Field var angle: Int = 0
@@ -1051,6 +1148,7 @@ struct UpdateActivityOptions: Record {
     @Field var hasPrevious: Bool = false
     @Field var climbUuid: String = ""
     @Field var queue: [UpdateActivityQueueItem] = []
+    @Field var supportsMirroring: Bool = false
     @Field var widgetNavigationAllowed: Bool = true
     @Field var isPartySession: Bool = false
     @Field var boardConnection: String = "connectedByMe"
@@ -1061,6 +1159,10 @@ struct UpdateActivityOptions: Record {
 }
 
 struct UpdateActivityClimbOptions: Record {
+    @Field var sessionId: String?
+    @Field var queueSequence: Int?
+    @Field var queueItemUuid: String?
+    @Field var mirrored: Bool = false
     @Field var climbName: String = ""
     @Field var climbDifficulty: String = ""
     @Field var angle: Int = 0
@@ -1069,6 +1171,7 @@ struct UpdateActivityClimbOptions: Record {
     @Field var hasNext: Bool = false
     @Field var hasPrevious: Bool = false
     @Field var climbUuid: String = ""
+    @Field var supportsMirroring: Bool = false
     @Field var widgetNavigationAllowed: Bool = true
     @Field var isPartySession: Bool = false
     @Field var boardConnection: String = "connectedByMe"

--- a/packages/mobile/modules/live-activity/ios/LiveActivityModulePod.podspec
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityModulePod.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = { ios: '16.4' }
   s.swift_version  = '5.9'
   s.source_files   = '*.swift'
+  s.resources      = '*.lproj'
   s.frameworks     = 'ActivityKit', 'CoreBluetooth', 'WidgetKit', 'AppIntents'
   s.dependency 'ExpoModulesCore'
   # libwebp-backed coder for the bundled board-background webp(s) composited into

--- a/packages/mobile/modules/live-activity/ios/MirrorClimbIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/MirrorClimbIntent.swift
@@ -1,0 +1,91 @@
+import ActivityKit
+import AppIntents
+
+@available(iOS 17.0, *)
+struct MirrorClimbIntent: LiveActivityIntent {
+    static let title: LocalizedStringResource = "Mirror climb"
+    @Parameter(title: "Session") var sessionId: String
+    @Parameter(title: "Queue item") var queueItemUuid: String
+    @Parameter(title: "Mirrored") var mirrored: Bool
+
+    init() { sessionId = ""; queueItemUuid = ""; mirrored = false }
+    init(sessionId: String, queueItemUuid: String, mirrored: Bool) {
+        self.sessionId = sessionId
+        self.queueItemUuid = queueItemUuid
+        self.mirrored = mirrored
+    }
+
+    func perform() async throws -> some IntentResult {
+        guard await MirrorIntentGate.shared.begin() else { return .result() }
+        await performMirror()
+        await MirrorIntentGate.shared.end()
+        return .result()
+    }
+
+    private func performMirror() async {
+        #if !WIDGET_EXTENSION
+        let diagnosticRun = LiveActivityIntentDiagnostics.begin(kind: .mirrorClimb)
+        var completionClass = LiveActivityIntentCompletionClass.serverRejected
+        defer { diagnosticRun.complete(completionClass) }
+        #endif
+        guard let defaults = SharedConstants.sharedDefaults,
+              SharedMirrorState.canMirror(sessionId: sessionId, queueItemUuid: queueItemUuid, in: defaults)
+        else { return }
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.networkStarted)
+        #endif
+        let response = await WidgetNetworking.sendMirror(sessionId: sessionId, queueItemUuid: queueItemUuid, mirrored: mirrored)
+        guard case .success(let receipt) = response else {
+            #if !WIDGET_EXTENSION
+            diagnosticRun.mark(response == .retryableFailure ? .networkFinishedRetryable : .networkFinishedTerminal)
+            completionClass = response == .retryableFailure ? .retryableNetworkFailure : .serverRejected
+            #endif
+            return
+        }
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.networkFinishedSuccess)
+        completionClass = .success
+        #endif
+        if let snapshot = SharedMirrorState.apply(receipt, in: defaults) {
+            let updatedItems = snapshot.items
+            let index = snapshot.index
+            let item = updatedItems[index]
+            let state = ClimbSessionAttributes.ContentState(
+                climbName: item.climbName, climbDifficulty: VGradeFormatter.formatVGrade(item.difficulty),
+                angle: item.angle, currentIndex: index, totalClimbs: updatedItems.count,
+                hasNext: index < updatedItems.count - 1, hasPrevious: index > 0, climbUuid: item.climbUuid,
+                queueItemUuid: item.uuid, mirrored: item.mirrored, supportsMirroring: true,
+                boardConnection: "connectedByMe", holderDisplayName: nil
+            )
+            for activity in Activity<ClimbSessionAttributes>.activities where activity.attributes.sessionId == sessionId && activity.activityState == .active {
+                guard SharedMirrorState.isCurrent(receipt, in: defaults) else { break }
+                await activity.update(ActivityContent(state: state, staleDate: Date().addingTimeInterval(SharedConstants.liveActivityStaleInterval)))
+            }
+            #if !WIDGET_EXTENSION
+            diagnosticRun.mark(.activityKitUpdated)
+            diagnosticRun.mark(.bleStarted)
+            let succeeded = await LiveActivityBleBridge.writeBoardForIntent(items: updatedItems, currentIndex: index, mirrorReceipt: receipt)
+            diagnosticRun.mark(succeeded ? .bleFinishedSuccess : .bleFinishedFailure)
+            if !succeeded { completionClass = .bleFailure }
+            #endif
+        }
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            CFNotificationName(SharedConstants.queueNavigateNotification as CFString), nil, nil, true
+        )
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.darwinPosted)
+        #endif
+    }
+}
+
+private actor MirrorIntentGate {
+    static let shared = MirrorIntentGate()
+    private var busy = false
+    func begin() -> Bool {
+        guard !busy else { return false }
+        busy = true
+        return true
+    }
+    func end() { busy = false }
+}

--- a/packages/mobile/modules/live-activity/ios/SessionWebSocketManager.swift
+++ b/packages/mobile/modules/live-activity/ios/SessionWebSocketManager.swift
@@ -81,6 +81,7 @@ final class SessionWebSocketManager {
     // MARK: - Connection State
 
     private var urlSession: URLSession
+    private var subscriptionSequence = -1
     private var webSocketTask: URLSessionWebSocketTask?
     private(set) var isConnected = false
     private var subscriptionId: String = "1"
@@ -168,6 +169,7 @@ final class SessionWebSocketManager {
         // of the old one), so a sequence carried over from the previous
         // connection must not gap-check the new stream.
         self.lastSequence = -1
+        self.subscriptionSequence = SharedConstants.sharedDefaults.map { SharedMirrorState.sequence(in: $0) } ?? -1
 
         let urlString: String
         if let wsUrl = self.wsUrl, !wsUrl.isEmpty {
@@ -493,12 +495,21 @@ final class SessionWebSocketManager {
         )
         queueItems = newState.items
         currentIndex = newState.currentIndex
-        persistAndNotify(repaintBoard: QueueEventRepaintPolicy.shouldRepaintBoard(for: event))
+        let fullSyncSequence: Int?
+        if case .fullSync = event { fullSyncSequence = subscriptionSequence } else { fullSyncSequence = nil }
+        persistAndNotify(repaintBoard: QueueEventRepaintPolicy.shouldRepaintBoard(for: event), subscriptionSequence: fullSyncSequence)
     }
 
-    private func persistAndNotify(repaintBoard: Bool = false) {
+    private func persistAndNotify(repaintBoard: Bool = false, subscriptionSequence: Int? = nil) {
         if let defaults = SharedConstants.sharedDefaults {
-            SharedQueueState.save(items: queueItems, currentIndex: currentIndex, to: defaults)
+            // HTTP mirror may be ahead of this socket's buffered deltas. Reduce those
+            // internally until it catches up, without repainting an older wall state.
+            guard SharedMirrorState.persist(items: queueItems, currentIndex: currentIndex, sequence: lastSequence, subscriptionSequence: subscriptionSequence, in: defaults) else {
+                // The FullSync was requested before a newer mirror confirmation.
+                // Reconnect so a fresh authoritative snapshot can safely rebaseline.
+                if subscriptionSequence != nil { webSocketTask?.cancel(with: .goingAway, reason: nil) }
+                return
+            }
         }
         if repaintBoard {
             BoardBleManager.shared.displayCurrentItem(items: queueItems, currentIndex: currentIndex)

--- a/packages/mobile/modules/live-activity/ios/SharedConstants.swift
+++ b/packages/mobile/modules/live-activity/ios/SharedConstants.swift
@@ -17,6 +17,10 @@ enum SharedConstants {
     /// https://ws.boardsesh.com/api/widget/navigate). The widget POSTs button
     /// taps here. Kept fully qualified rather than derived from `serverUrlKey`
     /// so the native contract remains explicit.
+    static let widgetMirrorUrlKey = "bs_widget_mirror_url"
+    static let supportsMirroringKey = "bs_supports_mirroring"
+    static let queueSequenceKey = "bs_queue_sequence"
+    static let pendingMirrorKey = "bs_pending_mirror"
     static let widgetNavigateUrlKey = "bs_widget_navigate_url"
     /// Fully-qualified backend `/api/widget/take-control` URL. The widget
     /// POSTs non-driver lightbulb taps here before enabling local navigation.

--- a/packages/mobile/modules/live-activity/ios/SharedMirrorState.swift
+++ b/packages/mobile/modules/live-activity/ios/SharedMirrorState.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+struct SharedMirrorConfirmation: Codable, Equatable, Sendable {
+    let sessionId: String
+    let queueItemUuid: String
+    let mirrored: Bool
+    let sequence: Int
+    let stateHash: String
+    let stateHashOrdered: String?
+
+    var eventBody: [String: Any] {
+        var body: [String: Any] = [
+            "kind": "confirmed", "sessionId": sessionId, "queueItemUuid": queueItemUuid,
+            "mirrored": mirrored, "sequence": sequence, "stateHash": stateHash
+        ]
+        if let stateHashOrdered { body["stateHashOrdered"] = stateHashOrdered }
+        return body
+    }
+}
+
+/// A durable receipt, retained until JS has applied this sequence (or a newer full sync).
+enum SharedMirrorState {
+    private static let lock = NSLock()
+
+    static func pending(in defaults: UserDefaults) -> SharedMirrorConfirmation? {
+        guard let bytes = defaults.data(forKey: SharedConstants.pendingMirrorKey),
+              let receipt = try? JSONDecoder().decode(SharedMirrorConfirmation.self, from: bytes),
+              receipt.sessionId == defaults.string(forKey: SharedConstants.sessionIdKey) else { return nil }
+        return receipt
+    }
+
+    static func acknowledge(sessionId: String, sequence: Int, in defaults: UserDefaults) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let receipt = pending(in: defaults), receipt.sessionId == sessionId,
+              receipt.sequence <= sequence else { return }
+        defaults.removeObject(forKey: SharedConstants.pendingMirrorKey)
+    }
+
+    static func sequence(in defaults: UserDefaults) -> Int {
+        defaults.object(forKey: SharedConstants.queueSequenceKey) as? Int ?? -1
+    }
+
+    /// Publish a complete queue snapshot only if it is at least as new as the native receipt.
+    @discardableResult
+    static func persist(items: [SharedQueueItem], currentIndex: Int, sequence: Int, subscriptionSequence: Int? = nil, in defaults: UserDefaults) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if sequence < Self.sequence(in: defaults) {
+            // A subscription requested after the last accepted update is authoritative,
+            // including when the server recovered with a reset sequence counter.
+            guard subscriptionSequence == Self.sequence(in: defaults) else { return false }
+            defaults.removeObject(forKey: SharedConstants.pendingMirrorKey)
+        }
+        SharedQueueState.save(items: items, currentIndex: currentIndex, to: defaults)
+        defaults.set(sequence, forKey: SharedConstants.queueSequenceKey)
+        return true
+    }
+
+    static func isCurrent(_ receipt: SharedMirrorConfirmation, in defaults: UserDefaults) -> Bool {
+        let (items, index) = SharedQueueState.load(from: defaults)
+        return sequence(in: defaults) == receipt.sequence
+            && canMirror(sessionId: receipt.sessionId, queueItemUuid: receipt.queueItemUuid, in: defaults)
+            && items.indices.contains(index) && items[index].mirrored == receipt.mirrored
+    }
+
+    /// Commit an HTTP result atomically against native WebSocket updates.
+    static func apply(_ receipt: SharedMirrorConfirmation, in defaults: UserDefaults) -> (items: [SharedQueueItem], index: Int)? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard receipt.sessionId == defaults.string(forKey: SharedConstants.sessionIdKey),
+              receipt.sequence >= sequence(in: defaults),
+              let bytes = try? JSONEncoder().encode(receipt) else { return nil }
+        defaults.set(bytes, forKey: SharedConstants.pendingMirrorKey)
+        guard canMirror(sessionId: receipt.sessionId, queueItemUuid: receipt.queueItemUuid, in: defaults) else { return nil }
+        let (items, index) = SharedQueueState.load(from: defaults)
+        let updatedItems = items.map { item in
+            item.uuid == receipt.queueItemUuid ? SharedQueueItem(
+                uuid: item.uuid, climbUuid: item.climbUuid, climbName: item.climbName,
+                difficulty: item.difficulty, angle: item.angle, frames: item.frames,
+                setterUsername: item.setterUsername, mirrored: receipt.mirrored
+            ) : item
+        }
+        SharedQueueState.save(items: updatedItems, currentIndex: index, to: defaults)
+        defaults.set(receipt.sequence, forKey: SharedConstants.queueSequenceKey)
+        return (updatedItems, index)
+    }
+
+    static func canMirror(sessionId: String, queueItemUuid: String, in defaults: UserDefaults) -> Bool {
+        let (items, index) = SharedQueueState.load(from: defaults)
+        return defaults.string(forKey: SharedConstants.sessionIdKey) == sessionId
+            && defaults.bool(forKey: SharedConstants.supportsMirroringKey)
+            && defaults.string(forKey: SharedConstants.boardConnectionKey) == "connectedByMe"
+            && SharedWidgetWallControlState.load(from: defaults).navigationAllowed
+            && items.indices.contains(index) && items[index].uuid == queueItemUuid
+    }
+}

--- a/packages/mobile/modules/live-activity/ios/WidgetNetworking.swift
+++ b/packages/mobile/modules/live-activity/ios/WidgetNetworking.swift
@@ -6,7 +6,45 @@ enum WidgetNavigationResult: Equatable {
     case retryableFailure
 }
 
+enum WidgetMirrorResult: Equatable {
+    case success(SharedMirrorConfirmation)
+    case serverRejected
+    case retryableFailure
+}
+
 enum WidgetNetworking {
+    static func sendMirror(sessionId: String, queueItemUuid: String, mirrored: Bool) async -> WidgetMirrorResult {
+        guard let defaults = SharedConstants.sharedDefaults,
+              let urlString = defaults.string(forKey: SharedConstants.widgetMirrorUrlKey),
+              let url = URL(string: urlString),
+              let token = SharedKeychain.get(SharedKeychain.livePushTokenKey), !token.isEmpty
+        else { return .serverRejected }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 10
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: [
+            "sessionId": sessionId, "queueItemUuid": queueItemUuid, "mirrored": mirrored
+        ])
+        do {
+            let (bytes, response) = try await URLSession.shared.data(for: request)
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            if status == 410 {
+                CFNotificationCenterPostNotification(
+                    CFNotificationCenterGetDarwinNotifyCenter(),
+                    CFNotificationName(SharedConstants.pushRegistrationStaleNotification as CFString), nil, nil, true
+                )
+            }
+            if (400...499).contains(status) { return .serverRejected }
+            guard status == 200,
+                  let receipt = try? JSONDecoder().decode(SharedMirrorConfirmation.self, from: bytes),
+                  receipt.sessionId == sessionId, receipt.queueItemUuid == queueItemUuid,
+                  receipt.mirrored == mirrored, receipt.sequence >= 0 else { return .retryableFailure }
+            return .success(receipt)
+        } catch { return .retryableFailure }
+    }
+
     private static func postWidgetRequest(urlKey: String, body: [String: Any], requestName: String) async -> WidgetNavigationResult {
         guard let defaults = SharedConstants.sharedDefaults,
               let widgetUrl = defaults.string(forKey: urlKey)

--- a/packages/mobile/modules/live-activity/ios/WoodsBoardData.swift
+++ b/packages/mobile/modules/live-activity/ios/WoodsBoardData.swift
@@ -18,15 +18,34 @@ enum WoodsBoardData {
 
     private static let ledMaps: [String: [Int: Int]] = decode(ledMapsJSON)
 
+    // Generated from the same row geometry used by JS's hold mirroring.
+    private static let rowLengths: [String: [Int]] = [
+        "8x10": [11, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 11, 11, 11],
+        "12x12": [17, 17, 17, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 17, 17, 17, 17, 16]
+    ]
+
     /// Woods size_id → dimension per WOODS_SIZES in
     /// packages/shared/board-config/src/woods-config.ts. Unknown sizes return
     /// nil so the caller can refuse the write instead of darkening the wall.
-    static func ledMap(forSizeId sizeId: Int) -> [Int: Int]? {
+    static func ledMap(forSizeId sizeId: Int, mirrored: Bool = false) -> [Int: Int]? {
+        let dimension: String
         switch sizeId {
-        case 1: return ledMaps["8x10"]
-        case 2: return ledMaps["12x12"]
+        case 1: dimension = "8x10"
+        case 2: dimension = "12x12"
         default: return nil
         }
+        guard let ledMap = ledMaps[dimension] else { return nil }
+        guard mirrored else { return ledMap }
+        guard let rows = rowLengths[dimension] else { return nil }
+        var reflected: [Int: Int] = [:]
+        var start = 0
+        for length in rows {
+            for column in 0..<length {
+                reflected[start + column] = ledMap[start + length - 1 - column]
+            }
+            start += length
+        }
+        return reflected
     }
 
     private static func decode(_ json: String) -> [String: [Int: Int]] {

--- a/packages/mobile/modules/live-activity/ios/de.lproj/Localizable.strings
+++ b/packages/mobile/modules/live-activity/ios/de.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"Mirror climb" = "Boulder spiegeln";
+"Unmirror climb" = "Spiegelung aufheben";

--- a/packages/mobile/modules/live-activity/ios/en.lproj/Localizable.strings
+++ b/packages/mobile/modules/live-activity/ios/en.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"Mirror climb" = "Mirror climb";
+"Unmirror climb" = "Unmirror climb";

--- a/packages/mobile/modules/live-activity/ios/es.lproj/Localizable.strings
+++ b/packages/mobile/modules/live-activity/ios/es.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"Mirror climb" = "Espejear bloque";
+"Unmirror climb" = "Quitar espejo";

--- a/packages/mobile/modules/live-activity/ios/fr.lproj/Localizable.strings
+++ b/packages/mobile/modules/live-activity/ios/fr.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"Mirror climb" = "Miroir du bloc";
+"Unmirror climb" = "Annuler le miroir";

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -215,6 +215,7 @@ export type LiveActivityStartSessionOptions = {
   authToken?: string;
   wsUrl?: string;
   graphqlUrl?: string;
+  supportsMirroring?: boolean;
   widgetNavigationAllowed: boolean;
   isPartySession: boolean;
   /** Board-connection state from this device's POV (see the type doc). */
@@ -249,6 +250,8 @@ export type LiveActivityStartSessionOptions = {
     contentTitleFallback: string;
     previousLabel: string;
     nextLabel: string;
+    mirrorLabel?: string;
+    unmirrorLabel?: string;
     /** Lightbulb action label while this device drives the wall (connectedByMe). */
     relightLabel: string;
     /** Lightbulb action label while a peer holds it / nobody is driving. */
@@ -270,6 +273,10 @@ export type LiveActivityQueueItem = {
 };
 
 export type LiveActivityUpdateOptions = {
+  sessionId?: string;
+  queueSequence?: number;
+  queueItemUuid?: string;
+  mirrored?: boolean;
   climbName: string;
   climbDifficulty: string;
   angle: number;
@@ -279,6 +286,7 @@ export type LiveActivityUpdateOptions = {
   hasPrevious: boolean;
   climbUuid: string;
   queue: LiveActivityQueueItem[];
+  supportsMirroring?: boolean;
   widgetNavigationAllowed: boolean;
   isPartySession: boolean;
   /** Board-connection state from this device's POV (see the type doc). */
@@ -304,13 +312,27 @@ export type LiveActivityUpdateOptions = {
 
 export type LiveActivityClimbUpdateOptions = Omit<LiveActivityUpdateOptions, 'queue'>;
 
+export type WidgetMirrorEvent = {
+  sessionId: string;
+  queueItemUuid: string;
+  mirrored: boolean;
+} & (
+  | { kind: 'request' }
+  | { kind: 'confirmed'; sequence: number; stateHash: string; stateHashOrdered?: string | null }
+);
+
 export type WidgetQueueNavigateEvent = {
   action: 'next' | 'previous';
   currentIndex: number;
   correlationId: string;
 };
 
-export type LiveActivityIntentDiagnosticKind = 'nextClimb' | 'previousClimb' | 'takeControl' | 'reconnectBoard';
+export type LiveActivityIntentDiagnosticKind =
+  | 'mirrorClimb'
+  | 'nextClimb'
+  | 'previousClimb'
+  | 'takeControl'
+  | 'reconnectBoard';
 
 export type LiveActivityIntentDiagnosticStage =
   | 'entered'
@@ -361,6 +383,9 @@ export type BoardControlEvent = {
 };
 
 type LiveActivityNativeModule = {
+  supportsMirrorControl?: boolean;
+  getPendingMirror?(): Promise<WidgetMirrorEvent | null>;
+  acknowledgeMirror?(sessionId: string, sequence: number): Promise<void>;
   isAvailable(): Promise<{ available: boolean }>;
   startSession(options: LiveActivityStartSessionOptions): Promise<void>;
   endSession(): Promise<void>;
@@ -370,6 +395,7 @@ type LiveActivityNativeModule = {
   markIntentReactRootMounted?(): Promise<void>;
   /** Optional for OTA compatibility with binaries predating #4077. */
   consumeInterruptedIntentRuns?(): Promise<InterruptedLiveActivityIntentDiagnostic[]>;
+  addListener(event: 'queueMirror', listener: (payload: WidgetMirrorEvent) => void): EventSubscription;
   addListener(event: 'queueNavigate', listener: (payload: WidgetQueueNavigateEvent) => void): EventSubscription;
 };
 
@@ -385,11 +411,13 @@ export const liveActivityNative = requireOptionalNativeModule<LiveActivityNative
 // requireOptionalNativeModule returns null on iOS (where 'LiveActivity'/'BoardBle'
 // are the live modules) and in Expo Go / pre-module builds.
 type SessionPresenceNativeModule = {
+  supportsMirrorControl?: boolean;
   isAvailable(): Promise<{ available: boolean }>;
   startSession(options: LiveActivityStartSessionOptions): Promise<void>;
   endSession(): Promise<void>;
   updateActivity(options: LiveActivityUpdateOptions): Promise<void>;
   updateActivityClimb(options: LiveActivityClimbUpdateOptions): Promise<void>;
+  addListener(event: 'queueMirror', listener: (payload: WidgetMirrorEvent) => void): EventSubscription;
   addListener(event: 'queueNavigate', listener: (payload: WidgetQueueNavigateEvent) => void): EventSubscription;
   // Android-only: lightbulb taps on the ongoing notification (reconnect/reassert).
   addListener(event: 'boardControl', listener: (payload: BoardControlEvent) => void): EventSubscription;

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -432,7 +432,7 @@ export function PlayDrawer({
   }, []);
 
   const { queue, currentClimbQueueItem } = useQueueData();
-  const { setCurrentClimb, nextClimb, previousClimb, addToQueue } = useQueueActions();
+  const { setCurrentClimb, nextClimb, previousClimb, addToQueue, mirrorCurrentClimb } = useQueueActions();
   const { sessionId } = useQueueSessionId();
   const playlistSuggestionSource = usePlaylistSuggestionSource();
   const bluetooth = useOptionalBluetoothContext();
@@ -456,32 +456,16 @@ export function PlayDrawer({
   const isPreview = drawerPreviewItem != null;
 
   const displayedClimbUuid = displayedClimb?.uuid;
-  // A flip only applies to the climb it was made on. With no local flip for the
-  // climb on screen, fall back to the orientation the wall was last asked for:
-  // the drawer is a route on iPhone, so reopening it must show the flip that is
-  // actually lit rather than assuming none and lying about the wall.
-  //
-  // The fallback reads a ref through a context callback, which is safe on two
-  // invariants — break either and this silently shows the wrong orientation:
-  //  - Single writer. Only the effect below states an intent, and it writes back
-  //    exactly what this line computed, so the ref cannot drift from the toggle.
-  //  - Single instance. `/play` and the iPad pane are mutually exclusive
-  //    (`(tabs)/_layout.tsx`), so two drawers never state intents at once.
-  // The React Compiler memoises this on `mirrorFlip`/`displayedClimbUuid`/
-  // `bluetooth`, so a ref changed underneath is NOT re-read, and the read is
-  // invisible to `react-hooks/refs` — lint will not catch a second writer.
-  //
-  // With nothing stated for this climb either, fall back to the climb's OWN
-  // mirror: activating a mirrored logbook tick carries `mirrored: true` through
-  // `tickToClimb`, and that ascent must relight the way it was climbed. A stated
-  // `false` is not the same as nothing stated, which is why the reader is
-  // tri-state — otherwise turning a mirrored tick's flip off would be undone by
-  // its own `climb.mirrored` on the next render.
-  const isMirrored = resolveMirroredOrientation({
-    explicitFlip: mirrorFlip != null && mirrorFlip.climbUuid === displayedClimbUuid ? mirrorFlip.mirrored : undefined,
-    statedIntent: bluetooth?.getMirrorIntent(displayedClimbUuid),
-    climbMirrored: displayedClimb?.mirrored,
-  });
+  // Live sessions have one shared orientation. Preview/solo flips stay local.
+  const sharesMirrorState = sessionId !== null && !isPreview;
+  const isMirrored = sharesMirrorState
+    ? displayedClimb?.mirrored === true
+    : resolveMirroredOrientation({
+        explicitFlip:
+          mirrorFlip != null && mirrorFlip.climbUuid === displayedClimbUuid ? mirrorFlip.mirrored : undefined,
+        statedIntent: bluetooth?.getMirrorIntent(displayedClimbUuid),
+        climbMirrored: displayedClimb?.mirrored,
+      });
   const clearMirror = useCallback(() => setMirrorFlip(null), []);
 
   // #5099: the shown climb does not have to belong to the board the climber has
@@ -961,42 +945,22 @@ export function PlayDrawer({
     setDrawerPreviewIsWallClimb(false);
   }, [drawerPreviewItem, drawerPreviewSuggestionSource, setCurrentClimb, markLatchExit]);
 
-  // Keep the wall's orientation in lockstep with the toggle, declaratively.
-  //
-  // `isMirrored` is reset to false at eight different navigation sites, and the
-  // provider can't see any of them: an intent set once by the tap would outlive
-  // the reset, so returning to a climb you had flipped would light it mirrored
-  // under a screen (and a button) showing it un-mirrored. Re-stating it here
-  // means there is one place the two can disagree, and it is this line.
-  //
-  // Not gated on `isConnected`: recording the intent while disconnected is what
-  // lets a flip survive until the lightbulb re-takes the wall. A preview is
-  // deliberately excluded — mirroring what you are merely looking at must not
-  // re-light the live climb (the Browsing chrome promises the wall stays put).
-  //
-  // Known gap: while a party peer's `climb.mirrored` and this local toggle
-  // disagree, the local one wins on this device's wall — for a toggle made on
-  // the climb already showing. On a peer-driven climb CHANGE the auto-sender
-  // runs first and falls back to `climb.mirrored`, and the restatement below
-  // deliberately doesn't reassert, so the peer's orientation would stand with
-  // the screen reading un-mirrored. Unreachable today: nothing in the app calls
-  // `mirrorCurrentClimb`, so that fallback is always false.
+  // Solo and preview surfaces retain their existing local mirror semantics.
   useEffect(() => {
-    if (isPreview || !displayedClimbUuid) return;
-    // The rule itself lives in `nextMirrorIntentAction`, where it is unit-tested
-    // without a renderer — this effect is just the wiring.
+    if (isPreview || sharesMirrorState || !displayedClimbUuid) return;
     const action = nextMirrorIntentAction({ isPreview, displayedClimbUuid, mirrorFlip });
     if (action.kind === 'state') bluetooth?.setMirrorIntent(action.climbUuid, action.mirrored);
     else if (action.kind === 'retain') bluetooth?.retainMirrorIntentFor(action.climbUuid);
-  }, [bluetooth, displayedClimbUuid, mirrorFlip, isPreview]);
+  }, [bluetooth, displayedClimbUuid, mirrorFlip, isPreview, sharesMirrorState]);
 
-  // Local state only — the effect above is what carries the flip to the wall,
-  // through the AutoSender's normal write so the dedup record and the
-  // wall-confirm describe the orientation actually lit.
   const handleMirror = useCallback(() => {
     if (!displayedClimbUuid) return;
-    setMirrorFlip({ climbUuid: displayedClimbUuid, mirrored: !isMirrored });
-  }, [displayedClimbUuid, isMirrored]);
+    if (sharesMirrorState && currentClimbQueueItem) {
+      void mirrorCurrentClimb(!isMirrored, currentClimbQueueItem.uuid);
+    } else {
+      setMirrorFlip({ climbUuid: displayedClimbUuid, mirrored: !isMirrored });
+    }
+  }, [displayedClimbUuid, isMirrored, sharesMirrorState, currentClimbQueueItem, mirrorCurrentClimb]);
 
   const handleToggleFavorite = useCallback(() => {
     if (!displayedClimb) return;

--- a/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
@@ -2,6 +2,7 @@
 import { act, render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { WidgetMirrorEvent } from '../../../../modules/live-activity/src/index';
 import { LiveActivityBridge } from '../live-activity-bridge';
 
 type QueueNavigateEvent = {
@@ -24,14 +25,20 @@ function makeItem(index: number): ClimbQueueItem {
 
 const queue = vi.hoisted(() => ({
   sessionId: 'session-1' as string | null,
+  mirrorCurrentClimb: vi.fn(),
+  dispatchWidgetMirror: vi.fn(async () => true),
   dispatchWidgetNavigation: vi.fn(),
   state: {
+    serverSequence: 4,
     queue: [] as ClimbQueueItem[],
     currentClimbQueueItem: null as ClimbQueueItem | null,
   },
 }));
 
 const widget = vi.hoisted(() => ({
+  mirrorListener: null as null | ((event: WidgetMirrorEvent) => void),
+  pendingMirror: vi.fn(async (): Promise<WidgetMirrorEvent | null> => null),
+  acknowledgeMirror: vi.fn(async () => {}),
   listener: null as null | ((event: QueueNavigateEvent) => void),
   boardControlListener: null as null | ((event: BoardControlEvent) => void),
   useLiveActivity: vi.fn(),
@@ -86,6 +93,8 @@ vi.mock('../../board-render-settings', () => ({
   requestedBoardRenderMode: (settings: { mode: string }) => (settings.mode === 'classic' ? 'classic' : 'aura'),
 }));
 
+vi.mock('react-native', () => ({ AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) } }));
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
@@ -96,6 +105,8 @@ vi.mock('../../../providers/queue-provider', () => ({
   useQueue: () => ({
     state: queue.state,
     sessionId: queue.sessionId,
+    mirrorCurrentClimb: queue.mirrorCurrentClimb,
+    dispatchWidgetMirror: queue.dispatchWidgetMirror,
     dispatchWidgetNavigation: queue.dispatchWidgetNavigation,
   }),
 }));
@@ -140,6 +151,14 @@ vi.mock('../use-live-activity', () => ({
 }));
 
 vi.mock('../live-activity-plugin', () => ({
+  getPendingWidgetMirror: widget.pendingMirror,
+  acknowledgeWidgetMirror: widget.acknowledgeMirror,
+  addWidgetMirrorListener: (listener: (event: WidgetMirrorEvent) => void) => {
+    widget.mirrorListener = listener;
+    return () => {
+      widget.mirrorListener = null;
+    };
+  },
   addWidgetQueueNavigateListener: (listener: (event: QueueNavigateEvent) => void) => {
     widget.listener = listener;
     return () => {
@@ -528,5 +547,68 @@ describe('LiveActivityBridge on a wall with no LED light kit', () => {
         widgetNavigationAllowed: false,
       }),
     );
+  });
+});
+
+describe('mirror controls', () => {
+  beforeEach(() => {
+    queue.sessionId = 'session-1';
+    queue.state.queue = [makeItem(0)];
+    queue.state.currentClimbQueueItem = queue.state.queue[0];
+    boardState.boardConnection = 'connectedByMe';
+    boardState.inAppBoardConnection = 'connectedByMe';
+    boardState.ledless = false;
+    queue.mirrorCurrentClimb.mockClear();
+    queue.dispatchWidgetMirror.mockClear();
+    queue.dispatchWidgetMirror.mockResolvedValue(true);
+    widget.acknowledgeMirror.mockClear();
+    widget.pendingMirror.mockResolvedValue(null);
+  });
+  const tap = { kind: 'request', sessionId: 'session-1', queueItemUuid: 'queue-item-0', mirrored: true } as const;
+  const receipt = { ...tap, kind: 'confirmed', sequence: 5, stateHash: 'hash' } as const;
+
+  it('routes a supported Android mirror tap through the shared mutation', async () => {
+    render(<LiveActivityBridge boardName="tension" layoutId={1} sizeId={1} setIds="1" />);
+    await act(async () => {
+      widget.mirrorListener?.(tap);
+    });
+    expect(queue.mirrorCurrentClimb).toHaveBeenCalledWith(true, 'queue-item-0');
+  });
+  it.each(['heldByPeer', 'disconnected'] as const)('drops a tap after ownership changes to %s', async (connection) => {
+    boardState.boardConnection = connection;
+    render(<LiveActivityBridge boardName="tension" layoutId={1} sizeId={1} setIds="1" />);
+    await act(async () => {
+      widget.mirrorListener?.(tap);
+    });
+    expect(queue.mirrorCurrentClimb).not.toHaveBeenCalled();
+  });
+  it('drops unsupported, stale-item and stale-session taps', async () => {
+    const view = renderBridge();
+    await act(async () => {
+      widget.mirrorListener?.(tap);
+    });
+    view.rerender(<LiveActivityBridge boardName="tension" layoutId={1} sizeId={1} setIds="1" />);
+    await act(async () => {
+      widget.mirrorListener?.({ ...tap, sessionId: 'old-session' });
+      widget.mirrorListener?.({ ...tap, queueItemUuid: 'old-slot' });
+    });
+    expect(queue.mirrorCurrentClimb).not.toHaveBeenCalled();
+  });
+  it('replays an iOS receipt without sending a second mirror mutation', async () => {
+    widget.pendingMirror.mockResolvedValue(receipt);
+    await act(async () => {
+      renderBridge();
+    });
+    expect(queue.dispatchWidgetMirror).toHaveBeenCalledWith(receipt);
+    expect(widget.acknowledgeMirror).toHaveBeenCalledWith('session-1', 5);
+    expect(queue.mirrorCurrentClimb).not.toHaveBeenCalled();
+  });
+  it('retains a receipt when reconciliation is not ready', async () => {
+    queue.dispatchWidgetMirror.mockResolvedValue(false);
+    widget.pendingMirror.mockResolvedValue(receipt);
+    await act(async () => {
+      renderBridge();
+    });
+    expect(widget.acknowledgeMirror).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
@@ -185,7 +185,7 @@ describe('LiveActivityBridge widget navigation (always-live)', () => {
 
   beforeEach(() => {
     queue.sessionId = 'session-1';
-    queue.state = { queue: threeItemQueue, currentClimbQueueItem: threeItemQueue[0] };
+    queue.state = { serverSequence: 4, queue: threeItemQueue, currentClimbQueueItem: threeItemQueue[0] };
     queue.dispatchWidgetNavigation.mockClear();
     widget.listener = null;
     widget.boardControlListener = null;
@@ -349,7 +349,7 @@ describe('LiveActivityBridge widget navigation (always-live)', () => {
 describe('LiveActivityBridge lightbulb (boardControl)', () => {
   beforeEach(() => {
     queue.sessionId = 'session-1';
-    queue.state = { queue: [climbItem], currentClimbQueueItem: climbItem };
+    queue.state = { serverSequence: 4, queue: [climbItem], currentClimbQueueItem: climbItem };
     widget.boardControlListener = null;
     widget.useLiveActivity.mockClear();
     boardState.boardConnection = 'connectedByMe';
@@ -463,7 +463,7 @@ describe('LiveActivityBridge lightbulb (boardControl)', () => {
 describe('LiveActivityBridge session-presence gating', () => {
   beforeEach(() => {
     queue.sessionId = 'session-1';
-    queue.state = { queue: [], currentClimbQueueItem: null };
+    queue.state = { serverSequence: 4, queue: [], currentClimbQueueItem: null };
     widget.useLiveActivity.mockClear();
     boardState.boardConnection = 'connectedByMe';
     boardState.holderDisplayName = null;
@@ -471,7 +471,7 @@ describe('LiveActivityBridge session-presence gating', () => {
 
   it('keeps a solo queue (no session) out of session presence', () => {
     queue.sessionId = null;
-    queue.state = { queue: [climbItem], currentClimbQueueItem: climbItem };
+    queue.state = { serverSequence: 4, queue: [climbItem], currentClimbQueueItem: climbItem };
     renderBridge();
 
     expect(widget.useLiveActivity).toHaveBeenCalledWith(
@@ -511,7 +511,7 @@ describe('LiveActivityBridge notification thumbnail board', () => {
 
   it('renders a Homewall queue head on the Homewall, not on the selected 12x12', () => {
     const item = boardClimbItem('kilter', 8);
-    queue.state = { queue: [item], currentClimbQueueItem: item };
+    queue.state = { serverSequence: 4, queue: [item], currentClimbQueueItem: item };
     renderBridge();
 
     expect(climbRender.useNativeClimbRender).toHaveBeenCalledWith(
@@ -521,7 +521,7 @@ describe('LiveActivityBridge notification thumbnail board', () => {
 
   it('keeps the selected board for a climb that carries no board of its own', () => {
     const item = makeItem(0);
-    queue.state = { queue: [item], currentClimbQueueItem: item };
+    queue.state = { serverSequence: 4, queue: [item], currentClimbQueueItem: item };
     renderBridge();
 
     expect(climbRender.useNativeClimbRender).toHaveBeenCalledWith(

--- a/packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts
+++ b/packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts
@@ -35,6 +35,8 @@ const DUPLICATED_FILES = [
   'SharedKeychain.swift',
   'TakeControlIntent.swift',
   'WidgetNetworking.swift',
+  'SharedMirrorState.swift',
+  'MirrorClimbIntent.swift',
 ];
 
 function sha(path: string): string {
@@ -46,6 +48,7 @@ const RECORDER_SYMBOL_PATTERN = /LiveActivityIntentDiagnostic|diagnosticRun|comp
 const PRODUCTION_WIDGET_COMPILATION_CONDITIONS = new Set(['WIDGET_EXTENSION']);
 
 const TYPESCRIPT_DIAGNOSTIC_KINDS = {
+  mirrorClimb: true,
   nextClimb: true,
   previousClimb: true,
   takeControl: true,
@@ -238,7 +241,12 @@ describe('Widget target Swift drift', () => {
   });
 
   it('guards every shared-intent recorder call from widget compilation', () => {
-    const instrumentedFiles = ['ClimbNavigationIntent.swift', 'TakeControlIntent.swift', 'ReconnectBoardIntent.swift'];
+    const instrumentedFiles = [
+      'ClimbNavigationIntent.swift',
+      'TakeControlIntent.swift',
+      'ReconnectBoardIntent.swift',
+      'MirrorClimbIntent.swift',
+    ];
 
     for (const file of instrumentedFiles) {
       const source = readFileSync(join(WIDGET_TARGET, file), 'utf8');
@@ -292,6 +300,7 @@ describe('Widget target Swift drift', () => {
     }).sort();
 
     expect(intentTypes).toEqual([
+      'MirrorClimbIntent',
       'NextClimbIntent',
       'PreviousClimbIntent',
       'ReconnectBoardIntent',

--- a/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
+++ b/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
@@ -1,6 +1,7 @@
+import { AppState } from 'react-native';
 import { useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getBoardCapabilities, toBoardName } from '@boardsesh/board-config';
+import { getBoardCapabilities, toBoardName, boardSupportsMirroring } from '@boardsesh/board-config';
 import { nativeBleSupportsBoard } from '../ble/adapter-factory';
 import { requestedBoardRenderMode, useBoardRenderSettings } from '../board-render-settings';
 import { resolveClimbRenderBoard } from '../boards/climb-render-board';
@@ -9,6 +10,10 @@ import { useBoardConnectionState } from '../../components/ble/use-board-connecti
 import { useNativeClimbRender } from '../../hooks/use-native-climb-render';
 import { useLiveActivity } from './use-live-activity';
 import {
+  addWidgetMirrorListener,
+  getPendingWidgetMirror,
+  acknowledgeWidgetMirror,
+  type WidgetMirrorEvent,
   addWidgetQueueNavigateListener,
   addBoardControlListener,
   isAndroidSessionPresence,
@@ -31,7 +36,7 @@ type LiveActivityBridgeProps = {
 // selected) so a guest user without a board doesn't trigger Live Activity
 // authorization prompts at random.
 export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: LiveActivityBridgeProps) {
-  const { state, sessionId, dispatchWidgetNavigation } = useQueue();
+  const { state, sessionId, dispatchWidgetNavigation, mirrorCurrentClimb, dispatchWidgetMirror } = useQueue();
   const { t } = useTranslation('session');
   // Board-connection ownership (shared with the in-app lightbulb). Drives the
   // Live Activity lightbulb + Previous/Next visibility: controls show only while
@@ -100,6 +105,8 @@ export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: Live
       contentTitleFallback: t('mobile.session.notification.contentTitleFallback'),
       previousLabel: t('mobile.session.notification.previous'),
       nextLabel: t('mobile.session.notification.next'),
+      mirrorLabel: t('mobile.session.notification.mirror'),
+      unmirrorLabel: t('mobile.session.notification.unmirror'),
       relightLabel: t('mobile.session.notification.relight'),
       reconnectLabel: t('mobile.session.notification.reconnect'),
       onWallTemplate: t('mobile.session.notification.onWall'),
@@ -108,6 +115,7 @@ export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: Live
   );
 
   useLiveActivity({
+    queueSequence: state.serverSequence,
     queue: state.queue,
     currentClimbQueueItem: state.currentClimbQueueItem,
     board: { boardName, layoutId, sizeId, setIds },
@@ -204,6 +212,50 @@ export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: Live
     });
     return unsubscribe;
   }, []);
+
+  const handleMirrorRef = useRef<(event: WidgetMirrorEvent) => Promise<void>>(async () => {});
+  handleMirrorRef.current = async (event) => {
+    if (event.sessionId !== sessionId) return;
+    if (event.kind === 'confirmed') {
+      // Native already changed the wall. Replay the sequenced result, never toggle again.
+      if (await dispatchWidgetMirror(event)) await acknowledgeWidgetMirror(event.sessionId, event.sequence);
+    } else if (
+      boardConnection === 'connectedByMe' &&
+      boardSupportsMirroring(boardName, layoutId) &&
+      state.currentClimbQueueItem?.uuid === event.queueItemUuid
+    ) {
+      await mirrorCurrentClimb(event.mirrored, event.queueItemUuid);
+    }
+  };
+  useEffect(() => {
+    const receive = (event: WidgetMirrorEvent) => {
+      void handleMirrorRef
+        .current(event)
+        .catch((error: unknown) => console.warn('[LiveActivity] Mirror sync failed:', error));
+    };
+    const replay = () => {
+      void getPendingWidgetMirror().then((event) => {
+        if (event) receive(event);
+      });
+    };
+    const unsubscribe = addWidgetMirrorListener(receive);
+    const appState = AppState.addEventListener('change', (next) => {
+      if (next === 'active') replay();
+    });
+    replay();
+    return () => {
+      unsubscribe();
+      appState.remove();
+    };
+  }, [sessionId]);
+
+  useEffect(() => {
+    void getPendingWidgetMirror()
+      .then((event) => {
+        if (event) return handleMirrorRef.current(event);
+      })
+      .catch((error: unknown) => console.warn('[LiveActivity] Mirror replay failed:', error));
+  }, [state.queue]);
 
   return null;
 }

--- a/packages/mobile/src/lib/live-activity/live-activity-plugin.ts
+++ b/packages/mobile/src/lib/live-activity/live-activity-plugin.ts
@@ -6,6 +6,7 @@ import {
   type LiveActivityUpdateOptions,
   type LiveActivityClimbUpdateOptions,
   type WidgetQueueNavigateEvent,
+  type WidgetMirrorEvent,
   type BoardControlEvent,
   type InterruptedLiveActivityIntentDiagnostic,
 } from '../../../modules/live-activity/src/index';
@@ -104,3 +105,20 @@ export function addBoardControlListener(callback: (event: BoardControlEvent) => 
 }
 
 export type { WidgetQueueNavigateEvent, BoardControlEvent, InterruptedLiveActivityIntentDiagnostic };
+
+/** New native binaries only; older OTA hosts do not declare this event. */
+export function addWidgetMirrorListener(callback: (event: WidgetMirrorEvent) => void): () => void {
+  if (!sessionModule?.supportsMirrorControl) return () => {};
+  const subscription = sessionModule.addListener('queueMirror', callback);
+  return () => subscription.remove();
+}
+
+export async function getPendingWidgetMirror(): Promise<WidgetMirrorEvent | null> {
+  return (await liveActivityNative?.getPendingMirror?.()) ?? null;
+}
+
+export async function acknowledgeWidgetMirror(sessionId: string, sequence: number): Promise<void> {
+  await liveActivityNative?.acknowledgeMirror?.(sessionId, sequence);
+}
+
+export type { WidgetMirrorEvent };

--- a/packages/mobile/src/lib/live-activity/use-live-activity.ts
+++ b/packages/mobile/src/lib/live-activity/use-live-activity.ts
@@ -1,3 +1,4 @@
+import { boardSupportsMirroring } from '@boardsesh/board-config';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Platform } from 'react-native';
 import type { ClimbQueueItem } from '@boardsesh/queue';
@@ -28,12 +29,15 @@ type AndroidNotificationStrings = {
   contentTitleFallback: string;
   previousLabel: string;
   nextLabel: string;
+  mirrorLabel?: string;
+  unmirrorLabel?: string;
   relightLabel: string;
   reconnectLabel: string;
   onWallTemplate: string;
 };
 
 type UseLiveActivityOptions = {
+  queueSequence?: number;
   queue: ClimbQueueItem[];
   currentClimbQueueItem: ClimbQueueItem | null;
   board: BoardConfig | null;
@@ -145,6 +149,7 @@ async function resolveBoardBackgroundPaths(board: BoardConfig): Promise<string[]
 // circuits at the plugin layer (the selected module is null), so this hook is
 // safe to mount unconditionally.
 export function useLiveActivity({
+  queueSequence,
   queue,
   currentClimbQueueItem,
   board,
@@ -203,6 +208,8 @@ export function useLiveActivity({
   overlayValidatorRef.current = validateAndroidThumbnailOverlay;
   const backgroundPathsRef = useRef(androidThumbnailBackgroundPaths);
   backgroundPathsRef.current = androidThumbnailBackgroundPaths;
+  const queueSequenceRef = useRef(queueSequence);
+  queueSequenceRef.current = queueSequence;
   const queueRef = useRef(queue);
   queueRef.current = queue;
   const currentClimbRef = useRef(currentClimbQueueItem);
@@ -338,6 +345,7 @@ export function useLiveActivity({
             layoutId: stableBoard.layoutId,
             sizeId: stableBoard.sizeId,
             setIds: stableBoard.setIds,
+            supportsMirroring: boardSupportsMirroring(stableBoard.boardName, stableBoard.layoutId),
             widgetNavigationAllowed: widgetNavigationAllowedRef.current,
             isPartySession: isPartySessionRef.current,
             boardConnection: boardConnectionRef.current,
@@ -365,7 +373,12 @@ export function useLiveActivity({
             hasNext: idx < q.length - 1,
             hasPrevious: idx > 0,
             climbUuid: displayItem.climb.uuid,
+            sessionId: sessionIdRef.current ?? undefined,
+            queueSequence: queueSequenceRef.current,
+            queueItemUuid: displayItem.uuid,
+            mirrored: displayItem.climb.mirrored === true,
             queue: serializedQueueRef.current,
+            supportsMirroring: boardSupportsMirroring(stableBoard.boardName, stableBoard.layoutId),
             widgetNavigationAllowed: widgetNavigationAllowedRef.current,
             isPartySession: isPartySessionRef.current,
             boardConnection: boardConnectionRef.current,
@@ -463,7 +476,12 @@ export function useLiveActivity({
       hasNext: currentIndex < queueRef.current.length - 1,
       hasPrevious: currentIndex > 0,
       climbUuid: displayItem.climb.uuid,
+      sessionId: sessionIdRef.current ?? undefined,
+      queueSequence: queueSequenceRef.current,
+      queueItemUuid: displayItem.uuid,
+      mirrored: displayItem.climb.mirrored === true,
       queue: serializedQueue,
+      supportsMirroring: boardSupportsMirroring(stableBoard.boardName, stableBoard.layoutId),
       widgetNavigationAllowed,
       isPartySession,
       boardConnection,
@@ -487,6 +505,7 @@ export function useLiveActivity({
     // its thumbnail in the new mode.
     renderMode,
     serializedQueue,
+    queueSequence,
     stableBoard,
     widgetNavigationAllowed,
   ]);
@@ -511,6 +530,11 @@ export function useLiveActivity({
       hasNext: currentIndex < queue.length - 1,
       hasPrevious: currentIndex > 0,
       climbUuid: displayItem.climb.uuid,
+      sessionId: sessionIdRef.current ?? undefined,
+      queueSequence: queueSequenceRef.current,
+      queueItemUuid: displayItem.uuid,
+      mirrored: displayItem.climb.mirrored === true,
+      supportsMirroring: boardSupportsMirroring(stableBoard.boardName, stableBoard.layoutId),
       widgetNavigationAllowed,
       isPartySession,
       boardConnection,

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -235,9 +235,13 @@ vi.mock('../../components/ble/BleControlSheet', () => ({
 
 vi.mock('../queue-provider', () => ({
   useQueue: () => ({
+    sessionId: queue.sessionId,
     state: { currentClimbQueueItem: queue.currentClimbQueueItem, queue: [] },
   }),
-  useQueueActions: () => ({ setCurrentClimb: vi.fn() }),
+  useQueueActions: () => ({
+    setCurrentClimb: vi.fn(),
+    getQueueSnapshot: () => ({ currentClimbQueueItem: queue.currentClimbQueueItem, queue: [] }),
+  }),
   useQueueSessionControls: () => {
     const activeSessionId = queue.sessionId;
     return {
@@ -541,12 +545,25 @@ describe('BluetoothProvider wall-confirm integration', () => {
     expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(1);
   });
 
+  it('uses confirmed session mirroring for automatic writes and relighting', async () => {
+    bluetooth.sendFramesToBoardForOptions = () => async (frames, mirrored, signal, sendContext) =>
+      bluetooth.state.sendFramesToBoard(frames, mirrored, signal, sendContext);
+    queue.currentClimbQueueItem = makeQueueItem('climb-1', 'p1r12', true);
+    renderProvider(createElement(BluetoothProbe));
+    await waitFor(() => expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(1));
+    expect(bluetooth.state.sendFramesToBoard.mock.calls[0]?.[1]).toBe(true);
+    act(() => capturedBluetooth?.setMirrorIntent('climb-1', false));
+    await act(async () => {
+      await capturedBluetooth?.relightPresenceClimb(makePresenceClimb({ climbUuid: 'climb-1', frames: 'p1r12' }));
+    });
+    expect(bluetooth.state.sendFramesToBoard.mock.calls.at(-1)?.[1]).toBe(true);
+  });
+
   // ── Mirror intent (#5217) ────────────────────────────────────────────────
-  // The play drawer's flip is drawer-local state — it never writes
-  // `climb.mirrored`. It hands the provider an intent instead, so the flip rides
-  // the AutoSender's normal write and the dedup record follows it.
+  // Solo climbs keep their local mirror intent; sessions use confirmed queue state.
 
   it('re-pushes the current climb mirrored when the drawer flips it', async () => {
+    queue.sessionId = null;
     bluetooth.sendFramesToBoardForOptions = () => async (frames, mirrored, signal, sendContext) =>
       bluetooth.state.sendFramesToBoard(frames, mirrored, signal, sendContext);
 
@@ -578,6 +595,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
   });
 
   it('keeps the wall mirrored when the same climb is re-broadcast after a flip', async () => {
+    queue.sessionId = null;
     // The bug this guards: a direct sendFramesToBoard left the dedup record
     // describing the un-mirrored orientation, so the next byte-identical
     // re-broadcast re-pushed un-mirrored frames and silently un-flipped the wall.
@@ -610,9 +628,6 @@ describe('BluetoothProvider wall-confirm integration', () => {
         }),
       );
     });
-    await waitFor(() => {
-      expect(queue.confirmClimbOnWall).toHaveBeenCalled();
-    });
 
     // No third write, and nothing un-mirrored went out.
     expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(2);
@@ -625,6 +640,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
   });
 
   it('falls back to the queue item once the current climb changes', async () => {
+    queue.sessionId = null;
     bluetooth.sendFramesToBoardForOptions = () => async (frames, mirrored, signal, sendContext) =>
       bluetooth.state.sendFramesToBoard(frames, mirrored, signal, sendContext);
 
@@ -670,6 +686,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
   });
 
   it('does not re-light a stale flip when you navigate back to a climb you had mirrored', async () => {
+    queue.sessionId = null;
     // The drawer resets its mirror toggle on every navigation, so returning to a
     // climb you had flipped must NOT light it mirrored under an un-mirrored
     // screen. The drawer re-states the orientation on each climb change; this
@@ -742,6 +759,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
   });
 
   it('does not write again when the orientation is restated unchanged', async () => {
+    queue.sessionId = null;
     // Restating the same orientation must not produce a write: the drain wakes,
     // computes the same signature, and dedups.
     bluetooth.sendFramesToBoardForOptions = () => async (frames, mirrored, signal, sendContext) =>
@@ -762,6 +780,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
   });
 
   it('un-flips the wall when you turn off a climb that is mirrored by default', async () => {
+    queue.sessionId = null;
     // A mirrored ascent (a logbook tick, or a crew member's item) is already lit
     // mirrored off its own `climb.mirrored`. Turning the flip OFF records the
     // first intent for that climb — so anything that decides "no write needed"
@@ -1936,6 +1955,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
     });
 
     it('relights a climb in the orientation it is still flipped to', async () => {
+      queue.sessionId = null;
       // A flip belongs to the climb, so every write path honours it. Relighting
       // it un-mirrored would leave the wall disagreeing with the toggle a drawer
       // opening on that climb will show — reachable on iPhone, where the player
@@ -1970,6 +1990,7 @@ describe('BluetoothProvider wall-confirm integration', () => {
     });
 
     it('leaves the undone wall alone when the current climb is still flipped', async () => {
+      queue.sessionId = null;
       // Undo relights the PREVIOUS climb; the current one is still flipped. The
       // flip must stay recorded — dropping it makes the next drain compute an
       // un-mirrored current climb, whose signature no longer matches what was

--- a/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-sync-gate.test.tsx
@@ -221,6 +221,7 @@ type Snapshot = {
   subscribeToPlaybackEvents: ReturnType<typeof useQueue>['subscribeToPlaybackEvents'];
   removeFromQueue: ReturnType<typeof useQueue>['removeFromQueue'];
   addToQueue: ReturnType<typeof useQueue>['addToQueue'];
+  dispatchWidgetMirror: ReturnType<typeof useQueue>['dispatchWidgetMirror'];
 };
 
 const user = (overrides: Partial<SessionUser> = {}): SessionUser => ({
@@ -387,6 +388,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
       subscribeToPlaybackEvents: queue.subscribeToPlaybackEvents,
       removeFromQueue: queue.removeFromQueue,
       addToQueue: queue.addToQueue,
+      dispatchWidgetMirror: queue.dispatchWidgetMirror,
     });
   }, [
     queue.state,
@@ -394,6 +396,7 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
     queue.subscribeToPlaybackEvents,
     queue.removeFromQueue,
     queue.addToQueue,
+    queue.dispatchWidgetMirror,
     onSnapshot,
   ]);
   return null;
@@ -441,6 +444,56 @@ describe('QueueProvider queue sync gate', () => {
     graph.execute.mockResolvedValue(createJoinSessionResponse());
     http.request.mockReset();
     routeHttpRequest(queueStateResponse([]));
+  });
+
+  it('restores the full queue before acknowledging a receipt received before FullSync', async () => {
+    const snapshots: Snapshot[] = [];
+    const mirroredItem = makeQueueItem('native-current');
+    mirroredItem.climb.mirrored = true;
+    let queueStateCalls = 0;
+    routeHttpRequest(queueStateResponse([mirroredItem], mirroredItem, 100), {
+      onQueueStateCall: () => queueStateCalls++,
+    });
+    renderProvider((snapshot) => snapshots.push(snapshot));
+    await waitFor(() => expect(ws.getQueueUpdatesSink()).not.toBeNull());
+    let acknowledged = false;
+    await act(async () => {
+      acknowledged = await snapshots.at(-1)!.dispatchWidgetMirror({
+        kind: 'confirmed',
+        sessionId: 'session-1',
+        queueItemUuid: 'native-current',
+        mirrored: true,
+        sequence: 100,
+        stateHash: 'mirror-hash',
+      });
+    });
+    expect(acknowledged).toBe(true);
+    expect(queueStateCalls).toBe(1);
+    expect(snapshots.at(-1)?.state.currentClimbQueueItem?.uuid).toBe('native-current');
+    expect(snapshots.at(-1)?.state.currentClimbQueueItem?.climb.mirrored).toBe(true);
+    expect(snapshots.at(-1)?.state.serverSequence).toBe(100);
+  });
+
+  it.each(['unavailable', 'older'] as const)('retains a receipt when reconciliation is %s', async (responseKind) => {
+    const snapshots: Snapshot[] = [];
+    routeHttpRequest(
+      responseKind === 'unavailable' ? { session: { queueState: null } } : queueStateResponse([], null, 98),
+    );
+    renderProvider((snapshot) => snapshots.push(snapshot));
+    await waitFor(() => expect(ws.getQueueUpdatesSink()).not.toBeNull());
+    let acknowledged = true;
+    await act(async () => {
+      acknowledged = await snapshots.at(-1)!.dispatchWidgetMirror({
+        kind: 'confirmed',
+        sessionId: 'session-1',
+        queueItemUuid: 'native-current',
+        mirrored: true,
+        sequence: 100,
+        stateHash: 'mirror-hash',
+      });
+    });
+    expect(acknowledged).toBe(false);
+    expect(snapshots.at(-1)?.state.serverSequence).not.toBe(100);
   });
 
   it('ignores an out-of-order stale event (no dispatch, no state change)', async () => {

--- a/packages/mobile/src/providers/__tests__/queue-provider.test.ts
+++ b/packages/mobile/src/providers/__tests__/queue-provider.test.ts
@@ -452,3 +452,24 @@ describe('findPreviousQueueItem', () => {
     expect(findPreviousQueueItem([itemA], orphan)).toBeNull();
   });
 });
+
+it('commits server sequence with the mirrored snapshot and rebaselines on full sync', () => {
+  const item = makeClimbQueueItem({ uuid: 'current' });
+  const before = makeState({ queue: [item], currentClimbQueueItem: item, serverSequence: 4 });
+  const mirrored = queueReducer(before, {
+    type: 'DELTA_MIRROR_CURRENT_CLIMB',
+    serverSequence: 5,
+    payload: { mirroredUuid: item.uuid, mirrored: true },
+  });
+  expect(before.serverSequence).toBe(4);
+  expect(before.currentClimbQueueItem?.climb.mirrored).toBeUndefined();
+  expect(mirrored.serverSequence).toBe(5);
+  expect(mirrored.currentClimbQueueItem?.climb.mirrored).toBe(true);
+  const reset = queueReducer(mirrored, {
+    type: 'INITIAL_QUEUE_DATA',
+    serverSequence: 1,
+    payload: { queue: [item], currentClimbQueueItem: item },
+  });
+  expect(reset.serverSequence).toBe(1);
+  expect(reset.currentClimbQueueItem?.climb.mirrored).toBeUndefined();
+});

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -368,7 +368,7 @@ function BluetoothAutoSender({
     encodingSignature: string;
   };
 
-  const { state } = useQueue();
+  const { state, sessionId } = useQueue();
   const { currentClimbQueueItem } = state;
   const onWallConfirmedRef = useRef(onWallConfirmed);
   useEffect(() => {
@@ -535,7 +535,8 @@ function BluetoothAutoSender({
           // reads this one value, so the wall and our record of it agree.
           const intent = mirrorIntentRef.current;
           const effectiveMirrored = resolveMirroredOrientation({
-            statedIntent: intent != null && intent.climbUuid === item.climb.uuid ? intent.mirrored : undefined,
+            statedIntent:
+              !sessionId && intent != null && intent.climbUuid === item.climb.uuid ? intent.mirrored : undefined,
             climbMirrored: item.climb.mirrored,
           });
 
@@ -626,7 +627,15 @@ function BluetoothAutoSender({
     };
 
     void drain();
-  }, [currentClimbQueueItem, sendFramesToBoard, reassertNonce, mirrorNonce, colorSignature, encodingSignature]);
+  }, [
+    currentClimbQueueItem,
+    sendFramesToBoard,
+    reassertNonce,
+    mirrorNonce,
+    colorSignature,
+    encodingSignature,
+    sessionId,
+  ]);
 
   return null;
 }
@@ -751,7 +760,7 @@ export function BluetoothProvider({
   const { showUndoWallChangeSnackbar } = useQueueSnackbar();
   // Queue actions (no state subscription, so the provider doesn't re-render on
   // queue changes) + toast, for advancing past a spill climb and telling the user.
-  const { setCurrentClimb } = useQueueActions();
+  const { setCurrentClimb, getQueueSnapshot } = useQueueActions();
   const { showToast } = useToast();
   const [autoDisconnectBle] = useSetting('autoDisconnectBle');
   const [autoDisconnectTimeoutSeconds] = useSetting('autoDisconnectTimeoutSeconds');
@@ -842,10 +851,22 @@ export function BluetoothProvider({
   // logbook tick carries `climb.mirrored` through `tickToClimb`), and only the
   // caller knows what to fall back to; collapsing "unstated" into `false` would
   // relight such an ascent un-mirrored.
-  const mirrorIntentFor = useCallback((climbUuid: string | undefined): boolean | undefined => {
-    const intent = mirrorIntentRef.current;
-    return intent != null && intent.climbUuid === climbUuid ? intent.mirrored : undefined;
-  }, []);
+  const mirrorIntentFor = useCallback(
+    (climbUuid: string | undefined): boolean | undefined => {
+      const intent = mirrorIntentRef.current;
+      if (sessionIdRef.current) {
+        const { currentClimbQueueItem, queue } = getQueueSnapshot();
+        // Current slot wins when a climb is queued twice in different orientations.
+        if (currentClimbQueueItem && currentClimbQueueItem.climb.uuid === climbUuid)
+          return currentClimbQueueItem.climb.mirrored === true;
+        const matches = queue.filter((item) => item.climb.uuid === climbUuid);
+        // A non-current duplicate has no unambiguous orientation without a queue UUID.
+        return matches.length === 1 ? matches[0].climb.mirrored === true : undefined;
+      }
+      return intent != null && intent.climbUuid === climbUuid ? intent.mirrored : undefined;
+    },
+    [getQueueSnapshot],
+  );
   // Drop a flip that belongs to some OTHER climb, keep one that belongs to this
   // one. The slot holds explicit taps only, so this is how navigation forgets a
   // flip while a dismiss-and-reopen still finds it.

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -1,3 +1,4 @@
+import type { WidgetMirrorEvent } from '../../modules/live-activity/src/index';
 import {
   useReducer,
   useState,
@@ -750,6 +751,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       pendingUnsyncedCurrentRef.current = null;
       dispatch({
         type: 'INITIAL_QUEUE_DATA',
+        serverSequence: queueState.sequence,
         payload: {
           queue: queueState.queue.map(toClimbQueueItem),
           currentClimbQueueItem: queueState.currentClimbQueueItem
@@ -1481,6 +1483,46 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
+  const mirrorRequestRef = useRef(false);
+  const mirrorCurrentClimb = useCallback(
+    async (mirrored: boolean, queueItemUuid: string) => {
+      if (
+        !sessionIdRef.current ||
+        stateRef.current.currentClimbQueueItem?.uuid !== queueItemUuid ||
+        mirrorRequestRef.current
+      )
+        return;
+      mirrorRequestRef.current = true;
+      try {
+        await mutations.mirrorCurrentClimb(mirrored, queueItemUuid);
+        // Subscription confirmation normally arrives first; refresh also covers a lost echo.
+        await resyncQueueFromServerRef.current();
+      } catch (error) {
+        showQueueMutationErrorToast(error, t, showToast);
+      } finally {
+        mirrorRequestRef.current = false;
+      }
+    },
+    [mutations, showToast, t],
+  );
+
+  const dispatchWidgetMirror = useCallback(async (event: Extract<WidgetMirrorEvent, { kind: 'confirmed' }>) => {
+    if (event.sessionId !== sessionIdRef.current) return false;
+    const gate = queueSyncGateRef.current;
+    if (!gate) return false;
+    const envelope = { ...event, __typename: 'ClimbMirrored' as const };
+    const decision = gate.evaluateIncoming(envelope);
+    if (decision === 'ignore-stale') return true;
+    if (decision === 'resync-gap') return resyncQueueFromServerRef.current();
+    gate.noteApplied(envelope);
+    dispatch({
+      type: 'DELTA_MIRROR_CURRENT_CLIMB',
+      serverSequence: event.sequence,
+      payload: { mirroredUuid: event.queueItemUuid, mirrored: event.mirrored },
+    });
+    return true;
+  }, []);
+
   const setPlaylistSuggestionSource = useCallback((source: PlaylistSuggestionSource | null) => {
     setPlaylistSuggestionSourceState(source);
   }, []);
@@ -1549,6 +1591,8 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       nextClimb,
       previousClimb,
       dispatchWidgetNavigation,
+      mirrorCurrentClimb,
+      dispatchWidgetMirror,
       setPlaylistSuggestionSource,
       refreshPlaylistSuggestionSource,
       clearSession,
@@ -1574,6 +1618,8 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       nextClimb,
       previousClimb,
       dispatchWidgetNavigation,
+      mirrorCurrentClimb,
+      dispatchWidgetMirror,
       setPlaylistSuggestionSource,
       refreshPlaylistSuggestionSource,
       clearSession,

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -1510,10 +1510,17 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     if (event.sessionId !== sessionIdRef.current) return false;
     const gate = queueSyncGateRef.current;
     if (!gate) return false;
+    const reconcileReceipt = async () => {
+      const reconciled = await resyncQueueFromServerRef.current();
+      return reconciled && event.sessionId === sessionIdRef.current && (gate.getLastSequence() ?? -1) >= event.sequence;
+    };
+    // A receipt is a delta, not a full queue snapshot. On resume the gate can
+    // be empty while native navigation is several events ahead of JS.
+    if (gate.getLastSequence() === null) return reconcileReceipt();
     const envelope = { ...event, __typename: 'ClimbMirrored' as const };
     const decision = gate.evaluateIncoming(envelope);
     if (decision === 'ignore-stale') return true;
-    if (decision === 'resync-gap') return resyncQueueFromServerRef.current();
+    if (decision === 'resync-gap') return reconcileReceipt();
     gate.noteApplied(envelope);
     dispatch({
       type: 'DELTA_MIRROR_CURRENT_CLIMB',

--- a/packages/mobile/src/providers/queue/queue-contexts.ts
+++ b/packages/mobile/src/providers/queue/queue-contexts.ts
@@ -1,3 +1,4 @@
+import type { WidgetMirrorEvent } from '../../../modules/live-activity/src/index';
 import { createContext, useContext } from 'react';
 import type {
   QueueState,
@@ -68,6 +69,8 @@ type QueueContextValue = {
    * can't double-advance when the WebSocket echo lands before the Darwin event.
    * Mirrors web's `dispatchWidgetNavigation`.
    */
+  mirrorCurrentClimb: (mirrored: boolean, queueItemUuid: string) => Promise<void>;
+  dispatchWidgetMirror: (event: Extract<WidgetMirrorEvent, { kind: 'confirmed' }>) => Promise<boolean>;
   dispatchWidgetNavigation: (item: ClimbQueueItem, correlationId: string) => void;
   /** Replace the playlist suggestion source that drives swipe-through climbs. */
   setPlaylistSuggestionSource: (source: PlaylistSuggestionSource | null) => void;

--- a/packages/mobile/src/providers/queue/use-session-realtime.ts
+++ b/packages/mobile/src/providers/queue/use-session-realtime.ts
@@ -596,7 +596,7 @@ export function useSessionRealtime({
             // sequence slot).
             gate.noteApplied(gateEvent);
             if (result.kind !== 'dispatch') return;
-            dispatch(result.action);
+            dispatch({ ...result.action, serverSequence: gateEvent.sequence ?? undefined });
             switch (result.eventType) {
               case 'QueueItemAdded': {
                 // The server echoes our own adds back to us. A locally

--- a/packages/mobile/targets/BoardseshWidgets/ClimbNavigationIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/ClimbNavigationIntent.swift
@@ -112,6 +112,9 @@ enum ClimbNavigationIntent {
             hasNext: newIndex < items.count - 1,
             hasPrevious: newIndex > 0,
             climbUuid: newItem.climbUuid,
+            queueItemUuid: newItem.uuid,
+            mirrored: newItem.mirrored,
+            supportsMirroring: defaults.bool(forKey: SharedConstants.supportsMirroringKey),
             // Prev/Next are only shown when this device drives the wall, so the
             // optimistic frame keeps the bulb lit + controls shown.
             boardConnection: "connectedByMe",

--- a/packages/mobile/targets/BoardseshWidgets/ClimbSessionAttributes.swift
+++ b/packages/mobile/targets/BoardseshWidgets/ClimbSessionAttributes.swift
@@ -12,6 +12,9 @@ struct ClimbSessionAttributes: ActivityAttributes {
         var hasNext: Bool
         var hasPrevious: Bool
         var climbUuid: String
+        var queueItemUuid: String? = nil
+        var mirrored: Bool? = nil
+        var supportsMirroring: Bool? = nil
         /// Who currently drives the board, from THIS device's point of view:
         /// "connectedByMe" | "heldByPeer" | "disconnected". Optional so an older
         /// binary decoding a newer push (or vice-versa) never fails to decode;

--- a/packages/mobile/targets/BoardseshWidgets/ClimbSessionLiveActivity.swift
+++ b/packages/mobile/targets/BoardseshWidgets/ClimbSessionLiveActivity.swift
@@ -223,6 +223,7 @@ private func resolveBoardState(
 private struct ThumbnailView: View {
     @Environment(\.colorScheme) private var colorScheme
     let climbUuid: String
+    var mirrored: Bool = false
     let width: CGFloat
     let height: CGFloat
 
@@ -234,6 +235,7 @@ private struct ThumbnailView: View {
             Image(uiImage: image)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
+                .scaleEffect(x: mirrored ? -1 : 1, y: 1)
                 .frame(width: width, height: height)
                 .clipShape(RoundedRectangle(cornerRadius: VelvetSend.Radius.lg, style: .continuous))
         } else {
@@ -404,6 +406,10 @@ private struct WallControlButton: View {
 
 @available(iOS 17.0, *)
 private struct NavigationControlsView: View {
+    let sessionId: String
+    let queueItemUuid: String?
+    let mirrored: Bool
+    let supportsMirroring: Bool
     let hasPrevious: Bool
     let hasNext: Bool
 
@@ -429,6 +435,18 @@ private struct NavigationControlsView: View {
             // connectedByMe is the only state that renders this row, so the bulb
             // is always lit here.
             WallControlButton(lit: true)
+            if supportsMirroring, let queueItemUuid {
+                Button(intent: MirrorClimbIntent(sessionId: sessionId, queueItemUuid: queueItemUuid, mirrored: !mirrored)) {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(mirrored ? Color.accentColor : Color.primary)
+                        .frame(width: 40, height: 40)
+                        .background(mirrored ? Color.accentColor.opacity(0.18) : Color.clear, in: Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(mirrored ? String(localized: "Unmirror climb") : String(localized: "Mirror climb"))
+                .accessibilityAddTraits(mirrored ? .isSelected : [])
+            }
 
             Button(intent: NextClimbIntent()) {
                 NavigationButtonLabel(
@@ -519,6 +537,10 @@ private struct DisconnectedFooter: View {
 /// state that instantiates NavigationControlsView.
 @available(iOS 17.0, *)
 private struct SessionFooter: View {
+    let sessionId: String
+    let queueItemUuid: String?
+    let mirrored: Bool
+    let supportsMirroring: Bool
     let state: ResolvedBoardState
     let hasPrevious: Bool
     let hasNext: Bool
@@ -527,6 +549,8 @@ private struct SessionFooter: View {
         switch state.connection {
         case .connectedByMe:
             NavigationControlsView(
+                sessionId: sessionId, queueItemUuid: queueItemUuid,
+                mirrored: mirrored, supportsMirroring: supportsMirroring,
                 hasPrevious: hasPrevious,
                 hasNext: hasNext
             )
@@ -555,6 +579,7 @@ struct ClimbSessionLiveActivity: Widget {
                 DynamicIslandExpandedRegion(.leading) {
                     ThumbnailView(
                         climbUuid: context.state.climbUuid,
+                        mirrored: context.state.mirrored ?? false,
                         width: 48,
                         height: 60
                     )
@@ -571,6 +596,10 @@ struct ClimbSessionLiveActivity: Widget {
 
                 DynamicIslandExpandedRegion(.bottom) {
                     SessionFooter(
+                        sessionId: context.attributes.sessionId,
+                        queueItemUuid: context.state.queueItemUuid,
+                        mirrored: context.state.mirrored ?? false,
+                        supportsMirroring: context.state.supportsMirroring ?? (SharedConstants.sharedDefaults?.bool(forKey: SharedConstants.supportsMirroringKey) ?? false),
                         state: state,
                         hasPrevious: context.state.hasPrevious,
                         hasNext: context.state.hasNext
@@ -712,6 +741,7 @@ private struct LockScreenView: View {
             // Thumbnail
             ThumbnailView(
                 climbUuid: context.state.climbUuid,
+                        mirrored: context.state.mirrored ?? false,
                 width: 76,
                 height: 96
             )
@@ -747,6 +777,10 @@ private struct LockScreenView: View {
                 // disconnected hide the nav controls entirely so the card
                 // shrinks instead of leaving an empty gap.
                 SessionFooter(
+                        sessionId: context.attributes.sessionId,
+                        queueItemUuid: context.state.queueItemUuid,
+                        mirrored: context.state.mirrored ?? false,
+                        supportsMirroring: context.state.supportsMirroring ?? (SharedConstants.sharedDefaults?.bool(forKey: SharedConstants.supportsMirroringKey) ?? false),
                     state: state,
                     hasPrevious: context.state.hasPrevious,
                     hasNext: context.state.hasNext

--- a/packages/mobile/targets/BoardseshWidgets/MirrorClimbIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/MirrorClimbIntent.swift
@@ -1,0 +1,91 @@
+import ActivityKit
+import AppIntents
+
+@available(iOS 17.0, *)
+struct MirrorClimbIntent: LiveActivityIntent {
+    static let title: LocalizedStringResource = "Mirror climb"
+    @Parameter(title: "Session") var sessionId: String
+    @Parameter(title: "Queue item") var queueItemUuid: String
+    @Parameter(title: "Mirrored") var mirrored: Bool
+
+    init() { sessionId = ""; queueItemUuid = ""; mirrored = false }
+    init(sessionId: String, queueItemUuid: String, mirrored: Bool) {
+        self.sessionId = sessionId
+        self.queueItemUuid = queueItemUuid
+        self.mirrored = mirrored
+    }
+
+    func perform() async throws -> some IntentResult {
+        guard await MirrorIntentGate.shared.begin() else { return .result() }
+        await performMirror()
+        await MirrorIntentGate.shared.end()
+        return .result()
+    }
+
+    private func performMirror() async {
+        #if !WIDGET_EXTENSION
+        let diagnosticRun = LiveActivityIntentDiagnostics.begin(kind: .mirrorClimb)
+        var completionClass = LiveActivityIntentCompletionClass.serverRejected
+        defer { diagnosticRun.complete(completionClass) }
+        #endif
+        guard let defaults = SharedConstants.sharedDefaults,
+              SharedMirrorState.canMirror(sessionId: sessionId, queueItemUuid: queueItemUuid, in: defaults)
+        else { return }
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.networkStarted)
+        #endif
+        let response = await WidgetNetworking.sendMirror(sessionId: sessionId, queueItemUuid: queueItemUuid, mirrored: mirrored)
+        guard case .success(let receipt) = response else {
+            #if !WIDGET_EXTENSION
+            diagnosticRun.mark(response == .retryableFailure ? .networkFinishedRetryable : .networkFinishedTerminal)
+            completionClass = response == .retryableFailure ? .retryableNetworkFailure : .serverRejected
+            #endif
+            return
+        }
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.networkFinishedSuccess)
+        completionClass = .success
+        #endif
+        if let snapshot = SharedMirrorState.apply(receipt, in: defaults) {
+            let updatedItems = snapshot.items
+            let index = snapshot.index
+            let item = updatedItems[index]
+            let state = ClimbSessionAttributes.ContentState(
+                climbName: item.climbName, climbDifficulty: VGradeFormatter.formatVGrade(item.difficulty),
+                angle: item.angle, currentIndex: index, totalClimbs: updatedItems.count,
+                hasNext: index < updatedItems.count - 1, hasPrevious: index > 0, climbUuid: item.climbUuid,
+                queueItemUuid: item.uuid, mirrored: item.mirrored, supportsMirroring: true,
+                boardConnection: "connectedByMe", holderDisplayName: nil
+            )
+            for activity in Activity<ClimbSessionAttributes>.activities where activity.attributes.sessionId == sessionId && activity.activityState == .active {
+                guard SharedMirrorState.isCurrent(receipt, in: defaults) else { break }
+                await activity.update(ActivityContent(state: state, staleDate: Date().addingTimeInterval(SharedConstants.liveActivityStaleInterval)))
+            }
+            #if !WIDGET_EXTENSION
+            diagnosticRun.mark(.activityKitUpdated)
+            diagnosticRun.mark(.bleStarted)
+            let succeeded = await LiveActivityBleBridge.writeBoardForIntent(items: updatedItems, currentIndex: index, mirrorReceipt: receipt)
+            diagnosticRun.mark(succeeded ? .bleFinishedSuccess : .bleFinishedFailure)
+            if !succeeded { completionClass = .bleFailure }
+            #endif
+        }
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            CFNotificationName(SharedConstants.queueNavigateNotification as CFString), nil, nil, true
+        )
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.darwinPosted)
+        #endif
+    }
+}
+
+private actor MirrorIntentGate {
+    static let shared = MirrorIntentGate()
+    private var busy = false
+    func begin() -> Bool {
+        guard !busy else { return false }
+        busy = true
+        return true
+    }
+    func end() { busy = false }
+}

--- a/packages/mobile/targets/BoardseshWidgets/SharedConstants.swift
+++ b/packages/mobile/targets/BoardseshWidgets/SharedConstants.swift
@@ -17,6 +17,10 @@ enum SharedConstants {
     /// https://ws.boardsesh.com/api/widget/navigate). The widget POSTs button
     /// taps here. Kept fully qualified rather than derived from `serverUrlKey`
     /// so the native contract remains explicit.
+    static let widgetMirrorUrlKey = "bs_widget_mirror_url"
+    static let supportsMirroringKey = "bs_supports_mirroring"
+    static let queueSequenceKey = "bs_queue_sequence"
+    static let pendingMirrorKey = "bs_pending_mirror"
     static let widgetNavigateUrlKey = "bs_widget_navigate_url"
     /// Fully-qualified backend `/api/widget/take-control` URL. The widget
     /// POSTs non-driver lightbulb taps here before enabling local navigation.

--- a/packages/mobile/targets/BoardseshWidgets/SharedMirrorState.swift
+++ b/packages/mobile/targets/BoardseshWidgets/SharedMirrorState.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+struct SharedMirrorConfirmation: Codable, Equatable, Sendable {
+    let sessionId: String
+    let queueItemUuid: String
+    let mirrored: Bool
+    let sequence: Int
+    let stateHash: String
+    let stateHashOrdered: String?
+
+    var eventBody: [String: Any] {
+        var body: [String: Any] = [
+            "kind": "confirmed", "sessionId": sessionId, "queueItemUuid": queueItemUuid,
+            "mirrored": mirrored, "sequence": sequence, "stateHash": stateHash
+        ]
+        if let stateHashOrdered { body["stateHashOrdered"] = stateHashOrdered }
+        return body
+    }
+}
+
+/// A durable receipt, retained until JS has applied this sequence (or a newer full sync).
+enum SharedMirrorState {
+    private static let lock = NSLock()
+
+    static func pending(in defaults: UserDefaults) -> SharedMirrorConfirmation? {
+        guard let bytes = defaults.data(forKey: SharedConstants.pendingMirrorKey),
+              let receipt = try? JSONDecoder().decode(SharedMirrorConfirmation.self, from: bytes),
+              receipt.sessionId == defaults.string(forKey: SharedConstants.sessionIdKey) else { return nil }
+        return receipt
+    }
+
+    static func acknowledge(sessionId: String, sequence: Int, in defaults: UserDefaults) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let receipt = pending(in: defaults), receipt.sessionId == sessionId,
+              receipt.sequence <= sequence else { return }
+        defaults.removeObject(forKey: SharedConstants.pendingMirrorKey)
+    }
+
+    static func sequence(in defaults: UserDefaults) -> Int {
+        defaults.object(forKey: SharedConstants.queueSequenceKey) as? Int ?? -1
+    }
+
+    /// Publish a complete queue snapshot only if it is at least as new as the native receipt.
+    @discardableResult
+    static func persist(items: [SharedQueueItem], currentIndex: Int, sequence: Int, subscriptionSequence: Int? = nil, in defaults: UserDefaults) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if sequence < Self.sequence(in: defaults) {
+            // A subscription requested after the last accepted update is authoritative,
+            // including when the server recovered with a reset sequence counter.
+            guard subscriptionSequence == Self.sequence(in: defaults) else { return false }
+            defaults.removeObject(forKey: SharedConstants.pendingMirrorKey)
+        }
+        SharedQueueState.save(items: items, currentIndex: currentIndex, to: defaults)
+        defaults.set(sequence, forKey: SharedConstants.queueSequenceKey)
+        return true
+    }
+
+    static func isCurrent(_ receipt: SharedMirrorConfirmation, in defaults: UserDefaults) -> Bool {
+        let (items, index) = SharedQueueState.load(from: defaults)
+        return sequence(in: defaults) == receipt.sequence
+            && canMirror(sessionId: receipt.sessionId, queueItemUuid: receipt.queueItemUuid, in: defaults)
+            && items.indices.contains(index) && items[index].mirrored == receipt.mirrored
+    }
+
+    /// Commit an HTTP result atomically against native WebSocket updates.
+    static func apply(_ receipt: SharedMirrorConfirmation, in defaults: UserDefaults) -> (items: [SharedQueueItem], index: Int)? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard receipt.sessionId == defaults.string(forKey: SharedConstants.sessionIdKey),
+              receipt.sequence >= sequence(in: defaults),
+              let bytes = try? JSONEncoder().encode(receipt) else { return nil }
+        defaults.set(bytes, forKey: SharedConstants.pendingMirrorKey)
+        guard canMirror(sessionId: receipt.sessionId, queueItemUuid: receipt.queueItemUuid, in: defaults) else { return nil }
+        let (items, index) = SharedQueueState.load(from: defaults)
+        let updatedItems = items.map { item in
+            item.uuid == receipt.queueItemUuid ? SharedQueueItem(
+                uuid: item.uuid, climbUuid: item.climbUuid, climbName: item.climbName,
+                difficulty: item.difficulty, angle: item.angle, frames: item.frames,
+                setterUsername: item.setterUsername, mirrored: receipt.mirrored
+            ) : item
+        }
+        SharedQueueState.save(items: updatedItems, currentIndex: index, to: defaults)
+        defaults.set(receipt.sequence, forKey: SharedConstants.queueSequenceKey)
+        return (updatedItems, index)
+    }
+
+    static func canMirror(sessionId: String, queueItemUuid: String, in defaults: UserDefaults) -> Bool {
+        let (items, index) = SharedQueueState.load(from: defaults)
+        return defaults.string(forKey: SharedConstants.sessionIdKey) == sessionId
+            && defaults.bool(forKey: SharedConstants.supportsMirroringKey)
+            && defaults.string(forKey: SharedConstants.boardConnectionKey) == "connectedByMe"
+            && SharedWidgetWallControlState.load(from: defaults).navigationAllowed
+            && items.indices.contains(index) && items[index].uuid == queueItemUuid
+    }
+}

--- a/packages/mobile/targets/BoardseshWidgets/WidgetNetworking.swift
+++ b/packages/mobile/targets/BoardseshWidgets/WidgetNetworking.swift
@@ -6,7 +6,45 @@ enum WidgetNavigationResult: Equatable {
     case retryableFailure
 }
 
+enum WidgetMirrorResult: Equatable {
+    case success(SharedMirrorConfirmation)
+    case serverRejected
+    case retryableFailure
+}
+
 enum WidgetNetworking {
+    static func sendMirror(sessionId: String, queueItemUuid: String, mirrored: Bool) async -> WidgetMirrorResult {
+        guard let defaults = SharedConstants.sharedDefaults,
+              let urlString = defaults.string(forKey: SharedConstants.widgetMirrorUrlKey),
+              let url = URL(string: urlString),
+              let token = SharedKeychain.get(SharedKeychain.livePushTokenKey), !token.isEmpty
+        else { return .serverRejected }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 10
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: [
+            "sessionId": sessionId, "queueItemUuid": queueItemUuid, "mirrored": mirrored
+        ])
+        do {
+            let (bytes, response) = try await URLSession.shared.data(for: request)
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            if status == 410 {
+                CFNotificationCenterPostNotification(
+                    CFNotificationCenterGetDarwinNotifyCenter(),
+                    CFNotificationName(SharedConstants.pushRegistrationStaleNotification as CFString), nil, nil, true
+                )
+            }
+            if (400...499).contains(status) { return .serverRejected }
+            guard status == 200,
+                  let receipt = try? JSONDecoder().decode(SharedMirrorConfirmation.self, from: bytes),
+                  receipt.sessionId == sessionId, receipt.queueItemUuid == queueItemUuid,
+                  receipt.mirrored == mirrored, receipt.sequence >= 0 else { return .retryableFailure }
+            return .success(receipt)
+        } catch { return .retryableFailure }
+    }
+
     private static func postWidgetRequest(urlKey: String, body: [String: Any], requestName: String) async -> WidgetNavigationResult {
         guard let defaults = SharedConstants.sharedDefaults,
               let widgetUrl = defaults.string(forKey: urlKey)

--- a/packages/mobile/targets/BoardseshWidgets/de.lproj/Localizable.strings
+++ b/packages/mobile/targets/BoardseshWidgets/de.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"Mirror climb" = "Boulder spiegeln";
+"Unmirror climb" = "Spiegelung aufheben";

--- a/packages/mobile/targets/BoardseshWidgets/en.lproj/Localizable.strings
+++ b/packages/mobile/targets/BoardseshWidgets/en.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"Mirror climb" = "Mirror climb";
+"Unmirror climb" = "Unmirror climb";

--- a/packages/mobile/targets/BoardseshWidgets/es.lproj/Localizable.strings
+++ b/packages/mobile/targets/BoardseshWidgets/es.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"Mirror climb" = "Espejear bloque";
+"Unmirror climb" = "Quitar espejo";

--- a/packages/mobile/targets/BoardseshWidgets/fr.lproj/Localizable.strings
+++ b/packages/mobile/targets/BoardseshWidgets/fr.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"Mirror climb" = "Miroir du bloc";
+"Unmirror climb" = "Annuler le miroir";

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -6408,7 +6408,7 @@ type Mutation {
   """
   Toggle mirrored display for the current climb.
   """
-  mirrorCurrentClimb(mirrored: Boolean!): ClimbQueueItem
+  mirrorCurrentClimb(mirrored: Boolean!, expectedQueueItemUuid: ID): ClimbQueueItem
 
   """
   Broadcast the current playback state for a variable-speed climb so

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -4093,6 +4093,7 @@ export type MutationMergeGymsArgs = {
 
 /** Root mutation type for all write operations. */
 export type MutationMirrorCurrentClimbArgs = {
+  expectedQueueItemUuid?: InputMaybe<Scalars['ID']['input']>;
   mirrored: Scalars['Boolean']['input'];
 };
 

--- a/packages/shared-schema/src/schema/mutations.ts
+++ b/packages/shared-schema/src/schema/mutations.ts
@@ -72,7 +72,7 @@ export const mutationsTypeDefs = /* GraphQL */ `
     """
     Toggle mirrored display for the current climb.
     """
-    mirrorCurrentClimb(mirrored: Boolean!): ClimbQueueItem
+    mirrorCurrentClimb(mirrored: Boolean!, expectedQueueItemUuid: ID): ClimbQueueItem
 
     """
     Broadcast the current playback state for a variable-speed climb so

--- a/packages/shared/board-config/src/board-mirroring.ts
+++ b/packages/shared/board-config/src/board-mirroring.ts
@@ -1,0 +1,9 @@
+/**
+ * Whether a board supports mirroring climbs.
+ * Tension boards support mirroring (except layout 11), Decoy boards support it,
+ * and Woods supports it via its own row-reflection geometry
+ * (`getWoodsMirroredHoldLocation`/`mirroredHoldId`). MoonBoard does not.
+ */
+export function boardSupportsMirroring(boardName: string, layoutId: number): boolean {
+  return (boardName === 'tension' && layoutId !== 11) || boardName === 'decoy' || boardName === 'woods';
+}

--- a/packages/shared/board-config/src/index.ts
+++ b/packages/shared/board-config/src/index.ts
@@ -10,3 +10,4 @@ export * from './resolve-render-board';
 export * from './moonboard-cell-sets';
 export * from './woods-config';
 export type { Angle, SetIdList, ClimbCompatibilityInput, BoardCompatibilityTarget } from './types';
+export * from './board-mirroring';

--- a/packages/shared/board-config/src/woods-config.ts
+++ b/packages/shared/board-config/src/woods-config.ts
@@ -8,12 +8,13 @@
 // The on-screen hold geometry and board art come from the decompiled Woods app.
 import {
   WOODS_BOARD_SIZES,
+  WOODS_ROW_LENGTHS,
   WOODS_WIRE_ROLE,
   WOODS_HOLD_POSITIONS,
   type WoodsBoardSize,
 } from '@boardsesh/board-constants/woods';
 
-export { WOODS_BOARD_SIZES };
+export { WOODS_BOARD_SIZES, WOODS_ROW_LENGTHS };
 export type { WoodsBoardSize };
 
 // Woods supports 20–70° in 5° steps (Woods app API: angle 20–70 step 5).
@@ -81,13 +82,6 @@ export function encodeWoodsHoldsToFrames(holds: Array<{ type: string; baseHoldLo
 // `getHoldPositionFromRowColumn`). Totals: 8x10 = 485, 12x12 = 894 — matching the
 // LED maps. Narrower rows align with every-other column of the widest row, which
 // falls out of the edge-to-edge spread (e.g. an 11-hold row over a 21-hold row).
-
-const repeat = (count: number, value: number): number[] => Array.from({ length: count }, () => value);
-
-export const WOODS_ROW_LENGTHS: Record<WoodsBoardSize, number[]> = {
-  '8x10': [...repeat(1, 11), ...repeat(21, 21), ...repeat(3, 11)],
-  '12x12': [...repeat(3, 17), ...repeat(23, 33), ...repeat(3, 17), ...repeat(1, 17), ...repeat(1, 16)],
-};
 
 export type WoodsRowColumn = { row: number; column: number };
 

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -4090,6 +4090,7 @@ export type MutationMergeGymsArgs = {
 
 /** Root mutation type for all write operations. */
 export type MutationMirrorCurrentClimbArgs = {
+  expectedQueueItemUuid?: InputMaybe<Scalars['ID']['input']>;
   mirrored: Scalars['Boolean']['input'];
 };
 

--- a/packages/shared/graphql/src/operations/queue-session.ts
+++ b/packages/shared/graphql/src/operations/queue-session.ts
@@ -172,8 +172,8 @@ export const SET_CURRENT_CLIMB = `
 `;
 
 export const MIRROR_CURRENT_CLIMB = `
-  mutation MirrorCurrentClimb($mirrored: Boolean!) {
-    mirrorCurrentClimb(mirrored: $mirrored) {
+  mutation MirrorCurrentClimb($mirrored: Boolean!, $expectedQueueItemUuid: ID) {
+    mirrorCurrentClimb(mirrored: $mirrored, expectedQueueItemUuid: $expectedQueueItemUuid) {
       ${QUEUE_ITEM_FIELDS}
     }
   }

--- a/packages/shared/i18n/locales/de/session.json
+++ b/packages/shared/i18n/locales/de/session.json
@@ -476,6 +476,8 @@
         "contentTitleFallback": "Kletter-Session",
         "previous": "Zurück",
         "next": "Weiter",
+        "mirror": "Boulder spiegeln",
+        "unmirror": "Spiegelung aufheben",
         "relight": "Wand neu beleuchten",
         "reconnect": "Mit Board verbinden",
         "onWall": "{{name}} ist an der Wand"

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -476,6 +476,8 @@
         "contentTitleFallback": "Climbing session",
         "previous": "Previous",
         "next": "Next",
+        "mirror": "Mirror climb",
+        "unmirror": "Unmirror climb",
         "relight": "Relight wall",
         "reconnect": "Connect to board",
         "onWall": "{{name}} is on the wall"

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -476,6 +476,8 @@
         "contentTitleFallback": "Sesión de escalada",
         "previous": "Anterior",
         "next": "Siguiente",
+        "mirror": "Espejear bloque",
+        "unmirror": "Quitar espejo",
         "relight": "Reactivar el muro",
         "reconnect": "Conectar al plafón",
         "onWall": "{{name}} está en el muro"

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -476,6 +476,8 @@
         "contentTitleFallback": "Session d'escalade",
         "previous": "Précédent",
         "next": "Suivant",
+        "mirror": "Miroir du bloc",
+        "unmirror": "Annuler le miroir",
         "relight": "Rallumer le mur",
         "reconnect": "Se connecter à la board",
         "onWall": "{{name}} est sur le mur"

--- a/packages/shared/play-view/src/board-utils.ts
+++ b/packages/shared/play-view/src/board-utils.ts
@@ -1,9 +1,1 @@
-/**
- * Whether a board supports mirroring climbs.
- * Tension boards support mirroring (except layout 11), Decoy boards support it,
- * and Woods supports it via its own row-reflection geometry
- * (`getWoodsMirroredHoldLocation`/`mirroredHoldId`). MoonBoard does not.
- */
-export function boardSupportsMirroring(boardName: string, layoutId: number): boolean {
-  return (boardName === 'tension' && layoutId !== 11) || boardName === 'decoy' || boardName === 'woods';
-}
+export { boardSupportsMirroring } from '@boardsesh/board-config';

--- a/packages/shared/queue-react/src/create-queue-mutations.ts
+++ b/packages/shared/queue-react/src/create-queue-mutations.ts
@@ -203,7 +203,7 @@ export type QueueMutationsActions<TItem> = {
    * climber cleared earlier in the app process.
    */
   wasUuidExplicitlyRemoved: (uuid: string) => boolean;
-  mirrorCurrentClimb: (mirrored: boolean) => Promise<void>;
+  mirrorCurrentClimb: (mirrored: boolean, expectedQueueItemUuid?: string) => Promise<void>;
   /**
    * Broadcast a playback engine state change for a multi-frame climb so party
    * peers stay in sync. Best-effort; no-op in solo (no active session).
@@ -502,10 +502,10 @@ export function createQueueMutations<TItem>(deps: QueueMutationsDeps<TItem>): Qu
 
     wasUuidExplicitlyRemoved: (uuid) => removedUuids.has(uuid),
 
-    mirrorCurrentClimb: async (mirrored) => {
+    mirrorCurrentClimb: async (mirrored, expectedQueueItemUuid) => {
       const ready = await resolveCore({ allowCreate: false });
       if (!ready) return;
-      await runMutation(ready.client, { query: MIRROR_CURRENT_CLIMB, variables: { mirrored } });
+      await runMutation(ready.client, { query: MIRROR_CURRENT_CLIMB, variables: { mirrored, expectedQueueItemUuid } });
     },
 
     publishPlaybackState: async (input) => {

--- a/packages/shared/queue/src/__tests__/reducer.test.ts
+++ b/packages/shared/queue/src/__tests__/reducer.test.ts
@@ -276,6 +276,29 @@ describe('MIRROR_CLIMB', () => {
 });
 
 describe('DELTA_MIRROR_CURRENT_CLIMB', () => {
+  it('preserves a historical flip across optimistic navigation and its echo', () => {
+    const first = makeClimbQueueItem({ uuid: 'first' });
+    const next = makeClimbQueueItem({ uuid: 'next' });
+    let state = makeState({ queue: [first, next], currentClimbQueueItem: first });
+    state = queueReducer(state, {
+      type: 'DELTA_UPDATE_CURRENT_CLIMB',
+      payload: { item: next, correlationId: 'nav-next' },
+    });
+    state = queueReducer(state, {
+      type: 'DELTA_MIRROR_CURRENT_CLIMB',
+      payload: { mirroredUuid: first.uuid, mirrored: true },
+    });
+    expect(state.currentClimbQueueItem?.uuid).toBe(next.uuid);
+    expect(state.currentClimbQueueItem?.climb.mirrored).not.toBe(true);
+    state = queueReducer(state, {
+      type: 'DELTA_UPDATE_CURRENT_CLIMB',
+      payload: { item: next, isServerEvent: true, serverCorrelationId: 'nav-next' },
+    });
+    expect(state.queue[0].climb.mirrored).toBe(true);
+    state = queueReducer(state, { type: 'SET_CURRENT_CLIMB_QUEUE_ITEM', payload: state.queue[0] });
+    expect(state.currentClimbQueueItem?.climb.mirrored).toBe(true);
+  });
+
   it('applies mirrored state when mirroredUuid matches current climb', () => {
     const item = makeClimbQueueItem({ uuid: 'climb-1' });
     item.climb.mirrored = false;

--- a/packages/shared/queue/src/reducer.ts
+++ b/packages/shared/queue/src/reducer.ts
@@ -27,6 +27,14 @@ export function queueReducer<TSearchParams extends QueueSearchParams>(
   state: QueueState<TSearchParams>,
   action: QueueAction<TSearchParams>,
 ): QueueState<TSearchParams> {
+  const nextState = reduceQueue(state, action);
+  return action.serverSequence === undefined ? nextState : { ...nextState, serverSequence: action.serverSequence };
+}
+
+function reduceQueue<TSearchParams extends QueueSearchParams>(
+  state: QueueState<TSearchParams>,
+  action: QueueAction<TSearchParams>,
+): QueueState<TSearchParams> {
   switch (action.type) {
     case 'SET_CURRENT_CLIMB': {
       const currentIndex = state.currentClimbQueueItem

--- a/packages/shared/queue/src/reducer.ts
+++ b/packages/shared/queue/src/reducer.ts
@@ -343,39 +343,19 @@ function reduceQueue<TSearchParams extends QueueSearchParams>(
 
     case 'DELTA_MIRROR_CURRENT_CLIMB': {
       const { mirrored, mirroredUuid } = action.payload;
-      if (!state.currentClimbQueueItem) return state;
-      // Server-sourced events carry the uuid of the climb that was actually
-      // mirrored on the server, or null when the server had no current
-      // climb at publish time (a pre-B7 no-op event from history replay).
-      // Suppress both cases:
-      //   - null uuid: the server intentionally mirrored "nothing", so
-      //     applying it to whatever the local current climb happens to be
-      //     would mirror an unrelated climb until the next FullSync.
-      //   - uuid mismatch: peer navigated to a different climb between the
-      //     mirror mutation firing and the broadcast reaching us.
-      // Local-origin dispatches always pass the local current climb's
-      // uuid, so neither branch fires there.
-      if (mirroredUuid === null || state.currentClimbQueueItem.uuid !== mirroredUuid) {
-        return state;
-      }
-
-      const updatedCurrentItem = {
-        ...state.currentClimbQueueItem,
-        climb: {
-          ...state.currentClimbQueueItem.climb,
-          mirrored,
-        },
-      };
-
-      // Update the item in the queue as well if it exists
-      const updatedQueue = state.queue.map((item) =>
-        item.uuid === state.currentClimbQueueItem?.uuid ? updatedCurrentItem : item,
-      );
-
+      if (mirroredUuid === null) return state;
+      const mirrorsCurrent = state.currentClimbQueueItem?.uuid === mirroredUuid;
+      if (!mirrorsCurrent && !state.queue.some((item) => item.uuid === mirroredUuid)) return state;
+      const mirrorItem = (item: ClimbQueueItem) => ({ ...item, climb: { ...item.climb, mirrored } });
+      // Optimistic navigation may already point elsewhere. The event still
+      // updates its exact queue slot so returning to it preserves the flip.
       return {
         ...state,
-        queue: updatedQueue,
-        currentClimbQueueItem: updatedCurrentItem,
+        queue: state.queue.map((item) => (item.uuid === mirroredUuid ? mirrorItem(item) : item)),
+        currentClimbQueueItem:
+          mirrorsCurrent && state.currentClimbQueueItem
+            ? mirrorItem(state.currentClimbQueueItem)
+            : state.currentClimbQueueItem,
       };
     }
 

--- a/packages/shared/queue/src/types.ts
+++ b/packages/shared/queue/src/types.ts
@@ -113,6 +113,8 @@ export type ClimbRegradePatch = {
 export type QueueSearchParams = Record<string, unknown>;
 
 export type QueueState<TSearchParams extends QueueSearchParams = QueueSearchParams> = {
+  /** Server sequence committed with this queue snapshot. */
+  serverSequence?: number;
   queue: ClimbQueue;
   currentClimbQueueItem: ClimbQueueItem | null;
   climbSearchParams: TSearchParams;
@@ -123,6 +125,11 @@ export type QueueState<TSearchParams extends QueueSearchParams = QueueSearchPara
 };
 
 export type QueueAction<TSearchParams extends QueueSearchParams = QueueSearchParams> =
+  QueueActionPayload<TSearchParams> & {
+    serverSequence?: number;
+  };
+
+type QueueActionPayload<TSearchParams extends QueueSearchParams> =
   | { type: 'ADD_TO_QUEUE'; payload: ClimbQueueItem }
   | { type: 'REMOVE_FROM_QUEUE'; payload: ClimbQueueItem[] }
   | { type: 'SET_CURRENT_CLIMB'; payload: ClimbQueueItem }

--- a/scripts/__tests__/prepare-rn-ios-tests.test.ts
+++ b/scripts/__tests__/prepare-rn-ios-tests.test.ts
@@ -39,6 +39,8 @@ const MODULE_SOURCE_NAMES = [
   'SessionQueueState.swift',
   'SharedKeychain.swift',
   'WidgetNetworking.swift',
+  'SharedMirrorState.swift',
+  'MirrorClimbIntent.swift',
   'LiveActivityIntentDiagnostics.swift',
   'ClimbNavigationIntent.swift',
   'NextClimbIntent.swift',

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -90,6 +90,14 @@ const TEST_SOURCE_FILES = [
     projectPath: 'BoardseshTests/LiveActivitySources/SharedKeychain.swift',
   },
   {
+    sourcePath: '../modules/live-activity/ios/SharedMirrorState.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/SharedMirrorState.swift',
+  },
+  {
+    sourcePath: '../modules/live-activity/ios/MirrorClimbIntent.swift',
+    projectPath: 'BoardseshTests/LiveActivitySources/MirrorClimbIntent.swift',
+  },
+  {
     sourcePath: '../modules/live-activity/ios/WidgetNetworking.swift',
     projectPath: 'BoardseshTests/LiveActivitySources/WidgetNetworking.swift',
   },


### PR DESCRIPTION
## Summary

Mirror the current session climb from the iOS Lock Screen, expanded Dynamic Island, or Android foreground notification. The button appears on supported layouts while this phone controls Bluetooth. Previous, Next, and the lightbulb remain available.

Mirroring updates the shared queue only after server confirmation. The app, other session participants, thumbnails, and LEDs use that orientation. A durable iOS receipt reconciles background changes when the app opens; queue sequence checks prevent older snapshots from undoing them. The active-session in-app mirror button follows the same shared state; solo climbs and previews retain local mirroring.

Validation: monorepo typecheck passed; all 9,297 mobile tests pass on the rebased branch. Focused integration coverage (148 tests) and shared queue/board geometry coverage (536 tests) pass. Earlier Android native module compilation and all 41 unit tests passed, along with 24 backend tests and both Metro bundles. Two independent code reviews found three issues, now fixed and re-reviewed: Woods native LED reflection, receipt replay before a queue baseline, and historical mirror updates racing navigation. Mandatory Astra BLE review is clear. Updated Woods XCTest compilation and locked-device BLE testing remain CI/device gates.

Rebased onto current main, preserving its no-LED-wall behavior and test coverage. Corrected the CI fixture types and Conventional Commit PR title. The external Claude review job hit its account's weekly quota; it produced no review.

Deploy the additive backend endpoint/schema before shipping new native iOS and Android builds. These controls require a native update.

## Release Notes

Mirror your climb from the Lock Screen or Android notification, then pick up the same mirrored climb in the app.

## Test plan

1. Start a signed-in Tension/Woods session with Bluetooth; Mirror appears when locked.
2. Tap notification Mirror; board holds and thumbnail flip together.
3. Open the climb; mirrored holds and selected Mirror persist.
4. Tap Mirror again; widget, app, and board return to normal.
5. Switch to Kilter; notification and Live Activity hide Mirror.

## Risk

Risk: 5/5 — native lock-screen actions write Bluetooth and reconcile shared session state.
