### PR TITLE
feat(ios): make performance captures reproducible

### DIFF
--- a/docs/ios-profiling.md
+++ b/docs/ios-profiling.md
@@ -1,0 +1,89 @@
+# Repeatable local iOS profiling
+
+`vp run mobile:profile:ios` builds in a fresh dedicated checkout, reserves an explicit simulator, checks the installed executable identity, and retains local evidence under `.boardsesh/`. It never resets app data or the simulator keychain. Use the local fixture account and backend; the runner rejects a non-local backend URL. Seed fixtures first; `--fixtures <manifest>` defaults to `.boardsesh/ios-performance-fixtures.json` and must describe at least 200 owned and 200 community playlists with real climbs. The manifest hash and non-secret fixture settings are recorded with each run.
+
+```sh
+EXPO_PUBLIC_BACKEND_URL=http://localhost:8198 \
+EXPO_PUBLIC_SCREENSHOT_MODE=1 \
+BOARDSESH_METRO_USE_WATCHMAN=1 \
+vp run mobile:profile:ios -- \
+  --udid <simulator-udid> \
+  --source-ref <commit-with-instrumentation> \
+  --configuration Release \
+  --run-dir .boardsesh/profile-baseline-release
+```
+
+Maestro must be installed and able to find a local JDK before any build starts. If Java is not on PATH, set `JAVA_HOME` to its installed location (for Homebrew JDK 21 on Apple Silicon, `/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home`). The runner checks `maestro --version` and does not download Java.
+
+Create a dedicated simulator in Xcode first and use its UDID throughout the comparison. `--checkout <path>` accepts an already prepared dedicated worktree, but refuses one containing a generated `packages/mobile/ios` project. Dependencies can be installed beforehand with `vp install`. The default creates a detached git worktree at the requested source ref and installs its dependencies. Checkouts and evidence remain available after failure.
+
+Use `--configuration Debug --port <free-port>` for React attribution and tracing capability checks. The runner excludes Expo's development launcher and menu using the dedicated checkout's `expo.autolinking.ios.exclude` configuration. It sets the generated React Native bundle provider to the chosen localhost port and verifies the native dependencies no longer contain the launcher/menu. These changes are local to the generated profiling build. Ordinary Release captures use an embedded bundle.
+
+The build helper can also be used independently without launching:
+
+```sh
+BOARDSESH_PROFILE_BUILD=1 \
+BOARDSESH_PROFILE_SOURCE_DIR=/path/to/fresh/profiling-checkout \
+BOARDSESH_IOS_BUILD_CACHE_DIR=/path/to/run/native-cache/build \
+vp run mobile:build-sim-app -- --configuration Release --app-out /path/to/run/app
+```
+
+The caller is responsible for preserving identical fixture, authentication, rendering, and instrumentation settings across baseline and candidate. Never compare an instrumented candidate with an uninstrumented baseline. Include at least 200 owned and 200 community playlists with real climbs for shelf population measurements.
+
+## Captures and validity
+
+The run manifest records the source commit, tracked patch, untracked source hashes, native fingerprint, build configuration, final generated input hashes, executable UUID and SHA256, embedded bundle SHA256, simulator UDID, Metro port, and owned process IDs. The installed application is checked both before and after capture. Foreign installation, an incomplete capture, or missing required samples marks the run invalid and preserves its artifacts.
+
+Debug navigation runs two warm-up four-tab loops followed by five measured loops. JavaScript callback gaps and React render durations are attribution evidence, not native UI FPS. The capture checks `Tracing.start` in a fresh process and records whether a trace completes. React renderer profiles and native `sample` remain explicit fallbacks; unavailable tracing is recorded, never called a completed trace.
+
+Release captures include ten process-cold, warm-cache launches and twenty browsing/background cycles in one process. Startup artifacts are written to the app's local Documents directory by `EXPO_PUBLIC_PROFILE_STARTUP=1`. Each launch must produce a new runtime ID. The host measures when the deferred artifact export becomes observable, which includes polling and export delay; it is not time to first displayed frame. The JS timestamps and native runtime markers retain separate clock labels.
+
+Memory sampling uses physical footprint at settled Home after each browsing/background cycle. A missing footprint or changed process invalidates the memory sequence. Run retained-object/allocation inspection separately and record distinct climb/render keys before changing any cache limit or claiming a leak. A simulator result does not establish a phone performance budget.
+
+## Ownership and cleanup
+
+Build commands acquire the shared cache lock before prebuild, cache changes, or CocoaPods work. A failed Xcode build fails even if an old `.app` exists. A new app export is staged and validated before the previous successful export is replaced.
+
+Simulator build/launch, screenshot, navigation, log, and shutdown commands share leases in `~/Library/Caches/boardsesh/simulator-leases`. A live foreign lease is refused. A stopped or incomplete lease is also refused: inspect the recorded owner and remove only that stale lease metadata before retrying. A long run's ownership is never stolen based only on its age. Child commands inherit the selected UDID and ownership token.
+
+For existing ad-hoc commands, select the same device explicitly:
+
+```sh
+BOARDSESH_IOS_SIMULATOR_UDID=<simulator-udid> vp run check:mobile-simulator
+BOARDSESH_IOS_SIMULATOR_UDID=<simulator-udid> vp run mobile:screenshot
+```
+
+Multi-device store screenshot runs must not inherit a lease for a different model; otherwise the tool refuses to label one simulator's images as another model. Screenshot installation preserves app data and keychain. If a capture needs a clean account, create a dedicated simulator or sign out through the app.
+
+Metro started by a profiling run is stopped only through its recorded owned process group. Ad-hoc shutdown no longer kills arbitrary listeners found by port. Stop an ad-hoc Metro through the terminal that started it. The selected simulator stays booted for inspection.
+
+`--host localhost`, `--host=localhost`, and `--localhost` now advertise localhost even when Tailscale is configured. `BOARDSESH_METRO_USE_WATCHMAN=1` explicitly checks Watchman availability; leaving it unset preserves Expo's default.
+
+## Local fixture seed
+
+The additive fixture script requires an explicit loopback database URL and the existing `test@boardsesh.com` account:
+
+```sh
+BOARDSESH_PROFILE_DATABASE_URL=postgresql://postgres:password@localhost:5432/main \
+vp exec tsx packages/db/scripts/seed-ios-performance.ts
+```
+
+It creates 200 owned and 200 public community playlists, each referencing twelve real Tension climbs. Repeating it preserves the same fixture identifiers. The local `.boardsesh/ios-performance-fixtures.json` records those identifiers, climb references, and their SHA256. Existing user data is preserved.
+
+Use `EXPO_PUBLIC_SCREENSHOT_USER_EMAIL=test@boardsesh.com` and `EXPO_PUBLIC_SCREENSHOT_USER_PASSWORD=test` with the local screenshot mode if automatic fixture login is needed. The local backend must have its development authentication secret configured. Select the same board, angle, language, and rendering mode in both runs.
+
+The `performance.now()` values exported by this RN version can be monotonic uptime values. Derive durations by subtracting marks within the same launch; do not interpret a raw mark as milliseconds since process creation or compare raw marks across launches. A visible Home commit is also distinct from the native screen displaying its pixels.
+
+The runner records completed overlay filenames from the app's existing `board-thumbnails` cache. Unique trailing hashes distinguish frame/color signatures, while full filenames include board configuration, style, and resolution. These are render-cache observations, not counts of retained objects or exact climb UUIDs. Keep allocation inspection separate from the launch and navigation measurements.
+
+The supported Debug exclusion follows [Expo's autolinking configuration](https://docs.expo.dev/modules/autolinking/). Interpret [React Native DevTools profiles](https://reactnative.dev/docs/react-native-devtools) alongside native tools; JavaScript timings do not replace displayed-frame measurements.
+
+For post-profiling smoke validation, reuse the verified export without another build or Expo's implicit Metro selection:
+
+```sh
+BOARDSESH_IOS_SIMULATOR_UDID=<simulator-udid> \
+BOARDSESH_IOS_SMOKE_APP_PATH=/path/to/run/app/Boardsesh.app \
+vp run check:mobile-simulator
+```
+
+This opt-in mode validates the existing executable and bundle identity, installs in place, and launches the plist's bundle identifier on the leased device before the normal log smoke check. Leave `BOARDSESH_IOS_SMOKE_APP_PATH` unset for the usual build-and-launch flow. A Debug export still requires its selected Metro server to be running.

--- a/docs/ios-profiling.md
+++ b/docs/ios-profiling.md
@@ -36,7 +36,11 @@ The run manifest records the source commit, tracked patch, untracked source hash
 
 Debug navigation runs two warm-up four-tab loops followed by five measured loops. JavaScript callback gaps and React render durations are attribution evidence, not native UI FPS. The capture checks `Tracing.start` in a fresh process and records whether a trace completes. React renderer profiles and native `sample` remain explicit fallbacks; unavailable tracing is recorded, never called a completed trace.
 
+Debug capture selects an exact app identifier from Metro's registered runtimes and refuses ambiguous targets or debugger URLs outside the selected localhost port. A transport timeout or an unfinished trace aborts the run: tracing overhead must not silently remain active during the measured loops. A Watchman binary can be installed while its operating-system watcher still fails; retain that startup as invalid, preserve unrelated watchers, and verify the source identity again after recovery.
+
 Release captures include ten process-cold, warm-cache launches and twenty browsing/background cycles in one process. Startup artifacts are written to the app's local Documents directory by `EXPO_PUBLIC_PROFILE_STARTUP=1`. Each launch must produce a new runtime ID. The host measures when the deferred artifact export becomes observable, which includes polling and export delay; it is not time to first displayed frame. The JS timestamps and native runtime markers retain separate clock labels.
+
+The selected source ref must include the mobile startup collector, introduced separately from the tooling in [the feedback/startup PR](https://github.com/boardsesh/boardsesh/pull/5328). The runner checks this prerequisite before a native build. The collector is opt-in, keeps one mark per phase, and replaces a fixed local export file rather than appending telemetry.
 
 Memory sampling uses physical footprint at settled Home after each browsing/background cycle. A missing footprint or changed process invalidates the memory sequence. Run retained-object/allocation inspection separately and record distinct climb/render keys before changing any cache limit or claiming a leak. A simulator result does not establish a phone performance budget.
 

--- a/packages/db/scripts/seed-ios-performance.ts
+++ b/packages/db/scripts/seed-ios-performance.ts
@@ -1,0 +1,105 @@
+/** Local-only, additive fixtures for the iOS performance comparison. */
+import { createHash } from 'node:crypto';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { and, asc, eq, inArray } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { boardClimbs, playlistClimbs, playlistOwnership, playlists, users } from '../src/schema/index';
+
+async function main() {
+  const databaseUrl = process.env.BOARDSESH_PROFILE_DATABASE_URL;
+  if (!databaseUrl || !['localhost', '127.0.0.1', '[::1]'].includes(new URL(databaseUrl).hostname)) {
+    throw new Error('Set BOARDSESH_PROFILE_DATABASE_URL to the explicitly selected loopback fixture database.');
+  }
+  const connection = postgres(databaseUrl, { max: 1 });
+  const db = drizzle(connection);
+  try {
+    const [testUser] = await db.select({ id: users.id }).from(users).where(eq(users.email, 'test@boardsesh.com'));
+    if (!testUser) throw new Error('The local test@boardsesh.com fixture account must exist first.');
+    const climbs = await db
+      .select({ uuid: boardClimbs.uuid, name: boardClimbs.name, layoutId: boardClimbs.layoutId })
+      .from(boardClimbs)
+      .where(and(eq(boardClimbs.boardType, 'tension'), eq(boardClimbs.isDraft, false), eq(boardClimbs.isListed, true)))
+      .orderBy(asc(boardClimbs.uuid))
+      .limit(12);
+    if (climbs.length < 12) throw new Error('Load the real Tension climb catalogue before seeding.');
+    const communityOwnerId = 'ios-performance-community-fixture-v1';
+    const fixedTimestamp = new Date('2026-09-08T00:00:00Z');
+    const fixtureUuids: string[] = [];
+    await db.transaction(async (transaction) => {
+      await transaction
+        .insert(users)
+        .values({
+          id: communityOwnerId,
+          name: 'Local performance crew',
+          email: 'ios-performance-fixture@example.invalid',
+          createdAt: fixedTimestamp,
+          updatedAt: fixedTimestamp,
+        })
+        .onConflictDoNothing();
+      for (const shelf of ['owned', 'community'] as const) {
+        for (let index = 0; index < 200; index++) {
+          const ordinal = String(index + 1).padStart(3, '0');
+          const uuid = `ios-performance-v1-${shelf}-${ordinal}`;
+          fixtureUuids.push(uuid);
+          await transaction
+            .insert(playlists)
+            .values({
+              uuid,
+              boardType: 'tension',
+              layoutId: null,
+              name: `Performance ${shelf} ${ordinal}`,
+              description: 'Local deterministic fixture with real Tension climbs.',
+              isPublic: shelf === 'community',
+              createdAt: new Date(fixedTimestamp.getTime() + index * 1000),
+              updatedAt: new Date(fixedTimestamp.getTime() + index * 1000),
+            })
+            .onConflictDoNothing();
+          const [playlist] = await transaction
+            .select({ id: playlists.id })
+            .from(playlists)
+            .where(eq(playlists.uuid, uuid));
+          if (!playlist) throw new Error(`Fixture insert missing: ${uuid}`);
+          await transaction
+            .insert(playlistOwnership)
+            .values({
+              playlistId: playlist.id,
+              userId: shelf === 'owned' ? testUser.id : communityOwnerId,
+              role: 'owner',
+            })
+            .onConflictDoNothing();
+          await transaction
+            .insert(playlistClimbs)
+            .values(
+              climbs.map((climb, position) => ({
+                playlistId: playlist.id,
+                climbUuid: climb.uuid,
+                angle: 40,
+                position,
+              })),
+            )
+            .onConflictDoNothing();
+        }
+      }
+    });
+    const seededPlaylists = await db
+      .select({ uuid: playlists.uuid })
+      .from(playlists)
+      .where(inArray(playlists.uuid, fixtureUuids));
+    if (seededPlaylists.length !== 400) throw new Error('Incomplete fixture set.');
+    const identity = { version: 1, boardType: 'tension', angle: 40, owned: 200, community: 200, climbs, fixtureUuids };
+    const artifact = { ...identity, sha256: createHash('sha256').update(JSON.stringify(identity)).digest('hex') };
+    const outputDirectory = resolve(process.cwd(), '.boardsesh');
+    mkdirSync(outputDirectory, { recursive: true });
+    writeFileSync(resolve(outputDirectory, 'ios-performance-fixtures.json'), JSON.stringify(artifact, null, 2));
+    console.log(`Local fixture ready: 200 owned + 200 community playlists, 12 real climbs each; ${artifact.sha256}`);
+  } finally {
+    await connection.end();
+  }
+}
+
+void main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/packages/mobile/metro-watchman.cjs
+++ b/packages/mobile/metro-watchman.cjs
@@ -1,0 +1,13 @@
+const { spawnSync } = require('node:child_process');
+
+/** Opt-in only: preserve Expo defaults and fail clearly when Watchman is absent. */
+function configureWatchman(config, env = process.env, run = spawnSync) {
+  if (env.BOARDSESH_METRO_USE_WATCHMAN !== '1') return;
+  const watchman = run('watchman', ['--version'], { encoding: 'utf8', timeout: 5000 });
+  if (watchman.status !== 0) {
+    throw new Error('BOARDSESH_METRO_USE_WATCHMAN=1 requires an available Watchman installation.');
+  }
+  config.resolver.useWatchman = true;
+}
+
+module.exports = { configureWatchman };

--- a/packages/mobile/metro.config.js
+++ b/packages/mobile/metro.config.js
@@ -4,6 +4,7 @@
 // unchanged.
 const { getSentryExpoConfig } = require('@sentry/react-native/metro');
 const path = require('path');
+const { configureWatchman } = require('./metro-watchman.cjs');
 const { applyExpoWebResponseHeaders } = require('./expo-web-response-headers.cjs');
 const { resolveWebRuntimeModulePath } = require('./metro-web-runtime-resolution.cjs');
 
@@ -13,6 +14,8 @@ const monorepoRoot = path.resolve(projectRoot, '../..');
 const config = getSentryExpoConfig(projectRoot);
 
 config.watchFolders = [monorepoRoot];
+
+configureWatchman(config);
 
 function escapedPathPattern(filePath) {
   return path

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-virtual-wall.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-virtual-wall.test.tsx
@@ -58,6 +58,7 @@ const bluetooth = vi.hoisted(() => {
       connect: vi.fn(async () => true),
       disconnect: vi.fn(async () => {}),
       sendFramesToBoard: vi.fn<SendFramesToBoard>(async () => true),
+      consumeBackgroundAdoptSendGate: vi.fn(() => false),
       pickerState: null as PickerState | null,
       reconnectSerialForCurrentBoard: null,
       connectInitialSendRef: { current: null as { frames: string; mirrored: boolean; colorSignature: string } | null },

--- a/scripts/__tests__/ios-profiling-tools.test.ts
+++ b/scripts/__tests__/ios-profiling-tools.test.ts
@@ -1,0 +1,360 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { exportBuiltApp } from '../lib/ios-build-export';
+import { resolveMetroHostname } from '../lib/metro-host';
+import { acquireSimulatorLease, guardSimulatorCommand, selectSimulatorUdid } from '../lib/ios-simulator-lease';
+import {
+  assertMatchingIdentity,
+  hasUsefulStartupArtifact,
+  validateCaptureFiles,
+  type IosAppIdentity,
+} from '../lib/ios-profile-identity';
+import { extractIosDeviceArgs } from '../mobile-ios-run';
+import { parseProfileArgs } from '../mobile-profile-ios';
+
+const scratch: string[] = [];
+const udid = '561A4D7D-12C6-4B27-A956-A69C4436F4BE';
+function directory(): string {
+  const path = mkdtempSync(join(tmpdir(), 'boardsesh-profile-test-'));
+  scratch.push(path);
+  return path;
+}
+afterEach(() => {
+  for (const path of scratch.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe('Metro host resolution', () => {
+  it.each([['--host', 'localhost'], ['--host=localhost'], ['--localhost']])('advertises loopback for %j', (...args) => {
+    const fallback = vi.fn(() => ({ hostname: 'host.ts.net', source: 'tailscale' as const }));
+    expect(resolveMetroHostname(args, fallback).hostname).toBe('localhost');
+    expect(fallback).not.toHaveBeenCalled();
+  });
+  it('keeps the default resolver for LAN', () => {
+    expect(resolveMetroHostname(['--lan'], () => ({ hostname: 'host.ts.net', source: 'tailscale' })).hostname).toBe(
+      'host.ts.net',
+    );
+  });
+});
+
+describe('validated build exports', () => {
+  it('never publishes a stale product after a failed build', () => {
+    const root = directory();
+    const built = join(root, 'built.app');
+    const exported = join(root, 'out/Boardsesh.app');
+    mkdirSync(built);
+    mkdirSync(exported, { recursive: true });
+    writeFileSync(join(built, 'Info.plist'), 'plist');
+    writeFileSync(join(built, 'Boardsesh'), 'stale');
+    writeFileSync(join(exported, 'Boardsesh'), 'previous good');
+    expect(() => exportBuiltApp(65, built, join(root, 'out'))).toThrow(/refusing any pre-existing/);
+    expect(readFileSync(join(exported, 'Boardsesh'), 'utf8')).toBe('previous good');
+  });
+  it('preserves the prior export when a successful build produced an incomplete app', () => {
+    const root = directory();
+    mkdirSync(join(root, 'out/Boardsesh.app'), { recursive: true });
+    writeFileSync(join(root, 'out/Boardsesh.app/Boardsesh'), 'previous');
+    expect(() => exportBuiltApp(0, join(root, 'missing.app'), join(root, 'out'))).toThrow(/complete/);
+    expect(readFileSync(join(root, 'out/Boardsesh.app/Boardsesh'), 'utf8')).toBe('previous');
+  });
+  it('publishes a validated successful build', () => {
+    const root = directory();
+    const built = join(root, 'built.app');
+    mkdirSync(built);
+    writeFileSync(join(built, 'Info.plist'), 'plist');
+    writeFileSync(join(built, 'Boardsesh'), 'new');
+    const destination = exportBuiltApp(0, built, join(root, 'out'));
+    expect(readFileSync(join(destination, 'Boardsesh'), 'utf8')).toBe('new');
+  });
+});
+
+describe('simulator ownership', () => {
+  it('refuses foreign active ownership, including old leases', () => {
+    const root = directory();
+    const leases = join(root, 'leases');
+    const lease = acquireSimulatorLease(udid, root, leases);
+    expect(() => acquireSimulatorLease(udid, directory(), leases)).toThrow(/leased by/);
+    lease.release();
+    expect(existsSync(join(leases, `${udid}.lock`))).toBe(false);
+  });
+  it('allows explicit inherited ownership without releasing its parent', () => {
+    const root = directory();
+    const leases = join(root, 'leases');
+    const parent = acquireSimulatorLease(udid, root, leases);
+    const child = acquireSimulatorLease(udid, root, leases, parent.owner.token);
+    child.release();
+    expect(existsSync(join(leases, `${udid}.lock`))).toBe(true);
+    parent.release();
+  });
+  it('does not steal an incomplete lease', () => {
+    const root = directory();
+    const leases = join(root, 'leases');
+    mkdirSync(join(leases, `${udid}.lock`), { recursive: true });
+    expect(() => acquireSimulatorLease(udid, root, leases)).toThrow(/incomplete lease/);
+  });
+  it('rejects ambiguous booted selection at the command boundary', () => {
+    expect(() => guardSimulatorCommand('xcrun', ['simctl', 'shutdown', 'booted'], directory())).toThrow(
+      /explicit UDID/,
+    );
+  });
+  it('does not select the only booted simulator when a different device was requested', () => {
+    const devices = [{ udid, name: 'Someone else simulator', state: 'Booted' }];
+    expect(() => selectSimulatorUdid(devices, 'Owned simulator')).toThrow(/Select exactly one/);
+    expect(selectSimulatorUdid(devices, udid)).toBe(udid);
+  });
+  it('leaves Android Maestro commands alone', () => {
+    expect(() => guardSimulatorCommand('maestro', ['--device', 'emulator-5554', 'test'], directory())).not.toThrow();
+  });
+});
+
+const identity: IosAppIdentity = {
+  bundleIdentifier: 'app',
+  executableUuid: 'uuid',
+  executableSha256: 'binary',
+  embeddedBundleSha256: 'bundle',
+};
+describe('capture validity', () => {
+  it.each(['executableUuid', 'executableSha256', 'embeddedBundleSha256', 'bundleIdentifier'] as const)(
+    'rejects a changed %s',
+    (field) => {
+      expect(() => assertMatchingIdentity(identity, { ...identity, [field]: 'foreign' })).toThrow(/identity changed/);
+    },
+  );
+  it('rejects incomplete captures', () => {
+    expect(() => validateCaptureFiles({}, { valid: false })).toThrow(/incomplete/);
+    expect(() => validateCaptureFiles({}, {})).toThrow(/incomplete/);
+    expect(() => validateCaptureFiles(null, { valid: true })).toThrow(/missing/);
+    expect(() => validateCaptureFiles({}, { valid: true })).toThrow(/incomplete/);
+  });
+  it('requires an explicit simulator for profiling', () => {
+    expect(() => parseProfileArgs(['--udid', 'booted'])).toThrow(/explicitly owned/);
+    expect(parseProfileArgs(['--udid', udid, '--configuration', 'Debug', '--port', '8097']).port).toBe(8097);
+  });
+  it.each([['--device', udid], ['-d', udid], [`--device=${udid}`]])('normalizes Expo device flags %j', (...flags) => {
+    expect(extractIosDeviceArgs(['--no-bundler', ...flags])).toEqual({ requested: udid, remaining: ['--no-bundler'] });
+  });
+});
+
+const require = createRequire(import.meta.url);
+const { configureWatchman } = require('../../packages/mobile/metro-watchman.cjs') as {
+  configureWatchman: (
+    config: { resolver: { useWatchman: boolean | null } },
+    env: Record<string, string>,
+    run: () => { status: number | null },
+  ) => void;
+};
+describe('Watchman opt-in', () => {
+  it('does not probe or alter Expo defaults when disabled', () => {
+    const config = { resolver: { useWatchman: null } };
+    const probe = vi.fn(() => ({ status: 0 }));
+    configureWatchman(config, {}, probe);
+    expect(config.resolver.useWatchman).toBeNull();
+    expect(probe).not.toHaveBeenCalled();
+  });
+  it('fails explicitly when Watchman is unavailable', () => {
+    expect(() =>
+      configureWatchman({ resolver: { useWatchman: null } }, { BOARDSESH_METRO_USE_WATCHMAN: '1' }, () => ({
+        status: null,
+      })),
+    ).toThrow(/available Watchman/);
+  });
+  it('enables available Watchman only when requested', () => {
+    const config = { resolver: { useWatchman: null } };
+    configureWatchman(config, { BOARDSESH_METRO_USE_WATCHMAN: '1' }, () => ({ status: 0 }));
+    expect(config.resolver.useWatchman).toBe(true);
+  });
+});
+
+describe('complete comparison sample counts', () => {
+  const navigation = Array.from({ length: 20 }, (_, index) => ({
+    loop: Math.floor(index / 4) + 1,
+    route: ['home', 'climbs', 'discover', 'profile'][index % 4],
+    observation: { gaps: [16.7] },
+    routeConfirmed: true,
+    nativeSampleComplete: true,
+  }));
+  const debug = { configuration: 'Debug', warmupLoops: 2, measuredLoops: 5, navigation };
+  const verdict = { valid: true, completed: true, configuration: 'Debug' };
+  it('accepts all five measured loops after two warmups', () => {
+    expect(() => validateCaptureFiles(debug, verdict)).not.toThrow();
+  });
+  it('rejects missing loops and callback observations', () => {
+    expect(() => validateCaptureFiles({ ...debug, navigation: navigation.slice(1) }, verdict)).toThrow(
+      /Incomplete Debug/,
+    );
+    expect(() =>
+      validateCaptureFiles(
+        { ...debug, navigation: navigation.map((entry) => ({ ...entry, observation: { gaps: [] } })) },
+        verdict,
+      ),
+    ).toThrow(/Invalid navigation/);
+  });
+  it('rejects missing Release launches and memory samples even with a successful verdict', () => {
+    expect(() =>
+      validateCaptureFiles(
+        { configuration: 'Release', launches: [], memory: [] },
+        { valid: true, completed: true, configuration: 'Release' },
+      ),
+    ).toThrow(/Incomplete Release/);
+  });
+});
+
+function releaseCapture() {
+  return {
+    configuration: 'Release',
+    launches: Array.from({ length: 10 }, (_, index) => ({
+      trial: index + 1,
+      hostExportObservedMs: 2500,
+      artifact: {
+        runId: `runtime-${index + 1}`,
+        marks: [{ name: 'home.useful.commit', timestampMs: 1500, outcome: 'content' }],
+      },
+    })),
+    memory: Array.from({ length: 20 }, (_, index) => ({ cycle: index + 1, pid: 1234, footprintMiB: 250 })),
+  };
+}
+const releaseVerdict = { valid: true, completed: true, configuration: 'Release' };
+
+describe('Release artifact integrity', () => {
+  it('accepts ten distinct useful launches and twenty cycles in one process', () => {
+    expect(() => validateCaptureFiles(releaseCapture(), releaseVerdict)).not.toThrow();
+  });
+  it.each(['content', 'empty', 'offline', 'error'])('accepts the visible %s outcome', (outcome) => {
+    expect(
+      hasUsefulStartupArtifact({ runId: 'runtime', marks: [{ name: 'home.useful.commit', timestampMs: 0, outcome }] }),
+    ).toBe(true);
+  });
+  it.each([null, {}, [], { runId: 'runtime' }, { runId: 'runtime', marks: [null] }])(
+    'rejects malformed artifact %j',
+    (artifact) => {
+      expect(hasUsefulStartupArtifact(artifact)).toBe(false);
+      const recorded = releaseCapture();
+      expect(() =>
+        validateCaptureFiles(
+          {
+            ...recorded,
+            launches: recorded.launches.map((launch, index) => (index === 0 ? { ...launch, artifact } : launch)),
+          },
+          releaseVerdict,
+        ),
+      ).toThrow(/Invalid or stale/);
+    },
+  );
+  it.each(['', ' ', '\t\n'])('rejects empty runtime identity %j', (runId) => {
+    const recorded = releaseCapture();
+    recorded.launches[0].artifact.runId = runId;
+    expect(() => validateCaptureFiles(recorded, releaseVerdict)).toThrow(/Invalid or stale/);
+  });
+  it.each([NaN, Infinity, -Infinity, -1, undefined, null, '1500'])(
+    'rejects invalid useful timestamp %j',
+    (timestampMs) => {
+      const recorded = releaseCapture();
+      const artifact = {
+        runId: 'runtime-first',
+        marks: [{ name: 'home.useful.commit', timestampMs, outcome: 'content' }],
+      };
+      expect(hasUsefulStartupArtifact(artifact)).toBe(false);
+      expect(() =>
+        validateCaptureFiles(
+          { ...recorded, launches: [{ ...recorded.launches[0], artifact }, ...recorded.launches.slice(1)] },
+          releaseVerdict,
+        ),
+      ).toThrow(/Invalid or stale/);
+    },
+  );
+  it.each([
+    [],
+    [{ name: 'root.commit', timestampMs: 10 }],
+    [{ name: 'home.useful.commit', timestampMs: 10, outcome: 'loading' }],
+    [{ name: 'home.useful.commit', timestampMs: 10 }],
+    [
+      { name: 'home.useful.commit', timestampMs: 10, outcome: 'content' },
+      { name: 'home.useful.commit', timestampMs: 20, outcome: 'empty' },
+    ],
+  ])('rejects missing, loading, or ambiguous useful commits %j', (...marks) => {
+    // Vitest spreads array table rows; restore the artifact marks array.
+    const recorded = releaseCapture();
+    expect(() =>
+      validateCaptureFiles(
+        {
+          ...recorded,
+          launches: [
+            { ...recorded.launches[0], artifact: { runId: 'runtime-first', marks } },
+            ...recorded.launches.slice(1),
+          ],
+        },
+        releaseVerdict,
+      ),
+    ).toThrow(/Invalid or stale/);
+  });
+  it('rejects a reused launch runtime and a changed memory process', () => {
+    const stale = releaseCapture();
+    stale.launches[1].artifact.runId = stale.launches[0].artifact.runId;
+    expect(() => validateCaptureFiles(stale, releaseVerdict)).toThrow(/Invalid or stale/);
+    const switched = releaseCapture();
+    switched.memory[10].pid += 1;
+    expect(() => validateCaptureFiles(switched, releaseVerdict)).toThrow(/changed process/);
+  });
+});
+
+function debugCapture() {
+  return {
+    configuration: 'Debug',
+    warmupLoops: 2,
+    measuredLoops: 5,
+    capability: { react: { available: true, complete: true }, nativeSample: { complete: true } },
+    navigation: Array.from({ length: 20 }, (_, index) => ({
+      loop: Math.floor(index / 4) + 1,
+      route: ['home', 'climbs', 'discover', 'profile'][index % 4],
+      routeConfirmed: true,
+      nativeSampleComplete: false,
+      observation: { gaps: [16.7] },
+    })),
+  };
+}
+const debugVerdict = { valid: true, completed: true, configuration: 'Debug' };
+
+describe('Debug attribution and navigation integrity', () => {
+  it('accepts complete React attribution without native sampling', () => {
+    expect(() => validateCaptureFiles(debugCapture(), debugVerdict)).not.toThrow();
+  });
+  it('accepts all complete in-scenario native samples as an explicit React fallback', () => {
+    const recorded = debugCapture();
+    recorded.capability.react = { available: false, complete: false };
+    for (const observation of recorded.navigation) observation.nativeSampleComplete = true;
+    expect(() => validateCaptureFiles(recorded, debugVerdict)).not.toThrow();
+  });
+  it.each([false, undefined, 'true'])('rejects an unconfirmed destination %j', (routeConfirmed) => {
+    const recorded = debugCapture();
+    expect(() =>
+      validateCaptureFiles(
+        {
+          ...recorded,
+          navigation: recorded.navigation.map((observation, index) =>
+            index === 7 ? { ...observation, routeConfirmed } : observation,
+          ),
+        },
+        debugVerdict,
+      ),
+    ).toThrow(/Invalid navigation/);
+  });
+  it.each([
+    {},
+    { react: { available: true } },
+    { react: { available: true, complete: false }, nativeSample: { complete: true } },
+    { react: { available: false, complete: true } },
+  ])('rejects missing attribution despite an idle terminal sample %j', (capability) => {
+    expect(() => validateCaptureFiles({ ...debugCapture(), capability }, debugVerdict)).toThrow(
+      /neither complete React/,
+    );
+  });
+  it('rejects one incomplete scenario when React attribution is unavailable', () => {
+    const recorded = debugCapture();
+    recorded.capability.react = { available: false, complete: false };
+    for (const observation of recorded.navigation) observation.nativeSampleComplete = true;
+    recorded.navigation[12].nativeSampleComplete = false;
+    expect(() => validateCaptureFiles(recorded, debugVerdict)).toThrow(/neither complete React/);
+  });
+});

--- a/scripts/__tests__/mobile-ios-run.test.ts
+++ b/scripts/__tests__/mobile-ios-run.test.ts
@@ -217,18 +217,15 @@ describe('acquireBuildLock', () => {
     expect(existsSync(paths.lockPath)).toBe(false);
   });
 
-  it('replaces stale lock directories', () => {
+  it('does not steal an old lock from a potentially live build', () => {
     const tempDir = makeTempDir();
     const paths = makePaths(tempDir);
     mkdirSync(paths.lockPath, { recursive: true });
     const staleTime = new Date(clock.now() - 13 * 60 * 60 * 1000);
     utimesSync(paths.lockPath, staleTime, staleTime);
 
-    const lock = acquireBuildLock(paths, nodeFileSystem, clock);
-
-    expect(lock.path).toBe(paths.lockPath);
-    expect(readFileSync(join(paths.lockPath, 'owner.txt'), 'utf8')).toContain('sharedBuildPath=');
-    lock.release();
+    expect(() => acquireBuildLock(paths, nodeFileSystem, clock)).toThrow(/another Boardsesh iOS build/);
+    expect(existsSync(paths.lockPath)).toBe(true);
   });
 });
 

--- a/scripts/__tests__/mobile-profile-capture.test.ts
+++ b/scripts/__tests__/mobile-profile-capture.test.ts
@@ -1,0 +1,139 @@
+import http from 'node:http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  CdpClient,
+  distribution,
+  physicalFootprintMiB,
+  selectDebuggerTarget,
+  usefulStartup,
+} from '../mobile-profile-capture';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('profiling measurement validity', () => {
+  it('rejects stale, loading, and malformed startup artifacts', () => {
+    const artifact = { runId: 'current', marks: [{ name: 'home.useful.commit', timestampMs: 12, outcome: 'content' }] };
+    expect(usefulStartup(artifact, 'previous')).toBe(true);
+    expect(usefulStartup(artifact, 'current')).toBe(false);
+    expect(usefulStartup({ ...artifact, marks: [{ name: 'root.commit', timestampMs: 1 }] }, null)).toBe(false);
+    expect(usefulStartup(null, null)).toBe(false);
+    for (const outcome of ['empty', 'offline', 'error'])
+      expect(
+        usefulStartup({ ...artifact, marks: [{ name: 'home.useful.commit', timestampMs: 12, outcome }] }, null),
+      ).toBe(true);
+  });
+  it('distinguishes physical footprint from RSS and peak footprint', () => {
+    expect(physicalFootprintMiB('Physical footprint:         195.7M\nPhysical footprint (peak): 294.3M')).toBe(195.7);
+    expect(physicalFootprintMiB('Physical footprint: 1.5G')).toBe(1536);
+    expect(physicalFootprintMiB('Physical footprint: 1024K')).toBe(1);
+    expect(physicalFootprintMiB('RSS: 123M\nPhysical footprint (peak): 294.3M')).toBeNull();
+  });
+  it('retains individual sample order and reports nearest-rank distributions', () => {
+    expect(distribution([3, 1, 2])).toEqual({ samples: [3, 1, 2], count: 3, min: 1, median: 2, p95: 3, max: 3 });
+    expect(distribution([]).median).toBeNull();
+  });
+});
+
+describe('Metro debugger target selection', () => {
+  const selectedApp = 'com.boardsesh.app';
+  const runtime = {
+    appId: selectedApp,
+    title: 'Boardsesh [React Native Bridgeless]',
+    webSocketDebuggerUrl: 'ws://localhost:8097/inspector/debug?device=owned&page=1',
+  };
+
+  it('selects the actual React Native title without requiring the word Hermes', () => {
+    expect(selectDebuggerTarget([runtime], selectedApp)).toBe(runtime);
+  });
+
+  it('uses the exact app identifier instead of a Hermes title or a shared prefix', () => {
+    const developmentRuntime = {
+      ...runtime,
+      appId: 'com.boardsesh.app.dev',
+      title: 'Hermes React Native',
+      webSocketDebuggerUrl: 'ws://localhost:8097/inspector/debug?device=foreign&page=1',
+    };
+    expect(selectDebuggerTarget([developmentRuntime, runtime], selectedApp)).toBe(runtime);
+    expect(selectDebuggerTarget([runtime, developmentRuntime], developmentRuntime.appId)).toBe(developmentRuntime);
+    expect(selectDebuggerTarget([developmentRuntime], selectedApp)).toBeUndefined();
+  });
+
+  it('refuses multiple registered runtimes for the same application', () => {
+    const secondRuntime = {
+      ...runtime,
+      webSocketDebuggerUrl: 'ws://localhost:8097/inspector/debug?device=second&page=1',
+    };
+    expect(() => selectDebuggerTarget([runtime, secondRuntime], selectedApp)).toThrow(/Multiple runtimes.*ambiguous/);
+  });
+
+  it('ignores malformed entries without selecting an unrelated application', () => {
+    expect(
+      selectDebuggerTarget(
+        [
+          null,
+          'Hermes',
+          42,
+          {},
+          { appId: selectedApp },
+          { appId: selectedApp, webSocketDebuggerUrl: 123 },
+          { ...runtime, appId: 'com.example.app' },
+        ],
+        selectedApp,
+      ),
+    ).toBeUndefined();
+  });
+
+  it.each([null, undefined, {}, 'Hermes'])('rejects a malformed target-list response: %j', (targets) => {
+    expect(() => selectDebuggerTarget(targets, selectedApp)).toThrow(/Invalid Metro debugger target list/);
+  });
+});
+
+describe('CDP connection ownership and Origin', () => {
+  it.each(['ws://other-host.example:8097/inspector/debug', 'ws://localhost:8081/inspector/debug'])(
+    'rejects a debugger endpoint outside the selected Metro: %s',
+    async (endpoint) => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          json: async () => [{ appId: 'com.boardsesh.app', webSocketDebuggerUrl: endpoint }],
+        })),
+      );
+      await expect(CdpClient.connect(8097)).rejects.toThrow(/outside the selected local Metro/);
+    },
+  );
+
+  it("supplies Metro's required localhost Origin to the actual WebSocket handshake", async () => {
+    const port = 8097;
+    const endpoint = `ws://localhost:${port}/inspector/debug?device=fixture&page=1`;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        json: async () => [
+          {
+            appId: 'com.boardsesh.app.dev',
+            title: 'Boardsesh [React Native Bridgeless]',
+            webSocketDebuggerUrl: endpoint,
+          },
+        ],
+      })),
+    );
+    // Exercise the pinned ws constructor, intercepting only its HTTP transport.
+    // This catches an omitted Origin without binding a port or using Metro/RN.
+    const interceptedTransport = new Error('Fixture intercepted the HTTP upgrade before network I/O.');
+    let upgradeOptions: unknown;
+    vi.spyOn(http, 'request').mockImplementation((options: unknown) => {
+      upgradeOptions = options;
+      throw interceptedTransport;
+    });
+    await expect(CdpClient.connect(port, 'com.boardsesh.app.dev')).rejects.toBe(interceptedTransport);
+    expect(upgradeOptions).toMatchObject({
+      host: 'localhost',
+      port: String(port),
+      path: '/inspector/debug?device=fixture&page=1',
+      headers: { Origin: `http://localhost:${port}`, Upgrade: 'websocket' },
+    });
+  });
+});

