### PR TITLE
fix(mobile): put the Woods LED table in scope for both test suites

### DIFF
--- a/packages/mobile/ios-tests/WoodsBoardBleTests.swift
+++ b/packages/mobile/ios-tests/WoodsBoardBleTests.swift
@@ -5,16 +5,23 @@ import XCTest
 // dispatch (#3314). The byte-exact fixtures mirror
 // packages/shared/ble-protocol/src/__tests__/woods.test.ts — keep the two in
 // lockstep, and docs/WOODS_BLUETOOTH_PROTOCOL_SPEC.md is the wire authority.
+/// File-scoped so BOTH suites in this file can reach it: the encoder tests below
+/// build expected packets from the table, and `WoodsBoardBleManagerTests`'
+/// mirroring cases assert against the reflected one. It was a `private` method of
+/// the first class, which put it out of scope for the second (#5313).
+@available(iOS 17.0, *)
+private func woodsLedMap(_ sizeId: Int) -> [Int: Int] {
+    guard let map = WoodsBoardData.ledMap(forSizeId: sizeId) else {
+        XCTFail("expected a Woods LED table for size_id \(sizeId)")
+        return [:]
+    }
+    return map
+}
+
 @available(iOS 17.0, *)
 final class WoodsBoardBleTests: XCTestCase {
 
-    private func ledMap(_ sizeId: Int) -> [Int: Int] {
-        guard let map = WoodsBoardData.ledMap(forSizeId: sizeId) else {
-            XCTFail("expected a Woods LED table for size_id \(sizeId)")
-            return [:]
-        }
-        return map
-    }
+    private func ledMap(_ sizeId: Int) -> [Int: Int] { woodsLedMap(sizeId) }
 
     private func ascii(_ result: BoardBlePacketResult) -> String {
         String(decoding: result.packet, as: UTF8.self)
@@ -159,6 +166,8 @@ final class WoodsBoardBleTests: XCTestCase {
 /// through `testHooks.sync {}`, acks fire inline, no sleeps.
 @available(iOS 17.0, *)
 final class WoodsBoardBleManagerTests: XCTestCase {
+    private func ledMap(_ sizeId: Int) -> [Int: Int] { woodsLedMap(sizeId) }
+
     private var scheduler: FakeBleTimerScheduler!
     private var manager: BoardBleManager!
     private var suiteName: String!


### PR DESCRIPTION
## Summary

`main`'s Swift suite does not compile, so the macOS `build-and-test` job fails on every mobile PR. This is a one-file scope repair.

#5313 added three mirroring tests to `WoodsBoardBleManagerTests`:

```
WoodsBoardBleTests.swift:274:52: error: cannot find 'ledMap' in scope
WoodsBoardBleTests.swift:281:52: error: cannot find 'ledMap' in scope
WoodsBoardBleTests.swift:286:28: error: cannot find 'ledMap' in scope
```

`ledMap(_:)` was a `private` method of `WoodsBoardBleTests`, the *other* class in the same file, so it was never in scope for the manager suite.

The tests are in the right class — they drive `displayWoods` / `reassembled`, which only the manager suite defines. It is the helper that was misplaced. So it moves to a file-scoped `woodsLedMap`, and each suite keeps a one-line accessor: the encoder tests build expected packets from the table, the mirroring tests assert against the reflected one, and both read from the same source.

## Why it reached main

`ios-rn-ci.yml` does not run on `main`, so a Swift compile break there is invisible until the next PR's ~30-minute macOS job picks it up. That is the same way the `WaiterPoolOutcomeTests` break reached main before repair PR #4170. Found while chasing a red `build-and-test` on #4551, which touches none of these files.

## Test plan

1. CI green.

## Risk

Risk: 1/5 — test-only scope change; no production Swift touched.

## Release Notes

- [x] No release note needed (internal / technical change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182jHtWo7NzfWGhdr8bgpas
