### PR TITLE
chore(mobile): lead the 2.5.0 store notes with Woods, and cover the wider iOS window

### DIFF
--- a/fastlane/metadata/android/de-DE/changelogs/default.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/default.txt
@@ -1,5 +1,5 @@
 Neu in 2.5:
-- Übernimm die Wand an einem Board ohne LEDs: Crew und Hallen-Bildschirm folgen dem Boulder, den du zeigst. Schalt die Beleuchtung in den Board-Einstellungen aus; ihr wechselt euch weiter ab, dein Winkel bleibt.
-- Spiegle deinen Boulder direkt aus der Android-Benachrichtigung, während dein Handy das Board steuert; App, Crew und LEDs folgen.
-- Heruntergeladene Boulder bleiben nach einem App-Update aktuell.
-- Die Boulder-Suche schließt sich, ohne dass ein Vorschau-Sheet aufspringt.
+- Läuft mit Woods, von vorn bis hinten: Leg dein 12x12 oder 8x10 an, stöbere in über 5.000 Bouldern mit ihren Regeln, beleuchte sie per Bluetooth, bau und remixe eigene, spiegle einen Boulder, das Board zieht mit.
+- Übernimm die Wand an einem Board ohne LEDs: Crew und Hallen-Bildschirm folgen dem Boulder, den du zeigst.
+- Spiegle deinen Boulder aus der Android-Benachrichtigung; App, Crew und LEDs folgen.
+- Griffe zeichnen schneller; geladene Boulder bleiben nach Updates aktuell.

--- a/fastlane/metadata/android/de-DE/full_description.txt
+++ b/fastlane/metadata/android/de-DE/full_description.txt
@@ -1,10 +1,10 @@
 Suche dir einen Boulder, und dein Board leuchtet auf. Weniger Zeit am Handy, mehr Zeit an der Wand.
 
 GRIFFE BELEUCHTEN
-Suche dir einen beliebigen Boulder, und Boardsesh beleuchtet die Griffe an der Wand über Bluetooth, auf Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper und So iLL. Volle LED-Steuerung auf allen sieben, nicht nur Stöbern.
+Suche dir einen beliebigen Boulder, und Boardsesh beleuchtet die Griffe an der Wand über Bluetooth, auf Kilter, Tension, MoonBoard, Woods, Decoy, Touchstone, Grasshopper und So iLL. Volle LED-Steuerung auf allen acht, nicht nur Stöbern.
 
 EINE APP FÜR JEDES BOARD, AN DEM DU KLETTERST
-Kilter, Tension und MoonBoard bringen jeweils ihre eigene App für ihr eigenes Board mit. Boardsesh kann alle drei, dazu Decoy, Touchstone, Grasshopper und So iLL — alles an einem Ort. Deine komplette Kletterhistorie über alle Boards hinweg liegt hier.
+Kilter, Tension und MoonBoard bringen jeweils ihre eigene App für ihr eigenes Board mit. Boardsesh kann alle drei, dazu Woods, Decoy, Touchstone, Grasshopper und So iLL — alles an einem Ort. Deine komplette Kletterhistorie über alle Boards hinweg liegt hier.
 
 BOARD-VERLAUF, IMMER AN
 Teilt ihr euch ein Board, verlierst du den letzten Boulder schnell aus den Augen, und irgendwer löscht ihn immer aus Versehen.

--- a/fastlane/metadata/android/de-DE/short_description.txt
+++ b/fastlane/metadata/android/de-DE/short_description.txt
@@ -1,1 +1,1 @@
-Kilter, Tension, MoonBoard & mehr beleuchten. Eine Warteschlange für die Crew.
+Kilter, Tension, MoonBoard, Woods beleuchten. Eine Warteschlange für die Crew.

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,5 +1,5 @@
 New in 2.5:
-- Take the wall on a board with no LEDs: your crew and the gym screen follow the climb you put up. Switch Lights off in the board's settings; turns keep rotating and your angle stays put.
-- Mirror your climb straight from the Android notification while your phone drives the board; the app, your crew and the LEDs follow.
-- Downloaded climbs stay up to date after an app update.
-- Closing climb search no longer pops up a stray preview sheet.
+- Works with Woods, front to back: add your 12x12 or 8x10, browse 5,000+ climbs with their rules, light them over Bluetooth, set and remix your own, and mirror a climb so the wall flips with it.
+- Take the wall on a board with no LEDs: your crew and the gym screen follow the climb you put up.
+- Mirror your climb from the Android notification; the app, your crew and the LEDs follow.
+- Holds draw faster. Downloaded climbs stay current after an app update.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,10 +1,10 @@
 Search a climb, watch your wall light up. Less time on your phone, more time on the wall.
 
 LIGHT THE HOLDS
-Search any climb and Boardsesh lights the holds on the wall over Bluetooth, on Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper and So iLL. Full LED control on all seven, not browse-only.
+Search any climb and Boardsesh lights the holds on the wall over Bluetooth, on Kilter, Tension, MoonBoard, Woods, Decoy, Touchstone, Grasshopper and So iLL. Full LED control on all eight, not browse-only.
 
 ONE APP FOR EVERY BOARD YOU CLIMB
