### PR TITLE
chore(mobile): bump to 2.5.0 and write the store release notes

### DIFF
--- a/fastlane/metadata/android/de-DE/changelogs/default.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/default.txt
@@ -1,5 +1,5 @@
-Neu in 2.4:
-- Aura, der neue Look für dein Board: beleuchtete Griffe leuchten in ihrer eigenen Silhouette, die Wand tritt zurück. Neuer Standard auf jedem Board, Woods inklusive.
-- Stell ihn dir ein unter Profil > Mehr > Board-Look: Vorgaben, Leuchten, Schleier, Markierungen, Farbsehschwäche-Paletten. Lieber Kreise? Darstellung auf Klassisch.
-- MoonBoard: mit dem quelloffenen Arduino-LED-Controller „Griff darüber beleuchten“ aktivieren.
-- Panels schließen zuverlässig.
+Neu in 2.5:
+- Übernimm die Wand an einem Board ohne LEDs: Crew und Hallen-Bildschirm folgen dem Boulder, den du zeigst. Schalt die Beleuchtung in den Board-Einstellungen aus; ihr wechselt euch weiter ab, dein Winkel bleibt.
+- Spiegle deinen Boulder direkt aus der Android-Benachrichtigung, während dein Handy das Board steuert; App, Crew und LEDs folgen.
+- Heruntergeladene Boulder bleiben nach einem App-Update aktuell.
+- Die Boulder-Suche schließt sich, ohne dass ein Vorschau-Sheet aufspringt.

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,5 +1,5 @@
-New in 2.4:
-- Aura, a new look for your board: lit holds glow in their own shape and the wall dims back, so the climb reads from across the room. It's the new default on every board, Woods included.
-- Make it yours under Profile > More > Board look: presets, glow, veil, marks, colour-vision palettes. Want the old circles? Set Render to Classic.
-- MoonBoard: running the open-source Arduino LED controller? Turn on "Light the hold above".
-- Sheets close reliably after backgrounding.
+New in 2.5:
+- Take the wall on a board with no LEDs: your crew and the gym screen follow the climb you put up. Switch Lights off in the board's settings; turns keep rotating and your angle stays put.
+- Mirror your climb straight from the Android notification while your phone drives the board; the app, your crew and the LEDs follow.
+- Downloaded climbs stay up to date after an app update.
+- Closing climb search no longer pops up a stray preview sheet.

--- a/fastlane/metadata/android/es-ES/changelogs/default.txt
+++ b/fastlane/metadata/android/es-ES/changelogs/default.txt
@@ -1,5 +1,5 @@
-Novedades de 2.4:
-- Aura, el nuevo aspecto de tu plafón: las presas encendidas brillan con su propia silueta y el muro se atenúa. Es el aspecto por defecto en todos los plafones, Woods incluido.
-- Hazlo tuyo en Perfil > Más > Aspecto del plafón: preajustes, resplandor, velo, marcas, paletas para daltonismo. ¿Prefieres círculos? Pon Renderizado en Clásico.
-- MoonBoard: con el controlador LED de código abierto con Arduino, activa «Iluminar la presa de arriba».
-- Los paneles se cierran bien.
+Novedades de 2.5:
+- Toma el muro en un plafón sin LED: tu gente y la pantalla del rocódromo siguen el bloque que pones. Desactiva Luces en los ajustes del plafón; los turnos siguen rotando y tu ángulo se mantiene.
+- Espejea tu bloque desde la notificación de Android mientras tu teléfono controla el plafón; la app, tu gente y los LED lo siguen.
+- Los bloques descargados se mantienen al día tras actualizar la app.
+- Cerrar la búsqueda de bloques ya no hace aparecer un panel de vista previa.