--- a/scripts/lib/ios-build-export.ts
+++ b/scripts/lib/ios-build-export.ts
@@ -1,0 +1,40 @@
+import { cpSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+export function assertSuccessfulBuild(status: number, appPath: string): void {
+  if (status !== 0)
+    throw new Error(`Xcode build failed (exit ${status}); refusing any pre-existing .app at ${appPath}.`);
+  if (!existsSync(join(appPath, 'Info.plist')) || !existsSync(join(appPath, 'Boardsesh'))) {
+    throw new Error(`Xcode did not produce a complete Boardsesh.app at ${appPath}.`);
+  }
+  if (statSync(join(appPath, 'Boardsesh')).size === 0) throw new Error('Built executable is empty.');
+}
+
+/** Publish only a fully copied product; rollback preserves the last good export. */
+export function exportBuiltApp(status: number, appPath: string, appOut: string): string {
+  assertSuccessfulBuild(status, appPath);
+  mkdirSync(appOut, { recursive: true });
+  const destination = join(appOut, 'Boardsesh.app');
+  const stage = join(appOut, `.Boardsesh-${randomUUID()}.app`);
+  const previous = join(appOut, `.Boardsesh-previous-${randomUUID()}.app`);
+  try {
+    cpSync(appPath, stage, { recursive: true });
+    assertSuccessfulBuild(0, stage);
+    // Ensure the copy has the same executable before replacing a working export.
+    if (!readFileSync(join(stage, 'Boardsesh')).equals(readFileSync(join(appPath, 'Boardsesh')))) {
+      throw new Error('Staged executable differs from the built executable.');
+    }
+    if (existsSync(destination)) renameSync(destination, previous);
+    try {
+      renameSync(stage, destination);
+    } catch (error) {
+      if (existsSync(previous)) renameSync(previous, destination);
+      throw error;
+    }
+    rmSync(previous, { recursive: true, force: true });
+    return destination;
+  } finally {
+    rmSync(stage, { recursive: true, force: true });
+  }
+}

--- a/scripts/lib/ios-profile-identity.ts
+++ b/scripts/lib/ios-profile-identity.ts
@@ -1,0 +1,165 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface IosAppIdentity {
+  bundleIdentifier: string;
+  executableUuid: string;
+  executableSha256: string;
+  embeddedBundleSha256: string | null;
+}
+
+export function fileSha256(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+export function readAppIdentity(appPath: string, configuration: 'Debug' | 'Release'): IosAppIdentity {
+  const plist = (key: string) =>
+    execFileSync('plutil', ['-extract', key, 'raw', '-o', '-', join(appPath, 'Info.plist')], {
+      encoding: 'utf8',
+    }).trim();
+  const executable = join(appPath, plist('CFBundleExecutable'));
+  const uuid = execFileSync('xcrun', ['dwarfdump', '--uuid', executable], { encoding: 'utf8' })
+    .split('\n')
+    .map((line) => /UUID: ([0-9A-F-]+) \(([^)]+)\)/i.exec(line))
+    .filter((match) => match !== null)
+    .map((match) => `${match[1]} (${match[2]})`)
+    .sort()
+    .join(', ');
+  if (!uuid) throw new Error(`Executable has no UUID: ${executable}`);
+  const bundlePath = join(appPath, 'main.jsbundle');
+  if (configuration === 'Release' && !existsSync(bundlePath))
+    throw new Error('Release profiling requires an embedded bundle.');
+  return {
+    bundleIdentifier: plist('CFBundleIdentifier'),
+    executableUuid: uuid,
+    executableSha256: fileSha256(executable),
+    embeddedBundleSha256: existsSync(bundlePath) ? fileSha256(bundlePath) : null,
+  };
+}
+
+export function assertMatchingIdentity(expected: IosAppIdentity, actual: IosAppIdentity): void {
+  for (const field of ['bundleIdentifier', 'executableUuid', 'executableSha256', 'embeddedBundleSha256'] as const) {
+    if (expected[field] !== actual[field])
+      throw new Error(`Installed app identity changed: ${field}. Capture is invalid.`);
+  }
+}
+
+function objectRecord(candidate: unknown): Record<string, unknown> | null {
+  return candidate !== null && typeof candidate === 'object' && !Array.isArray(candidate)
+    ? (candidate as Record<string, unknown>)
+    : null;
+}
+
+/** A useful Home commit must come from a complete, identifiable runtime artifact. */
+export function hasUsefulStartupArtifact(artifact: unknown): boolean {
+  const recorded = objectRecord(artifact);
+  if (typeof recorded?.runId !== 'string' || recorded.runId.trim().length === 0 || !Array.isArray(recorded.marks))
+    return false;
+  let usefulMarks = 0;
+  for (const candidate of recorded.marks) {
+    const mark = objectRecord(candidate);
+    if (
+      typeof mark?.name !== 'string' ||
+      typeof mark.timestampMs !== 'number' ||
+      !Number.isFinite(mark.timestampMs) ||
+      mark.timestampMs < 0
+    )
+      return false;
+    if (mark.name === 'home.useful.commit') {
+      if (typeof mark.outcome !== 'string' || !['content', 'empty', 'offline', 'error'].includes(mark.outcome))
+        return false;
+      usefulMarks += 1;
+    }
+  }
+  // Duplicate first-useful marks are ambiguous, even if one looks plausible.
+  return usefulMarks === 1;
+}
+
+export function validateCaptureFiles(measurements: unknown, validity: unknown): void {
+  const recorded = objectRecord(measurements);
+  const verdict = objectRecord(validity);
+  if (!recorded) throw new Error('Measurements are missing.');
+  if (verdict?.valid !== true || verdict.completed !== true || verdict.configuration !== recorded.configuration) {
+    throw new Error(
+      'Capture did not explicitly report a completed matching configuration; retain artifacts as incomplete.',
+    );
+  }
+  if (recorded.configuration === 'Release') {
+    if (
+      !Array.isArray(recorded.launches) ||
+      recorded.launches.length !== 10 ||
+      !Array.isArray(recorded.memory) ||
+      recorded.memory.length !== 20
+    ) {
+      throw new Error('Incomplete Release capture: expected ten launches and twenty memory cycles.');
+    }
+    const runtimeIds = new Set<string>();
+    for (const [index, trial] of recorded.launches.entries()) {
+      const launch = objectRecord(trial);
+      const artifact = objectRecord(launch?.artifact);
+      if (
+        launch?.trial !== index + 1 ||
+        !hasUsefulStartupArtifact(artifact) ||
+        typeof artifact?.runId !== 'string' ||
+        runtimeIds.has(artifact.runId) ||
+        typeof launch.hostExportObservedMs !== 'number' ||
+        !Number.isFinite(launch.hostExportObservedMs) ||
+        launch.hostExportObservedMs < 0
+      ) {
+        throw new Error('Invalid or stale launch sample.');
+      }
+      runtimeIds.add(artifact.runId);
+    }
+    const memoryPid = objectRecord(recorded.memory[0])?.pid;
+    for (const [index, observation] of recorded.memory.entries()) {
+      const sample = objectRecord(observation);
+      if (
+        sample?.cycle !== index + 1 ||
+        typeof memoryPid !== 'number' ||
+        !Number.isInteger(memoryPid) ||
+        memoryPid <= 0 ||
+        sample.pid !== memoryPid ||
+        typeof sample.footprintMiB !== 'number' ||
+        !Number.isFinite(sample.footprintMiB) ||
+        sample.footprintMiB <= 0
+      ) {
+        throw new Error('Invalid memory sample or changed process.');
+      }
+    }
+  } else if (recorded.configuration === 'Debug') {
+    if (
+      recorded.warmupLoops !== 2 ||
+      recorded.measuredLoops !== 5 ||
+      !Array.isArray(recorded.navigation) ||
+      recorded.navigation.length !== 20
+    ) {
+      throw new Error('Incomplete Debug capture: expected two warmups and five measured four-tab loops.');
+    }
+    const capabilities = objectRecord(recorded.capability);
+    const react = objectRecord(capabilities?.react);
+    const completeReactAttribution = react?.available === true && react.complete === true;
+    const completeScenarioSamples = recorded.navigation.every(
+      (observation) => objectRecord(observation)?.nativeSampleComplete === true,
+    );
+    if (!completeReactAttribution && !completeScenarioSamples) {
+      throw new Error('Debug capture has neither complete React attribution nor complete in-scenario native samples.');
+    }
+    const routes = ['home', 'climbs', 'discover', 'profile'];
+    for (const [index, observation] of recorded.navigation.entries()) {
+      const sample = objectRecord(observation);
+      const timing = objectRecord(sample?.observation);
+      if (
+        sample?.loop !== Math.floor(index / 4) + 1 ||
+        sample.route !== routes[index % 4] ||
+        sample.routeConfirmed !== true ||
+        !Array.isArray(timing?.gaps) ||
+        timing.gaps.length === 0 ||
+        !timing.gaps.every((gap) => typeof gap === 'number' && Number.isFinite(gap) && gap >= 0)
+      ) {
+        throw new Error('Invalid navigation sample or missing callback observations.');
+      }
+    }
+  } else throw new Error('Unknown profiling configuration.');
+}

--- a/scripts/lib/ios-simulator-lease.ts
+++ b/scripts/lib/ios-simulator-lease.ts
@@ -1,0 +1,142 @@
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export interface SimulatorLeaseOwner {
+  token: string;
+  pid: number;
+  worktree: string;
+  udid: string;
+  startedAt: string;
+}
+
+export function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+export function acquireSimulatorLease(
+  udid: string,
+  worktree: string,
+  directory = join(homedir(), 'Library', 'Caches', 'boardsesh', 'simulator-leases'),
+  inheritedToken = process.env.BOARDSESH_SIMULATOR_LEASE_TOKEN,
+): { owner: SimulatorLeaseOwner; release(): void } {
+  if (!/^[0-9a-f-]{36}$/i.test(udid))
+    throw new Error('A simulator lease requires an explicit UDID; "booted" is unsafe.');
+  const leasePath = join(directory, `${udid.toUpperCase()}.lock`);
+  mkdirSync(directory, { recursive: true });
+  const owner: SimulatorLeaseOwner = {
+    token: randomUUID(),
+    pid: process.pid,
+    worktree: realpathSync(worktree),
+    udid,
+    startedAt: new Date().toISOString(),
+  };
+  try {
+    mkdirSync(leasePath);
+  } catch {
+    let existing: SimulatorLeaseOwner;
+    try {
+      existing = JSON.parse(readFileSync(join(leasePath, 'owner.json'), 'utf8')) as SimulatorLeaseOwner;
+    } catch {
+      throw new Error(`Simulator ${udid} has an incomplete lease at ${leasePath}; refusing to steal it.`);
+    }
+    if (
+      existing.token === inheritedToken &&
+      existing.udid.toUpperCase() === udid.toUpperCase() &&
+      processIsAlive(existing.pid)
+    ) {
+      return { owner: existing, release() {} };
+    }
+    // Never steal a live lease, even when a long run exceeds a time threshold.
+    if (processIsAlive(existing.pid)) {
+      throw new Error(`Simulator ${udid} is leased by ${existing.worktree} (PID ${existing.pid}).`);
+    }
+    throw new Error(
+      `Simulator ${udid} has a stopped owner. Remove only the stale lease at ${leasePath} before retrying.`,
+    );
+  }
+  writeFileSync(join(leasePath, 'owner.json'), JSON.stringify(owner));
+  return {
+    owner,
+    release() {
+      try {
+        const current = JSON.parse(readFileSync(join(leasePath, 'owner.json'), 'utf8')) as SimulatorLeaseOwner;
+        if (current.token === owner.token) rmSync(leasePath, { recursive: true });
+      } catch {
+        /* Already released. */
+      }
+    },
+  };
+}
+
+const heldLeases = new Map<string, ReturnType<typeof acquireSimulatorLease>>();
+
+export function holdSimulatorLease(udid: string, worktree: string): void {
+  const selected = process.env.BOARDSESH_IOS_SIMULATOR_UDID;
+  if (selected && selected.toUpperCase() !== udid.toUpperCase()) {
+    throw new Error(`Requested simulator ${udid} differs from selected simulator ${selected}.`);
+  }
+  if (heldLeases.has(udid)) return;
+  const lease = acquireSimulatorLease(udid, worktree);
+  heldLeases.set(udid, lease);
+  process.once('exit', () => lease.release());
+}
+
+/** Shared boundary for screenshot, status-bar, launch, navigation and shutdown. */
+export function guardSimulatorCommand(command: string, args: readonly string[], worktree: string): void {
+  if (command === 'maestro') {
+    const deviceIndex = args.indexOf('--device');
+    if (deviceIndex >= 0 && /^[0-9a-f-]{36}$/i.test(args[deviceIndex + 1])) {
+      holdSimulatorLease(args[deviceIndex + 1], worktree);
+    }
+    return;
+  }
+  if (command !== 'xcrun' || args[0] !== 'simctl') return;
+  if (['list', 'help', 'create'].includes(args[1])) return;
+  const device = args[2];
+  if (!device) throw new Error('Simulator action is missing its explicit UDID.');
+  holdSimulatorLease(device, worktree);
+}
+
+export function resolveSimulatorUdid(requested = process.env.BOARDSESH_IOS_SIMULATOR_UDID): string {
+  const listing = JSON.parse(
+    execFileSync('xcrun', ['simctl', 'list', 'devices', 'available', '--json'], {
+      encoding: 'utf8',
+    }),
+  ) as { devices: Record<string, { udid: string; name: string; state: string }[]> };
+  return selectSimulatorUdid(Object.values(listing.devices).flat(), requested);
+}
+
+export function selectSimulatorUdid(
+  devices: readonly { udid: string; name: string; state: string }[],
+  requested?: string,
+): string {
+  const matches = requested
+    ? devices.filter((device) => device.udid.toUpperCase() === requested.toUpperCase() || device.name === requested)
+    : devices.filter((device) => device.state === 'Booted');
+  if (matches.length !== 1)
+    throw new Error('Select exactly one simulator with BOARDSESH_IOS_SIMULATOR_UDID or --device.');
+  return matches[0].udid;
+}
+
+/** Shell wrappers execute their entire flow under one inherited lease. */
+export function leaseEnvironment(
+  udid: string,
+  worktree: string,
+): {
+  env: NodeJS.ProcessEnv;
+  release(): void;
+} {
+  const lease = acquireSimulatorLease(udid, resolve(worktree));
+  return {
+    env: { ...process.env, BOARDSESH_IOS_SIMULATOR_UDID: udid, BOARDSESH_SIMULATOR_LEASE_TOKEN: lease.owner.token },
+    release: () => lease.release(),
+  };
+}

--- a/scripts/lib/metro-host.ts
+++ b/scripts/lib/metro-host.ts
@@ -1,0 +1,18 @@
+import { resolveTailscaleHostname, type TailscaleHostResolution } from './tailscale-hostname';
+
+/** Binding and the manifest's advertised bundle hostname must agree. */
+export function resolveMetroHostname(
+  args: readonly string[],
+  resolveDefault: () => TailscaleHostResolution = resolveTailscaleHostname,
+): TailscaleHostResolution {
+  let host: string | undefined;
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    if (argument === '--localhost') host = 'localhost';
+    else if (argument === '--lan') host = 'lan';
+    else if (argument === '--tunnel') host = 'tunnel';
+    else if (argument === '--host') host = args[++index];
+    else if (argument.startsWith('--host=')) host = argument.slice('--host='.length);
+  }
+  return host === 'localhost' ? { hostname: 'localhost', source: 'env' } : resolveDefault();
+}