-Kilter, Tension and MoonBoard each ship their own app for their own board. Boardsesh works across all of them, plus Decoy, Touchstone, Grasshopper and So iLL, in one place. Your whole climbing history across every board lives here.
+Kilter, Tension and MoonBoard each ship their own app for their own board. Boardsesh works across all of them, plus Woods, Decoy, Touchstone, Grasshopper and So iLL, in one place. Your whole climbing history across every board lives here.
 
 BOARD HISTORY, ALWAYS ON
 Share a board and you lose track of the last climb fast, and someone always wipes it by accident.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Light Kilter, Tension, MoonBoard & more. Share one queue, climb as a crew.
+Light Kilter, Tension, MoonBoard, Woods. Share one queue, climb as a crew.

--- a/fastlane/metadata/android/es-ES/changelogs/default.txt
+++ b/fastlane/metadata/android/es-ES/changelogs/default.txt
@@ -1,5 +1,5 @@
 Novedades de 2.5:
-- Toma el muro en un plafón sin LED: tu gente y la pantalla del rocódromo siguen el bloque que pones. Desactiva Luces en los ajustes del plafón; los turnos siguen rotando y tu ángulo se mantiene.
-- Espejea tu bloque desde la notificación de Android mientras tu teléfono controla el plafón; la app, tu gente y los LED lo siguen.
-- Los bloques descargados se mantienen al día tras actualizar la app.
-- Cerrar la búsqueda de bloques ya no hace aparecer un panel de vista previa.
+- Compatible con Woods de principio a fin: añade tu 12x12 o 8x10, explora más de 5.000 bloques con sus reglas, enciéndelos por Bluetooth, crea y remezcla los tuyos, y espejea un bloque y el muro lo sigue.
+- Toma el muro en un plafón sin LED: tu gente y la pantalla del rocódromo siguen el bloque que pones.
+- Espejea tu bloque desde la notificación de Android; la app, tu gente y los LED lo siguen.
+- Las presas se dibujan más rápido y los bloques descargados siguen al día.

--- a/fastlane/metadata/android/es-ES/full_description.txt
+++ b/fastlane/metadata/android/es-ES/full_description.txt
@@ -1,17 +1,17 @@
 Busca una vía y mira cómo se enciende tu muro. Menos tiempo en el móvil, más tiempo en el muro.
 
 ILUMINA LAS PRESAS
-Busca cualquier vía y Boardsesh enciende las presas del muro por Bluetooth, en Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper y So iLL. Control total de los LED en las siete, no solo para mirar.
+Busca cualquier vía y Boardsesh enciende las presas del muro por Bluetooth, en Kilter, Tension, MoonBoard, Woods, Decoy, Touchstone, Grasshopper y So iLL. Control total de los LED en los ocho, no solo para mirar.
 
-UNA APP PARA CADA TABLA QUE ESCALAS
-Kilter, Tension y MoonBoard traen cada uno su propia app para su propia tabla. Boardsesh funciona con todas ellas, más Decoy, Touchstone, Grasshopper y So iLL, en un solo sitio. Todo tu historial de escalada en cada tabla vive aquí.
+UNA APP PARA CADA PLAFÓN QUE ESCALAS
+Kilter, Tension y MoonBoard traen cada uno su propia app para su propio plafón. Boardsesh funciona con todos ellos, más Woods, Decoy, Touchstone, Grasshopper y So iLL, en un solo sitio. Todo tu historial de escalada en cada plafón vive aquí.
 
 HISTORIAL DEL MURO, SIEMPRE ACTIVO
 Si compartes muro, enseguida pierdes la cuenta de la última vía, y siempre hay alguien que la borra sin querer.
-En Boardsesh cada tabla a la que te conectas tiene un feed en directo de lo que hay encendido en esa pared ahora mismo: el nombre de la vía, quién la encendió, quién la montó, el grado y el ángulo, y los encadenes recientes. Se actualiza según cambia la pared, así que siempre sabes qué hay puesto.
+En Boardsesh cada plafón al que te conectas tiene un feed en directo de lo que hay encendido en ese muro ahora mismo: el nombre de la vía, quién la encendió, quién la montó, el grado y el ángulo, y los encadenes recientes. Se actualiza según cambia el muro, así que siempre sabes qué hay puesto.
 
 SIGUE CONECTADO
-Boardsesh mantiene viva la conexión con tu tabla en segundo plano, así las presas siguen encendidas durante tus pegadas aunque se apague la pantalla o cambies de app. Una notificación permanente pone Anterior y Siguiente en tu pantalla de bloqueo, para que te muevas por la cola sin volver a abrir la app. No tienes que reconectar entre vía y vía.
+Boardsesh mantiene viva la conexión con tu plafón en segundo plano, así las presas siguen encendidas durante tus pegadas aunque se apague la pantalla o cambies de app. Una notificación permanente pone Anterior y Siguiente en tu pantalla de bloqueo, para que te muevas por la cola sin volver a abrir la app. No tienes que reconectar entre vía y vía.
 
 SESIONES CON TU EQUIPO
 Abre una sesión y tú y tu equipo compartís una cola que cualquiera puede llevar. Cualquiera enciende la siguiente vía en el muro. Al terminar te llevas un resumen y el seguimiento: encadenes e intentos, reparto de grados, tu vía más dura y el progreso a lo largo del tiempo.
