### PR TITLE
fix(mobile): keep player swipe dismissal smooth after release

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -363,6 +363,29 @@ is fine. A navigator _below_ the modal you're standing in needs the dismiss firs
 
 ## A latency footgun (any route)
 
+### Player swipe dismissal
+
+The player keeps its native opening and chevron-close transitions. A downward
+swipe instead owns one Reanimated translation for the entire route surface,
+including its opaque backing and glass. `use-drawer-dismiss-gesture` continues
+that transform on release with the downward velocity and a clamped spring. It
+does not wait for JavaScript to start a second native animation from the dragged
+position: that handoff caused a visible pause just after release.
+
+`use-play-swipe-dismiss` removes the route only after the spring finishes. It
+sets `animation: 'none'`, then yields two animation frames before dismissal so
+the option update and removal are separate native mounting transactions. Those
+frames happen with the player already offscreen. The closing latch survives
+gesture finalization, blocks repeat touches and chevron taps, and releases on
+animation cancellation. A completion after unmount is ignored; if another modal
+has taken focus, the player restores itself underneath it instead of dismissing
+the newer modal. The route's existing programmatic close waiter stays native.
+
+The iPad pane does not receive this route-owned animation. Keep the modal's
+live-behind presentation and accessory-host mount rules above when changing it.
+
+### Opening a heavy route
+
 A modal route's present animation can't START until React commits the route's first frame. If
 that first render is heavy (the player mounts board geometry + a stack of hooks), the slide
 visibly lags the tap. Paint only a cheap first frame (a solid/`GlassSurface` background) and

--- a/docs/react-native-performance.md
+++ b/docs/react-native-performance.md
@@ -371,6 +371,20 @@ render is stuck in our queue or stuck in native.
 
 ## Profiling workflow
 
+For player swipe dismissal on ProMotion iPhones, target the 120 Hz presentation
+budget (8.33 ms) in a release build. Record the OS/build, active display cadence,
+power and accessibility settings, and compare slow releases around 80% openness,
+fast flicks and cancelled drags from the Climbs tab. Include 30 warm dismissals
+with a large logbook and a player whose below-fold sections have loaded. Report
+missed presentation deadlines and any repeatable plateau after finger-up; an
+average FPS counter or a screen recording alone cannot establish 120 fps.
+
+The release spring runs entirely on the UI thread. Navigation and host cleanup
+happen after the whole surface is offscreen; see the player swipe dismissal
+contract in `docs/mobile-sheets-vs-routes.md`. Unit tests cover ordering and races,
+but physical-device timing remains a separate acceptance check. Check the built
+app's `CADisableMinimumFrameDurationOnPhone` flag before measuring ProMotion.
+
 Required evidence for any list / provider / theme PR: a **before/after recording on the climbs list
 and the play drawer**, captured on a large-logbook account. A claim of "this is faster" without a
 recording does not clear review.

