### PR TITLE
ci(mobile): push the iOS listing text again once the draft has a version to write onto

### DIFF
--- a/.github/workflows/mobile-store-draft.yml
+++ b/.github/workflows/mobile-store-draft.yml
@@ -307,6 +307,10 @@ jobs:
     # tagged build before attaching it; keep this above that bound.
     timeout-minutes: 60
     environment: Production
+    # actions: write lets the last step dispatch mobile-store-metadata.yml.
+    permissions:
+      contents: read
+      actions: write
 
     steps:
       - name: Checkout repository
@@ -377,6 +381,21 @@ jobs:
 
       # Surface a best-effort failure loudly (continue-on-error keeps the job
       # green otherwise, which would hide a broken draft submission).
+      # deliver can only write listing text onto an EDITABLE App Store version,
+      # so the Mobile Store Metadata run that fired when the copy landed on main
+      # was a no-op whenever no version existed yet — the normal case, since the
+      # notes are written before the native change (runbook §1). The draft step
+      # above just created (or confirmed) that version, so push the text and
+      # What's New onto it now. A workflow_dispatch made with GITHUB_TOKEN does
+      # start a run; only push/pull_request events from the token are suppressed.
+      # Android needs nothing here: its What's New rides the AAB and its listing
+      # text is not version-bound.
+      - name: Push listing text and What's New onto the drafted version
+        if: steps.draft.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run mobile-store-metadata.yml --ref main -f platform=ios
+
       - name: Warn if the App Store draft step failed
         if: steps.draft.outcome == 'failure'
         run: echo "::warning::App Store draft submission failed (see the step above). Best-effort — re-run after resolving, or prepare the draft manually in App Store Connect."

--- a/.github/workflows/mobile-store-metadata.yml
+++ b/.github/workflows/mobile-store-metadata.yml
@@ -26,6 +26,10 @@ name: Mobile Store Metadata
 # ios metadata lane also skips cleanly when there's no editable version (see the
 # Fastfile), so the iOS job no longer burns the budget either.
 #
+# Also dispatched with platform: ios by mobile-store-draft.yml right after it
+# creates the App Store version for a release, because the automatic run below
+# skips iOS whenever no version is editable yet (see the ios metadata lane).
+#
 # Runs automatically when the committed listing assets change on main
 # (fastlane/metadata/**, fastlane/Fastfile, or app-stores/google/screenshots/**),
 # pushing to both stores. The Android screenshot set is refreshed by

--- a/docs/mobile-store-release.md
+++ b/docs/mobile-store-release.md
@@ -61,15 +61,21 @@ fingerprint in an immutable
 `fingerprint-<platform>-<hash>` tag prevents duplicate native builds when a later
 `main` push is JS-only.
 
-## 3. Update listing material when needed
+## 3. Listing material
 
-Run these from the Actions tab only when the corresponding material changed:
+Listing text is automatic. **Mobile Store Metadata** (`mobile-store-metadata.yml`)
+runs on every `main` push that touches `fastlane/metadata/**`, the Fastfile, or
+the committed Play screenshots, and pushes listing text plus the Play icon and
+feature graphic. The iOS half can only write onto an *editable* App Store
+version, so when the copy lands before a version exists (the normal order, §1)
+that run skips iOS; `mobile-store-draft.yml` dispatches it again with
+`platform: ios` right after it creates the version (§4), so the text and What's
+New land without anyone running it by hand. Dispatch it manually only to re-push
+unchanged copy.
 
-- **Mobile Store Metadata** (`mobile-store-metadata.yml`, `platform: all`) pushes
-  listing text plus the Play icon and feature graphic.
-- **Mobile Screenshots** (`mobile-screenshots-ios.yml` and
-  `mobile-screenshots-android.yml`, `upload: true`) captures and uploads each
-  platform independently.
+Screenshots stay on demand: **Mobile Screenshots** (`mobile-screenshots-ios.yml`
+and `mobile-screenshots-android.yml`, `upload: true`) captures and uploads each
+platform independently.
 
 The iOS `release_notes.txt` is pushed by Mobile Store Metadata. Android release
 notes ship with the AAB from each