@@ -28,4 +28,4 @@ Sigue a tu equipo y a los aperturistas, busca escaladores y fija playlists desde
 GRATIS, SIN ANUNCIOS, SIN SUSCRIPCIONES
 Código abierto en GitHub.
 
-Boardsesh es un proyecto comunitario que funciona con estas tablas y no está afiliado ni respaldado por ningún fabricante de tablas.
+Boardsesh es un proyecto comunitario que funciona con estos plafones y no está afiliado ni respaldado por ningún fabricante de plafones.

--- a/fastlane/metadata/android/es-ES/short_description.txt
+++ b/fastlane/metadata/android/es-ES/short_description.txt
@@ -1,1 +1,1 @@
-Ilumina Kilter, Tension, MoonBoard y más. Comparte una cola, escala en equipo.
+Ilumina Kilter, Tension, MoonBoard, Woods. Comparte una cola, escala en equipo.

--- a/fastlane/metadata/android/fr-FR/changelogs/default.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/default.txt
@@ -1,5 +1,5 @@
 Nouveautés de la version 2.5 :
-- Prends le mur sur une board sans LED : ton crew et l'écran de la salle suivent le bloc que tu mets. Désactive l'Éclairage dans les réglages de la board ; le tour de rôle continue, ton angle reste.
-- Mets ton bloc en miroir depuis la notification Android quand ton téléphone pilote la board ; l'app, ton crew et les LED suivent.
-- Les blocs téléchargés restent à jour après une mise à jour.
-- Fermer la recherche de blocs ne fait plus surgir de feuille d'aperçu.
+- Compatible Woods de bout en bout : ajoute ta 12x12 ou 8x10, parcours 5 000 blocs et leurs règles, allume-les en Bluetooth, ouvre et remixe les tiens, mets un bloc en miroir et le mur suit.
+- Prends le mur sur une board sans LED : ton crew et l'écran de la salle suivent le bloc que tu mets.
+- Mets ton bloc en miroir depuis la notification Android ; l'app, ton crew et les LED suivent.
+- Les prises s'affichent plus vite et les blocs téléchargés restent à jour.

--- a/fastlane/metadata/android/fr-FR/full_description.txt
+++ b/fastlane/metadata/android/fr-FR/full_description.txt
@@ -1,10 +1,10 @@
 Cherche une voie, regarde ton mur s'allumer. Moins de temps sur ton téléphone, plus de temps sur le mur.
 
 ALLUME LES PRISES
-Cherche n'importe quelle voie et Boardsesh allume les prises sur le mur en Bluetooth, sur Kilter, Tension, MoonBoard, Decoy, Touchstone, Grasshopper et So iLL. Contrôle complet des LED sur les sept, pas seulement la consultation.
+Cherche n'importe quelle voie et Boardsesh allume les prises sur le mur en Bluetooth, sur Kilter, Tension, MoonBoard, Woods, Decoy, Touchstone, Grasshopper et So iLL. Contrôle complet des LED sur les huit, pas seulement la consultation.
 
 UNE SEULE APPLI POUR TOUTES LES BOARDS QUE TU GRIMPES
-Kilter, Tension et MoonBoard ont chacune leur appli pour leur propre board. Boardsesh marche avec toutes, plus Decoy, Touchstone, Grasshopper et So iLL, au même endroit. Tout ton historique d'escalade sur chaque board vit ici.
+Kilter, Tension et MoonBoard ont chacune leur appli pour leur propre board. Boardsesh marche avec toutes, plus Woods, Decoy, Touchstone, Grasshopper et So iLL, au même endroit. Tout ton historique d'escalade sur chaque board vit ici.
 
 L'HISTORIQUE DE BOARD, TOUJOURS ACTIF
 Partage une board et tu perds vite le fil de la dernière voie, et quelqu'un finit toujours par l'effacer par accident.

--- a/fastlane/metadata/android/fr-FR/short_description.txt
+++ b/fastlane/metadata/android/fr-FR/short_description.txt
@@ -1,1 +1,1 @@
-Allume Kilter, Tension, MoonBoard & plus. Une file, grimpe en crew.
+Allume Kilter, Tension, MoonBoard, Woods. Une file, grimpe en crew.

--- a/fastlane/metadata/de-DE/description.txt
+++ b/fastlane/metadata/de-DE/description.txt
@@ -1,7 +1,7 @@
 Suche dir einen Boulder, und dein Board leuchtet auf. Weniger Zeit am Handy, mehr Zeit an der Wand.
 
 EINE APP FÜR JEDES BOARD, AN DEM DU KLETTERST
