### PR TITLE
ci(mobile): draft the store release after each native deploy, and make the lanes attach the build

### DIFF
--- a/.github/workflows/mobile-store-draft.yml
+++ b/.github/workflows/mobile-store-draft.yml
@@ -10,16 +10,25 @@ name: Mobile Store Draft Submission
 #
 # OFF BY DEFAULT: both jobs are gated on the repo variable
 # ENABLE_STORE_DRAFT_SUBMISSION == 'true' because they mutate live store state.
-# Flip the variable on once you've validated the lanes. Runs on a schedule (so a
-# draft is prepared shortly after a build finishes processing) and on demand.
-# Lives on cheap ubuntu (not the 60-min macOS build) and separate from the native
-# builds so build-processing latency never blocks a release. Idempotent — deliver
-# / supply update the existing draft rather than duplicating it.
+# Flip the variable on once you've validated the lanes. Runs whenever a
+# TestFlight or Play deploy on main completes (workflow_run) and on demand — no
+# schedule, so a draft follows each native build by minutes rather than hours.
+# The candidate check tolerates the other platform not being there yet (it exits
+# quietly and that platform's own completion re-triggers this), and the iOS lane
+# waits for App Store Connect to finish processing the build before attaching
+# it. Lives on cheap ubuntu (not the 60-min macOS build) and separate from the
+# native builds so that wait never blocks a release. Idempotent — re-running
+# updates the existing draft rather than duplicating it.
 
 on:
-  schedule:
-    # Offset from mobile-auto-version-bump.yml (0 */6) so they don't collide.
-    - cron: '30 */6 * * *'
+  workflow_run:
+    # Names must match the `name:` of the two deploy workflows exactly;
+    # scripts/native-release-workflows.test.ts pins both.
+    workflows:
+      - iOS TestFlight Deploy (React Native)
+      - Android Play Internal Deploy (React Native)
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       platform:
@@ -57,6 +66,9 @@ env:
 
 jobs:
   main-candidate:
+    # workflow_run fires on every completion; a failed or cancelled deploy has
+    # nothing new to draft. Dispatch runs are always allowed.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Only the Maps key is mapped into pinned-main code below. It is required
@@ -291,7 +303,9 @@ jobs:
       vars.ENABLE_STORE_DRAFT_SUBMISSION == 'true' &&
       (github.event_name != 'workflow_dispatch' || github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'all')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # The lane waits up to 45 min for App Store Connect to finish processing the
+    # tagged build before attaching it; keep this above that bound.
+    timeout-minutes: 60
     environment: Production
 
     steps:

--- a/.github/workflows/mobile-store-draft.yml
+++ b/.github/workflows/mobile-store-draft.yml
@@ -8,9 +8,10 @@ name: Mobile Store Draft Submission
 # no metadata (those are owned by mobile-store-metadata.yml / the screenshot
 # workflows), no review submission, no rollout.
 #
-# OFF BY DEFAULT: both jobs are gated on the repo variable
-# ENABLE_STORE_DRAFT_SUBMISSION == 'true' because they mutate live store state.
-# Flip the variable on once you've validated the lanes. Runs whenever a
+# ALWAYS ON: there is no enable flag. What protects the stores is that this only
+# ever prepares DRAFTS (submit_for_review: false, release_status: draft), and
+# that main-candidate refuses to draft anything but the exact highest build tag
+# for main's version whose fingerprint matches main's head. Runs whenever a
 # TestFlight or Play deploy on main completes (workflow_run) and on demand — no
 # schedule, so a draft follows each native build by minutes rather than hours.
 # The candidate check tolerates the other platform not being there yet (it exits
@@ -300,7 +301,6 @@ jobs:
     needs: main-candidate
     if: >-
       needs.main-candidate.outputs.candidate_ready == 'true' &&
-      vars.ENABLE_STORE_DRAFT_SUBMISSION == 'true' &&
       (github.event_name != 'workflow_dispatch' || github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'all')
     runs-on: ubuntu-latest
     # The lane waits up to 45 min for App Store Connect to finish processing the