--- a/fastlane/metadata/android/fr-FR/changelogs/default.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/default.txt
@@ -1,5 +1,5 @@
-Nouveautés de la version 2.4 :
-- Aura, le nouveau look de ta board : les prises allumées brillent dans leur propre silhouette et le mur s'assombrit. Look par défaut sur toutes les boards, Woods compris.
-- À régler dans Profil > Plus > Look de la board : préréglages, lueur, voile, marques, palettes daltonisme. Tu préfères les cercles ? Mets Rendu sur Classique.
-- MoonBoard : avec le contrôleur LED open source Arduino, active « Allumer la prise du dessus ».
-- Les panneaux se ferment bien.
+Nouveautés de la version 2.5 :
+- Prends le mur sur une board sans LED : ton crew et l'écran de la salle suivent le bloc que tu mets. Désactive l'Éclairage dans les réglages de la board ; le tour de rôle continue, ton angle reste.
+- Mets ton bloc en miroir depuis la notification Android quand ton téléphone pilote la board ; l'app, ton crew et les LED suivent.
+- Les blocs téléchargés restent à jour après une mise à jour.
+- Fermer la recherche de blocs ne fait plus surgir de feuille d'aperçu.

--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -1,19 +1,18 @@
-Neu in 2.4:
+Neu in 2.5:
 
-AURA: EIN NEUER LOOK FÜR DEIN BOARD
+ÜBERNIMM DIE WAND, AUCH OHNE LEDS
 
-Beleuchtete Griffe leuchten jetzt in ihrer eigenen Silhouette, direkt vom Board-Bild abgepaust, während der Rest der Wand zurücktritt. Schluss mit farbigen Kreisen über dem Foto: Du liest den Boulder quer durch die Halle. Der Look heißt Aura. Er ist jetzt Standard auf jedem Board, Woods inklusive, und am Kilter Homewall kommt das Licht von der LED-Platte rund um jeden Griff.
+Du kletterst an einem Board ohne LED-Kit? Übernimm die Wand, und die ganze Session folgt dem Boulder, den du zeigst, der Hallen-Bildschirm auch. Schalt die Beleuchtung in den Einstellungen des Boards aus: Ihr wechselt euch weiter ab, dein Winkel bleibt stehen, und Sessions an einer benannten Wand loggst du auch von der Uhr.
 
-Stell ihn dir ein unter Profil > Mehr > Board-Look. Starte mit einer Vorgabe (Aura, Aura dezent, Aura kräftig, Maximaler Kontrast) oder nimm alles selbst in die Hand: Leuchten, Schleier, Markierungen, Listen-Vorschau, Rollen-Glyphen und Farbsehschwäche-Paletten, die auch dein Board in diesen Farben beleuchten, nicht nur den Bildschirm. Lieber die alten Kreise? Stell Darstellung auf Klassisch.
+SPIEGELN VOM SPERRBILDSCHIRM
 
-MOONBOARD
-
-- Du nutzt den quelloffenen Arduino-LED-Controller fürs MoonBoard? Aktiviere „Griff darüber beleuchten“ für eine zweite, gedimmte LED über jedem beleuchteten Start- und Handgriff.
+Während dein Handy das Board steuert, bekommen Live-Aktivität und Dynamic Island einen Spiegeln-Button neben Zurück, Weiter und der Glühbirne. App, Crew, Vorschaubilder und LEDs folgen dem gespiegelten Boulder, und er bleibt gespiegelt, wenn du die App öffnest.
 
 BEHOBEN
 