--- a/scripts/mobile-build-sim-app.ts
+++ b/scripts/mobile-build-sim-app.ts
@@ -26,12 +26,22 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { exportBuiltApp } from './lib/ios-build-export';
+import {
+  acquireBuildLock,
+  createMobileIosCachePaths,
+  ensureSharedBuildCache,
+  nodeFileSystem,
+  systemClock,
+} from './mobile-ios-run';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ROOT_DIR = process.env.BOARDSESH_PROFILE_SOURCE_DIR
+  ? resolve(process.env.BOARDSESH_PROFILE_SOURCE_DIR)
+  : resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const MOBILE_DIR = resolve(ROOT_DIR, 'packages', 'mobile');
 const IOS_DIR = resolve(MOBILE_DIR, 'ios');
 const DERIVED_DATA_DIR = resolve(IOS_DIR, 'build');
@@ -178,7 +188,7 @@ function ensureNativeProject(clean: boolean): void {
     return;
   }
   if (existsSync(WORKSPACE_PATH)) {
-    if (screenshotNativeProjectNeedsRefresh()) {
+    if (process.env.BOARDSESH_PROFILE_BUILD !== '1' && screenshotNativeProjectNeedsRefresh()) {
       expoPrebuild(true);
       return;
     }
@@ -254,37 +264,52 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
   // Tells app.config.ts to register ./plugins/with-screenshot-dev-menu, which
   // bakes dev-menu suppression into Info.plist so the dev-client chrome can't
   // cover the captured screens on a cold relaunch. Read at prebuild time.
-  process.env.BOARDSESH_SCREENSHOT_BUILD = '1';
+  if (process.env.BOARDSESH_PROFILE_BUILD !== '1') process.env.BOARDSESH_SCREENSHOT_BUILD = '1';
 
   try {
-    ensureNativeProject(options.clean);
-    podInstall();
+    const paths = createMobileIosCachePaths(process.env, MOBILE_DIR);
+    const lock = acquireBuildLock(paths, nodeFileSystem, systemClock);
+    try {
+      ensureNativeProject(options.clean);
+      if (process.env.BOARDSESH_PROFILE_BUILD === '1' && options.configuration === 'Debug') {
+        const port = Number(process.env.BOARDSESH_METRO_PORT ?? '8081');
+        if (!Number.isInteger(port) || port < 1 || port > 65535) throw new Error('Invalid profiling Metro port.');
+        const delegatePath = join(IOS_DIR, 'Boardsesh', 'AppDelegate.swift');
+        const delegate = readFileSync(delegatePath, 'utf8').replace(
+          /^\s*RCTBundleURLProvider\.sharedSettings\(\)\.jsLocation = "localhost:\d+"\n/gm,
+          '',
+        );
+        const marker = 'return RCTBundleURLProvider.sharedSettings().jsBundleURL';
+        if (!delegate.includes(marker)) throw new Error('Could not configure profiling AppDelegate bundle URL.');
+        writeFileSync(
+          delegatePath,
+          delegate.replace(
+            marker,
+            `RCTBundleURLProvider.sharedSettings().jsLocation = "localhost:${port}"\n    ${marker}`,
+          ),
+        );
+      }
+      ensureSharedBuildCache(paths, nodeFileSystem, systemClock);
+      podInstall();
 
-    let status = xcodebuild(options.configuration);
-    const appPath = builtAppPath(options.configuration);
-    if (status !== 0 && !existsSync(appPath)) {
-      // RN New Architecture codegen ("Generate Specs") can race the compile on a
-      // cold/clean build ("Build input file cannot be found: …/ReactCodegen/
-      // *-generated.mm"). The specs land during that first attempt, so a second
-      // build finds them — the well-known "build twice on a clean checkout"
-      // quirk that bites every fresh CI runner. Retry once.
-      console.log(
-        `${LOG} First build failed without producing the .app (likely the cold-build codegen race); retrying once...`,
-      );
-      status = xcodebuild(options.configuration);
+      let status = xcodebuild(options.configuration);
+      const appPath = builtAppPath(options.configuration);
+      if (status !== 0) {
+        // RN New Architecture codegen ("Generate Specs") can race the compile on a
+        // cold/clean build ("Build input file cannot be found: …/ReactCodegen/
+        // *-generated.mm"). The specs land during that first attempt, so a second
+        // build finds them — the well-known "build twice on a clean checkout"
+        // quirk that bites every fresh CI runner. Retry once.
+        console.log(`${LOG} First build failed; retrying once for the cold-build codegen race...`);
+        status = xcodebuild(options.configuration);
+      }
+
+      const destination = exportBuiltApp(status, appPath, options.appOut);
+      console.log(`${LOG} Built ${options.configuration} simulator app -> ${destination}`);
+      return 0;
+    } finally {
+      lock.release();
     }
-
-    if (!existsSync(appPath)) {
-      console.error(`${LOG} FAILED: ${appPath} not found after build (exit ${status}).`);
-      return status === 0 ? 1 : status;
-    }
-
-    mkdirSync(options.appOut, { recursive: true });
-    const destination = join(options.appOut, APP_NAME);
-    rmSync(destination, { force: true, recursive: true });
-    cpSync(appPath, destination, { recursive: true });
-    console.log(`${LOG} Built ${options.configuration} simulator app -> ${destination}`);
-    return 0;
   } catch (error) {
     console.error(`${LOG} FAILED: ${error instanceof Error ? error.message : String(error)}`);
     return 1;

--- a/scripts/mobile-dev-start.ts
+++ b/scripts/mobile-dev-start.ts
@@ -6,9 +6,11 @@ import { createServer } from 'node:net';
 import { resolve, dirname, join, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { resolveTailscaleHostname } from './lib/tailscale-hostname';
+import { resolveMetroHostname } from './lib/metro-host';
 
-const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ROOT_DIR = process.env.BOARDSESH_PROFILE_SOURCE_DIR
+  ? resolve(process.env.BOARDSESH_PROFILE_SOURCE_DIR)
+  : resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const METRO_DEFAULT_PORT = 8081;
 const METRO_MAX_PORT = 8099;
 const BOARDSESH_DIR = join(ROOT_DIR, '.boardsesh');
@@ -158,7 +160,7 @@ async function main() {
   const branchName = resolveCurrentBranchName();
   const commitSha = runGitCommand(['rev-parse', '--short', 'HEAD']);
   const qaNotes = resolveQaNotes(cliQaNotesPath);
-  const tailscale = resolveTailscaleHostname();
+  const tailscale = resolveMetroHostname(passthroughArgs);
   const metroPort = await resolveMetroPort(passthroughArgs);
   const metroPassthroughArgs = withMetroPort(passthroughArgs, metroPort);
   const startedAt = new Date().toISOString();
@@ -199,7 +201,9 @@ async function main() {
 
   // Bind Metro on 0.0.0.0 (Expo's --host lan) so devices on the same Tailnet can
   // reach the bundler. Respect a user-supplied --host so manual overrides win.
-  const userPassedHost = metroPassthroughArgs.some((arg) => arg === '--host' || arg.startsWith('--host='));
+  const userPassedHost = metroPassthroughArgs.some(
+    (arg) => arg === '--host' || arg.startsWith('--host=') || ['--localhost', '--lan', '--tunnel'].includes(arg),
+  );
   // We ship a custom dev client (EAS preview-build flow); Metro must serve the
   // dev-client bundle, not the Expo Go one. Opt out by passing --go.
   const userPickedClient = passthroughArgs.some(

--- a/scripts/mobile-ios-run.ts
+++ b/scripts/mobile-ios-run.ts
@@ -1,12 +1,15 @@
 /// <reference types="node" />
 
-import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { leaseEnvironment, resolveSimulatorUdid } from './lib/ios-simulator-lease';
 import {
   existsSync,
   lstatSync,
   mkdirSync,
   readdirSync,
   readlinkSync,
+  readFileSync,
   renameSync,
   rmSync,
   rmdirSync,
@@ -20,7 +23,6 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const MOBILE_DIR = resolve(ROOT_DIR, 'packages', 'mobile');
 const DEFAULT_CACHE_DIR = join(homedir(), 'Library', 'Caches', 'boardsesh', 'xcode', 'packages-mobile-ios', 'build');
-const LOCK_STALE_MS = 12 * 60 * 60 * 1000;
 
 export interface MobileIosCachePaths {
   mobileDir: string;
@@ -42,6 +44,7 @@ export interface FileSystemOps {
   rmdir(path: string): void;
   symlink(target: string, path: string): void;
   writeFile(path: string, contents: string): void;
+  readFile(path: string): string;
 }
 
 export interface Runner {
@@ -83,6 +86,7 @@ export const nodeFileSystem: FileSystemOps = {
   rmdir: rmdirSync,
   symlink: symlinkSync,
   writeFile: writeFileSync,
+  readFile: (path) => readFileSync(path, 'utf8'),
 };
 
 export const nodeRunner: Runner = {
@@ -194,28 +198,52 @@ export function acquireBuildLock(paths: MobileIosCachePaths, fs: FileSystemOps, 
   try {
     fs.mkdirExclusive(paths.lockPath);
   } catch {
-    if (isStaleLock(paths.lockPath, fs, clock)) {
-      fs.rm(paths.lockPath);
-      fs.mkdirExclusive(paths.lockPath);
-    } else {
-      throw new Error(
-        `another Boardsesh iOS build is using the shared cache at ${paths.sharedBuildPath}. ` +
-          `Wait for it to finish, then rerun this command.`,
-      );
-    }
+    throw new Error(
+      `another Boardsesh iOS build is using the shared cache at ${paths.sharedBuildPath}. ` +
+        `Wait for it to finish. A stopped owner's lock must be inspected and removed explicitly: ${paths.lockPath}`,
+    );
   }
 
-  fs.writeFile(
-    join(paths.lockPath, 'owner.txt'),
-    [`pid=${process.pid}`, `startedAt=${clock.isoNow()}`, `sharedBuildPath=${paths.sharedBuildPath}`, ''].join('\n'),
-  );
+  const ownerToken = randomUUID();
+  const ownerPath = join(paths.lockPath, 'owner.txt');
+  const ownerContents = [
+    `token=${ownerToken}`,
+    `pid=${process.pid}`,
+    `startedAt=${clock.isoNow()}`,
+    `sharedBuildPath=${paths.sharedBuildPath}`,
+    '',
+  ].join('\n');
+  fs.writeFile(ownerPath, ownerContents);
 
   return {
     path: paths.lockPath,
     release() {
-      fs.rm(paths.lockPath);
+      if (fs.exists(ownerPath) && fs.readFile(ownerPath) === ownerContents) fs.rm(paths.lockPath);
     },
   };
+}
+
+export function extractIosDeviceArgs(args: readonly string[]): { requested: string | undefined; remaining: string[] } {
+  let requested: string | undefined;
+  const remaining: string[] = [];
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    if (argument === '--device' || argument === '-d') {
+      const candidate = args[++index];
+      if (!candidate || candidate.startsWith('-')) throw new Error('Pass an explicit device name or UDID.');
+      requested = candidate;
+    } else if (argument.startsWith('--device=')) requested = argument.slice('--device='.length);
+    else remaining.push(argument);
+  }
+  return { requested, remaining };
+}
+
+function isPhysicalDevice(requested: string): boolean {
+  const listing = execFileSync('xcrun', ['xctrace', 'list', 'devices'], { encoding: 'utf8', timeout: 15000 });
+  const physicalSection = listing.split('== Simulators ==')[0];
+  return physicalSection
+    .split('\n')
+    .some((line) => line.includes(`(${requested})`) || line.startsWith(`${requested} (`));
 }
 
 export function main(): number {
@@ -223,27 +251,44 @@ export function main(): number {
 
   try {
     validateExpoRunIosArgs(passthroughArgs);
-    const paths = createMobileIosCachePaths();
-    ensureIosProject(paths, nodeFileSystem, nodeRunner);
-    const cacheResult = ensureSharedBuildCache(paths, nodeFileSystem, systemClock);
-
-    console.log(`[mobile:ios] Shared Xcode build cache: ${cacheResult.sharedBuildPath}`);
-    if (cacheResult.importedExistingBuild) {
-      console.log('[mobile:ios] Imported existing packages/mobile/ios/build into the shared cache.');
-    }
-    if (cacheResult.movedAsidePath) {
-      console.log(`[mobile:ios] Preserved existing worktree build output at ${cacheResult.movedAsidePath}`);
-    }
-
-    const lock = acquireBuildLock(paths, nodeFileSystem, systemClock);
+    const { requested, remaining } = extractIosDeviceArgs(passthroughArgs);
+    let simulator: ReturnType<typeof leaseEnvironment>;
     try {
-      const status = nodeRunner.run('vp', ['exec', 'expo', 'run:ios', ...passthroughArgs], {
-        cwd: paths.mobileDir,
-        env: { ...process.env },
-      });
-      return status ?? 1;
+      const udid = resolveSimulatorUdid(requested);
+      simulator = leaseEnvironment(udid, ROOT_DIR);
+      remaining.push('--device', udid);
+    } catch (error) {
+      if (!requested || !isPhysicalDevice(requested)) throw error;
+      // Physical iPhone builds cannot interfere with a simulator lease.
+      simulator = { env: { ...process.env }, release() {} };
+      remaining.push('--device', requested);
+    }
+
+    try {
+      const paths = createMobileIosCachePaths();
+      const lock = acquireBuildLock(paths, nodeFileSystem, systemClock);
+      try {
+        ensureIosProject(paths, nodeFileSystem, nodeRunner);
+        const cacheResult = ensureSharedBuildCache(paths, nodeFileSystem, systemClock);
+
+        console.log(`[mobile:ios] Shared Xcode build cache: ${cacheResult.sharedBuildPath}`);
+        if (cacheResult.importedExistingBuild) {
+          console.log('[mobile:ios] Imported existing packages/mobile/ios/build into the shared cache.');
+        }
+        if (cacheResult.movedAsidePath) {
+          console.log(`[mobile:ios] Preserved existing worktree build output at ${cacheResult.movedAsidePath}`);
+        }
+
+        const status = nodeRunner.run('vp', ['exec', 'expo', 'run:ios', ...remaining], {
+          cwd: paths.mobileDir,
+          env: simulator.env,
+        });
+        return status ?? 1;
+      } finally {
+        lock.release();
+      }
     } finally {
-      lock.release();
+      simulator.release();
     }
   } catch (error) {
     console.error(`[mobile:ios] FAILED: ${error instanceof Error ? error.message : String(error)}`);
@@ -256,16 +301,6 @@ function isEmptyDirectory(path: string, fs: FileSystemOps): boolean {
     const stats = fs.lstat(path);
     if (!stats.isDirectory() || stats.isSymbolicLink()) return false;
     return fs.readdir(path).length === 0;
-  } catch {
-    return false;
-  }
-}
-
-function isStaleLock(path: string, fs: FileSystemOps, clock: Clock): boolean {
-  try {
-    const stats = fs.lstat(path);
-    if (!stats.isDirectory()) return false;
-    return typeof stats.mtimeMs === 'number' && clock.now() - stats.mtimeMs > LOCK_STALE_MS;
   } catch {
     return false;
   }

--- a/scripts/mobile-ios-shots.ts
+++ b/scripts/mobile-ios-shots.ts
@@ -1,3 +1,4 @@
+import { guardSimulatorCommand } from './lib/ios-simulator-lease';
 /// <reference types="node" />
 
 /**
@@ -219,6 +220,7 @@ function parseShotsArgs(argv: readonly string[]): ShotsOptions {
 }
 
 function simctl(args: string[], env: NodeJS.ProcessEnv = process.env): { status: number; stdout: string } {
+  guardSimulatorCommand('xcrun', ['simctl', ...args], ROOT_DIR);
   const result = runCapture('xcrun', ['simctl', ...args], { env });
   return { status: result.status, stdout: result.stdout };
 }
@@ -311,6 +313,7 @@ function runMaestroFlowFile(udid: string, flowYaml: string, env: NodeJS.ProcessE
   const dir = mkdtempSync(join(tmpdir(), 'boardsesh-ios-nav-'));
   const flowFile = join(dir, 'flow.yaml');
   try {
+    guardSimulatorCommand('maestro', ['--device', udid], ROOT_DIR);
     writeFileSync(flowFile, flowYaml, 'utf8');
     return runInherit('maestro', ['--device', udid, 'test', flowFile], { env, cwd: dir });
   } finally {
@@ -350,6 +353,7 @@ function runFlow(udid: string, options: ShotsOptions, env: NodeJS.ProcessEnv): v
   const password = process.env.SCREENSHOT_USER_PASSWORD ?? DEFAULT_USER_PASSWORD;
   const captureDir = mkdtempSync(join(tmpdir(), 'boardsesh-ios-flow-'));
   try {
+    guardSimulatorCommand('maestro', ['--device', udid], ROOT_DIR);
     console.log(`${LOG} Running Maestro flow ${options.flow} on ${udid}...`);
     const status = runInherit(
       'maestro',
@@ -419,7 +423,7 @@ function assertDarwinWithSimctl(): void {
 
 function attachToSimulator(device: string): DeviceInfo {
   assertDarwinWithSimctl();
-  const booted = resolveBootedIosDevice(device);
+  const booted = resolveBootedIosDevice(process.env.BOARDSESH_IOS_SIMULATOR_UDID ?? device);
   if (!booted) {
     throw new Error('No booted simulator — start one with `vp run mobile:ios-shots` (in the background) first.');
   }
@@ -449,10 +453,9 @@ function runNavigateSubcommand(options: ShotsOptions): number {
 }
 
 function killMetro(): void {
-  const result = runCapture('lsof', ['-nP', `-iTCP:${METRO_PORT}`, '-sTCP:LISTEN', '-t']);
-  const pids = result.stdout.split(/\s+/).filter(Boolean);
-  for (const pid of pids) runCapture('kill', [pid]);
-  if (pids.length > 0) console.log(`${LOG} Stopped Metro on port ${METRO_PORT}.`);
+  // Only the process that spawned Metro owns its ChildProcess handle. Never kill
+  // arbitrary listeners discovered by port: they may belong to another checkout.
+  console.log(`${LOG} Stop Metro through the process that started it (Ctrl-C).`);
 }
 
 function runShutdownSubcommand(options: ShotsOptions): number {
@@ -525,16 +528,8 @@ async function runFullPipeline(options: ShotsOptions): Promise<number> {
   applyCleanStatusBar(device.udid);
 
   console.log(`${LOG} Installing ${appPath} on ${device.name}...`);
-  simctl(['uninstall', device.udid, APP_ID]); // ignore failure (not installed yet)
   const install = simctl(['install', device.udid, appPath]);
   if (install.status !== 0) throw new Error(`simctl install exited ${install.status}`);
-  if (!options.keepKeychain) {
-    // The shared keychain group (group.com.boardsesh.app) survives uninstall, so a
-    // stale token from a prior --backend local run would auth against the wrong
-    // backend. A clean keychain forces a fresh sign-in with the baked creds.
-    console.log(`${LOG} Resetting simulator keychain (clears any stale auth token)...`);
-    simctl(['keychain', device.udid, 'reset']);
-  }
 
   if (portInUse(METRO_PORT)) {
     throw new Error(`port ${METRO_PORT} is already in use; stop it (another Metro would serve the wrong bundle).`);

--- a/scripts/mobile-profile-capture.ts
+++ b/scripts/mobile-profile-capture.ts
@@ -505,7 +505,7 @@ export async function main(argv = process.argv.slice(2)) {
       limitations: [
         'Simulator only; device validation required.',
         'No native FPS claim.',
-        'Pending supplemental captures: allocation inspection, distinct render keys, and 20/100/200 shelf populations.',
+        'Pending supplemental captures: allocation inspection, exact distinct climb IDs, and 20/100/200 shelf populations.',
       ],
     });
     return 0;

--- a/scripts/mobile-profile-capture.ts
+++ b/scripts/mobile-profile-capture.ts
@@ -1,0 +1,521 @@
+/// <reference types="node" />
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { performance } from 'node:perf_hooks';
+import { hasUsefulStartupArtifact } from './lib/ios-profile-identity';
+import { guardSimulatorCommand, holdSimulatorLease } from './lib/ios-simulator-lease';
+
+const require = createRequire(import.meta.url);
+const expoRequire = createRequire(require.resolve('@expo/cli/package.json'));
+// Expo already pins ws; its Origin option is required by Metro's inspector proxy.
+const InspectorWebSocket = expoRequire('ws') as new (url: string, options: { origin: string }) => WebSocket;
+
+interface CaptureOptions {
+  runDir: string;
+  udid: string;
+  appId: string;
+  configuration: 'Debug' | 'Release';
+  port: number;
+}
+interface StartupArtifact {
+  runId: string;
+  marks: { name: string; timestampMs: number; outcome?: string }[];
+}
+export function distribution(samples: number[]) {
+  const sorted = [...samples].sort((left, right) => left - right);
+  const percentile = (fraction: number) => sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)] ?? null;
+  return {
+    samples,
+    count: samples.length,
+    min: sorted[0] ?? null,
+    median: percentile(0.5),
+    p95: percentile(0.95),
+    max: sorted.at(-1) ?? null,
+  };
+}
+export function physicalFootprintMiB(report: string): number | null {
+  const match = report.match(/^Physical footprint:\s+([\d.]+)([KMG])(?:B)?/m);
+  if (!match) return null;
+  return Number(match[1]) * (match[2] === 'G' ? 1024 : match[2] === 'K' ? 1 / 1024 : 1);
+}
+export function usefulStartup(artifact: unknown, previousRunId: string | null): artifact is StartupArtifact {
+  return hasUsefulStartupArtifact(artifact) && (artifact as StartupArtifact).runId !== previousRunId;
+}
+export function readRenderKeys(container: string) {
+  const directory = join(container, 'Library', 'Caches', 'board-thumbnails');
+  const renderKeys = existsSync(directory)
+    ? readdirSync(directory)
+        .filter((name) => /^v\d+_.*\.png$/.test(name))
+        .sort()
+    : [];
+  return {
+    renderKeys,
+    renderedClimbSignatures: [...new Set(renderKeys.map((key) => key.split('_').at(-1) ?? ''))].sort((left, right) =>
+      left.localeCompare(right),
+    ),
+    meaning:
+      'Completed on-disk overlay cache keys, with distinct frame/color signatures; these are not retained-object or UUID counts.',
+  };
+}
+
+const pause = (milliseconds: number) => new Promise<void>((resolvePause) => setTimeout(resolvePause, milliseconds));
+function save(directory: string, name: string, artifact: unknown) {
+  writeFileSync(join(directory, name), JSON.stringify(artifact, null, 2));
+}
+function simctl(options: CaptureOptions, args: string[]): string {
+  guardSimulatorCommand('xcrun', ['simctl', ...args], process.cwd());
+  return execFileSync('xcrun', ['simctl', ...args], {
+    encoding: 'utf8',
+    timeout: 30_000,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+function previousStartupRunId(options: CaptureOptions): string | null {
+  try {
+    const container = simctl(options, ['get_app_container', options.udid, options.appId, 'data']);
+    const artifact = JSON.parse(
+      readFileSync(join(container, 'Documents', 'boardsesh-profile', 'startup-latest.json'), 'utf8'),
+    ) as Partial<StartupArtifact>;
+    return typeof artifact.runId === 'string' ? artifact.runId : null;
+  } catch {
+    return null;
+  }
+}
+function launch(options: CaptureOptions): number {
+  const output = simctl(options, ['launch', options.udid, options.appId]);
+  const pid = Number(output.match(/:\s*(\d+)\s*$/)?.[1]);
+  if (!Number.isInteger(pid) || pid <= 0) throw new Error(`Could not identify launched app PID: ${output}`);
+  return pid;
+}
+function terminate(options: CaptureOptions) {
+  try {
+    simctl(options, ['terminate', options.udid, options.appId]);
+  } catch (error) {
+    if (!String(error).includes('not running') && !String(error).includes('found nothing to terminate')) throw error;
+  }
+}
+function navigate(options: CaptureOptions, route: string) {
+  const assertion =
+    route === 'home' || route === 'climbs'
+      ? `    id: ${route}-screen`
+      : `    text: '${route === 'discover' ? 'My Playlists' : 'Progress'}'`;
+  const flowPath = join(options.runDir, `navigate-${route}.yaml`);
+  writeFileSync(
+    flowPath,
+    `appId: ${options.appId}\n---\n- openLink: com.boardsesh.app://${route}\n- tapOn:\n    text: Open\n    optional: true\n- waitForAnimationToEnd\n- extendedWaitUntil:\n    visible:\n  ${assertion}\n    timeout: 15000\n`,
+  );
+  const args = ['--device', options.udid, 'test', flowPath];
+  guardSimulatorCommand('maestro', args, process.cwd());
+  const navigation = spawnSync('maestro', args, { timeout: 60_000, stdio: 'pipe' });
+  writeFileSync(
+    join(options.runDir, `navigate-${route}.log`),
+    Buffer.concat([navigation.stdout ?? Buffer.alloc(0), navigation.stderr ?? Buffer.alloc(0)]),
+  );
+  if (navigation.status !== 0) throw new Error(`Navigation to ${route} was not confirmed; capture is incomplete.`);
+}
+
+function screenshot(options: CaptureOptions, name: string) {
+  simctl(options, ['io', options.udid, 'screenshot', join(options.runDir, name)]);
+}
+async function waitForStartup(options: CaptureOptions, previousRunId: string | null) {
+  const container = simctl(options, ['get_app_container', options.udid, options.appId, 'data']);
+  const path = join(container, 'Documents', 'boardsesh-profile', 'startup-latest.json');
+  const deadline = performance.now() + 45_000;
+  while (performance.now() < deadline) {
+    try {
+      const artifact: unknown = JSON.parse(readFileSync(path, 'utf8'));
+      if (usefulStartup(artifact, previousRunId)) return artifact;
+    } catch {
+      /* File may not exist yet, or writer may be replacing it. */
+    }
+    await pause(100);
+  }
+  throw new Error('No fresh useful Home commit artifact within 45 seconds.');
+}
+
+export interface DebuggerTarget {
+  appId: string;
+  webSocketDebuggerUrl: string;
+}
+export function selectDebuggerTarget(candidates: unknown, appId: string): DebuggerTarget | undefined {
+  if (!Array.isArray(candidates)) throw new Error('Invalid Metro debugger target list.');
+  const matching = candidates.filter(
+    (target): target is DebuggerTarget =>
+      target !== null &&
+      typeof target === 'object' &&
+      target.appId === appId &&
+      typeof target.webSocketDebuggerUrl === 'string',
+  );
+  if (matching.length > 1) throw new Error(`Multiple runtimes for ${appId}; refusing an ambiguous capture.`);
+  return matching[0];
+}
+
+class CdpProtocolError extends Error {}
+
+export class CdpClient {
+  private sequence = 0;
+  private pending = new Map<
+    number,
+    { resolve(result: unknown): void; reject(error: Error): void; timer: ReturnType<typeof setTimeout> }
+  >();
+  readonly events: { method: string; params?: Record<string, unknown> }[] = [];
+  constructor(private socket: WebSocket) {
+    socket.addEventListener('message', (event) => {
+      const response = JSON.parse(String(event.data)) as {
+        id?: number;
+        result?: unknown;
+        error?: unknown;
+        method?: string;
+        params?: Record<string, unknown>;
+      };
+      if (response.id !== undefined) {
+        const request = this.pending.get(response.id);
+        if (!request) return;
+        clearTimeout(request.timer);
+        this.pending.delete(response.id);
+        if (response.error) request.reject(new CdpProtocolError(JSON.stringify(response.error)));
+        else request.resolve(response.result);
+      } else if (response.method && this.events.length < 100_000)
+        this.events.push({ method: response.method, params: response.params });
+    });
+  }
+  static async connect(port: number, appId = 'com.boardsesh.app') {
+    let runtime: DebuggerTarget | undefined;
+    const deadline = Date.now() + 10000;
+    while (!runtime && Date.now() < deadline) {
+      const targets: unknown = await (
+        await fetch(`http://localhost:${port}/json/list`, { signal: AbortSignal.timeout(5000) })
+      ).json();
+      runtime = selectDebuggerTarget(targets, appId);
+      if (!runtime) await pause(250);
+    }
+    if (!runtime) throw new Error(`No registered debugger runtime for ${appId}.`);
+    const socketUrl = new URL(runtime.webSocketDebuggerUrl);
+    if (!['localhost', '127.0.0.1'].includes(socketUrl.hostname) || Number(socketUrl.port) !== port)
+      throw new Error('Debugger target points outside the selected local Metro.');
+    const socket = new InspectorWebSocket(runtime.webSocketDebuggerUrl, { origin: `http://localhost:${port}` });
+    await new Promise<void>((resolveOpen, reject) => {
+      const timer = setTimeout(() => reject(new Error('CDP connection timeout.')), 5000);
+      socket.addEventListener(
+        'open',
+        () => {
+          clearTimeout(timer);
+          resolveOpen();
+        },
+        { once: true },
+      );
+      socket.addEventListener(
+        'error',
+        () => {
+          clearTimeout(timer);
+          reject(new Error('CDP connection failed.'));
+        },
+        { once: true },
+      );
+    });
+    return new CdpClient(socket);
+  }
+  call(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    const id = ++this.sequence;
+    return new Promise((resolveResult, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${method} timed out.`));
+      }, 10_000);
+      this.pending.set(id, { resolve: resolveResult, reject, timer });
+      this.socket.send(JSON.stringify({ id, method, params }));
+    });
+  }
+  async evaluate(expression: string): Promise<unknown> {
+    const response = (await this.call('Runtime.evaluate', { expression, returnByValue: true, awaitPromise: true })) as {
+      result?: { value?: unknown };
+      exceptionDetails?: unknown;
+    };
+    if (response.exceptionDetails) throw new Error(JSON.stringify(response.exceptionDetails));
+    return response.result?.value;
+  }
+  close() {
+    for (const request of this.pending.values()) {
+      clearTimeout(request.timer);
+      request.reject(new Error('CDP closed.'));
+    }
+    this.pending.clear();
+    this.socket.close();
+  }
+}
+
+async function initializeDebugNavigation(cdp: CdpClient) {
+  const ready = await cdp.evaluate(`(() => {
+    for (const definition of __r.getModules().values()) {
+      if (!definition.isInitialized) continue;
+      const exported = definition.publicModule?.exports;
+      if (!exported || typeof exported !== 'object') continue;
+      if (typeof exported.router?.navigate === 'function') globalThis.__boardseshCaptureRouter = exported.router;
+      if (typeof exported.store?.getRouteInfo === 'function') globalThis.__boardseshCaptureRouterStore = exported.store;
+    }
+    return !!globalThis.__boardseshCaptureRouter && !!globalThis.__boardseshCaptureRouterStore;
+  })()`);
+  if (!ready) throw new Error('Initialized Expo Router navigation/state APIs unavailable.');
+}
+async function navigateDebug(cdp: CdpClient, route: string, settleMs: number) {
+  await cdp.evaluate(`__boardseshCaptureRouter.navigate(${JSON.stringify('/' + route)}); true`);
+  await pause(settleMs);
+  const pathname = await cdp.evaluate('__boardseshCaptureRouterStore.getRouteInfo().pathname');
+  if (pathname !== '/' + route)
+    throw new Error(`Expected /${route}, observed ${String(pathname)}; navigation capture invalid.`);
+}
+
+async function captureDebug(options: CaptureOptions) {
+  const previousRunId = previousStartupRunId(options);
+  terminate(options);
+  const pid = launch(options);
+  await waitForStartup(options, previousRunId);
+  const cdp = await CdpClient.connect(options.port, options.appId);
+  const capability: Record<string, unknown> = {};
+  const navigation: unknown[] = [];
+  let tracingStarted = false;
+  try {
+    // A capability probe in a fresh process; an incomplete trace is never a pass.
+    try {
+      await cdp.call('Tracing.start');
+      tracingStarted = true;
+      await pause(250);
+      await cdp.call('Tracing.end');
+      const deadline = Date.now() + 10_000;
+      while (!cdp.events.some((event) => event.method === 'Tracing.tracingComplete') && Date.now() < deadline)
+        await pause(50);
+      const complete = cdp.events.some((event) => event.method === 'Tracing.tracingComplete');
+      const chunks = cdp.events.filter((event) => event.method === 'Tracing.dataCollected');
+      capability.tracing = { complete, chunks: chunks.length };
+      save(options.runDir, 'tracing-probe.json', cdp.events);
+      if (!complete) throw new Error('Tracing did not finish; refusing measurements with uncertain tracing overhead.');
+      tracingStarted = false;
+    } catch (error) {
+      capability.tracing = { complete: false, reason: String(error) };
+      if (tracingStarted || !(error instanceof CdpProtocolError)) {
+        await cdp.call('Tracing.end').catch(() => undefined);
+        throw error;
+      }
+    }
+    await initializeDebugNavigation(cdp);
+    const routes = ['home', 'climbs', 'discover', 'profile'];
+    for (let loop = 0; loop < 2; loop++)
+      for (const route of routes) {
+        await navigateDebug(cdp, route, 2000);
+      }
+    const rendererId = await cdp.evaluate(
+      `(() => { const hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__; return hook?.rendererInterfaces ? [...hook.rendererInterfaces.keys()].find(id => hook.rendererInterfaces.get(id).startProfiling) ?? null : null; })()`,
+    );
+    capability.react = { available: typeof rendererId === 'number', complete: false };
+    if (typeof rendererId === 'number')
+      await cdp.evaluate(
+        `__REACT_DEVTOOLS_GLOBAL_HOOK__.rendererInterfaces.get(${rendererId}).startProfiling(true); true`,
+      );
+    for (let loop = 1; loop <= 5; loop++) {
+      for (const route of routes) {
+        await cdp.evaluate(
+          `(() => { globalThis.__boardseshCapture = { gaps: [], longTasks: [], previous: performance.now() }; const state = __boardseshCapture; state.observer = new PerformanceObserver(list => { for (const entry of list.getEntries()) if(state.longTasks.length < 1000) state.longTasks.push(entry.duration); }); state.observer.observe({entryTypes:['longtask']}); const frame = () => { const now = performance.now(); if(state.gaps.length < 2000) state.gaps.push(now-state.previous); state.previous=now; state.frame=requestAnimationFrame(frame); }; state.frame=requestAnimationFrame(frame); return true; })()`,
+        );
+        const sampleStartedAt = performance.now();
+        let sampleCompleted: Promise<boolean> | undefined;
+        if (typeof rendererId !== 'number') {
+          const nativeSample = spawn(
+            'sample',
+            [String(pid), '5', '-file', join(options.runDir, `navigation-${loop}-${route}.sample.txt`)],
+            { stdio: 'ignore' },
+          );
+          sampleCompleted = new Promise<boolean>((resolveSample) => {
+            nativeSample.once('error', () => resolveSample(false));
+            nativeSample.once('exit', (status) => resolveSample(status === 0));
+          });
+        }
+        await navigateDebug(cdp, route, 4000);
+        const navigationConfirmedAt = performance.now();
+        const nativeSampleComplete = sampleCompleted
+          ? (await sampleCompleted) && navigationConfirmedAt - sampleStartedAt <= 5000
+          : false;
+        const observation = await cdp.evaluate(
+          `(() => { const state=__boardseshCapture; cancelAnimationFrame(state.frame); state.observer.disconnect(); return { gaps:state.gaps, longTasks:state.longTasks }; })()`,
+        );
+        navigation.push({
+          loop,
+          route,
+          routeConfirmed: true,
+          nativeSampleComplete,
+          sampleStartedAt,
+          navigationConfirmedAt,
+          observation,
+        });
+        save(options.runDir, 'navigation.json', navigation);
+        screenshot(options, `navigation-${loop}-${route}.png`);
+        console.log(`[mobile:profile] Debug loop ${loop}/5 ${route}`);
+      }
+    }
+    if (typeof rendererId === 'number') {
+      await cdp.evaluate(`__REACT_DEVTOOLS_GLOBAL_HOOK__.rendererInterfaces.get(${rendererId}).stopProfiling(); true`);
+      const profile = await cdp.evaluate(
+        `__REACT_DEVTOOLS_GLOBAL_HOOK__.rendererInterfaces.get(${rendererId}).getProfilingData()`,
+      );
+      save(options.runDir, 'react-profile.json', profile);
+      const reactProfile = profile as { dataForRoots?: { commitData?: unknown[] }[] };
+      const complete = reactProfile.dataForRoots?.some((root) => (root.commitData?.length ?? 0) > 0) ?? false;
+      capability.react = { available: true, complete };
+      if (!complete) throw new Error('React profiling returned no commits.');
+      const names = await cdp.evaluate(
+        `(() => { const renderer=__REACT_DEVTOOLS_GLOBAL_HOOK__.rendererInterfaces.get(${rendererId}); const profile=renderer.getProfilingData(); const ids=new Set(profile.dataForRoots.flatMap(root=>root.commitData.flatMap(commit=>commit.fiberActualDurations.map(pair=>pair[0])))); return [...ids].map(id=>[id,renderer.getDisplayNameForElementID(id)]); })()`,
+      );
+      save(options.runDir, 'react-names.json', names);
+    }
+    const samplePath = join(options.runDir, 'debug-native.sample.txt');
+    const sample = spawnSync('sample', [String(pid), '1', '-file', samplePath], { timeout: 15_000, stdio: 'pipe' });
+    const nativeSampleComplete =
+      sample.status === 0 && existsSync(samplePath) && readFileSync(samplePath, 'utf8').includes('Call graph:');
+    capability.nativeSample = { complete: nativeSampleComplete };
+    if (
+      typeof rendererId !== 'number' &&
+      !navigation.every((entry) => (entry as { nativeSampleComplete: boolean }).nativeSampleComplete)
+    )
+      throw new Error('Neither React attribution nor complete in-scenario native samples are available.');
+    return {
+      configuration: 'Debug',
+      warmupLoops: 2,
+      measuredLoops: 5,
+      navigation,
+      capability,
+      timingMeaning: 'JS callback gaps and React render durations, not native FPS.',
+    };
+  } finally {
+    try {
+      await cdp.evaluate(
+        `(() => { const state=globalThis.__boardseshCapture; if(state) { cancelAnimationFrame(state.frame); state.observer?.disconnect(); } for(const renderer of globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__?.rendererInterfaces?.values() ?? []) renderer.stopProfiling?.(); delete globalThis.__boardseshCapture; return true; })()`,
+      );
+    } catch {
+      /* The owned runtime may have exited; never hide the capture failure. */
+    }
+    cdp.close();
+  }
+}
+
+async function captureRelease(options: CaptureOptions) {
+  const launches: unknown[] = [];
+  let previousRunId: string | null = null;
+  // First fixture login/cache population is excluded from the ten warm-cache launches.
+  previousRunId = previousStartupRunId(options);
+  terminate(options);
+  launch(options);
+  const warmup = await waitForStartup(options, previousRunId);
+  previousRunId = warmup.runId;
+  navigate(options, 'home');
+  await pause(3000);
+  const hostExportObservedMs: number[] = [];
+  for (let trial = 1; trial <= 10; trial++) {
+    terminate(options);
+    await pause(500);
+    const hostStart = performance.now();
+    const pid = launch(options);
+    const artifact = await waitForStartup(options, previousRunId);
+    const observedMs = performance.now() - hostStart;
+    hostExportObservedMs.push(observedMs);
+    previousRunId = artifact.runId;
+    save(options.runDir, `startup-${trial}.json`, artifact);
+    screenshot(options, `launch-${trial}.png`);
+    launches.push({ trial, pid, hostExportObservedMs: observedMs, artifact });
+    save(options.runDir, 'launches.json', launches);
+    console.log(
+      `[mobile:profile] Release launch ${trial}/10: local useful-commit export observed ${Math.round(observedMs)} ms`,
+    );
+    await pause(2000);
+  }
+  const pid = launch(options);
+  const memory: {
+    cycle: number;
+    pid: number;
+    footprintMiB: number | null;
+    renderKeys: ReturnType<typeof readRenderKeys>;
+  }[] = [];
+  const appContainer = simctl(options, ['get_app_container', options.udid, options.appId, 'data']);
+  const initialRenderKeys = readRenderKeys(appContainer);
+  const flowPath = join(options.runDir, 'browse-cycle.yaml');
+  writeFileSync(
+    flowPath,
+    `appId: ${options.appId}\n---\n- repeat:\n    times: 3\n    commands:\n      - swipe:\n          start: 50%,75%\n          end: 50%,30%\n          duration: 400\n- waitForAnimationToEnd\n`,
+  );
+  for (let cycle = 1; cycle <= 20; cycle++) {
+    navigate(options, 'climbs');
+    await pause(1000);
+    const args = ['--device', options.udid, 'test', flowPath];
+    guardSimulatorCommand('maestro', args, process.cwd());
+    const browsing = spawnSync('maestro', args, { timeout: 60_000, stdio: 'pipe' });
+    writeFileSync(
+      join(options.runDir, `browse-${cycle}.log`),
+      Buffer.concat([browsing.stdout ?? Buffer.alloc(0), browsing.stderr ?? Buffer.alloc(0)]),
+    );
+    if (browsing.status !== 0) throw new Error(`Browsing cycle ${cycle} failed; incomplete memory run.`);
+    simctl(options, ['launch', options.udid, 'com.apple.Preferences']);
+    await pause(2000);
+    if (launch(options) !== pid) throw new Error('Memory run app process changed; samples cannot be compared.');
+    navigate(options, 'home');
+    await pause(3000);
+    const samplePath = join(options.runDir, `memory-${cycle}.sample.txt`);
+    const sampled = spawnSync('sample', [String(pid), '1', '-file', samplePath], { timeout: 15_000, stdio: 'pipe' });
+    if (sampled.status !== 0 || !existsSync(samplePath)) throw new Error(`Native memory sample ${cycle} failed.`);
+    const footprintMiB = physicalFootprintMiB(readFileSync(samplePath, 'utf8'));
+    if (footprintMiB === null || !Number.isFinite(footprintMiB))
+      throw new Error(`Physical footprint missing in sample ${cycle}.`);
+    memory.push({ cycle, pid, footprintMiB, renderKeys: readRenderKeys(appContainer) });
+    save(options.runDir, 'memory.json', memory);
+    console.log(`[mobile:profile] Release memory cycle ${cycle}/20: ${memory.at(-1)?.footprintMiB} MiB`);
+  }
+  return {
+    configuration: 'Release',
+    initialRenderKeys,
+    launches,
+    memory,
+    hostExportObservedMs: distribution(hostExportObservedMs),
+    hostTimingMeaning:
+      'Host launch to local useful-commit artifact observation; includes deferred export and polling, not first displayed frame.',
+    memoryMeaning:
+      'Same-process physical footprint at settled Home after browsing/background; allocation attribution and distinct render-key counts require separate capture.',
+  };
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const flags = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) flags.set(argv[index], argv[index + 1]);
+  const options: CaptureOptions = {
+    runDir: resolve(flags.get('--run-dir') ?? '.boardsesh/ios-profile-capture'),
+    udid: flags.get('--udid') ?? '',
+    appId: flags.get('--app-id') ?? 'com.boardsesh.app',
+    configuration: flags.get('--configuration') === 'Debug' ? 'Debug' : 'Release',
+    port: Number(flags.get('--port') ?? '8097'),
+  };
+  mkdirSync(options.runDir, { recursive: true });
+  holdSimulatorLease(options.udid, process.cwd());
+  try {
+    const measurements =
+      options.configuration === 'Debug' ? await captureDebug(options) : await captureRelease(options);
+    save(options.runDir, 'measurements.json', measurements);
+    save(options.runDir, 'capture-validity.json', {
+      valid: true,
+      completed: true,
+      configuration: options.configuration,
+      limitations: [
+        'Simulator only; device validation required.',
+        'No native FPS claim.',
+        'Pending supplemental captures: allocation inspection, distinct render keys, and 20/100/200 shelf populations.',
+      ],
+    });
+    return 0;
+  } catch (error) {
+    save(options.runDir, 'capture-validity.json', { valid: false, completed: false, error: String(error) });
+    console.error(error);
+    return 1;
+  }
+}
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)
+  void main().then((status) => {
+    process.exitCode = status;
+  });

--- a/scripts/mobile-profile-ios.ts
+++ b/scripts/mobile-profile-ios.ts
@@ -1,0 +1,373 @@
+/// <reference types="node" />
+
+import { spawn, spawnSync, execFileSync, type ChildProcess } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, openSync, closeSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { leaseEnvironment, resolveSimulatorUdid } from './lib/ios-simulator-lease';
+import { assertMatchingIdentity, fileSha256, readAppIdentity, validateCaptureFiles } from './lib/ios-profile-identity';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+export interface ProfileOptions {
+  udid: string;
+  sourceRef: string;
+  configuration: 'Debug' | 'Release';
+  port: number;
+  runDir: string;
+  checkout: string | null;
+  fixtureManifest: string;
+}
+
+export function parseProfileArgs(argv: readonly string[]): ProfileOptions {
+  const options: ProfileOptions = {
+    udid: process.env.BOARDSESH_IOS_SIMULATOR_UDID ?? '',
+    sourceRef: 'HEAD',
+    configuration: 'Release',
+    port: 8097,
+    runDir: join(ROOT, '.boardsesh', `ios-profile-${new Date().toISOString().replace(/[:.]/g, '-')}`),
+    checkout: null,
+    fixtureManifest: join(ROOT, '.boardsesh/ios-performance-fixtures.json'),
+  };
+  const args = argv.filter((argument) => argument !== '--');
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const argument = args[index + 1];
+    if (!argument || argument.startsWith('--')) throw new Error(`${flag} requires a value.`);
+    if (flag === '--udid') options.udid = argument;
+    else if (flag === '--source-ref') options.sourceRef = argument;
+    else if (flag === '--configuration' && (argument === 'Debug' || argument === 'Release'))
+      options.configuration = argument;
+    else if (flag === '--port') options.port = Number(argument);
+    else if (flag === '--run-dir') options.runDir = resolve(argument);
+    else if (flag === '--checkout') options.checkout = resolve(argument);
+    else if (flag === '--fixtures') options.fixtureManifest = resolve(argument);
+    else throw new Error(`Unknown option or invalid value: ${flag} ${argument}`);
+  }
+  if (!/^[0-9a-f-]{36}$/i.test(options.udid)) throw new Error('--udid must identify an explicitly owned simulator.');
+  if (!Number.isInteger(options.port) || options.port < 1 || options.port > 65535) throw new Error('Invalid --port.');
+  return options;
+}
+
+function run(command: string, args: string[], cwd: string, env: NodeJS.ProcessEnv): void {
+  const result = spawnSync(command, args, { cwd, env, stdio: 'inherit' });
+  if (result.status !== 0) throw new Error(`${command} failed with exit ${result.status ?? 1}.`);
+}
+
+export function assertCapturePrerequisites(env: NodeJS.ProcessEnv = process.env): void {
+  const maestro = spawnSync('maestro', ['--version'], { env, encoding: 'utf8', timeout: 15000 });
+  if (maestro.status !== 0) {
+    throw new Error(
+      'Maestro is unavailable or cannot find Java. Set JAVA_HOME to an installed JDK and verify maestro --version before building.',
+    );
+  }
+}
+
+async function assertFreePort(port: number): Promise<void> {
+  await new Promise<void>((resolvePort, reject) => {
+    const server = createServer();
+    server.once('error', () => reject(new Error(`Port ${port} is occupied; refusing to reuse or stop another Metro.`)));
+    server.listen(port, '127.0.0.1', () => server.close(() => resolvePort()));
+  });
+}
+
+async function waitForOwnedMetro(port: number, checkout: string, metro: ChildProcess): Promise<void> {
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    if (metro.exitCode !== null) throw new Error('Owned Metro exited before becoming ready.');
+    try {
+      const response = await fetch(`http://localhost:${port}/_boardsesh/metro-info`, {
+        signal: AbortSignal.timeout(2000),
+      });
+      const metadata = (await response.json()) as { rootDir?: string };
+      if (metadata.rootDir === checkout) return;
+      if (response.ok) throw new Error('Metro source identity differs from the profiling checkout.');
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('source identity')) throw error;
+    }
+    await new Promise((resolvePoll) => setTimeout(resolvePoll, 500));
+  }
+  throw new Error('Metro readiness timed out.');
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<number> {
+  const options = parseProfileArgs(argv);
+  if (process.platform !== 'darwin') throw new Error('iOS profiling requires macOS and Xcode.');
+  // Local fixtures only. Never silently send the screenshot account to production.
+  const apiUrl = process.env.EXPO_PUBLIC_BACKEND_URL ?? '';
+  if (!/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/.test(apiUrl)) {
+    throw new Error('Set EXPO_PUBLIC_BACKEND_URL to the seeded local backend before profiling.');
+  }
+  if (!existsSync(options.fixtureManifest))
+    throw new Error('Seed local profiling fixtures and pass their manifest with --fixtures.');
+  const fixtures = JSON.parse(readFileSync(options.fixtureManifest, 'utf8')) as {
+    owned?: number;
+    community?: number;
+    climbs?: unknown[];
+  };
+  if (
+    (fixtures.owned ?? 0) < 200 ||
+    (fixtures.community ?? 0) < 200 ||
+    !Array.isArray(fixtures.climbs) ||
+    fixtures.climbs.length === 0
+  ) {
+    throw new Error('Profiling requires at least 200 owned and 200 community playlists with real climbs.');
+  }
+  assertCapturePrerequisites();
+  if (existsSync(join(options.runDir, 'manifest.json')))
+    throw new Error('Run directory already has a manifest. Use a fresh run directory.');
+  mkdirSync(options.runDir, { recursive: true });
+  const checkout = options.checkout ?? join(options.runDir, 'source');
+  const udid = resolveSimulatorUdid(options.udid);
+  const lease = leaseEnvironment(udid, ROOT);
+  const env: NodeJS.ProcessEnv = {
+    ...lease.env,
+    BOARDSESH_PROFILE_BUILD: '1',
+    BOARDSESH_PROFILE_SOURCE_DIR: checkout,
+    BOARDSESH_SCREENSHOT_BUILD: undefined,
+    EXPO_PUBLIC_PROFILE_STARTUP: '1',
+    BOARDSESH_METRO_PORT: String(options.port),
+    TAILSCALE_HOSTNAME: 'localhost',
+    REACT_NATIVE_PACKAGER_HOSTNAME: 'localhost',
+    CI: '1',
+    BOARDSESH_IOS_BUILD_CACHE_DIR: join(options.runDir, 'native-cache', 'build'),
+  };
+  const manifest: Record<string, unknown> = {
+    version: 1,
+    startedAt: new Date().toISOString(),
+    sourceCheckout: checkout,
+    configuration: options.configuration,
+    udid,
+    metroPort: options.configuration === 'Debug' ? options.port : null,
+    clocks: {
+      host: 'host monotonic observation; command overhead included',
+      js: 'runtime performance.now; never subtract from host timestamps',
+    },
+    fixtureManifestSha256: fileSha256(options.fixtureManifest),
+    fixtureManifest: options.fixtureManifest,
+    fixtureEnvironment: Object.fromEntries(
+      [
+        'EXPO_PUBLIC_BACKEND_URL',
+        'EXPO_PUBLIC_SCREENSHOT_MODE',
+        'EXPO_PUBLIC_SCREENSHOT_THEME',
+        'EXPO_PUBLIC_SCREENSHOT_LOCALE',
+        'EXPO_PUBLIC_SCREENSHOT_BOARDS',
+        'EXPO_PUBLIC_SCREENSHOT_RENDER_MODE',
+      ].map((name) => [name, env[name] ?? null]),
+    ),
+    fallbackCaptures: ['React renderer commit profile', 'native sample'],
+    status: 'preparing',
+    ownedPids: [],
+  };
+  const save = () => writeFileSync(join(options.runDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+  let metro: ChildProcess | undefined;
+  try {
+    save();
+    if (!options.checkout) run('git', ['worktree', 'add', '--detach', checkout, options.sourceRef], ROOT, env);
+    if (!existsSync(join(checkout, 'packages/mobile/src/lib/profiling/startup-profile.ts'))) {
+      throw new Error(
+        'This source needs the companion startup instrumentation (src/lib/profiling/startup-profile.ts) before native profiling builds.',
+      );
+    }
+    // Profiling must never reuse a previously generated native project.
+    if (existsSync(join(checkout, 'packages/mobile/ios')))
+      throw new Error('Profiling checkout already has ios/. Use a fresh dedicated checkout.');
+    manifest.sourceCommit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: checkout, encoding: 'utf8' }).trim();
+    manifest.sourceDiff = execFileSync('git', ['diff', '--binary', 'HEAD'], {
+      cwd: checkout,
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+    }).trim();
+    manifest.sourceStatus = execFileSync('git', ['status', '--porcelain'], { cwd: checkout, encoding: 'utf8' });
+    const untrackedPaths = execFileSync('git', ['ls-files', '--others', '--exclude-standard', '-z'], {
+      cwd: checkout,
+      encoding: 'utf8',
+    })
+      .split('\0')
+      .filter(Boolean);
+    manifest.untrackedSourceHashes = Object.fromEntries(
+      untrackedPaths.map((path) => [path, fileSha256(join(checkout, path))]),
+    );
+    if (options.configuration === 'Debug') {
+      const packagePath = join(checkout, 'packages/mobile/package.json');
+      const packageJson = JSON.parse(readFileSync(packagePath, 'utf8')) as {
+        expo: { autolinking: { ios?: { exclude?: string[] } } };
+      };
+      const iosOptions = packageJson.expo.autolinking.ios ?? {};
+      const excludedModules = ['expo-dev-client', 'expo-dev-launcher', 'expo-dev-menu', 'expo-dev-menu-interface'];
+      packageJson.expo.autolinking.ios = {
+        ...iosOptions,
+        exclude: [...new Set([...(iosOptions.exclude ?? []), ...excludedModules])],
+      };
+      writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+      manifest.debugAutolinkingExclusions = excludedModules;
+    }
+    if (!existsSync(join(checkout, 'node_modules'))) run('vp', ['install'], checkout, env);
+    // Compute through the installed API, preserving the full source attribution artifact.
+    const fingerprintPath = join(options.runDir, 'native-fingerprint.json');
+    run(
+      'vp',
+      [
+        'exec',
+        'node',
+        '-e',
+        'require("@expo/fingerprint").createFingerprintAsync(process.cwd(), { platforms: ["ios"] }).then(result => require("node:fs").writeFileSync(process.argv[1], JSON.stringify(result)))',
+        fingerprintPath,
+      ],
+      join(checkout, 'packages/mobile'),
+      env,
+    );
+    manifest.nativeFingerprint = (JSON.parse(readFileSync(fingerprintPath, 'utf8')) as { hash: string }).hash;
+    manifest.status = 'building';
+    save();
+    run(
+      'vp',
+      [
+        'exec',
+        'tsx',
+        join(ROOT, 'scripts/mobile-build-sim-app.ts'),
+        '--app-out',
+        join(options.runDir, 'app'),
+        '--configuration',
+        options.configuration,
+      ],
+      checkout,
+      {
+        ...env,
+        BOARDSESH_PROFILE_SOURCE_DIR: checkout,
+      },
+    );
+    manifest.generatedInputs = Object.fromEntries(
+      [
+        'packages/mobile/package.json',
+        'packages/mobile/ios/Boardsesh/AppDelegate.swift',
+        'packages/mobile/ios/Podfile.lock',
+        'packages/mobile/ios/Podfile.properties.json',
+      ]
+        .filter((path) => existsSync(join(checkout, path)))
+        .map((path) => [path, fileSha256(join(checkout, path))]),
+    );
+    writeFileSync(
+      join(options.runDir, 'build-inputs.patch'),
+      execFileSync('git', ['diff', '--binary', 'HEAD'], {
+        cwd: checkout,
+        encoding: 'utf8',
+        maxBuffer: 16 * 1024 * 1024,
+      }),
+    );
+    if (options.configuration === 'Debug') {
+      const pods = readFileSync(join(checkout, 'packages/mobile/ios/Podfile.lock'), 'utf8');
+      if (/ExpoDevLauncher|EXDevLauncher|expo-dev-launcher|ExpoDevMenu|EXDevMenu|expo-dev-menu/.test(pods)) {
+        throw new Error('Profiling Debug build still contains Expo launcher/menu native modules.');
+      }
+    }
+    const appPath = join(options.runDir, 'app/Boardsesh.app');
+    const identity = readAppIdentity(appPath, options.configuration);
+    manifest.appIdentity = identity;
+    const simctl = (args: string[]) => execFileSync('xcrun', ['simctl', ...args], { env, encoding: 'utf8' }).trim();
+    const deviceListing = simctl(['list', 'devices', '--json']);
+    manifest.deviceListing = JSON.parse(deviceListing) as unknown;
+    const listing = JSON.parse(deviceListing) as { devices: Record<string, { udid: string; state: string }[]> };
+    if (
+      Object.values(listing.devices)
+        .flat()
+        .find((device) => device.udid === udid)?.state !== 'Booted'
+    )
+      simctl(['boot', udid]);
+    simctl(['bootstatus', udid, '-b']);
+    simctl(['install', udid, appPath]);
+    const installedPath = simctl(['get_app_container', udid, identity.bundleIdentifier, 'app']);
+    assertMatchingIdentity(identity, readAppIdentity(installedPath, options.configuration));
+    if (options.configuration === 'Debug') {
+      await assertFreePort(options.port);
+      const log = openSync(join(options.runDir, 'metro.log'), 'w');
+      try {
+        metro = spawn(
+          'vp',
+          [
+            'exec',
+            'tsx',
+            join(ROOT, 'scripts/mobile-dev-start.ts'),
+            '--host',
+            'localhost',
+            '--port',
+            String(options.port),
+          ],
+          {
+            cwd: checkout,
+            env,
+            stdio: ['ignore', log, log],
+            detached: true,
+          },
+        );
+      } finally {
+        closeSync(log);
+      }
+      manifest.ownedPids = [metro.pid];
+      save();
+      await waitForOwnedMetro(options.port, checkout, metro);
+    }
+    manifest.status = 'capturing';
+    save();
+    run(
+      'vp',
+      [
+        'exec',
+        'tsx',
+        join(ROOT, 'scripts/mobile-profile-capture.ts'),
+        '--run-dir',
+        options.runDir,
+        '--udid',
+        udid,
+        '--app-id',
+        identity.bundleIdentifier,
+        '--configuration',
+        options.configuration,
+        '--port',
+        String(options.port),
+        '--app-path',
+        appPath,
+      ],
+      checkout,
+      env,
+    );
+    assertMatchingIdentity(
+      identity,
+      readAppIdentity(simctl(['get_app_container', udid, identity.bundleIdentifier, 'app']), options.configuration),
+    );
+    validateCaptureFiles(
+      JSON.parse(readFileSync(join(options.runDir, 'measurements.json'), 'utf8')) as unknown,
+      JSON.parse(readFileSync(join(options.runDir, 'capture-validity.json'), 'utf8')) as unknown,
+    );
+    manifest.status = 'complete';
+    return 0;
+  } catch (error) {
+    manifest.status = 'invalid';
+    manifest.failure = error instanceof Error ? error.message : String(error);
+    console.error(manifest.failure);
+    return 1;
+  } finally {
+    if (metro?.pid && metro.exitCode === null && metro.signalCode === null) {
+      try {
+        process.kill(-metro.pid, 'SIGTERM');
+      } catch {
+        /* Owned process already exited. */
+      }
+    }
+    lease.release();
+    manifest.finishedAt = new Date().toISOString();
+    save();
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main()
+    .then((status) => {
+      process.exitCode = status;
+    })
+    .catch((error: unknown) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    });
+}

--- a/scripts/mobile-screenshot.sh
+++ b/scripts/mobile-screenshot.sh
@@ -9,6 +9,13 @@ if ! command -v xcrun &>/dev/null || ! xcrun simctl list devices &>/dev/null 2>&
   exit 0
 fi
 
+# Resolve once and hold ownership across the entire command, including launch/logs.
+if [ -z "${BOARDSESH_SIMULATOR_LEASE_TOKEN:-}" ]; then
+  cd "$ROOT_DIR"
+  exec vp exec tsx scripts/mobile-simulator-lease.ts bash "$SCRIPT_DIR/mobile-screenshot.sh" "$@"
+fi
+vp exec tsx "$SCRIPT_DIR/mobile-simulator-lease.ts" --assert-only
+
 DELAY=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -40,7 +47,7 @@ mkdir -p "$SCREENSHOT_DIR"
 TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 SCREENSHOT_PATH="$SCREENSHOT_DIR/mobile-${TIMESTAMP}.png"
 
-xcrun simctl io booted screenshot "$SCREENSHOT_PATH"
+xcrun simctl io "$BOARDSESH_IOS_SIMULATOR_UDID" screenshot "$SCREENSHOT_PATH"
 
 echo "[mobile-screenshot] Saved: .boardsesh/screenshots/mobile-${TIMESTAMP}.png"
 exit 0

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -1,3 +1,4 @@
+import { guardSimulatorCommand } from './lib/ios-simulator-lease';
 /// <reference types="node" />
 
 /**
@@ -434,11 +435,13 @@ export interface DeviceInfo {
 }
 
 function runInherit(command: string, args: string[], env: NodeJS.ProcessEnv, cwd: string = ROOT_DIR): number {
+  guardSimulatorCommand(command, args, ROOT_DIR);
   const result = spawnSync(command, args, { cwd, env, stdio: 'inherit' });
   return result.status ?? 1;
 }
 
 function runCapture(command: string, args: string[]): { status: number; stdout: string } {
+  guardSimulatorCommand(command, args, ROOT_DIR);
   const result = spawnSync(command, args, { encoding: 'utf8' });
   return { status: result.status ?? 1, stdout: result.stdout ?? '' };
 }
@@ -544,6 +547,20 @@ export function resolveAppStoreLocaleTargets(appLocales: readonly Locale[]): App
 
 export function findOrCreateIosDevice(screenshotDevice: IosScreenshotDevice): DeviceInfo {
   const devices = listSimulatorDevices();
+  const selectedUdid = process.env.BOARDSESH_IOS_SIMULATOR_UDID;
+  if (selectedUdid) {
+    const selectedDevice = devices.find((device) => device.udid.toUpperCase() === selectedUdid.toUpperCase());
+    if (!selectedDevice) throw new Error(`Selected simulator ${selectedUdid} is unavailable.`);
+    if (
+      screenshotDevice.name !== selectedDevice.name &&
+      screenshotDevice.name.toUpperCase() !== selectedUdid.toUpperCase()
+    ) {
+      throw new Error(
+        `Screenshot device ${screenshotDevice.name} differs from leased simulator ${selectedDevice.name}. Pass the leased device explicitly.`,
+      );
+    }
+    return selectedDevice;
+  }
   const booted = devices.find((device) => device.name === screenshotDevice.name && device.state === 'Booted');
   if (booted) return booted;
   const existing = devices.find((device) => device.name === screenshotDevice.name);
@@ -577,13 +594,15 @@ export function findOrCreateIosDevice(screenshotDevice: IosScreenshotDevice): De
  * still isn't unique. Returns null when nothing is booted.
  */
 export function resolveBootedIosDevice(name?: string): DeviceInfo | null {
+  name = process.env.BOARDSESH_IOS_SIMULATOR_UDID ?? name;
   const booted = listSimulatorDevices().filter((device) => device.state === 'Booted');
   if (booted.length === 0) return null;
-  if (booted.length === 1) return booted[0];
   if (name) {
-    const named = booted.filter((device) => device.name === name);
+    const named = booted.filter((device) => device.name === name || device.udid === name);
     if (named.length === 1) return named[0];
+    throw new Error(`Requested simulator ${name} is not uniquely booted.`);
   }
+  if (booted.length === 1) return booted[0];
   throw new Error(
     `Multiple booted simulators (${booted.map((device) => device.name).join(', ')}); pass --device "<name>" to pick one.`,
   );
@@ -905,25 +924,12 @@ function captureIosDevice(
   applyCleanStatusBar(device.udid);
 
   console.log(`${LOG} Installing ${appPath} on ${device.name} for ${localeTarget.appLocale}...`);
-  // Uninstall first so the run starts from a clean container (fresh AsyncStorage,
-  // so no stale active board). The dev-client + Metro path drops Maestro's
-  // `clearState`, which can't run before the bundle has loaded — the uninstall +
-  // install gives the same fresh-data guarantee.
-  runCapture('xcrun', ['simctl', 'uninstall', device.udid, APP_ID]);
+  // Install in place to preserve app data and the simulator keychain.
   const install = runCapture('xcrun', ['simctl', 'install', device.udid, appPath]);
   if (install.status !== 0) {
     console.error(`${LOG} FAILED: simctl install exited ${install.status}.`);
     return install.status;
   }
-
-  // Reset the simulator keychain so the app's auto-sign-in re-authenticates
-  // against the target backend. The auth token lives in a shared keychain access
-  // group (group.com.boardsesh.app) that survives both an app uninstall and the
-  // fresh install above — so without this a stale token (e.g. from a previous
-  // --backend local run) is reused and the app talks to the wrong backend with an
-  // invalid session. A clean keychain forces a fresh sign-in with the baked creds.
-  console.log(`${LOG} Resetting simulator keychain (clears any stale auth token)...`);
-  runCapture('xcrun', ['simctl', 'keychain', device.udid, 'reset']);
 
   const captureDir = mkdtempSync(join(tmpdir(), 'boardsesh-shots-'));
   try {

--- a/scripts/mobile-simulator-check.sh
+++ b/scripts/mobile-simulator-check.sh
@@ -10,6 +10,13 @@ if ! command -v xcrun &>/dev/null || ! xcrun simctl list devices &>/dev/null 2>&
   exit 0
 fi
 
+# Resolve once and hold ownership across the entire command, including launch/logs.
+if [ -z "${BOARDSESH_SIMULATOR_LEASE_TOKEN:-}" ]; then
+  cd "$ROOT_DIR"
+  exec vp exec tsx scripts/mobile-simulator-lease.ts bash "$SCRIPT_DIR/mobile-simulator-check.sh" "$@"
+fi
+vp exec tsx "$SCRIPT_DIR/mobile-simulator-lease.ts" --assert-only
+
 if [ ! -d "$MOBILE_DIR" ]; then
   echo "[mobile-sim] FAILED: packages/mobile/ not found at $MOBILE_DIR"
   exit 1
@@ -17,11 +24,18 @@ fi
 
 cd "$ROOT_DIR"
 
-echo "[mobile-sim] Building and launching on iOS simulator (shared-cache expo run:ios)..."
-
-if ! tsx scripts/mobile-ios-run.ts 2>&1; then
-  echo "[mobile-sim] FAILED: mobile iOS build exited with an error"
-  exit 1
+if [ -n "${BOARDSESH_IOS_SMOKE_APP_PATH:-}" ]; then
+  echo "[mobile-sim] Installing and launching the selected existing simulator app..."
+  if ! vp exec tsx scripts/mobile-simulator-smoke.ts "$BOARDSESH_IOS_SMOKE_APP_PATH" 2>&1; then
+    echo "[mobile-sim] FAILED: existing simulator app validation or launch failed"
+    exit 1
+  fi
+else
+  echo "[mobile-sim] Building and launching on iOS simulator (shared-cache expo run:ios)..."
+  if ! tsx scripts/mobile-ios-run.ts 2>&1; then
+    echo "[mobile-sim] FAILED: mobile iOS build exited with an error"
+    exit 1
+  fi
 fi
 
 mkdir -p "$ROOT_DIR/.boardsesh"
@@ -30,7 +44,7 @@ LOG_FILE="$ROOT_DIR/.boardsesh/mobile-device.log"
 
 echo "[mobile-sim] Capturing 30s of device logs..."
 
-xcrun simctl spawn booted log stream \
+xcrun simctl spawn "$BOARDSESH_IOS_SIMULATOR_UDID" log stream \
   --predicate 'subsystem == "com.boardsesh.app"' \
   --timeout 30 \
   > "$LOG_FILE" 2>&1 || true

--- a/scripts/mobile-simulator-lease.ts
+++ b/scripts/mobile-simulator-lease.ts
@@ -1,0 +1,25 @@
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { leaseEnvironment, resolveSimulatorUdid } from './lib/ios-simulator-lease';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const [command, ...args] = process.argv.slice(2).filter((argument) => argument !== '--');
+if (!command) throw new Error('Expected a command to run while holding the simulator lease.');
+const inheritedToken = process.env.BOARDSESH_SIMULATOR_LEASE_TOKEN;
+if (command === '--assert-only' && (!inheritedToken || !process.env.BOARDSESH_IOS_SIMULATOR_UDID)) {
+  throw new Error('An inherited simulator lease requires both its token and exact UDID.');
+}
+const lease = leaseEnvironment(resolveSimulatorUdid(), root);
+try {
+  if (command === '--assert-only') {
+    if (lease.env.BOARDSESH_SIMULATOR_LEASE_TOKEN !== inheritedToken) {
+      throw new Error('The inherited simulator lease token is stale or invalid.');
+    }
+  } else {
+    const result = spawnSync(command, args, { cwd: root, env: lease.env, stdio: 'inherit' });
+    process.exitCode = result.status ?? 1;
+  }
+} finally {
+  lease.release();
+}

--- a/scripts/mobile-simulator-smoke.ts
+++ b/scripts/mobile-simulator-smoke.ts
@@ -1,0 +1,33 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assertMatchingIdentity, readAppIdentity } from './lib/ios-profile-identity';
+import { guardSimulatorCommand, resolveSimulatorUdid } from './lib/ios-simulator-lease';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const appPath = process.argv[2];
+if (!appPath) throw new Error('Pass the existing simulator app export for the smoke check.');
+const configuration = existsSync(join(appPath, 'main.jsbundle')) ? 'Release' : 'Debug';
+const identity = readAppIdentity(resolve(appPath), configuration);
+const udid = resolveSimulatorUdid();
+const simctl = (args: string[]) => {
+  guardSimulatorCommand('xcrun', ['simctl', ...args], root);
+  return execFileSync('xcrun', ['simctl', ...args], { encoding: 'utf8' }).trim();
+};
+const listing = JSON.parse(simctl(['list', 'devices', '--json'])) as {
+  devices: Record<string, { udid: string; state: string }[]>;
+};
+if (
+  Object.values(listing.devices)
+    .flat()
+    .find((device) => device.udid === udid)?.state !== 'Booted'
+) {
+  simctl(['boot', udid]);
+}
+simctl(['bootstatus', udid, '-b']);
+simctl(['install', udid, resolve(appPath)]);
+const installedPath = simctl(['get_app_container', udid, identity.bundleIdentifier, 'app']);
+assertMatchingIdentity(identity, readAppIdentity(installedPath, configuration));
+simctl(['launch', udid, identity.bundleIdentifier]);
+console.log(`[mobile-sim] Launched verified ${configuration} export ${identity.bundleIdentifier} on ${udid}.`);

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "//": "Typechecks the repo-root scripts, which were previously never validated by CI — `vp run typecheck` only covered packages/*. Wired in via the `typecheck:scripts` task. Scoped to the Discord feedback pipeline, the dev-db discovery watchdog and the board-art geometry generator for now; widen `include` as other scripts are made type-clean.",
+  "//": "Typechecks the repo-root scripts wired into typecheck:scripts, including the Discord feedback pipeline, development tooling, board-art generation, Railway configuration, and iOS profiling/build/simulator ownership tools with their regression tests.",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
@@ -31,6 +31,23 @@
     "railway-apply.ts",
     "railway-apply.test.ts",
     "../infra/railway/config.ts",
-    "../infra/railway/plan.ts"
+    "../infra/railway/plan.ts",
+    "mobile-profile-capture.ts",
+    "mobile-profile-ios.ts",
+    "mobile-simulator-lease.ts",
+    "mobile-simulator-smoke.ts",
+    "lib/ios-profile-identity.ts",
+    "lib/ios-simulator-lease.ts",
+    "lib/ios-build-export.ts",
+    "lib/metro-host.ts",
+    "mobile-ios-run.ts",
+    "mobile-build-sim-app.ts",
+    "mobile-dev-start.ts",
+    "mobile-screenshots.ts",
+    "mobile-ios-shots.ts",
+    "__tests__/ios-profiling-tools.test.ts",
+    "__tests__/mobile-ios-run.test.ts",
+    "__tests__/mobile-screenshots.test.ts",
+    "__tests__/mobile-profile-capture.test.ts"
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -999,6 +999,10 @@ export default defineConfig({
         command: 'tsx scripts/mobile-ios-run.ts',
         cache: false,
       },
+      'mobile:profile:ios': {
+        command: 'tsx scripts/mobile-profile-ios.ts',
+        cache: false,
+      },
       'mobile:screenshot': {
         command: 'bash scripts/mobile-screenshot.sh',
         cache: false,


### PR DESCRIPTION
## Summary

Add an owned-simulator profiling workflow with fresh native projects, verified executable/bundle identities, bounded local startup artifacts supplied by companion #5328, and capture validity checks. Failed native builds cannot export stale apps; localhost Metro flags and opt-in Watchman are consistent.

Author verification: 9,351 mobile tests, mobile/repository typechecks, iOS/Android bundles, native Release smoke test, screenshot check, and lint/format passed. Independent implementation review completed. 152 focused tooling tests pass. Both fresh Release native fingerprints match; launcher-free Debug tracing completes. The capture command requires the companion startup collector. Includes a one-line repair for a missing baseline Bluetooth test mock; production BLE is unchanged.

Stack: [tooling #5327](https://github.com/boardsesh/boardsesh/pull/5327) → [feedback/startup #5328](https://github.com/boardsesh/boardsesh/pull/5328) → [Discover #5329](https://github.com/boardsesh/boardsesh/pull/5329). Separate PR bases keep each implementation diff focused.

Controlled results and limitations: [performance follow-up](https://github.com/boardsesh/boardsesh/blob/codex/ios-discover-performance/docs/ios-performance-follow-up-2026-09-08.md).

## Release Notes

none

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — local profiling, native build coordination, and simulator tooling.