--- a/packages/mobile/app/__tests__/play.test.tsx
+++ b/packages/mobile/app/__tests__/play.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LayoutChangeEvent } from 'react-native';
+import type { SwipeDismissAnimation } from '../../src/components/play-drawer/use-drawer-dismiss-gesture';
+
+const router = vi.hoisted(() => ({ dismiss: vi.fn() }));
+const navigation = vi.hoisted(() => ({ setOptions: vi.fn(), isFocused: vi.fn(() => true) }));
+const onClosed = vi.hoisted(() => vi.fn());
+const player = vi.hoisted(() => ({ swipeDismiss: null as SwipeDismissAnimation | null }));
+const surface = vi.hoisted(() => ({ onLayout: null as ((event: LayoutChangeEvent) => void) | null }));
+const boardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 1, setIds: '1', angle: 40 };
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-testid': 'backing' }, children),
+  StyleSheet: { create: (styles: unknown) => styles, absoluteFill: {} },
+  useWindowDimensions: () => ({ height: 900, width: 400 }),
+}));
+vi.mock('react-native-reanimated', async () => {
+  const { useRef } = await import('react');
+  return {
+    default: {
+      View: ({
+        children,
+        style,
+        onLayout,
+      }: {
+        children?: ReactNode;
+        style: unknown;
+        onLayout: typeof surface.onLayout;
+      }) => {
+        surface.onLayout = onLayout;
+        return createElement('div', { 'data-testid': 'moving-surface', 'data-style': JSON.stringify(style) }, children);
+      },
+    },
+    useSharedValue: (initial: unknown) => useRef({ value: initial }).current,
+    useAnimatedStyle: (factory: () => unknown) => factory(),
+    withSpring: (target: number) => target,
+    runOnUI: (callback: () => void) => callback,
+    runOnJS: (callback: () => void) => callback,
+  };
+});
+vi.mock('expo-router', () => ({ useRouter: () => router, useNavigation: () => navigation }));
+vi.mock('../../src/components/GlassSurface', () => ({
+  GlassSurface: () => createElement('div', { 'data-testid': 'glass' }),
+}));
+vi.mock('../../src/components/play-drawer', () => ({
+  PlayDrawer: ({ swipeDismiss, onClose }: { swipeDismiss: SwipeDismissAnimation; onClose: () => void }) => {
+    player.swipeDismiss = swipeDismiss;
+    return createElement('button', { onClick: onClose }, 'Close player');
+  },
+}));
+vi.mock('../../src/components/play-drawer/QueueSheet', () => ({ QueueSheet: () => null }));
+vi.mock('../../src/components/ble/DevicePickerSheetHost', () => ({ DevicePickerSheetHost: () => null }));
+vi.mock('../../src/components/play-drawer/use-queue-sheet-handlers', () => ({ useQueueSheetHandlers: () => ({}) }));
+vi.mock('../../src/providers/drawer-host-provider', () => ({
+  usePlayDrawerRoute: () => ({ activeBoardConfig: boardConfig, onPlayDrawerClosed: onClosed }),
+  useDrawerHost: () => ({ boardConfig }),
+}));
+vi.mock('../../src/providers/queue-provider', () => ({
+  useQueueActions: () => ({}),
+  useQueueSessionControls: () => ({}),
+}));
+vi.mock('../../src/providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { secondaryBackground: '#fff' }, colorScheme: 'light' }),
+}));
+vi.mock('../../src/theme/colors', () => ({ playDrawerMaterialTint: { light: 'transparent', dark: 'transparent' } }));
+vi.mock('../../src/components/create-climb/use-player-dismiss-and-wait', () => ({
+  usePlayerDismissAndWait: () => vi.fn(),
+}));
+vi.mock('../../src/providers/sheet-presentation-provider', () => ({ dismissManagedSheetAndWait: vi.fn() }));
+
+import PlayScreen from '../play';
+
+const frames = new Map<number, FrameRequestCallback>();
+let nextFrame = 0;
+function flushFrame() {
+  const scheduled = [...frames.values()];
+  frames.clear();
+  act(() => scheduled.forEach((callback) => callback(0)));
+}
+
+function renderPlayer() {
+  const rendered = render(createElement(PlayScreen));
+  flushFrame(); // Existing cheap-first-frame content gate.
+  const animation = player.swipeDismiss;
+  if (!animation) throw new Error('player did not receive the route animation');
+  return { ...rendered, animation };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  navigation.isFocused.mockReturnValue(true);
+  frames.clear();
+  nextFrame = 0;
+  player.swipeDismiss = null;
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    frames.set(++nextFrame, callback);
+    return nextFrame;
+  });
+  vi.stubGlobal('cancelAnimationFrame', (handle: number) => frames.delete(handle));
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('player swipe dismissal', () => {
+  it('keeps backing, glass and player inside the same translated surface', () => {
+    const { animation } = renderPlayer();
+    const movingSurface = screen.getByTestId('moving-surface');
+    expect(movingSurface.contains(screen.getByTestId('backing'))).toBe(true);
+    expect(movingSurface.contains(screen.getByTestId('glass'))).toBe(true);
+    expect(movingSurface.contains(screen.getByRole('button', { name: 'Close player' }))).toBe(true);
+    act(() => {
+      animation.translateY.value = 900;
+      animation.onComplete();
+    });
+    expect(movingSurface.getAttribute('data-style')).toContain('"translateY":900');
+  });
+
+  it('uses measured route height as the offscreen target', () => {
+    const { animation } = renderPlayer();
+    act(() => surface.onLayout?.({ nativeEvent: { layout: { height: 920 } } } as LayoutChangeEvent));
+    expect(animation.height.value).toBe(920);
+  });
+
+  it('preserves the native chevron close without changing route animation options', () => {
+    renderPlayer();
+    fireEvent.click(screen.getByRole('button', { name: 'Close player' }));
+    expect(router.dismiss).toHaveBeenCalledTimes(1);
+    expect(navigation.setOptions).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate until the spring finishes and native options have a separate frame to commit', () => {
+    const { animation } = renderPlayer();
+    animation.isDismissing.value = true;
+    expect(router.dismiss).not.toHaveBeenCalled();
+    expect(navigation.setOptions).not.toHaveBeenCalled();
+    act(() => animation.onComplete());
+    expect(navigation.setOptions).toHaveBeenCalledWith({ animation: 'none' });
+    expect(router.dismiss).not.toHaveBeenCalled();
+    flushFrame();
+    expect(router.dismiss).not.toHaveBeenCalled();
+    flushFrame();
+    expect(router.dismiss).toHaveBeenCalledTimes(1);
+    expect(onClosed).not.toHaveBeenCalled();
+  });
+
+  it('ignores button taps during a committed swipe and duplicate completions', () => {
+    const { animation } = renderPlayer();
+    animation.isDismissing.value = true;
+    fireEvent.click(screen.getByRole('button', { name: 'Close player' }));
+    expect(router.dismiss).not.toHaveBeenCalled();
+    act(() => {
+      animation.onComplete();
+      animation.onComplete();
+    });
+    flushFrame();
+    flushFrame();
+    expect(router.dismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a late completion after unmount and resets host state once', () => {
+    const { animation, unmount } = renderPlayer();
+    unmount();
+    act(() => animation.onComplete());
+    flushFrame();
+    flushFrame();
+    expect(router.dismiss).not.toHaveBeenCalled();
+    expect(navigation.setOptions).not.toHaveBeenCalled();
+    expect(onClosed).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels pending removal when another close unmounts the route', () => {
+    const { animation, unmount } = renderPlayer();
+    act(() => animation.onComplete());
+    flushFrame();
+    unmount();
+    flushFrame();
+    expect(router.dismiss).not.toHaveBeenCalled();
+  });
+
+  it('restores the player if a newer modal covers it before removal', () => {
+    const { animation } = renderPlayer();
+    animation.translateY.value = 900;
+    animation.isDismissing.value = true;
+    act(() => animation.onComplete());
+    flushFrame();
+    navigation.isFocused.mockReturnValue(false);
+    flushFrame();
+    expect(router.dismiss).not.toHaveBeenCalled();
+    expect(navigation.setOptions).toHaveBeenLastCalledWith({ animation: 'slide_from_bottom' });
+    expect(animation.translateY.value).toBe(0);
+    expect(animation.isDismissing.value).toBe(false);
+
+    navigation.isFocused.mockReturnValue(true);
+    act(() => animation.onComplete());
+    flushFrame();
+    flushFrame();
+    expect(router.dismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/app/play.tsx
+++ b/packages/mobile/app/play.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
+import Animated from 'react-native-reanimated';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { GlassSurface } from '../src/components/GlassSurface';
 import { PlayDrawer } from '../src/components/play-drawer';
@@ -17,11 +18,12 @@ import { useQueueActions, useQueueSessionControls } from '../src/providers/queue
 import { useTheme } from '../src/providers/theme-provider';
 import { playDrawerMaterialTint } from '../src/theme/colors';
 import { usePlayerDismissAndWait } from '../src/components/create-climb/use-player-dismiss-and-wait';
+import { usePlaySwipeDismiss } from '../src/components/play-drawer/use-play-swipe-dismiss';
 import type { Climb } from '@boardsesh/shared-schema';
 import { dismissManagedSheetAndWait, type DismissAndWaitResult } from '../src/providers/sheet-presentation-provider';
 
 /**
- * Full-screen "now playing" player route (`presentation: 'fullScreenModal'`,
+ * Full-screen "now playing" player route (`presentation: 'transparentModal'`,
  * registered in app/_layout.tsx). Replaces the old FullWindowOverlay: as a real
  * modal view controller, everything presented from inside its React tree — the
  * sub-drawers, the share sheet, and this route's own QueueSheet — stacks ABOVE
@@ -58,6 +60,7 @@ export default function PlayScreen() {
   const { setCurrentClimb } = useQueueActions();
   const { sessionId } = useQueueSessionControls();
   const { systemColors, colorScheme } = useTheme();
+  const { swipeDismiss, animatedStyle, onLayout, close } = usePlaySwipeDismiss();
 
   const queueSheetRef = useRef<QueueSheetHandle>(null);
   const presentQueue = useCallback(() => queueSheetRef.current?.present(), []);
@@ -117,7 +120,7 @@ export default function PlayScreen() {
   });
 
   return (
-    <View style={styles.root}>
+    <Animated.View style={[styles.root, animatedStyle]} onLayout={onLayout}>
       {/* Opaque backstop. The player is a transparentModal, so the live tabs
           screen sits behind it — paint a solid background under the glass so the
           Climbs list doesn't show through the translucent GlassSurface. */}
@@ -146,6 +149,8 @@ export default function PlayScreen() {
       {contentMounted && activeBoardConfig ? (
         <>
           <PlayDrawer
+            swipeDismiss={swipeDismiss}
+            onClose={close}
             boardConfig={activeBoardConfig}
             onAngleChange={onAngleChange}
             isAngleAdjustable={isAngleAdjustable}
@@ -174,7 +179,7 @@ export default function PlayScreen() {
           player's lightbulb (when disconnected) presents OVER the player. Claims
           the picker, suppressing the app-root instance while mounted. */}
       <DevicePickerSheetHost registerExternal />
-    </View>
+    </Animated.View>
   );
 }
 

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -59,7 +59,7 @@ import {
   shouldShowPanePlaceholder,
 } from './play-drawer-layout';
 import { useBelowFoldContentRequest } from './use-below-fold-content-request';
-import { useDrawerDismissGesture } from './use-drawer-dismiss-gesture';
+import { useDrawerDismissGesture, type SwipeDismissAnimation } from './use-drawer-dismiss-gesture';
 import { AngleSelectorSheet } from './AngleSelectorSheet';
 import { ClimbActionsSheet } from '../ClimbActionsSheet';
 import { AddBetaVideoSheet } from '../AddBetaVideoSheet';
@@ -149,6 +149,9 @@ export type PlayDrawerOpenTarget = {
 };
 
 type PlayDrawerProps = {
+  /** `/play` owns the transform so its backing and content travel together. */
+  swipeDismiss?: SwipeDismissAnimation;
+  onClose?: () => void;
   boardConfig: BoardConfig;
   onAngleChange?: (angle: number) => void;
   /** When false, the board's angle is fixed — the angle pill is hidden. */
@@ -235,13 +238,15 @@ const DEFAULT_LOGBOOK_HEADER_HEIGHT = 52;
 
 /**
  * Full-screen "now playing" player (Spotify-style track view). Rendered as the
- * content of the `app/play.tsx` modal route (`presentation: 'fullScreenModal'`):
- * the native modal VC gives the slide-up present, the swipe-down dismiss, and —
+ * content of the `app/play.tsx` modal route (`presentation: 'transparentModal'`):
+ * the native modal VC gives the slide-up present, button dismiss, and —
  * crucially — a view-controller stack that the sub-drawers / queue / share sheet
  * present ABOVE (the FullWindowOverlay it replaced could not, since native sheets
  * present off the key window beneath it).
  */
 export function PlayDrawer({
+  swipeDismiss,
+  onClose,
   boardConfig,
   onAngleChange,
   isAngleAdjustable = true,
@@ -370,8 +375,9 @@ export function PlayDrawer({
   const handleDismiss = useCallback(() => {
     // The pane is persistent — nothing to dismiss (and no modal to pop).
     if (isPane) return;
-    router.dismiss();
-  }, [isPane]);
+    if (onClose) onClose();
+    else router.dismiss();
+  }, [isPane, onClose]);
 
   // The header (title + grade) rides this exact value as the board so they swipe
   // in lockstep; the carousel's gesture writes into it (externalTranslateX). The
@@ -388,6 +394,7 @@ export function PlayDrawer({
   // when an accidental downward drift would otherwise yank the drawer down.
   const { gesture: dismissGesture, translateY: dismissTranslateY } = useDrawerDismissGesture({
     onDismiss: handleDismiss,
+    swipeDismiss,
     scrollYSV,
     scrollRef: scrollGestureRef,
     swipeTranslateX,
@@ -1235,7 +1242,7 @@ export function PlayDrawer({
         />
       ) : (
         <GestureDetector gesture={dismissGesture.enabled(!isPane)}>
-          <Animated.View style={[styles.content, dismissAnimatedStyle]}>
+          <Animated.View style={[styles.content, !swipeDismiss && dismissAnimatedStyle]}>
             <ScrollView
               ref={scrollRef}
               nestedScrollEnabled

--- a/packages/mobile/src/components/play-drawer/__tests__/use-drawer-dismiss-gesture.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-drawer-dismiss-gesture.test.ts
@@ -3,6 +3,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import type { SharedValue } from 'react-native-reanimated';
 
+const spring = vi.hoisted(() =>
+  vi.fn((target: number, _config?: unknown, _complete?: (finished: boolean) => void) => target),
+);
+
 // The hook composes a reanimated worklet Pan — stub the native layers so it runs
 // in node. These tests pin the axis-lock behaviour: while the carousel owns the
 // gesture as a horizontal swipe (offset non-zero) or is settling a fling, the
@@ -17,7 +21,8 @@ vi.mock('react-native-reanimated', async () => {
       if (ref.current === null) ref.current = { value: initial };
       return ref.current;
     },
-    withSpring: (toValue: unknown) => toValue,
+    withSpring: spring,
+    cancelAnimation: vi.fn(),
     runOnJS:
       (fn: (...args: unknown[]) => unknown) =>
       (...args: unknown[]) =>
@@ -159,5 +164,116 @@ describe('useDrawerDismissGesture', () => {
     handlers.onEnd({ velocityY: 0 });
 
     expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  function routeAnimation() {
+    return { translateY: sv(0), height: sv(900), isDismissing: sv(false), onComplete: vi.fn() };
+  }
+
+  it('continues the route transform with release velocity before calling any JS close', () => {
+    const swipeDismiss = routeAnimation();
+    const { result } = renderHook(() => useDrawerDismissGesture(makeOptions({ swipeDismiss })));
+    const handlers = latestHandlers();
+    handlers.onBegin();
+    handlers.onUpdate({ translationY: 180 });
+    expect(result.current.translateY).toBe(swipeDismiss.translateY);
+    expect(swipeDismiss.translateY.value).toBe(180);
+    handlers.onEnd({ velocityY: 800 });
+
+    expect(spring).toHaveBeenLastCalledWith(
+      900,
+      expect.objectContaining({ velocity: 800, overshootClamping: true }),
+      expect.any(Function),
+    );
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(swipeDismiss.onComplete).not.toHaveBeenCalled();
+    const complete = spring.mock.lastCall?.[2];
+    expect(complete).toBeDefined();
+    complete?.(true);
+    expect(swipeDismiss.onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the committed close locked through finger-up and repeated touches', () => {
+    const swipeDismiss = routeAnimation();
+    renderHook(() => useDrawerDismissGesture(makeOptions({ swipeDismiss })));
+    const handlers = latestHandlers();
+    handlers.onBegin();
+    handlers.onUpdate({ translationY: 180 });
+    handlers.onEnd({ velocityY: 800 });
+    handlers.onFinalize({}, true);
+    expect(swipeDismiss.isDismissing.value).toBe(true);
+    const closingOffset = swipeDismiss.translateY.value;
+
+    handlers.onBegin();
+    handlers.onUpdate({ translationY: 20 });
+    handlers.onEnd({ velocityY: 900 });
+    handlers.onFinalize({}, true);
+    expect(spring).toHaveBeenCalledTimes(1);
+    expect(swipeDismiss.translateY.value).toBe(closingOffset);
+    spring.mock.lastCall?.[2]?.(true);
+    expect(swipeDismiss.onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers an interrupted release spring without removing the route', () => {
+    const swipeDismiss = routeAnimation();
+    renderHook(() => useDrawerDismissGesture(makeOptions({ swipeDismiss })));
+    const handlers = latestHandlers();
+    handlers.onBegin();
+    handlers.onUpdate({ translationY: 180 });
+    handlers.onEnd({ velocityY: 0 });
+    spring.mock.lastCall?.[2]?.(false);
+    expect(swipeDismiss.isDismissing.value).toBe(false);
+    expect(swipeDismiss.translateY.value).toBe(0);
+    expect(swipeDismiss.onComplete).not.toHaveBeenCalled();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('returns a cancelled gesture home even when onEnd does not fire', () => {
+    const swipeDismiss = routeAnimation();
+    renderHook(() => useDrawerDismissGesture(makeOptions({ swipeDismiss })));
+    const handlers = latestHandlers();
+    handlers.onBegin();
+    handlers.onUpdate({ translationY: 80 });
+    handlers.onFinalize({}, false);
+    expect(swipeDismiss.translateY.value).toBe(0);
+    expect(swipeDismiss.isDismissing.value).toBe(false);
+    expect(swipeDismiss.onComplete).not.toHaveBeenCalled();
+  });
+
+  it('springs a short drag home without dismissing', () => {
+    const swipeDismiss = routeAnimation();
+    renderHook(() => useDrawerDismissGesture(makeOptions({ swipeDismiss })));
+    const handlers = latestHandlers();
+    handlers.onBegin();
+    handlers.onUpdate({ translationY: 70 });
+    handlers.onEnd({ velocityY: 100 });
+    handlers.onFinalize({}, true);
+    expect(swipeDismiss.translateY.value).toBe(0);
+    expect(swipeDismiss.isDismissing.value).toBe(false);
+    expect(swipeDismiss.onComplete).not.toHaveBeenCalled();
+  });
+
+  it('does not dismiss a drag that began below the top, even if scrolling reaches the top', () => {
+    const swipeDismiss = routeAnimation();
+    const scrollYSV = sv(100);
+    renderHook(() => useDrawerDismissGesture(makeOptions({ swipeDismiss, scrollYSV })));
+    const handlers = latestHandlers();
+    handlers.onBegin();
+    scrollYSV.value = 0;
+    handlers.onUpdate({ translationY: 200 });
+    handlers.onEnd({ velocityY: 1200 });
+    expect(swipeDismiss.translateY.value).toBe(0);
+    expect(swipeDismiss.isDismissing.value).toBe(false);
+    expect(swipeDismiss.onComplete).not.toHaveBeenCalled();
+  });
+
+  it('does not reverse direction when a long drag is released with upward velocity', () => {
+    const swipeDismiss = routeAnimation();
+    renderHook(() => useDrawerDismissGesture(makeOptions({ swipeDismiss })));
+    const handlers = latestHandlers();
+    handlers.onBegin();
+    handlers.onUpdate({ translationY: 180 });
+    handlers.onEnd({ velocityY: -50 });
+    expect(spring).toHaveBeenLastCalledWith(900, expect.objectContaining({ velocity: 0 }), expect.any(Function));
   });
 });

--- a/packages/mobile/src/components/play-drawer/use-drawer-dismiss-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-drawer-dismiss-gesture.ts
@@ -1,6 +1,6 @@
 import { useMemo, useRef, type ComponentType, type RefObject } from 'react';
 import { Gesture, type GestureType } from 'react-native-gesture-handler';
-import { useSharedValue, withSpring, runOnJS, type SharedValue } from 'react-native-reanimated';
+import { cancelAnimation, useSharedValue, withSpring, runOnJS, type SharedValue } from 'react-native-reanimated';
 import { springs } from '../../theme/animations';
 
 // Pull-down-to-dismiss for the full-screen player route. The route is a native
@@ -9,7 +9,8 @@ import { springs } from '../../theme/animations';
 // fired in the bare grabber region ("only works using the drag handle"). This
 // RNGH Pan lives in the same gesture tree as the scroll + board, so it can yield
 // to them and drive a dismiss from the WHOLE surface. The route sets
-// `gestureEnabled: false`; dismissal is `router.dismiss()` past the threshold.
+// `gestureEnabled: false`. A route-owned surface continues the release on the
+// UI thread and removes the route only once it is offscreen.
 //
 // Key wiring: the Pan is an ANCESTOR of the RNGH ScrollView, so it MUST declare
 // `.simultaneousWithExternalGesture(scrollRef)` — otherwise the native scroll
@@ -31,9 +32,19 @@ const DISMISS_DISTANCE_THRESHOLD = 110;
 /** Downward fling velocity (px/s) that commits a dismiss even on a short drag. */
 const DISMISS_VELOCITY_THRESHOLD = 600;
 
+export type SwipeDismissAnimation = {
+  translateY: SharedValue<number>;
+  height: SharedValue<number>;
+  isDismissing: SharedValue<boolean>;
+  /** Called after the surface has finished sliding offscreen. */
+  onComplete: () => void;
+};
+
 type UseDrawerDismissGestureOptions = {
   /** Dismiss the route (e.g. `router.dismiss`). */
   onDismiss: () => void;
+  /** The route moves its background and content as one surface. */
+  swipeDismiss?: SwipeDismissAnimation;
   /** Live scroll offset of the drawer's ScrollView. The dismiss only engages when
    *  the gesture starts at the very top (<= 0); anywhere else it's a scroll. */
   scrollYSV: SharedValue<number>;
@@ -59,13 +70,17 @@ type UseDrawerDismissGestureReturn = {
 
 export function useDrawerDismissGesture({
   onDismiss,
+  swipeDismiss,
   scrollYSV,
   scrollRef,
   swipeTranslateX,
   swipeIsAnimating,
 }: UseDrawerDismissGestureOptions): UseDrawerDismissGestureReturn {
-  const translateY = useSharedValue(0);
-  const isDismissing = useSharedValue(false);
+  const localTranslateY = useSharedValue(0);
+  const localIsDismissing = useSharedValue(false);
+  const translateY = swipeDismiss?.translateY ?? localTranslateY;
+  const isDismissing = swipeDismiss?.isDismissing ?? localIsDismissing;
+  const dismissHeight = swipeDismiss?.height;
   // Captured at touch-down: only a gesture that STARTS at the top can dismiss, so
   // a scroll-up that reaches the top doesn't suddenly yank the drawer down.
   const startedAtTop = useSharedValue(false);
@@ -73,7 +88,7 @@ export function useDrawerDismissGesture({
   // Captured ONCE by the gesture memo — must only close over the ref so a later
   // render's onDismiss is still reached (mirrors use-carousel-gesture).
   const onDismissRef = useRef(onDismiss);
-  onDismissRef.current = onDismiss;
+  onDismissRef.current = swipeDismiss?.onComplete ?? onDismiss;
   const commitDismiss = () => {
     onDismissRef.current();
   };
@@ -89,6 +104,8 @@ export function useDrawerDismissGesture({
       .failOffsetX([-DISMISS_FAIL_OFFSET_X, DISMISS_FAIL_OFFSET_X])
       .onBegin(() => {
         'worklet';
+        if (isDismissing.value) return;
+        cancelAnimation(translateY);
         startedAtTop.value = scrollYSV.value <= 0;
       })
       .onUpdate((event) => {
@@ -110,6 +127,7 @@ export function useDrawerDismissGesture({
       })
       .onEnd((event) => {
         'worklet';
+        if (isDismissing.value) return;
         // Same guard as onUpdate, and it must run BEFORE the velocity check: a fast
         // horizontal flick carries vertical velocity, so without this an accidental
         // down-component could satisfy velocityY > threshold and commit a dismiss
@@ -122,26 +140,43 @@ export function useDrawerDismissGesture({
           startedAtTop.value &&
           (translateY.value > DISMISS_DISTANCE_THRESHOLD || event.velocityY > DISMISS_VELOCITY_THRESHOLD);
         if (committed) {
-          // Hand off to the native route's slide-out; leave translateY where it is
-          // so the dismiss continues from the dragged position.
           isDismissing.value = true;
-          runOnJS(commitDismiss)();
+          if (dismissHeight) {
+            // Never pause at the release position waiting for navigation/JS.
+            // Continue this SAME transform, carrying the downward release speed.
+            translateY.value = withSpring(
+              Math.max(dismissHeight.value, translateY.value),
+              { ...springs.snappy, velocity: Math.max(0, event.velocityY), overshootClamping: true },
+              (finished) => {
+                if (finished) {
+                  runOnJS(commitDismiss)();
+                } else {
+                  isDismissing.value = false;
+                  translateY.value = withSpring(0, springs.interactive);
+                }
+              },
+            );
+          } else {
+            // Standalone hosts without a route-owned surface retain their close.
+            runOnJS(commitDismiss)();
+          }
         } else {
           translateY.value = withSpring(0, springs.interactive);
         }
       })
-      // The route normally unmounts after a committed dismiss, but a
-      // dismiss/re-navigate race on this live-behind `transparentModal` could
-      // leave the gesture alive with `isDismissing` stuck true — `onUpdate` would
-      // then early-return forever and the drawer could never be dragged again.
-      // Reset on finalize so the next drag always starts clean. (translateY is
-      // left as-is so a committed dismiss keeps sliding from the dragged offset.)
-      .onFinalize(() => {
+      // Finalize fires at finger-up, BEFORE the release spring completes. Keep
+      // its latch locked; a second touch must not interrupt a committed close.
+      // Cancellation (including a second finger) still returns an open drag home.
+      .onFinalize((_event, success) => {
         'worklet';
-        isDismissing.value = false;
+        if (!dismissHeight) {
+          isDismissing.value = false;
+          return;
+        }
+        if (!success && !isDismissing.value) translateY.value = withSpring(0, springs.interactive);
       });
     return scrollRef ? pan.simultaneousWithExternalGesture(scrollRef) : pan;
-  }, [translateY, isDismissing, startedAtTop, scrollYSV, scrollRef, swipeTranslateX, swipeIsAnimating]);
+  }, [translateY, isDismissing, dismissHeight, startedAtTop, scrollYSV, scrollRef, swipeTranslateX, swipeIsAnimating]);
 
   return { gesture, translateY };
 }

--- a/packages/mobile/src/components/play-drawer/use-play-swipe-dismiss.ts
+++ b/packages/mobile/src/components/play-drawer/use-play-swipe-dismiss.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useWindowDimensions, type LayoutChangeEvent } from 'react-native';
+import { useNavigation, useRouter } from 'expo-router';
+import { runOnJS, runOnUI, useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
+import { springs } from '../../theme/animations';
+import type { SwipeDismissAnimation } from './use-drawer-dismiss-gesture';
+
+/** Route-local motion: native open/button close, continuous UI-thread swipe close. */
+export function usePlaySwipeDismiss() {
+  const navigation = useNavigation();
+  const router = useRouter();
+  const { height: windowHeight } = useWindowDimensions();
+  const translateY = useSharedValue(0);
+  const height = useSharedValue(windowHeight);
+  const isDismissing = useSharedValue(false);
+  const mountedRef = useRef(false);
+  const removalRequestedRef = useRef(false);
+  const [offscreen, setOffscreen] = useState(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const onLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      height.value = event.nativeEvent.layout.height;
+    },
+    [height],
+  );
+
+  const onComplete = useCallback(() => {
+    if (!mountedRef.current || removalRequestedRef.current) return;
+    removalRequestedRef.current = true;
+    setOffscreen(true);
+  }, []);
+
+  useEffect(() => {
+    if (!offscreen) return;
+
+    // The surface is already offscreen. Commit the option update separately
+    // from removal, then give Fabric a frame to apply it to RNSScreen before
+    // popping. Never change options and dismiss in the same mounting batch:
+    // UIKit could otherwise start a second native slide with the old option.
+    navigation.setOptions({ animation: 'none' });
+    let frame = requestAnimationFrame(() => {
+      frame = requestAnimationFrame(() => {
+        if (!mountedRef.current) return;
+        if (navigation.isFocused()) {
+          router.dismiss();
+        } else {
+          // A different modal covered /play while JS was busy. Restore this
+          // player underneath it instead of popping that newer route.
+          navigation.setOptions({ animation: 'slide_from_bottom' });
+          translateY.value = withSpring(0, springs.interactive);
+          isDismissing.value = false;
+          removalRequestedRef.current = false;
+          setOffscreen(false);
+        }
+      });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [offscreen, navigation, router, translateY, isDismissing]);
+
+  const dismissNative = useCallback(() => {
+    if (!mountedRef.current) return;
+    if (navigation.isFocused()) router.dismiss();
+    else isDismissing.value = false;
+  }, [navigation, router, isDismissing]);
+
+  const close = useCallback(() => {
+    // A chevron tap retains the native close, but cannot race a released swipe.
+    runOnUI(() => {
+      'worklet';
+      if (isDismissing.value) return;
+      isDismissing.value = true;
+      runOnJS(dismissNative)();
+    })();
+  }, [isDismissing, dismissNative]);
+
+  const animatedStyle = useAnimatedStyle(() => ({ transform: [{ translateY: translateY.value }] }));
+  const swipeDismiss = useMemo<SwipeDismissAnimation>(
+    () => ({ translateY, height, isDismissing, onComplete }),
+    [translateY, height, isDismissing, onComplete],
+  );
+
+  return { swipeDismiss, animatedStyle, onLayout, close };
+}


### PR DESCRIPTION
## Summary

Releasing a downward swipe in the player held its position while JavaScript started a separate native close animation. Keep the entire player surface moving on the UI thread with the release velocity, then remove its route without a second slide. Opening, chevron dismissal, and programmatic sheet handoffs retain their native transitions.

The closing guard now survives finger-up, ignores repeated closes, and recovers from cancellation or a newer modal taking focus. The opaque backing and glass move with the board instead of remaining behind it.

Verification: 21 focused tests pass; lint, monorepo typecheck, iOS/Android Metro exports, and browser export pass. Both native fingerprints match the unchanged baseline, also confirmed by the PR's OTA compatibility check. The main CI aggregate is green.

The 2.5.0 iOS simulator build succeeded and its ProMotion flag is enabled. The simulator QA runner subsequently failed while activating the Simulator through System Events. An isolated Metro server was attempted to avoid another worktree's running server; simulator connectivity prevented completing live gesture QA. Physical iPhone frame timings and final gesture QA remain pending; this PR does not claim measured 120 fps.

Automated Claude review failed twice because its account has exhausted its weekly limit (reported reset: September 12, 07:00 UTC). No review was produced, so the PR remains a draft awaiting review and device QA.

The full mobile suite has 9,306 passing tests and 17 failures in `bluetooth-provider-virtual-wall.test.tsx`, with 42 unhandled rejections for a missing `consumeBackgroundAdoptSendGate` mock. An unchanged checkout at `38bf41c0f` reproduces the same 17 failures and 42 errors. That existing test failure blocks a fully green suite.

## Release Notes

Swipe the player closed in one continuous motion, without the pause after lifting your finger.

## Test plan

1. Climbs tab → open a climb → the player slides up.
2. Pull down one-fifth, release → player closes without pausing.
3. Make a short pull, release → player returns and responds.
4. Reopen, tap the chevron → player closes quickly.
5. Reopen, open Queue → sheet appears above the player.

## Risk

Risk: 3/5 — changes player dismissal and route teardown ordering.