-Kilter, Tension und MoonBoard bringen jeweils ihre eigene App für ihr eigenes Board mit. Boardsesh kann alle drei, dazu Decoy, Touchstone, Grasshopper und So iLL — alles an einem Ort. Deine komplette Kletterhistorie über alle Boards hinweg liegt hier.
+Kilter, Tension und MoonBoard bringen jeweils ihre eigene App für ihr eigenes Board mit. Boardsesh kann alle drei, dazu Woods, Decoy, Touchstone, Grasshopper und So iLL — alles an einem Ort. Deine komplette Kletterhistorie über alle Boards hinweg liegt hier.
 
 BOARD-VERLAUF, IMMER AN
 Teilt ihr euch ein Board, verlierst du den letzten Boulder schnell aus den Augen, und irgendwer löscht ihn immer aus Versehen.
@@ -25,6 +25,6 @@ Sichere deine Session in Apple Health, und importiere dein bisheriges Kilter- un
 FINDE MEHR ZUM KLETTERN
 Folge deiner Crew und Routenbauer*innen, suche nach Kletterer*innen, und pinne dir Playlists aus Entdecken.
 
-Unterstützte Boards: Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Decoy, Touchstone, Grasshopper und So iLL.
+Unterstützte Boards: Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Woods (12x12, 8x10), Decoy, Touchstone, Grasshopper und So iLL.
 
 Boardsesh ist ein Community-Projekt, das mit diesen Boards funktioniert. Es steht in keiner Verbindung zu den Board-Herstellern und wird von ihnen weder unterstützt noch empfohlen.

--- a/fastlane/metadata/de-DE/keywords.txt
+++ b/fastlane/metadata/de-DE/keywords.txt
@@ -1,1 +1,1 @@
-MoonBoard,Kilter,Tension,kilterboard,Bouldern,Klettern,Kletterboard,Trainingsboard,Routenbuch,LED
+MoonBoard,Kilter,Tension,kilterboard,Bouldern,Klettern,Kletterboard,Trainingsboard,Routenbuch,Woods

--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -1,5 +1,9 @@
 Neu in 2.5:
 
+LÄUFT MIT WOODS, VON VORN BIS HINTEN
+
+Du hast ein Woods Board? Leg dein 12x12 oder 8x10 an, stöbere durch über 5.000 Boulder mit ihren Match- und Fußregeln und beleuchte jeden davon per Bluetooth. Bau und remixe eigene Boulder auf beiden Größen (der Editor bietet nur Griffe an, die wirklich an deinem Board sind), spiegle einen Boulder und das Board zieht mit, und steuere Zurück, Weiter und Spiegeln vom Sperrbildschirm und der Dynamic Island. Griffe erscheinen im Aura-Look mit schärferen Konturen.
+
 ÜBERNIMM DIE WAND, AUCH OHNE LEDS
 
 Du kletterst an einem Board ohne LED-Kit? Übernimm die Wand, und die ganze Session folgt dem Boulder, den du zeigst, der Hallen-Bildschirm auch. Schalt die Beleuchtung in den Einstellungen des Boards aus: Ihr wechselt euch weiter ab, dein Winkel bleibt stehen, und Sessions an einer benannten Wand loggst du auch von der Uhr.
@@ -10,6 +14,7 @@ Während dein Handy das Board steuert, bekommen Live-Aktivität und Dynamic Isla
 
 BEHOBEN
 
+- Griffe zeichnen schneller: das Board-Rendering wartet nicht mehr auf den Rest der App.
 - Dein Board bleibt dunkel, bis du es willst. Ein Handy, das Stunden oder Tage später wieder in Reichweite kommt, beleuchtet nicht mehr deinen letzten Boulder. Glühbirne, Widget und Reconnects mitten im Boulder beleuchten das Board weiterhin sofort.
 - Der Boulder-Tab und seine Suche bleiben nicht mehr hängen, nachdem sich mitten in der Session eine Playlist darüber geschlossen hat. Kein App-Neustart mehr, um die Suche zurückzubekommen.
 - Heruntergeladene Boulder bleiben nach einem App-Update aktuell.

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -1,7 +1,7 @@
 Search a climb, watch your wall light up. Less time on your phone, more time on the wall.
 
 ONE APP FOR EVERY BOARD YOU CLIMB
-Kilter, Tension and MoonBoard each ship their own app for their own board. Boardsesh works across all of them, plus Decoy, Touchstone, Grasshopper and So iLL, in one place. Your whole climbing history across every board lives here.
+Kilter, Tension and MoonBoard each ship their own app for their own board. Boardsesh works across all of them, plus Woods, Decoy, Touchstone, Grasshopper and So iLL, in one place. Your whole climbing history across every board lives here.
 
 BOARD HISTORY, ALWAYS ON
 Share a board and you lose track of the last climb fast, and someone always wipes it by accident.
@@ -25,6 +25,6 @@ Save your session to Apple Health, and import your past Kilter and Tension logbo
 FIND MORE TO CLIMB
 Follow your crew and setters, search climbers, and pin playlists from Discover.
 