-- Das Verbinden mit einem Board löscht es nicht mehr: Was an der Wand leuchtet, bleibt an, bis du einen Boulder auswählst.
-- Boardfotos und Griff-Overlays laden ohne zusätzliche Pause.
-- Ein Woods-Boulder, den die App nicht exakt beleuchten kann, sagt das jetzt, statt die falschen Griffe zu beleuchten.
+- Dein Board bleibt dunkel, bis du es willst. Ein Handy, das Stunden oder Tage später wieder in Reichweite kommt, beleuchtet nicht mehr deinen letzten Boulder. Glühbirne, Widget und Reconnects mitten im Boulder beleuchten das Board weiterhin sofort.
+- Der Boulder-Tab und seine Suche bleiben nicht mehr hängen, nachdem sich mitten in der Session eine Playlist darüber geschlossen hat. Kein App-Neustart mehr, um die Suche zurückzubekommen.
+- Heruntergeladene Boulder bleiben nach einem App-Update aktuell.
+- Die Boulder-Suche schließt sich, ohne dass ein Vorschau-Sheet aufspringt.
 
 Kostenlos, werbefrei, Open Source.

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,19 +1,18 @@
-New in 2.4:
+New in 2.5:
 
-AURA: A NEW LOOK FOR YOUR BOARD
+TAKE THE WALL, NO LEDS NEEDED
 
-Lit holds now glow in their own shape, traced off the board art itself, while the rest of the wall dims back. No more coloured circles floating over the photo: the climb reads from across the room. It's called Aura. It's the new default on every board, Woods included, and on Kilter home walls the light comes off the LED plate around each hold.
+Climbing on a board with no light kit? Take the wall and everyone in the session follows the climb you put up, and so does the gym screen. Switch Lights off in the board's settings: turns keep rotating, your chosen angle stays put, and sessions on a named wall log from your watch too.
 
-Make it yours under Profile > More > Board look. Start from a preset (Aura, Aura Subtle, Aura Bold, Max contrast) or take over every part of it: glow, veil, marks, list thumbnails, role glyphs, and colour-vision palettes that light your wall in those colours too, not just your screen. Want the old circles back? Set Render to Classic.
+MIRROR FROM THE LOCK SCREEN
 
-MOONBOARD
-
-- Running the open-source Arduino MoonBoard LED controller? Turn on "Light the hold above" for a dimmer LED above each lit start and hand hold.
+While your phone drives the board, the Live Activity and Dynamic Island get a Mirror button next to Previous, Next and the lightbulb. The app, your crew, the thumbnails and the LEDs all follow the mirrored climb, and it's still mirrored when you open the app.
 
 FIXED
 
-- Connecting to a board no longer wipes it. What's lit on the wall stays lit until you pick a climb.
-- Board photos and hold overlays load without the extra pause.
-- A Woods climb the app can't light exactly now says so, instead of lighting the wrong holds.
+- Your board stays dark until you ask for it. A phone that drifts back into range hours or days later no longer relights your last climb. The lightbulb, the widget and mid-climb reconnects still light it instantly.
+- The Climbs tab and its search no longer go dead after a playlist closes over them mid-session. No more force-quitting to get search back.
+- Downloaded climbs stay up to date after an app update.
+- Closing climb search no longer pops up a stray preview sheet.
 
 Free, no ads, open source.

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -1,19 +1,18 @@
-Novedades de 2.4:
+Novedades de 2.5:
 
-AURA: UN NUEVO ASPECTO PARA TU PLAFÓN
+TOMA EL MURO, SIN LEDS
 
-Las presas encendidas brillan ahora con su propia silueta, calcada del dibujo del plafón, mientras el resto del muro se atenúa. Se acabaron los círculos de color sobre la foto: el bloque se lee desde el otro lado de la sala. Se llama Aura. Es el nuevo aspecto por defecto en todos los plafones, Woods incluido, y en los Kilter Homewall la luz sale de la placa LED que rodea cada presa.
+¿Escalas en un plafón sin kit de luces? Toma el muro y toda la sesión sigue el bloque que pones, y la pantalla del rocódromo también. Desactiva Luces en los ajustes del plafón: los turnos siguen rotando, tu ángulo se mantiene y las sesiones en un muro con nombre también se registran desde el reloj.
 