@@ -389,7 +389,6 @@ jobs:
     needs: main-candidate
     if: >-
       needs.main-candidate.outputs.candidate_ready == 'true' &&
-      vars.ENABLE_STORE_DRAFT_SUBMISSION == 'true' &&
       (github.event_name != 'workflow_dispatch' || github.event.inputs.platform == 'android' || github.event.inputs.platform == 'all')
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/docs/mobile-store-release.md
+++ b/docs/mobile-store-release.md
@@ -78,10 +78,9 @@ at 500 characters.
 
 ## 4. Prepare and submit the exact store builds
 
-`mobile-store-draft.yml` is best-effort and disabled unless
-`ENABLE_STORE_DRAFT_SUBMISSION` is `true`. It runs whenever **iOS TestFlight
-Deploy** or **Android Play Internal Deploy** completes on `main`, and on demand;
-there is no schedule. It pins the current `main` SHA, selects the exact highest
+`mobile-store-draft.yml` is best-effort and always on; there is no enable flag.
+It runs whenever **iOS TestFlight Deploy** or **Android Play Internal Deploy**
+completes on `main`, and on demand; there is no schedule. It pins the current `main` SHA, selects the exact highest
 iOS and Android build tags for that version, and checks that both tagged
 binaries match `main`'s platform fingerprints. Immediately before changing
 either store draft it rechecks that `main` and both selected tags have not

--- a/docs/mobile-store-release.md
+++ b/docs/mobile-store-release.md
@@ -79,17 +79,25 @@ at 500 characters.
 ## 4. Prepare and submit the exact store builds
 
 `mobile-store-draft.yml` is best-effort and disabled unless