-Supported boards: Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Decoy, Touchstone, Grasshopper and So iLL.
+Supported boards: Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Woods (12x12, 8x10), Decoy, Touchstone, Grasshopper and So iLL.
 
 Boardsesh is a community effort that works with these boards and is not affiliated with or endorsed by any board manufacturer.

--- a/fastlane/metadata/en-US/keywords.txt
+++ b/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-MoonBoard,Kilter,Tension,kilterboard,bouldering,beta,send,tick,logbook,led,workout,setter,party
+MoonBoard,Kilter,Tension,kilterboard,bouldering,beta,send,tick,logbook,led,workout,setter,Woods

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,5 +1,9 @@
 New in 2.5:
 
+WORKS WITH WOODS, FRONT TO BACK
+
+Got a Woods Board? Add your 12x12 or 8x10, browse 5,000+ climbs with their matching and feet rules, and light any of them over Bluetooth. Set and remix your own problems on either size (the creator only offers holds that are really on your wall), mirror a climb and the wall flips with it, and run Previous, Next and Mirror from the Lock Screen and Dynamic Island. Holds draw in the Aura look with crisper outlines.
+
 TAKE THE WALL, NO LEDS NEEDED
 
 Climbing on a board with no light kit? Take the wall and everyone in the session follows the climb you put up, and so does the gym screen. Switch Lights off in the board's settings: turns keep rotating, your chosen angle stays put, and sessions on a named wall log from your watch too.
@@ -10,6 +14,7 @@ While your phone drives the board, the Live Activity and Dynamic Island get a Mi
 
 FIXED
 
+- Holds draw faster: the board renderer no longer waits behind the rest of the app.
 - Your board stays dark until you ask for it. A phone that drifts back into range hours or days later no longer relights your last climb. The lightbulb, the widget and mid-climb reconnects still light it instantly.
 - The Climbs tab and its search no longer go dead after a playlist closes over them mid-session. No more force-quitting to get search back.
 - Downloaded climbs stay up to date after an app update.

--- a/fastlane/metadata/es-ES/description.txt
+++ b/fastlane/metadata/es-ES/description.txt
@@ -1,11 +1,11 @@
 Busca una vía y mira cómo se enciende tu muro. Menos tiempo en el móvil, más tiempo en el muro.
 
-UNA APP PARA CADA TABLA QUE ESCALAS
-Kilter, Tension y MoonBoard traen cada uno su propia app para su propia tabla. Boardsesh funciona con todas ellas, más Decoy, Touchstone, Grasshopper y So iLL, en un solo sitio. Todo tu historial de escalada en cada tabla vive aquí.
+UNA APP PARA CADA PLAFÓN QUE ESCALAS
+Kilter, Tension y MoonBoard traen cada uno su propia app para su propio plafón. Boardsesh funciona con todos ellos, más Woods, Decoy, Touchstone, Grasshopper y So iLL, en un solo sitio. Todo tu historial de escalada en cada plafón vive aquí.
 
 HISTORIAL DEL MURO, SIEMPRE ACTIVO
 Si compartes muro, enseguida pierdes la cuenta de la última vía, y siempre hay alguien que la borra sin querer.
-En Boardsesh cada tabla a la que te conectas tiene un feed en directo de lo que hay encendido en esa pared ahora mismo: el nombre de la vía, quién la encendió, quién la montó, el grado y el ángulo, y los encadenes recientes. Se actualiza según cambia la pared, así que siempre sabes qué hay puesto.
+En Boardsesh cada plafón al que te conectas tiene un feed en directo de lo que hay encendido en ese muro ahora mismo: el nombre de la vía, quién la encendió, quién la montó, el grado y el ángulo, y los encadenes recientes. Se actualiza según cambia el muro, así que siempre sabes qué hay puesto.
 
 SESIONES CON TU EQUIPO
 Abre una sesión y tú y tu equipo compartís una cola que cualquiera puede llevar. Cualquiera enciende la siguiente vía en el muro. Al terminar te llevas un resumen y el seguimiento: encadenes e intentos, reparto de grados, tu vía más dura y el progreso a lo largo del tiempo.
@@ -25,6 +25,6 @@ Guarda tu sesión en Apple Health e importa tu logbook antiguo de Kilter y Tensi
 ENCUENTRA MÁS PARA ESCALAR
 Sigue a tu equipo y a los aperturistas, busca escaladores y fija playlists desde Discover.
 
-Tablas compatibles: Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Decoy, Touchstone, Grasshopper y So iLL.
+Plafones compatibles: Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Woods (12x12, 8x10), Decoy, Touchstone, Grasshopper y So iLL.
 
-Boardsesh es un proyecto comunitario que funciona con estas tablas y no está afiliado ni respaldado por ningún fabricante de tablas.
+Boardsesh es un proyecto comunitario que funciona con estos plafones y no está afiliado ni respaldado por ningún fabricante de plafones.