-Hazlo tuyo en Perfil > Más > Aspecto del plafón. Empieza por un preajuste (Aura, Aura sutil, Aura intensa, Máximo contraste) o toma el control de cada detalle: resplandor, velo, marcas, miniaturas de listas, glifos de rol y paletas para daltonismo que también encienden tu plafón con esos colores, no solo la pantalla. ¿Prefieres los círculos de antes? Pon Renderizado en Clásico.
+ESPEJO DESDE LA PANTALLA DE BLOQUEO
 
-MOONBOARD
-
-- ¿Usas el controlador LED de código abierto con Arduino para MoonBoard? Activa «Iluminar la presa de arriba» para añadir un LED más tenue sobre cada presa de inicio o de mano iluminada.
+Mientras tu teléfono controla el plafón, la actividad en vivo y la Dynamic Island tienen un botón Espejo junto a Anterior, Siguiente y la bombilla. La app, tu gente, las miniaturas y los LED siguen el bloque espejeado, y sigue en espejo cuando abres la app.
 
 CORREGIDO
 
-- Conectarte a un plafón ya no lo apaga: lo que esté iluminado en el muro sigue así hasta que elijas un bloque.
-- Las fotos del plafón y las superposiciones de presas cargan sin la pausa extra.
-- Un bloque de Woods que la app no puede iluminar con exactitud ahora lo dice, en vez de encender las presas equivocadas.
+- Tu plafón se queda apagado hasta que tú lo pidas. Un teléfono que vuelve a entrar en alcance horas o días después ya no enciende tu último bloque. La bombilla, el widget y las reconexiones a mitad de bloque lo encienden al instante, como siempre.
+- La pestaña Bloques y su búsqueda ya no se quedan colgadas después de cerrar una lista encima a mitad de sesión. Se acabó forzar el cierre de la app para recuperar la búsqueda.
+- Los bloques descargados se mantienen al día tras actualizar la app.
+- Cerrar la búsqueda de bloques ya no hace aparecer un panel de vista previa.
 
 Gratis, sin anuncios, código abierto.

--- a/fastlane/metadata/es-MX/release_notes.txt
+++ b/fastlane/metadata/es-MX/release_notes.txt
@@ -1,19 +1,18 @@
-Novedades de 2.4:
+Novedades de 2.5:
 
-AURA: UN NUEVO ASPECTO PARA TU PLAFÓN
+TOMA EL MURO, SIN LEDS
 
-Las presas encendidas brillan ahora con su propia silueta, calcada del dibujo del plafón, mientras el resto del muro se atenúa. Se acabaron los círculos de color sobre la foto: el bloque se lee desde el otro lado de la sala. Se llama Aura. Es el nuevo aspecto por defecto en todos los plafones, Woods incluido, y en los Kilter Homewall la luz sale de la placa LED que rodea cada presa.
+¿Escalas en un plafón sin kit de luces? Toma el muro y toda la sesión sigue el bloque que pones, y la pantalla del rocódromo también. Desactiva Luces en los ajustes del plafón: los turnos siguen rotando, tu ángulo se mantiene y las sesiones en un muro con nombre también se registran desde el reloj.
 
-Hazlo tuyo en Perfil > Más > Aspecto del plafón. Empieza por un preajuste (Aura, Aura sutil, Aura intensa, Máximo contraste) o toma el control de cada detalle: resplandor, velo, marcas, miniaturas de listas, glifos de rol y paletas para daltonismo que también encienden tu plafón con esos colores, no solo la pantalla. ¿Prefieres los círculos de antes? Pon Renderizado en Clásico.
+ESPEJO DESDE LA PANTALLA DE BLOQUEO
 
-MOONBOARD
-
-- ¿Usas el controlador LED de código abierto con Arduino para MoonBoard? Activa «Iluminar la presa de arriba» para añadir un LED más tenue sobre cada presa de inicio o de mano iluminada.
+Mientras tu teléfono controla el plafón, la actividad en vivo y la Dynamic Island tienen un botón Espejo junto a Anterior, Siguiente y la bombilla. La app, tu gente, las miniaturas y los LED siguen el bloque espejeado, y sigue en espejo cuando abres la app.
 
 CORREGIDO
 