-`ENABLE_STORE_DRAFT_SUBMISSION` is `true`. It pins the current `main` SHA,
-selects the exact highest iOS and Android build tags for that version, and checks
-that both tagged binaries match `main`'s platform fingerprints. Immediately
-before changing either store draft it rechecks that `main` and both selected tags
-have not moved. A mismatch waits for a later run instead of drafting the wrong
-build.
+`ENABLE_STORE_DRAFT_SUBMISSION` is `true`. It runs whenever **iOS TestFlight
+Deploy** or **Android Play Internal Deploy** completes on `main`, and on demand;
+there is no schedule. It pins the current `main` SHA, selects the exact highest
+iOS and Android build tags for that version, and checks that both tagged
+binaries match `main`'s platform fingerprints. Immediately before changing
+either store draft it rechecks that `main` and both selected tags have not
+moved. A mismatch, or only one platform's build existing yet, waits for a later
+run (the other platform's completion re-triggers it) instead of drafting the
+wrong build.
+
+The iOS lane waits up to 45 minutes for App Store Connect to finish processing
+the tagged build, then attaches it to the editable version (creating the version
+first if needed). The Android lane promotes the internal-track release carrying
+the tagged versionCode to a production release in draft status.
 
 Review submission and rollout remain manual:
 
-- **App Store Connect:** attach the verified TestFlight build, confirm metadata
-  and screenshots, then submit it for review.
+- **App Store Connect:** confirm the attached TestFlight build, metadata and
+  screenshots, then submit it for review.
 - **Play Console:** promote the verified internal release to production.
 
 The scheduled **Mobile Release Anchor** workflow queries each store for the exact

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -352,10 +352,16 @@ platform :ios do
     UI.user_error!("Invalid RELEASE_VERSION: #{version}") unless version.match?(/^\d+\.\d+\.\d+$/)
     UI.user_error!("Invalid IOS_BUILD_NUMBER: #{build_number}") unless build_number.match?(/^\d+$/) && build_number.to_i.positive?
 
-    # Create the App Store version if it doesn't exist and attach the build,
-    # leaving it in 'Prepare for Submission' (a DRAFT). No screenshots/metadata
-    # here (owned by the screenshots/metadata lanes); crucially submit_for_review:
-    # false, so a human reviews and hits Submit — we never auto-submit.
+    # Create the App Store version if it doesn't exist, leaving it in 'Prepare
+    # for Submission' (a DRAFT). No screenshots/metadata here (owned by the
+    # screenshots/metadata lanes); crucially submit_for_review: false, so a human
+    # reviews and hits Submit — we never auto-submit.
+    #
+    # deliver only selects a build from inside submit_for_review
+    # (deliver/runner.rb → submit_for_review → select_build), which we never
+    # call, so `build_number` is inert here: this call ensures the version and
+    # nothing else. The build is attached below with the same Spaceship calls
+    # deliver's select_build makes.
     upload_to_app_store(
       api_key: api_key,
       app_identifier: APP_IDENTIFIER,
@@ -371,7 +377,42 @@ platform :ios do
       # force: true — no interactive HTML preview in CI (same as the other lanes).
       force: true
     )
-    UI.success("Prepared a draft App Store version #{version} with build #{build_number}.")
+
+    # The workflow_run trigger fires the moment the TestFlight upload returns,
+    # usually 10–40 minutes before App Store Connect finishes processing the
+    # build, and an unprocessed build cannot be attached. Wait for THIS build
+    # (app_version + build_version, select_latest: false), bounded so a build
+    # Apple never processes fails the job instead of hanging it. The ios job's
+    # timeout-minutes in mobile-store-draft.yml must stay above this bound.
+    require "spaceship"
+    app = Spaceship::ConnectAPI::App.find(APP_IDENTIFIER)
+    UI.user_error!("App #{APP_IDENTIFIER} not found on App Store Connect") if app.nil?
+    build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(
+      app_id: app.id,
+      platform: Spaceship::ConnectAPI::Platform::IOS,
+      app_version: version,
+      build_version: build_number,
+      poll_interval: 30,
+      timeout_duration: 45 * 60,
+      return_when_build_appears: false,
+      return_spaceship_testflight_build: false,
+      select_latest: false
+    )
+    unless build && build.app_version == version && build.version == build_number
+      UI.user_error!("App Store Connect returned build #{build&.app_version} (#{build&.version}) while waiting for #{version} (#{build_number}); refusing to attach the wrong build.")
+    end
+
+    # Attach the processed build to the editable version — until this happens
+    # the draft is a draft of nothing. Mirrors deliver's select_build:
+    # App#get_edit_app_store_version + AppStoreVersion#select_build. If the
+    # editable version is not the one just ensured (a stale draft of another
+    # version still open), refuse rather than attach to it.
+    edit_version = app.get_edit_app_store_version(platform: Spaceship::ConnectAPI::Platform::IOS)
+    if edit_version.nil? || edit_version.version_string != version
+      UI.user_error!("Editable App Store version is #{edit_version&.version_string || 'none'}, expected #{version}; not attaching build #{build_number}.")
+    end
+    edit_version.select_build(build_id: build.id)
+    UI.success("Prepared a draft App Store version #{version} with build #{build_number} attached.")
   end
 end
 
@@ -562,17 +603,22 @@ platform :android do
     UI.user_error!("Invalid RELEASE_VERSION: #{version}") unless version.match?(/^\d+\.\d+\.\d+$/)
     UI.user_error!("Invalid ANDROID_VERSION_CODE: #{version_code}") unless version_code.match?(/^\d+$/) && version_code.to_i.positive?
 
-    # Create a production release in DRAFT status referencing the build already
-    # uploaded (to the internal track by android-apk-rn.yml). release_status:
-    # 'draft' means it is never sent for review — a human promotes/rolls it out.
-    # No text/images/screenshots here (owned by the metadata/images/screenshots
-    # lanes); no AAB upload (the binary already exists).
+    # Promote the exact internal-track release (uploaded by android-apk-rn.yml)
+    # to a production release in DRAFT status — never sent for review; a human
+    # rolls it out. A plain `track: production` with every upload skipped is a
+    # no-op in supply (no version codes → update_track is never called, and the
+    # metadata skip flags short-circuit perform_upload_meta), so this goes
+    # through supply's promote_track: select the internal release carrying this
+    # versionCode and copy it to production with track_promote_release_status.
+    # No AAB upload (the binary already exists on internal); no text/images/
+    # screenshots (owned by the metadata/images/screenshots lanes).
     upload_to_play_store(
       package_name: APP_IDENTIFIER,
       json_key_data: json_key_data,
-      track: "production",
+      track: "internal",
+      track_promote_to: "production",
+      track_promote_release_status: "draft",
       version_code: version_code.to_i,
-      release_status: "draft",
       skip_upload_apk: true,
       skip_upload_aab: true,
       skip_upload_metadata: true,
@@ -581,6 +627,6 @@ platform :android do
       skip_upload_screenshots: true,
       timeout: 300
     )
-    UI.success("Prepared a draft production release for versionCode #{version_code}.")
+    UI.success("Prepared a draft production release for versionCode #{version_code}, promoted from internal.")
   end
 end

--- a/scripts/native-release-workflows.test.ts
+++ b/scripts/native-release-workflows.test.ts
@@ -156,6 +156,9 @@ describe('native release workflow contracts', () => {
     expect(workflowRun.types).toEqual(['completed']);
     expect(workflowRun.branches).toEqual(['main']);
     expect(triggers).toHaveProperty('workflow_dispatch');
+    // No enable flag: the candidate gates are the protection, and the lanes only make drafts.
+    expect(draft).not.toContain('ENABLE_STORE_DRAFT_SUBMISSION');
+    expect(draft).not.toMatch(/vars\.[A-Z_]*ENABLE/);
     // A failed or cancelled deploy has nothing to draft.
     expect(draft).toContain(
       "if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'",

--- a/scripts/native-release-workflows.test.ts
+++ b/scripts/native-release-workflows.test.ts
@@ -144,6 +144,43 @@ describe('native release workflow contracts', () => {
     expect(draft).not.toContain(removedReleaseBranch);
   });
 
+  it('drafts follow each completed native deploy instead of a schedule', () => {
+    const triggers = parse(draft)['on'] as Record<string, unknown>;
+    expect(triggers).not.toHaveProperty('schedule');
+    expect(draft).not.toContain('cron:');
+    const workflowRun = triggers.workflow_run as { workflows: string[]; types: string[]; branches: string[] };
+    expect(workflowRun.workflows).toEqual([
+      'iOS TestFlight Deploy (React Native)',
+      'Android Play Internal Deploy (React Native)',
+    ]);
+    expect(workflowRun.types).toEqual(['completed']);
+    expect(workflowRun.branches).toEqual(['main']);
+    expect(triggers).toHaveProperty('workflow_dispatch');
+    // A failed or cancelled deploy has nothing to draft.
+    expect(draft).toContain(
+      "if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'",
+    );
+    // The names the trigger subscribes to must keep matching the deploy workflows.
+    expect(ios).toMatch(/^name: iOS TestFlight Deploy \(React Native\)$/m);
+    expect(android).toMatch(/^name: Android Play Internal Deploy \(React Native\)$/m);
+  });
+
+  it('attaches the tagged build to the draft rather than relying on deliver/supply side effects', () => {
+    const fastfile = readFileSync('fastlane/Fastfile', 'utf8');
+    // deliver only selects a build inside submit_for_review, which the lane never calls,
+    // so the lane waits for THIS build to finish processing and attaches it itself.
+    expect(fastfile).toContain('FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(');
+    expect(fastfile).toContain('build_version: build_number,');
+    expect(fastfile).toContain('select_latest: false');
+    expect(fastfile).toContain('edit_version.select_build(build_id: build.id)');
+    // supply with every upload skipped never touches a track; promotion does.
+    expect(fastfile).toContain('track_promote_to: "production",');
+    expect(fastfile).toContain('track_promote_release_status: "draft",');
+    expect(fastfile).not.toMatch(/track: "production",\n\s+version_code:/);
+    // The processing wait (45 min) must fit inside the ios job's timeout.
+    expect(draft).toMatch(/^  ios:\n(?:.*\n){1,12}?\s+timeout-minutes: 60$/m);
+  });
+
   it('keeps the established main anchor on Production', () => {
     const anchor = workflow('mobile-auto-version-bump.yml');
     expect(anchor).toContain('environment: Production');


### PR DESCRIPTION
## Summary

Wires **Mobile Store Draft Submission** to run after every native deploy instead of every 6 hours, and fixes the two `draft_submission` lanes so a run actually produces a draft with a build in it.

**Trigger.** `mobile-store-draft.yml` now fires on `workflow_run` of *iOS TestFlight Deploy (React Native)* and *Android Play Internal Deploy (React Native)* on `main`, plus `workflow_dispatch`; the cron is gone. Runs whose triggering deploy did not succeed are skipped at the `main-candidate` job. The existing candidate check already handles one platform's build not existing yet (it exits quietly; that platform's own completion re-triggers), the fingerprint match against `main`, and the "main moved" recheck, so nothing about *what* gets drafted changes, only *when*.

**The lanes were no-ops.** The header says "flip the variable on once you've validated the lanes"; reading fastlane 2.236.1 shows why that mattered:

| Lane | As written | Why it did nothing | Now |
| --- | --- | --- | --- |
| iOS | `upload_to_app_store(build_number:, submit_for_review: false, …)` | `deliver` only selects a build inside `submit_for_review` (`runner.rb` → `submit_for_review` → `select_build`), which is never called. The version got created, no build attached. | After ensuring the version, wait for **this** build to finish processing (`BuildWatcher`, `select_latest: false`, 45-min bound, since `workflow_run` fires 10–40 min before App Store Connect is done), then `AppStoreVersion#select_build`, exactly what `deliver`'s `select_build` does. Refuses if the editable version isn't the one it ensured. ios job timeout 15 → 60 min. |
| Android | `upload_to_play_store(track: "production", version_code:, release_status: "draft", skip everything)` | With no APK/AAB, `update_track` is never called; with every metadata skip set, `perform_upload_meta` returns. Nothing touched. | `track: "internal"`, `track_promote_to: "production"`, `track_promote_release_status: "draft"`, `version_code:` → supply's `promote_track` copies the internal release carrying that versionCode to production as a draft. |

**Verification.** `ruby -c fastlane/Fastfile` passes (Ruby 3.3 in Docker; no Ruby on the dev box). `scripts/native-release-workflows.test.ts` pins the trigger names against the deploy workflows' `name:`, the conclusion guard, the absence of a cron, the bounded wait, the build attach, the promotion, and the 60-min timeout; each assertion was mutation-tested (re-adding a cron / breaking the guard, and reverting the lanes, each fail exactly one test). 72/72 across that file and `mobile-ci-env-parity.test.ts`. **What is not verified:** the lanes were not executed. They need store credentials and mutate live store state, so the first real run (the first native deploy after merge, or a `workflow_dispatch`) should be watched by a human. Runbook §4 updated.

**Always on from merge (second commit).** The `ENABLE_STORE_DRAFT_SUBMISSION` gate is gone; the variable was never set, so the workflow had never done anything. The protection that matters is already in the workflow: it only prepares drafts (no review submission, no rollout), and `main-candidate` refuses anything but the exact highest build tag for main's version whose fingerprint matches main's head. The contract test pins the absence of the flag.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 3/5 — release pipeline (workflow trigger + fastlane lanes) that cannot be executed in CI and goes live on merge; it only ever writes drafts, and a syntax error in the Fastfile would break every lane, which `ruby -c` rules out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZ7jMynfMZzKjG4kFHxaqX