--- a/fastlane/metadata/es-ES/keywords.txt
+++ b/fastlane/metadata/es-ES/keywords.txt
@@ -1,1 +1,1 @@
-MoonBoard,Kilter,Tension,kilterboard,escalada,boulder,bloque,beta,encadene,led,entreno,aperturista
+MoonBoard,Kilter,Tension,kilterboard,escalada,boulder,bloque,beta,encadene,led,aperturista,Woods

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -1,5 +1,9 @@
 Novedades de 2.5:
 
+COMPATIBLE CON WOODS, DE PRINCIPIO A FIN
+
+¿Tienes un Woods Board? Añade tu 12x12 o tu 8x10, explora más de 5.000 bloques con sus reglas de igualar y de pies, y enciende cualquiera por Bluetooth. Crea y remezcla tus propios bloques en cualquiera de los dos tamaños (el editor solo ofrece presas que están de verdad en tu muro), espejea un bloque y el muro lo sigue, y usa Anterior, Siguiente y Espejo desde la pantalla de bloqueo y la Dynamic Island. Las presas se dibujan con el aspecto Aura y contornos más nítidos.
+
 TOMA EL MURO, SIN LEDS
 
 ¿Escalas en un plafón sin kit de luces? Toma el muro y toda la sesión sigue el bloque que pones, y la pantalla del rocódromo también. Desactiva Luces en los ajustes del plafón: los turnos siguen rotando, tu ángulo se mantiene y las sesiones en un muro con nombre también se registran desde el reloj.
@@ -10,6 +14,7 @@ Mientras tu teléfono controla el plafón, la actividad en vivo y la Dynamic Isl
 
 CORREGIDO
 
+- Las presas se dibujan más rápido: el renderizado del plafón ya no espera al resto de la app.
 - Tu plafón se queda apagado hasta que tú lo pidas. Un teléfono que vuelve a entrar en alcance horas o días después ya no enciende tu último bloque. La bombilla, el widget y las reconexiones a mitad de bloque lo encienden al instante, como siempre.
 - La pestaña Bloques y su búsqueda ya no se quedan colgadas después de cerrar una lista encima a mitad de sesión. Se acabó forzar el cierre de la app para recuperar la búsqueda.
 - Los bloques descargados se mantienen al día tras actualizar la app.

--- a/fastlane/metadata/es-ES/subtitle.txt
+++ b/fastlane/metadata/es-ES/subtitle.txt
@@ -1,1 +1,1 @@
-Ilumina tablas, en equipo
+Ilumina plafones, en equipo

--- a/fastlane/metadata/es-MX/description.txt
+++ b/fastlane/metadata/es-MX/description.txt
@@ -1,11 +1,11 @@
 Busca una vía y mira cómo se enciende tu muro. Menos tiempo en el móvil, más tiempo en el muro.
 
-UNA APP PARA CADA TABLA QUE ESCALAS
-Kilter, Tension y MoonBoard traen cada uno su propia app para su propia tabla. Boardsesh funciona con todas ellas, más Decoy, Touchstone, Grasshopper y So iLL, en un solo sitio. Todo tu historial de escalada en cada tabla vive aquí.
+UNA APP PARA CADA PLAFÓN QUE ESCALAS
+Kilter, Tension y MoonBoard traen cada uno su propia app para su propio plafón. Boardsesh funciona con todos ellos, más Woods, Decoy, Touchstone, Grasshopper y So iLL, en un solo sitio. Todo tu historial de escalada en cada plafón vive aquí.
 
 HISTORIAL DEL MURO, SIEMPRE ACTIVO
 Si compartes muro, enseguida pierdes la cuenta de la última vía, y siempre hay alguien que la borra sin querer.
-En Boardsesh cada tabla a la que te conectas tiene un feed en directo de lo que hay encendido en esa pared ahora mismo: el nombre de la vía, quién la encendió, quién la montó, el grado y el ángulo, y los encadenes recientes. Se actualiza según cambia la pared, así que siempre sabes qué hay puesto.
+En Boardsesh cada plafón al que te conectas tiene un feed en directo de lo que hay encendido en ese muro ahora mismo: el nombre de la vía, quién la encendió, quién la montó, el grado y el ángulo, y los encadenes recientes. Se actualiza según cambia el muro, así que siempre sabes qué hay puesto.
 
 SESIONES CON TU EQUIPO
 Abre una sesión y tú y tu equipo compartís una cola que cualquiera puede llevar. Cualquiera enciende la siguiente vía en el muro. Al terminar te llevas un resumen y el seguimiento: encadenes e intentos, reparto de grados, tu vía más dura y el progreso a lo largo del tiempo.
@@ -25,6 +25,6 @@ Guarda tu sesión en Apple Health e importa tu logbook antiguo de Kilter y Tensi
 ENCUENTRA MÁS PARA ESCALAR
 Sigue a tu equipo y a los aperturistas, busca escaladores y fija playlists desde Discover.
 
-Tablas compatibles: Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Decoy, Touchstone, Grasshopper y So iLL.
+Plafones compatibles: Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Woods (12x12, 8x10), Decoy, Touchstone, Grasshopper y So iLL.
 
