### PR TITLE
fix(mobile): stop the stall-freshness boundary test racing the wall clock

### DIFF
--- a/packages/mobile/ios-tests/BoardBleRelightAuthorizationTests.swift
+++ b/packages/mobile/ios-tests/BoardBleRelightAuthorizationTests.swift
@@ -392,9 +392,17 @@ final class BoardBleRelightAuthorizationTests: XCTestCase {
         )
     }
 
-    /// The other side of the bound: a recovery that used its whole budget is
-    /// still the recovery we asked for, and still repaints the wall (#3181).
-    func testWriteStallOnTheFreshnessBoundStillReconnectsAndRelights() {
+    /// The other side of the bound: a recovery that spent nearly its whole
+    /// budget is still the recovery we asked for, and still repaints the
+    /// wall (#3181).
+    ///
+    /// Rewound to just INSIDE the bound, not exactly onto it. The guard reads
+    /// the wall clock when the disconnect is consumed, so a stamp aged by
+    /// exactly `implicitRelightMaxRequestAge` is already microseconds past the
+    /// bound by the time it is measured — that flake would read as a real
+    /// regression. Inclusivity of `<=` is pinned exactly, and without a clock,
+    /// by `testWriteStallRecoveryFreshnessMatrix`.
+    func testWriteStallJustInsideTheFreshnessBoundStillReconnectsAndRelights() {
         let peripheral = FakeWritablePeripheral()
         installConnection(peripheral: peripheral)
 
@@ -402,7 +410,8 @@ final class BoardBleRelightAuthorizationTests: XCTestCase {
         fireLatestOneShot(label: "writeAckWatchdog")
 
         let maxRequestAge = manager.testHooks.sync { manager.testHooks.implicitRelightMaxRequestAge }
-        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.rewindWriteStallRecovery(by: maxRequestAge) })
+        let almostTheWholeBudget = maxRequestAge - 10
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.rewindWriteStallRecovery(by: almostTheWholeBudget) })
 
         manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
 


### PR DESCRIPTION
## Summary

`main`'s Swift suite is red: 171 of 172 pass, and the one failure is a test I added in #4551 that races the wall clock.

`testWriteStallOnTheFreshnessBoundStillReconnectsAndRelights` rewound the stall's stamp by **exactly** `implicitRelightMaxRequestAge` (120 s), then let real time pass — a `fireDidDisconnect` hop and a queue round-trip — before `beginWriteStallReconnectOnBleQueue` read `Date()` to measure it. By then the age was microseconds *past* the inclusive bound, so the recovery was correctly abandoned and the test reported it as a regression:

```
XCTAssertEqual failed: ("[]") is not equal to ("[BEB56E74-…]")
XCTAssertEqual failed: ("nil") is not equal to ("Optional(…writeStallRecovery)")
XCTAssertEqual failed: ("0") is not equal to ("1")
XCTAssertEqual failed: ("1") is not equal to ("0")
```

The production guard is right. The test was measuring the clock rather than the bound, so it now rewinds to just inside the budget. Exact `<=` inclusivity keeps its coverage in `testWriteStallRecoveryFreshnessMatrix`, which pins the bound against a fixed `now` with no clock to race — the right place for it.

## How it reached main

`ios-rn-ci.yml` does not run on `main`, and #4551 merged before its macOS job finished. The compile break #5314 fixed had also been masking the whole suite since #5313, so these tests had never actually executed. #5314's own run — which landed after that PR was merged — is where this surfaced.

## Validation

The PR's own macOS job **skips**: `mobile-native-gate`'s path screen has no
`packages/mobile/ios-tests` entry, so a PR whose only change is a Swift test never runs
the Swift tests. That is the mechanism behind this whole chain — nothing on the PR or on
`main` executes a test-only Swift change.

So it was validated by manual `workflow_dispatch` (which bypasses the gate):
[run 34195614718](https://github.com/boardsesh/boardsesh/actions/runs/34195614718) —
`build-and-test` success, **172 tests, 0 failures**, up from 171/172 on `main`.
`testWriteStallJustInsideTheFreshnessBoundStillReconnectsAndRelights` passes, and the
#3181 / #4499 guards around it still do.

Worth fixing separately: adding `packages/mobile/ios-tests` to that path screen, and/or
running `ios-rn-ci.yml` on `main`, would stop the next one reaching `main`.

## Test plan

1. CI green.

## Risk

Risk: 1/5 — one test-only assertion window; no production Swift touched.

## Release Notes

- [x] No release note needed (internal / technical change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182jHtWo7NzfWGhdr8bgpas