@@ -90,8 +96,10 @@ wrong build.
 
 The iOS lane waits up to 45 minutes for App Store Connect to finish processing
 the tagged build, then attaches it to the editable version (creating the version
-first if needed). The Android lane promotes the internal-track release carrying
-the tagged versionCode to a production release in draft status.
+first if needed) and dispatches Mobile Store Metadata for iOS so the listing
+text and What's New land on that version (§3). The Android lane promotes the
+internal-track release carrying the tagged versionCode to a production release
+in draft status.
 
 Review submission and rollout remain manual:
 
@@ -110,7 +118,7 @@ future fingerprint.
 1. Set the release version and translate both stores' release notes on `main`.
 2. Land the focused native change; wait for TestFlight and Play internal builds.
 3. Complete native QA against the exact uploaded candidates.
-4. Update metadata or screenshots only when they changed.
+4. Re-capture screenshots if they changed; listing text pushes itself.
 5. Verify the store drafts select the tagged builds, then submit both manually.
 6. After approval, confirm both immutable release anchors were created.
 

--- a/scripts/native-release-workflows.test.ts
+++ b/scripts/native-release-workflows.test.ts
@@ -184,6 +184,21 @@ describe('native release workflow contracts', () => {
     expect(draft).toMatch(/^  ios:\n(?:.*\n){1,12}?\s+timeout-minutes: 60$/m);
   });
 
+  it('pushes listing text automatically, and again once the draft has a version to write onto', () => {
+    const metadata = workflow('mobile-store-metadata.yml');
+    const metadataTriggers = parse(metadata)['on'] as { push?: { branches: string[]; paths: string[] } };
+    expect(metadataTriggers.push?.branches).toEqual(['main']);
+    expect(metadataTriggers.push?.paths).toContain('fastlane/metadata/**');
+    // deliver skips iOS when no version is editable, so the draft workflow re-runs it for iOS
+    // right after creating the version — and only when that draft step actually succeeded.
+    expect(draft).toContain('gh workflow run mobile-store-metadata.yml --ref main -f platform=ios');
+    expect(draft).toMatch(
+      /if: steps\.draft\.outcome == 'success'\n\s+env:\n\s+GH_TOKEN: \$\{\{ github\.token \}\}\n\s+run: gh workflow run mobile-store-metadata\.yml/,
+    );
+    // GITHUB_TOKEN can only dispatch a workflow with actions: write on the job.
+    expect(draft).toMatch(/^  ios:\n(?:.*\n){1,20}?\s+permissions:\n\s+contents: read\n\s+actions: write$/m);
+  });
+
   it('keeps the established main anchor on Production', () => {
     const anchor = workflow('mobile-auto-version-bump.yml');
     expect(anchor).toContain('environment: Production');


### PR DESCRIPTION
## Summary

Closes the last manual step in the store-copy path. `mobile-store-metadata.yml` already runs on every `main` push that touches `fastlane/metadata/**` (runbook §3 wrongly said "run from the Actions tab"), but `deliver` can only write listing text onto an *editable* App Store version. When the copy lands before the version exists, which is the normal order (§1 says write the notes before the final native change), that run skips iOS with "No editable App Store version" and nothing re-pushes later. This morning's runs show it: the 06:00 run for #5315 skipped iOS; the 06:34 run for #5316 uploaded only because 2.5.0 had been created by hand in between.

**Change.** The `ios` job of `mobile-store-draft.yml` dispatches **Mobile Store Metadata** with `platform: ios` right after its draft step succeeds, i.e. once the version exists and has the build attached. The job gets `actions: write` (job-level, alongside `contents: read`) so `GITHUB_TOKEN` may dispatch; a `workflow_dispatch` made with that token does start a run (only push/pull_request events from it are suppressed). Android needs nothing: its What's New ships with the AAB and its listing text is not version-bound. Runbook §3 rewritten; screenshots stay on demand.

**Verification.** `scripts/native-release-workflows.test.ts` pins the metadata workflow's push trigger and paths, the dispatch command, the `steps.draft.outcome == 'success'` gate directly above it, and the job-level `actions: write`; dropping the gate and the permission fails exactly one test. 73/73 across that file and `mobile-ci-env-parity.test.ts`; `vp check` clean. The dispatch itself runs only on a real draft, so the next native release is its first live exercise.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — one extra step in a release workflow, gated on a successful draft, dispatching a workflow that already runs on its own; worst case is a duplicate metadata push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZ7jMynfMZzKjG4kFHxaqX