-- Conectarte a un plafón ya no lo apaga: lo que esté iluminado en el muro sigue así hasta que elijas un bloque.
-- Las fotos del plafón y las superposiciones de presas cargan sin la pausa extra.
-- Un bloque de Woods que la app no puede iluminar con exactitud ahora lo dice, en vez de encender las presas equivocadas.
+- Tu plafón se queda apagado hasta que tú lo pidas. Un teléfono que vuelve a entrar en alcance horas o días después ya no enciende tu último bloque. La bombilla, el widget y las reconexiones a mitad de bloque lo encienden al instante, como siempre.
+- La pestaña Bloques y su búsqueda ya no se quedan colgadas después de cerrar una lista encima a mitad de sesión. Se acabó forzar el cierre de la app para recuperar la búsqueda.
+- Los bloques descargados se mantienen al día tras actualizar la app.
+- Cerrar la búsqueda de bloques ya no hace aparecer un panel de vista previa.
 
 Gratis, sin anuncios, código abierto.

--- a/fastlane/metadata/fr-FR/release_notes.txt
+++ b/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,19 +1,18 @@
-Nouveautés de la version 2.4 :
+Nouveautés de la version 2.5 :
 
-AURA : UN NOUVEAU LOOK POUR TA BOARD
+PRENDS LE MUR, MÊME SANS LED
 
-Les prises allumées brillent maintenant dans leur propre silhouette, décalquée sur le visuel de la board, pendant que le reste du mur s'assombrit. Fini les cercles de couleur posés sur la photo : le bloc se lit depuis l'autre bout de la salle. Il s'appelle Aura. C'est le nouveau look par défaut sur toutes les boards, Woods compris, et sur les Kilter Homewall la lumière sort de la plaque LED qui entoure chaque prise.
+Tu grimpes sur une board sans kit LED ? Prends le mur : toute la session suit le bloc que tu mets, et l'écran de la salle aussi. Désactive l'Éclairage dans les réglages de la board : le tour de rôle continue, ton angle reste en place, et les sessions sur un mur nommé se loguent aussi depuis la montre.
 
-À toi de le régler dans Profil > Plus > Look de la board. Pars d'un préréglage (Aura, Aura discrète, Aura intense, Contraste max) ou reprends la main sur tout : lueur, voile, marques, vignettes de liste, glyphes de rôle et palettes daltonisme, qui allument aussi ta board dans ces couleurs, pas seulement l'écran. Tu préfères les cercles d'avant ? Mets Rendu sur Classique.
+MIROIR DEPUIS L'ÉCRAN VERROUILLÉ
 
-MOONBOARD
-
-- Tu utilises le contrôleur LED open source à base d'Arduino pour MoonBoard ? Active « Allumer la prise du dessus » pour ajouter une LED plus tamisée au-dessus de chaque prise de départ ou de main allumée.
+Quand ton téléphone pilote la board, l'activité en direct et la Dynamic Island ont un bouton Miroir à côté de Précédent, Suivant et l'ampoule. L'app, ton crew, les vignettes et les LED suivent le bloc en miroir, et il l'est encore quand tu ouvres l'app.
 
 CORRIGÉ
 