-Boardsesh es un proyecto comunitario que funciona con estas tablas y no está afiliado ni respaldado por ningún fabricante de tablas.
+Boardsesh es un proyecto comunitario que funciona con estos plafones y no está afiliado ni respaldado por ningún fabricante de plafones.

--- a/fastlane/metadata/es-MX/keywords.txt
+++ b/fastlane/metadata/es-MX/keywords.txt
@@ -1,1 +1,1 @@
-MoonBoard,Kilter,Tension,kilterboard,escalada,boulder,bloque,beta,encadene,led,entreno,aperturista
+MoonBoard,Kilter,Tension,kilterboard,escalada,boulder,bloque,beta,encadene,led,aperturista,Woods

--- a/fastlane/metadata/es-MX/release_notes.txt
+++ b/fastlane/metadata/es-MX/release_notes.txt
@@ -1,5 +1,9 @@
 Novedades de 2.5:
 
+COMPATIBLE CON WOODS, DE PRINCIPIO A FIN
+
+¿Tienes un Woods Board? Añade tu 12x12 o tu 8x10, explora más de 5.000 bloques con sus reglas de igualar y de pies, y enciende cualquiera por Bluetooth. Crea y remezcla tus propios bloques en cualquiera de los dos tamaños (el editor solo ofrece presas que están de verdad en tu muro), espejea un bloque y el muro lo sigue, y usa Anterior, Siguiente y Espejo desde la pantalla de bloqueo y la Dynamic Island. Las presas se dibujan con el aspecto Aura y contornos más nítidos.
+
 TOMA EL MURO, SIN LEDS
 
 ¿Escalas en un plafón sin kit de luces? Toma el muro y toda la sesión sigue el bloque que pones, y la pantalla del rocódromo también. Desactiva Luces en los ajustes del plafón: los turnos siguen rotando, tu ángulo se mantiene y las sesiones en un muro con nombre también se registran desde el reloj.
@@ -10,6 +14,7 @@ Mientras tu teléfono controla el plafón, la actividad en vivo y la Dynamic Isl
 
 CORREGIDO
 
+- Las presas se dibujan más rápido: el renderizado del plafón ya no espera al resto de la app.
 - Tu plafón se queda apagado hasta que tú lo pidas. Un teléfono que vuelve a entrar en alcance horas o días después ya no enciende tu último bloque. La bombilla, el widget y las reconexiones a mitad de bloque lo encienden al instante, como siempre.
 - La pestaña Bloques y su búsqueda ya no se quedan colgadas después de cerrar una lista encima a mitad de sesión. Se acabó forzar el cierre de la app para recuperar la búsqueda.
 - Los bloques descargados se mantienen al día tras actualizar la app.

--- a/fastlane/metadata/es-MX/subtitle.txt
+++ b/fastlane/metadata/es-MX/subtitle.txt
@@ -1,1 +1,1 @@
-Ilumina tablas, en equipo
+Ilumina plafones, en equipo

--- a/fastlane/metadata/fr-FR/description.txt
+++ b/fastlane/metadata/fr-FR/description.txt
@@ -1,7 +1,7 @@
 Cherche une voie, regarde ton mur s'allumer. Moins de temps sur ton téléphone, plus de temps sur le mur.
 
 UNE SEULE APPLI POUR TOUTES LES BOARDS QUE TU GRIMPES
-Kilter, Tension et MoonBoard ont chacune leur appli pour leur propre board. Boardsesh marche avec toutes, plus Decoy, Touchstone, Grasshopper et So iLL, au même endroit. Tout ton historique d'escalade sur chaque board vit ici.
+Kilter, Tension et MoonBoard ont chacune leur appli pour leur propre board. Boardsesh marche avec toutes, plus Woods, Decoy, Touchstone, Grasshopper et So iLL, au même endroit. Tout ton historique d'escalade sur chaque board vit ici.
 
 L'HISTORIQUE DE BOARD, TOUJOURS ACTIF
 Partage une board et tu perds vite le fil de la dernière voie, et quelqu'un finit toujours par l'effacer par accident.
@@ -25,6 +25,6 @@ Enregistre ta séance dans Apple Health, et importe ton ancien carnet Kilter et 
 TROUVE PLUS À GRIMPER
 Suis ta crew et les ouvreurs, cherche des grimpeurs, et épingle des playlists depuis Discover.
 
-Boards prises en charge : Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Decoy, Touchstone, Grasshopper et So iLL.
+Boards prises en charge : Kilter, Tension, MoonBoard (2010, 2016, 2024, Masters 2017, Masters 2019), Woods (12x12, 8x10), Decoy, Touchstone, Grasshopper et So iLL.
 
 Boardsesh est un projet communautaire qui fonctionne avec ces boards et n'est ni affilié à, ni soutenu par aucun fabricant de boards.

--- a/fastlane/metadata/fr-FR/keywords.txt
+++ b/fastlane/metadata/fr-FR/keywords.txt
@@ -1,1 +1,1 @@
-MoonBoard,Kilter,Tension,kilterboard,bloc,beta,send,grimpe,carnet,led,entrainement,ouvreur,crew
+MoonBoard,Kilter,Tension,kilterboard,bloc,beta,send,grimpe,carnet,led,entrainement,ouvreur,Woods