-- Se connecter à une board ne l'éteint plus : ce qui est allumé sur le mur le reste jusqu'à ce que tu choisisses un bloc.
-- Les photos de board et les superpositions de prises s'affichent sans pause supplémentaire.
-- Un bloc Woods que l'app ne peut pas allumer exactement le dit maintenant, au lieu d'allumer les mauvaises prises.
+- Ta board reste éteinte tant que tu ne demandes rien. Un téléphone qui repasse à portée des heures ou des jours plus tard ne rallume plus ton dernier bloc. L'ampoule, le widget et les reconnexions en plein bloc l'allument toujours instantanément.
+- L'onglet Blocs et sa recherche ne restent plus figés après la fermeture d'une playlist par-dessus en pleine session. Plus besoin de forcer la fermeture de l'app pour retrouver la recherche.
+- Les blocs téléchargés restent à jour après une mise à jour de l'app.
+- Fermer la recherche de blocs ne fait plus surgir une feuille d'aperçu.
 
 Gratuit, sans pub, open source.

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -301,7 +301,7 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
     name: appName,
     slug: 'boardsesh',
     owner: 'boardsesh',
-    version: '2.4.0',
+    version: '2.5.0',
     scheme: 'com.boardsesh.app',
     orientation: 'portrait',
     icon: iconPath,


### PR DESCRIPTION
## Summary

Prepares the next native release: bumps `version` in `packages/mobile/app.config.ts` from 2.4.0 to 2.5.0 and rewrites the store release notes for every locale.

**Why now.** App Store Connect closed the 2.4.0 train once the 2.4.0 release anchor (`1037e0462`, 2026-09-01) was approved. Every iOS TestFlight build on 2026-09-08 (`24af90d3a`, `4489a2448`, `036e70888`, `15e3aaf4f`, `92b52a786`) reached the upload step and failed with:

```
Invalid Pre-Release Train. The train version '2.4.0' is closed for new build submissions
CFBundleShortVersionString [2.4.0] must contain a higher version than that of the previously approved version [2.4.0]
```

Android took the same pushes fine (Play internal 2001101, 2001102, 2001105). The iOS side of the native train cannot ship until the version moves, so this is the "set the release version and translate both stores' release notes" step from `docs/mobile-store-release.md` §1.

**What the notes cover.** The merges from the first post-2.4.0 fingerprint change (`24af90d3a`, #5162) to HEAD. The 255 merges between the 2.4.0 anchor and that commit reached the 2.4.0 fleet by OTA and are not repeated.

| PR | In the notes as |
| --- | --- |
| #4762 take the wall on a board with no LEDs | New: "Take the wall, no LEDs needed" (both stores) |
| #5313 mirror from Live Activity / Android notification | New: "Mirror from the Lock Screen" (iOS) / notification line (Android) |
| #4551 stale BLE connect re-lighting the board | Fixed (iOS: the native gate is CoreBluetooth restore) |
| #5162 + #5158 tab bar relayout on accessory detach | Fixed (iOS: react-native-screens patch) |
| #5284 refresh cached climb fields after schema additions | Fixed (both) |
| #5310 floating PR picker interrupting climb search | Fixed (both) |
| #5285 preserve Android BLE disconnect errors | omitted, diagnostics only |
| #5311 restore SMTP email delivery | omitted, web only |

Translations follow the three glossaries (plafón / rocódromo, la board / allumer / enchaîné, das Board / beleuchten / du) and reuse the in-app labels for the new features: "Toma el muro" / "Prends le mur" / "Übernimm die Wand", "Luces" / "Éclairage" / "Beleuchtung", "Espejo" / "Miroir" / "Spiegeln". es-MX is byte-identical to es-ES, as in 2.4.

**Length gate.** `scripts/store-metadata-limits.test.ts` passes (29/29). Play changelogs sit at 454 / 493 / 494 / 496 of the 500-character cap (en / es / fr / de); iOS notes are 1.1k to 1.3k of 4000. `vp check` on the config file is clean.

**After merge.** The iOS `release_notes.txt` only reaches App Store Connect when someone dispatches **Mobile Store Metadata** (`mobile-store-metadata.yml`, `platform: all`). Android changelogs ship with the next AAB automatically.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 3/5 — a one-line version bump that moves the native fingerprint on purpose (it is the fix for the closed TestFlight train), plus store copy that is length-gated by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZ7jMynfMZzKjG4kFHxaqX