--- a/fastlane/metadata/fr-FR/release_notes.txt
+++ b/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,5 +1,9 @@
 Nouveautés de la version 2.5 :
 
+COMPATIBLE WOODS, DE BOUT EN BOUT
+
+Tu as une Woods Board ? Ajoute ta 12x12 ou ta 8x10, parcours plus de 5 000 blocs avec leurs règles de mains et de pieds, et allume n'importe lequel en Bluetooth. Ouvre et remixe tes propres blocs sur l'une ou l'autre taille (l'éditeur ne propose que les prises vraiment présentes sur ton mur), mets un bloc en miroir et le mur suit, et pilote Précédent, Suivant et Miroir depuis l'écran verrouillé et la Dynamic Island. Les prises s'affichent avec le look Aura et des contours plus nets.
+
 PRENDS LE MUR, MÊME SANS LED
 
 Tu grimpes sur une board sans kit LED ? Prends le mur : toute la session suit le bloc que tu mets, et l'écran de la salle aussi. Désactive l'Éclairage dans les réglages de la board : le tour de rôle continue, ton angle reste en place, et les sessions sur un mur nommé se loguent aussi depuis la montre.
@@ -10,6 +14,7 @@ Quand ton téléphone pilote la board, l'activité en direct et la Dynamic Islan
 
 CORRIGÉ
 
+- Les prises s'affichent plus vite : le rendu de la board n'attend plus le reste de l'app.
 - Ta board reste éteinte tant que tu ne demandes rien. Un téléphone qui repasse à portée des heures ou des jours plus tard ne rallume plus ton dernier bloc. L'ampoule, le widget et les reconnexions en plein bloc l'allument toujours instantanément.
 - L'onglet Blocs et sa recherche ne restent plus figés après la fermeture d'une playlist par-dessus en pleine session. Plus besoin de forcer la fermeture de l'app pour retrouver la recherche.
 - Les blocs téléchargés restent à jour après une mise à jour de l'app.


### PR DESCRIPTION
## Summary

Follow-up to #5315. Three things the first pass of the 2.5.0 store copy missed.

**Woods gets its own section, first.** Woods support shipped in 2.4.0 (#3306) but the 2.4 notes only mentioned it in passing, and the merges since then rounded it out: matching/feet rules everywhere (#5142, #5244), climb authoring and remixing with only on-wall holds offered (#5142, #5204), mirrored climbs that flip the wall (#5205, #5237), Previous/Next from the Live Activity and Dynamic Island (#5247), and the Aura hold outlines (#5140). The section is worded as compatibility ("Works with Woods", "Compatible con/avec", "Läuft mit") — no "official", no affiliation, per the trademark rule in CLAUDE.md. The climb count is stated as 5,000+ (prod import is 5,392, #4768 closed 2026-09-05).

**The iOS window opens earlier than Android's.** #5315 used the first `fingerprint-android-*` tag (#5162) as the boundary, but iOS uploads had been failing since the 2.4.0 train closed, so no `fingerprint-ios-*` tags exist for the period. The OTA-check comments show main's iOS fingerprint stayed at the anchor (`15f9b78d219b`) until #5247, then #5210 moved both platforms just before #5162. Added accordingly:

| PR | Added as |
| --- | --- |
| #5247 Woods on the native Live Activity BLE path | Lock Screen Previous/Next inside the Woods section (iOS) |
| #5210 board renders get their own queue | Fixed: "Holds draw faster" (both stores) |

**Woods in the listings themselves (second commit).** Every field that enumerates the supported boards now names Woods, in all locales: iOS `description.txt` (works-with sentence + "Supported boards" line with 12x12 / 8x10), Play `full_description.txt` (same sentences, "all seven" → eight), Play `short_description.txt` ("& more" → Woods, 74–79 of 80), and App Store `keywords.txt` (one weak term dropped per locale to stay ≤ 100: `party` / `entreno` / `crew` / `LED`; now 95–99). `promotional_text.txt` is deliberately untouched: it sells the Boardsesh grade, which Woods does not have yet. While there, the Spanish listings' "tabla / tablas / pared" (banned by `docs/i18n-spanish-glossary.md`) became plafón / plafones / muro, subtitle included.

**Lengths.** Play changelogs 469 / 492 / 494 / 495 of 500 (en / es / fr / de); iOS notes 1.7k to 1.9k of 4000. `scripts/store-metadata-limits.test.ts` passes (29/29) on every field. es-MX remains a byte copy of es-ES.

No native inputs touched: `fastlane/metadata` is outside the fingerprint, so this rides without a new build. After merge, dispatch **Mobile Store Metadata** (`platform: all`) so the iOS text, keywords and What's New land on the 2.5.0 version in App Store Connect and the Play listing updates; Play changelogs also ship with the next AAB.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — store copy only, length-gated by a test; no code or native config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZ7jMynfMZzKjG4kFHxaqX
