### PR TITLE
perf(mobile): pause closed feedback work and attribute startup

### DIFF
--- a/docs/ios-performance-follow-up-2026-09-08.md
+++ b/docs/ios-performance-follow-up-2026-09-08.md
@@ -1,0 +1,231 @@
+# iOS performance follow-up — 8 September 2026
+
+This follow-up addresses the five findings in [the original audit PR](https://github.com/boardsesh/boardsesh/pull/5323). Measurements use a dedicated iPhone 17 Pro simulator on iOS 26.5, local fixtures, and unchanged readiness gates and cache limits. Debug observations attribute JavaScript/React work; they are not native FPS or production performance budgets.
+
+## Controlled setup
+
+The baseline is fetched main `0691f93b` plus the audit document and startup instrumentation (capture checkout `fef7a08ec`). Instrumentation was installed before baseline capture. The candidate adds the reviewed Discover and feedback changes. Its only collector difference is a corrected description of the clock: RN `performance.now()` is monotonic uptime here, so compare differences within each run, never absolute values between processes or against host timestamps.
+
+The owned simulator is `EF3B3CC1-A130-4254-82A6-6ADCA7423106`, named **Boardsesh Performance Comparison 2026-09-08**. A shared simulator lease spans installation, navigation, screenshots, and profiling. No other simulator, Metro process, app data, or keychain was reset. Native builds and test suites finished before timed captures.
+
+Fixtures contain 200 owned and 200 community playlists, each containing twelve real Tension climbs. Fixture content hash: `837d9e4ee0c9546cb60a46c7c2c32150328334efc145459afdde70e2bf605014`. The local backend uses port 8198. Screenshot-mode automatic login, board selection, Aura rendering, and initial simulated wall are identical. Community popular/recent streams overlap, so their first merged page contains ten unique cards; pagination reaches all 200.
+
+Both Release apps are ordinary embedded builds from fresh dedicated native projects, with the same native fingerprint `3a1516787db2fe5b033b3a1462ba518dbee5bbee`. Debug uses a fresh launcher/menu-free project with supported Expo autolinking exclusions. The same validated Debug executable is reused for candidate JavaScript. The candidate temporary checkout hit `FSEventStreamStart` before recording; its successful Debug run uses the main workspace's existing Watchman watch and the same candidate source. The failed attempts remain explicitly invalid. Binary identities and source patch hashes are retained with the captures.
+
+## Finding dispositions
+
+| Finding | Disposition | Evidence / remaining work |
+| --- | --- | --- |
+| Stable Discover actions | Fixed | Callback-only card renders: 780 → 0 in five measured tab loops. |
+| Growing Discover shelves | Fixed | Both shelves mount seven cards at 20/100/200 loaded; real gestures request one page. |
+| Closed feedback subscriptions | Fixed | Closed form renders: 20 → 0; native drafts and dismissal pass. |
+| Startup attribution | Investigated without an established defect | Local phase marks added; initialization order and gates preserved. See distributions below. |
+| Repeatable profiling setup | Fixed | Owned simulator/build locks, valid binary identities, completed Debug tracing, stale-capture rejection, and local artifacts. OS watcher failure is retained as an invalid attempt. |
+| Retained-object / phone performance attribution | Explicitly awaiting device validation | Incomplete simulator allocation capture establishes no leak. Native FPS, energy, and allocation ownership remain unmeasured. |
+
+## Discover and feedback
+
+Two warm-up Home → Climbs → Discover → Profile loops preceded five measured loops in each Debug runtime. All twenty measured destinations were verified.
+
+| Metric | Baseline | Candidate |
+| --- | ---: | ---: |
+| Exact PlaylistCard renders caused only by action props | 780 | 0 |
+| Closed FeedbackSheet renders | 20 | 0 |
+| PlaylistCard self render time | 61.382 ms | 0 ms |
+| Closed FeedbackSheet self render time | 14.821 ms | 0 ms |
+| Largest React commit | 40.514 ms | 19.390 ms |
+| All React commits | 115 | 125 |
+| Owned shelf mounted cards at 20 / 100 / 200 loaded | 20 / 100 / 200 | 7 / 7 / 7 |
+| Community shelf mounted cards at 20 / 100 / 200 loaded | 20 / 100 / 200 | 7 / 7 / 7 |
+
+Zero renders means no measured updates after warm-up, not an empty screen. Native screenshots confirm visible cards. The candidate still has the fixed eight-card smart shelf and capped pinned grid. During a real horizontal gesture, the recycler used eight mounted cards while showing a different portion of the shelf.
+
+Maximum long tasks on each of the five Discover visits were **133.56, 139.28, 122.98, 138.38, 132.26 ms** before and **74.79, 78.84, 79.70, 80.92, 61.89 ms** after. Medians were **133.56 → 78.84 ms**; nearest-rank p95 values **139.28 → 80.92 ms**. This is one controlled Debug attribution comparison, not a production latency promise.
+
+Maximum JS callback gaps by Discover visit were **142.28, 147.96, 131.54, 146.87, 140.44 ms** before and **84.34, 87.28, 88.90, 89.00, 71.24 ms** after. These are JS callback gaps, not displayed-frame intervals.
+
+Mounted-card counts are actual React fibers in the native app. For this capacity probe, the existing pagination action is called once per settled page; it does not substitute for gesture testing. The final candidate probe asserts and records the actual loaded length at each target before counting mounted cards. Exact `PlaylistCard` matching excludes new adapters and list wrappers. No playlists are capped or removed.
+
+### Maximum JS long task per measured visit (ms)
+
+| Tab | Baseline visits 1–5 | Candidate visits 1–5 | Baseline p50 / p95 | Candidate p50 / p95 |
+| --- | --- | --- | ---: | ---: |
+| home | 55.97, 75.39, 76.51, 98.18, 79.04 | 75.45, 75.61, 75.55, 72.55, 74.63 | 76.51 / 98.18 | 75.45 / 75.61 |
+| climbs | 76.81, 78.78, 76.83, 56.79, 70.94 | 75.90, 75.14, 75.37, 74.98, 76.01 | 76.81 / 78.78 | 75.37 / 76.01 |
+| discover | 133.56, 139.28, 122.98, 138.38, 132.26 | 74.79, 78.84, 79.70, 80.92, 61.89 | 133.56 / 139.28 | 78.84 / 80.92 |
+| profile | 73.17, 72.35, 71.00, 72.52, 73.10 | 69.75, 70.35, 55.06, 72.64, 69.30 | 72.52 / 73.17 | 69.75 / 72.64 |
+
+### Maximum JS callback gap per measured visit (ms)
+
+| Tab | Baseline visits 1–5 | Candidate visits 1–5 | Baseline p50 / p95 | Candidate p50 / p95 |
+| --- | --- | --- | ---: | ---: |
+| home | 67.80, 84.29, 84.55, 105.45, 87.78 | 85.98, 83.14, 84.22, 80.00, 82.85 | 84.55 / 105.45 | 83.14 / 85.98 |
+| climbs | 85.21, 86.42, 85.80, 63.47, 79.74 | 84.61, 83.58, 83.95, 82.66, 84.40 | 85.21 / 86.42 | 83.95 / 84.61 |
+| discover | 142.28, 147.96, 131.54, 146.87, 140.44 | 84.34, 87.28, 88.90, 89.00, 71.24 | 142.28 / 147.96 | 87.28 / 89.00 |
+| profile | 82.06, 80.44, 80.55, 80.16, 81.68 | 77.32, 78.42, 61.76, 81.48, 77.94 | 80.55 / 82.06 | 77.94 / 81.48 |
+
+## Startup
+
+Ten process-cold, warm-cache launches per Release build terminate only the app. A useful Home commit must represent content, empty, offline, or error output; loading placeholders do not qualify. The collector writes one bounded local artifact after a one-second export delay. The host observation includes that delay, polling, and `simctl` overhead, so it is not time to first frame. Root-to-Home and gate spans use only the JS clock.
+
+All twenty original launches reached authenticated Home content with ready fonts/SQLite/splash marks and no SQLite background recovery. Percentiles use nearest rank; with ten samples, p95 equals the maximum.
+
+| Measurement | Baseline p50 | Candidate p50 | Difference | Baseline p95 | Candidate p95 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Host: local export observed | 3046.46 | 3658.19 | +611.73 | 3110.52 | 3784.03 |
+| JS: collector → useful Home | 333.37 | 675.22 | +341.85 | 384.12 | 719.06 |
+| JS: required fonts wait | 26.03 | 141.44 | +115.41 | 27.73 | 148.78 |
+| JS: SQLite initial launch gate | 3.24 | 112.50 | +109.26 | 3.47 | 125.61 |
+| JS: initial authentication | 16.37 | 15.81 | -0.56 | 18.57 | 18.51 |
+| JS: splash hide promise | 67.23 | 63.45 | -3.78 | 69.88 | 67.01 |
+| JS: splash resolved → useful Home | 172.81 | 300.21 | +127.40 | 228.40 | 354.10 |
+| JS: collector → root module ready | 22.01 | 20.21 | -1.80 | 26.73 | 23.38 |
+| JS: root module → root commit | 8.20 | 8.97 | +0.78 | 9.20 | 10.33 |
+| RN: startup start → end | 36.78 | 31.03 | -5.75 | 37.77 | 33.62 |
+
+The sequential candidate group was slower inside measured JS spans, so the host increase cannot be dismissed as polling alone. Mean additional waits concentrate in fonts (+116.32 ms), SQLite readiness (+111.29 ms), and splash resolution to useful Home (+114.12 ms). Authentication and root initialization show no corresponding increase. These spans include native dispatch and JS callback scheduling; they do not establish font-decoding or SQL CPU cost. Startup source is byte-identical between captured checkouts except the clock description. No gates were moved.
+
+RN's bundle-entry and runtime-start markers are almost coincident in these artifacts, with the bundle marker about 0.003–0.004 ms earlier. They do not isolate separate runtime-versus-bundle work. Native allocation/frame attribution remains necessary.
+
+### Baseline individual launches (ms)
+
+| Trial | Host export | JS collector → Home | Fonts | SQLite gate | Auth | Splash promise | Splash → Home | RN startup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 3041.99 | 318.86 | 21.67 | 3.11 | 15.95 | 67.26 | 171.81 | 36.67 |
+| 2 | 3110.52 | 371.70 | 22.57 | 3.43 | 16.21 | 67.11 | 220.98 | 36.37 |
+| 3 | 3056.74 | 374.23 | 25.63 | 3.42 | 16.38 | 66.58 | 224.94 | 37.14 |
+| 4 | 3057.94 | 369.84 | 25.70 | 3.10 | 16.59 | 66.47 | 220.49 | 37.13 |
+| 5 | 3055.14 | 384.12 | 26.03 | 3.24 | 18.57 | 68.83 | 228.40 | 36.51 |
+| 6 | 3046.46 | 323.27 | 26.54 | 3.31 | 16.37 | 67.43 | 171.82 | 37.15 |
+| 7 | 3057.37 | 323.27 | 27.30 | 3.23 | 16.33 | 67.02 | 171.56 | 37.67 |
+| 8 | 3042.51 | 326.68 | 26.71 | 3.19 | 15.79 | 69.88 | 172.64 | 36.78 |
+| 9 | 3032.71 | 377.75 | 27.04 | 3.47 | 16.82 | 67.51 | 224.18 | 37.77 |
+| 10 | 3041.22 | 333.37 | 27.73 | 3.44 | 17.39 | 67.23 | 172.81 | 36.76 |
+
+### Candidate individual launches (ms)
+
+| Trial | Host export | JS collector → Home | Fonts | SQLite gate | Auth | Splash promise | Splash → Home | RN startup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 3678.89 | 718.80 | 139.86 | 111.10 | 15.48 | 63.26 | 354.10 | 30.34 |
+| 2 | 3784.03 | 681.24 | 148.78 | 125.61 | 15.93 | 65.65 | 286.79 | 33.62 |
+| 3 | 3658.19 | 668.82 | 141.74 | 111.67 | 15.81 | 63.42 | 301.28 | 31.45 |
+| 4 | 3673.01 | 667.74 | 140.02 | 116.63 | 17.99 | 65.36 | 293.06 | 30.74 |
+| 5 | 3645.58 | 670.32 | 141.44 | 112.17 | 16.02 | 63.45 | 300.21 | 31.03 |
+| 6 | 3679.24 | 675.22 | 139.32 | 112.74 | 15.32 | 67.01 | 305.76 | 31.30 |
+| 7 | 3643.25 | 719.06 | 141.99 | 113.43 | 15.75 | 63.04 | 344.80 | 31.44 |
+| 8 | 3648.95 | 662.44 | 140.58 | 112.04 | 15.58 | 64.42 | 294.73 | 31.11 |
+| 9 | 3543.66 | 677.98 | 143.66 | 117.98 | 18.51 | 66.60 | 296.05 | 30.03 |
+| 10 | 3662.03 | 712.32 | 142.73 | 112.50 | 15.82 | 62.86 | 344.09 | 30.53 |
+
+### Reinstalled-build controls (A1/B1/A2/B2)
+
+A1/B1 are the original baseline/candidate groups; A2/B2 repeat the same respective executable and embedded bundle after the twenty-cycle browsing runs. Each group contains ten process-cold launches. The control identities match their originals before and after capture; app data, keychain, and caches remain preserved.
+
+All values below are milliseconds; p50 and p95 use nearest rank. Combined intervals are calculated within each individual trial before deriving distributions.
+
+| Measurement | A1 p50 | B1 p50 | A2 p50 | B2 p50 | B2 − A2 | B2 p95 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Host: local export observed | 3046.46 | 3658.19 | 3345.98 | 3634.63 | +288.65 | 3660.81 |
+| JS: collector → useful Home | 333.37 | 675.22 | 670.22 | 664.41 | -5.81 | 705.87 |
+| JS: required fonts wait | 26.03 | 141.44 | 136.49 | 140.09 | +3.60 | 150.52 |
+| JS: fonts ready → SQLite onInit starts | 2.68 | 0.03 | 40.19 | 0.03 | -40.17 | 0.03 |
+| JS: SQLite onInit → launch gate | 3.24 | 112.50 | 73.28 | 112.76 | +39.48 | 133.04 |
+| JS: fonts ready → SQLite launch gate | 5.93 | 112.53 | 113.66 | 112.78 | -0.88 | 133.07 |
+| JS: fonts start → SQLite launch gate | 32.48 | 253.64 | 250.15 | 252.47 | +2.32 | 283.59 |
+| JS: initial authentication | 16.37 | 15.81 | 14.99 | 15.23 | +0.24 | 18.07 |
+| JS: splash hide promise | 67.23 | 63.45 | 64.63 | 63.10 | -1.53 | 65.90 |
+| JS: splash resolved → useful Home | 172.81 | 300.21 | 301.15 | 298.53 | -2.63 | 340.77 |
+| RN: startup start → end | 36.78 | 31.03 | 34.40 | 30.99 | -3.41 | 35.47 |
+
+### A2 individual launches
+
+| Trial | Host export | JS collector → Home | Fonts | SQLite gate | Auth | Splash promise | Splash → Home | RN startup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 3350.35 | 677.86 | 142.74 | 74.09 | 16.17 | 66.62 | 304.18 | 34.40 |
+| 2 | 3352.13 | 708.88 | 139.27 | 101.97 | 15.76 | 68.18 | 299.92 | 34.49 |
+| 3 | 3310.49 | 714.72 | 137.86 | 36.01 | 14.66 | 63.74 | 350.67 | 40.25 |
+| 4 | 3345.98 | 654.75 | 135.30 | 73.24 | 14.99 | 64.63 | 293.68 | 34.15 |
+| 5 | 3350.23 | 663.87 | 136.49 | 73.47 | 15.07 | 63.17 | 301.15 | 34.23 |
+| 6 | 3337.58 | 652.97 | 136.82 | 72.79 | 14.07 | 65.06 | 290.31 | 35.25 |
+| 7 | 3364.18 | 662.79 | 136.08 | 74.44 | 14.89 | 64.79 | 298.70 | 37.02 |
+| 8 | 3297.88 | 716.86 | 135.82 | 73.28 | 15.60 | 63.19 | 356.23 | 34.03 |
+| 9 | 3337.82 | 670.22 | 137.04 | 74.22 | 14.76 | 64.25 | 306.72 | 34.94 |
+| 10 | 3350.30 | 672.12 | 135.48 | 73.18 | 15.24 | 71.34 | 304.13 | 34.16 |
+
+### B2 individual launches
+
+| Trial | Host export | JS collector → Home | Fonts | Fonts ready → SQLite start | SQLite onInit | Combined fonts ready → gate | Post-splash → Home | RN startup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 3557.57 | 661.58 | 140.54 | 0.03 | 112.39 | 112.42 | 294.89 | 35.17 |
+| 2 | 3659.70 | 686.65 | 150.52 | 0.03 | 133.04 | 133.07 | 290.86 | 32.68 |
+| 3 | 3522.70 | 705.87 | 139.25 | 0.03 | 113.20 | 113.23 | 339.30 | 29.88 |
+| 4 | 3554.88 | 659.95 | 140.09 | 0.03 | 112.86 | 112.88 | 291.91 | 35.47 |
+| 5 | 3637.64 | 661.82 | 140.96 | 0.03 | 111.29 | 111.32 | 299.26 | 29.91 |
+| 6 | 3634.63 | 673.59 | 141.58 | 0.02 | 113.59 | 113.62 | 303.49 | 29.44 |
+| 7 | 3660.81 | 705.04 | 138.65 | 0.03 | 112.76 | 112.78 | 340.77 | 29.78 |
+| 8 | 3649.75 | 664.41 | 139.64 | 0.02 | 110.59 | 110.61 | 302.79 | 31.57 |
+| 9 | 3536.77 | 666.33 | 140.38 | 0.03 | 112.90 | 112.93 | 298.53 | 30.99 |
+| 10 | 3652.04 | 657.27 | 139.38 | 0.03 | 110.92 | 110.94 | 294.35 | 32.01 |
+
+### Control interpretation
+
+Restoring the original baseline did not restore the original short font wait or first useful Home interval. In A2, some SQLite-related delay moves from onInit into the uninstrumented opening/dispatch interval before onInit: compare the combined fonts-ready-to-SQLite-gate interval rather than the onInit duration alone.
+
+The A/B/A/B results separate a repeatable difference associated with a build from drift that also affects restored baseline launches. They do not isolate the effect of Discover or feedback changes: preserved local data/cache state, host scheduling, native dispatch, and startup/export work outside measured spans remain uncontrolled. Smaller residual differences require interleaved replication and native attribution; no claim that the optimizations caused the delay, eliminated all delay, or improved displayed launch time follows from this run.
+
+Ordered samples and distributions for all four groups, plus B2−A2 and B2−B1 changes, are retained in startup-comparison.json.
+
+### Observed residual
+
+The B2−A2 host export p50 difference remains **+288.65 ms**, while the JS collector-to-Home p50 difference is **-5.81 ms**. All forty launches reached useful Home content. The remaining host-export difference is observed but not attributed: pre-collector launch work, deferred export scheduling/native file I/O, and host launch/container lookup/polling have no separate stamps.
+
+The control does not establish a user-visible startup regression or a startup speedup. It also does not erase the original slower measurements: it shows that nearly the same JS delays recur on the restored baseline and that further controlled native/host attribution is needed for the residual.
+
+
+
+
+
+## Memory
+
+Twenty browse/background cycles use one Release process per build. Each cycle browses three swipes, backgrounds into Settings, resumes Home, settles for three seconds, and samples physical footprint. Image-cache filenames supply completed render keys and frame/color signatures; they do not identify retained objects or exact distinct climb UUIDs.
+
+The original baseline process (PID 59831) rose from 256.8 to 291.9 MiB; the candidate process (PID 9536) rose from 252.9 to 284.0 MiB. Across the twenty settled observations, baseline p50/p95/max were 291.4/292.3/293.4 MiB; candidate values were 279.7/284.1/284.2 MiB.
+
+| Cycle | Baseline MiB | Candidate MiB | Baseline completed render keys | Candidate completed render keys |
+| ---: | ---: | ---: | ---: | ---: |
+| 1 | 256.8 | 252.9 | not sampled | 385 |
+| 2 | 265.8 | 258.2 | not sampled | 385 |
+| 3 | 269.8 | 266.0 | not sampled | 385 |
+| 4 | 272.2 | 266.5 | not sampled | 385 |
+| 5 | 279.6 | 271.0 | not sampled | 385 |
+| 6 | 280.5 | 270.9 | 146 | 385 |
+| 7 | 278.8 | 271.5 | 146 | 385 |
+| 8 | 278.7 | 280.2 | 163 | 385 |
+| 9 | 279.0 | 280.4 | 181 | 385 |
+| 10 | 292.1 | 281.8 | 199 | 385 |
+| 11 | 292.1 | 279.5 | 216 | 385 |
+| 12 | 292.3 | 279.7 | 234 | 385 |
+| 13 | 291.4 | 279.7 | 251 | 385 |
+| 14 | 291.7 | 279.7 | 269 | 385 |
+| 15 | 291.9 | 280.0 | 286 | 385 |
+| 16 | 291.8 | 284.0 | 304 | 385 |
+| 17 | 293.4 | 284.0 | 321 | 385 |
+| 18 | 291.9 | 284.1 | 338 | 385 |
+| 19 | 291.9 | 284.2 | 356 | 385 |
+| 20 | 291.9 | 284.0 | 373 | 385 |
+
+These are sequential browsing samples, not independent trials or a memory budget. The candidate reused **385 existing render-cache entries throughout**. The baseline sidecar began only after cycle six and saw growth from 146 to 373 entries. Earlier baseline key counts were not sampled. This cache-state difference prevents attributing the smaller candidate footprint to the app changes. Both runs preserved the same cache policy; neither proves that growth is unbounded or that a leak was fixed.
+
+Allocation inspection ran separately from the comparison. The simulator Allocations recorder did not complete and was stopped by its recorded PID. Its trace is invalid. There is no established retained-object defect and no basis here for a memory-leak claim or a cache-policy change. Allocation attribution, exact distinct-climb counts during Release browsing, and native frame/energy measurements remain device-validation work.
+
+## Verification and remaining device work
+
+Mobile typechecking, all 862 mobile test suites / 9,351 tests, iOS/Android bundle checks, and repository typechecking passed. Repository lint/format passed with existing warnings. A pre-existing Bluetooth test mock omitted `consumeBackgroundAdoptSendGate`; the same 17 failures reproduced on baseline. Adding its existing false-return default fixed the test setup without changing production BLE. Astra independently approved that test-only repair.
+
+Native QA confirmed that a programmatic scroll-to-end leaves 20 items loaded, one subsequent real gesture loads exactly 40, and settling does not drain further pages. A recycled card named “Performance owned 180” opened `/discover/ios-performance-v1-owned-180`. Appending kept the scroller in the same portion of the shelf: the first mounted item was “Performance owned 180”, rather than returning to item 200. This is a qualitative position check, not a pixel-offset measurement. The real drawer sequence opened feedback, preserved “Local performance QA draft” through ordinary dismissal/reopening, then stayed closed after drag dismissal and Home navigation. Submission freshness, failed uploads, attachment reuse, consent, authentication/pin changes, smart-pin hydration, duplicate pages, failed pages, and exhausted streams have automated coverage.
+
+Maximum native text-size QA exposed vertical glyph clipping in owned-card labels and shared text, including the unchanged pinned grid, smart shelf, and section headings. The new shelf allocates scaled height, but this run is not an accessibility pass for the existing text system. Text size was restored to `large` before Release measurement. Phone text-layout validation remains explicit follow-up work.
+
+The required simulator smoke and screenshot checks passed against the verified candidate Release export. The tooling has 152 focused tests and is included in the normal scripts typecheck. Three independently reviewed PRs separate [tooling #5327](https://github.com/boardsesh/boardsesh/pull/5327), [feedback/startup #5328](https://github.com/boardsesh/boardsesh/pull/5328), and [Discover #5329](https://github.com/boardsesh/boardsesh/pull/5329).
+
+Raw artifacts are retained locally under `.boardsesh/performance-follow-up-2026-09-08/`: source manifests and patches, executable UUIDs and hashes, embedded bundle hashes, individual measurements, screenshots, React change descriptions, native samples, completed capture verdicts, and rejected attempts. They are intentionally not committed. [The profiling guide](ios-profiling.md) documents repeat runs.

--- a/docs/ios-profiling.md
+++ b/docs/ios-profiling.md
@@ -1,0 +1,89 @@
+# Repeatable local iOS profiling
+
+`vp run mobile:profile:ios` builds in a fresh dedicated checkout, reserves an explicit simulator, checks the installed executable identity, and retains local evidence under `.boardsesh/`. It never resets app data or the simulator keychain. Use the local fixture account and backend; the runner rejects a non-local backend URL. Seed fixtures first; `--fixtures <manifest>` defaults to `.boardsesh/ios-performance-fixtures.json` and must describe at least 200 owned and 200 community playlists with real climbs. The manifest hash and non-secret fixture settings are recorded with each run.
+
+```sh
+EXPO_PUBLIC_BACKEND_URL=http://localhost:8198 \
+EXPO_PUBLIC_SCREENSHOT_MODE=1 \
+BOARDSESH_METRO_USE_WATCHMAN=1 \
+vp run mobile:profile:ios -- \
+  --udid <simulator-udid> \
+  --source-ref <commit-with-instrumentation> \
+  --configuration Release \
+  --run-dir .boardsesh/profile-baseline-release
+```
+
+Maestro must be installed and able to find a local JDK before any build starts. If Java is not on PATH, set `JAVA_HOME` to its installed location (for Homebrew JDK 21 on Apple Silicon, `/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home`). The runner checks `maestro --version` and does not download Java.
+
+Create a dedicated simulator in Xcode first and use its UDID throughout the comparison. `--checkout <path>` accepts an already prepared dedicated worktree, but refuses one containing a generated `packages/mobile/ios` project. Dependencies can be installed beforehand with `vp install`. The default creates a detached git worktree at the requested source ref and installs its dependencies. Checkouts and evidence remain available after failure.
+
+Use `--configuration Debug --port <free-port>` for React attribution and tracing capability checks. The runner excludes Expo's development launcher and menu using the dedicated checkout's `expo.autolinking.ios.exclude` configuration. It sets the generated React Native bundle provider to the chosen localhost port and verifies the native dependencies no longer contain the launcher/menu. These changes are local to the generated profiling build. Ordinary Release captures use an embedded bundle.
+
+The build helper can also be used independently without launching:
+
+```sh
+BOARDSESH_PROFILE_BUILD=1 \
+BOARDSESH_PROFILE_SOURCE_DIR=/path/to/fresh/profiling-checkout \
+BOARDSESH_IOS_BUILD_CACHE_DIR=/path/to/run/native-cache/build \
+vp run mobile:build-sim-app -- --configuration Release --app-out /path/to/run/app
+```
+
+The caller is responsible for preserving identical fixture, authentication, rendering, and instrumentation settings across baseline and candidate. Never compare an instrumented candidate with an uninstrumented baseline. Include at least 200 owned and 200 community playlists with real climbs for shelf population measurements.
+
+## Captures and validity
+
+The run manifest records the source commit, tracked patch, untracked source hashes, native fingerprint, build configuration, final generated input hashes, executable UUID and SHA256, embedded bundle SHA256, simulator UDID, Metro port, and owned process IDs. The installed application is checked both before and after capture. Foreign installation, an incomplete capture, or missing required samples marks the run invalid and preserves its artifacts.
+
+Debug navigation runs two warm-up four-tab loops followed by five measured loops. JavaScript callback gaps and React render durations are attribution evidence, not native UI FPS. The capture checks `Tracing.start` in a fresh process and records whether a trace completes. React renderer profiles and native `sample` remain explicit fallbacks; unavailable tracing is recorded, never called a completed trace.
+
+Release captures include ten process-cold, warm-cache launches and twenty browsing/background cycles in one process. Startup artifacts are written to the app's local Documents directory by `EXPO_PUBLIC_PROFILE_STARTUP=1`. Each launch must produce a new runtime ID. The host measures when the deferred artifact export becomes observable, which includes polling and export delay; it is not time to first displayed frame. The JS timestamps and native runtime markers retain separate clock labels.
+
+Memory sampling uses physical footprint at settled Home after each browsing/background cycle. A missing footprint or changed process invalidates the memory sequence. Run retained-object/allocation inspection separately and record distinct climb/render keys before changing any cache limit or claiming a leak. A simulator result does not establish a phone performance budget.
+
+## Ownership and cleanup
+
+Build commands acquire the shared cache lock before prebuild, cache changes, or CocoaPods work. A failed Xcode build fails even if an old `.app` exists. A new app export is staged and validated before the previous successful export is replaced.
+
+Simulator build/launch, screenshot, navigation, log, and shutdown commands share leases in `~/Library/Caches/boardsesh/simulator-leases`. A live foreign lease is refused. A stopped or incomplete lease is also refused: inspect the recorded owner and remove only that stale lease metadata before retrying. A long run's ownership is never stolen based only on its age. Child commands inherit the selected UDID and ownership token.
+
+For existing ad-hoc commands, select the same device explicitly:
+
+```sh
+BOARDSESH_IOS_SIMULATOR_UDID=<simulator-udid> vp run check:mobile-simulator
+BOARDSESH_IOS_SIMULATOR_UDID=<simulator-udid> vp run mobile:screenshot
+```
+
+Multi-device store screenshot runs must not inherit a lease for a different model; otherwise the tool refuses to label one simulator's images as another model. Screenshot installation preserves app data and keychain. If a capture needs a clean account, create a dedicated simulator or sign out through the app.
+
+Metro started by a profiling run is stopped only through its recorded owned process group. Ad-hoc shutdown no longer kills arbitrary listeners found by port. Stop an ad-hoc Metro through the terminal that started it. The selected simulator stays booted for inspection.
+
+`--host localhost`, `--host=localhost`, and `--localhost` now advertise localhost even when Tailscale is configured. `BOARDSESH_METRO_USE_WATCHMAN=1` explicitly checks Watchman availability; leaving it unset preserves Expo's default.
+
+## Local fixture seed
+
+The additive fixture script requires an explicit loopback database URL and the existing `test@boardsesh.com` account:
+
+```sh
+BOARDSESH_PROFILE_DATABASE_URL=postgresql://postgres:password@localhost:5432/main \
+vp exec tsx packages/db/scripts/seed-ios-performance.ts
+```
+
+It creates 200 owned and 200 public community playlists, each referencing twelve real Tension climbs. Repeating it preserves the same fixture identifiers. The local `.boardsesh/ios-performance-fixtures.json` records those identifiers, climb references, and their SHA256. Existing user data is preserved.
+
+Use `EXPO_PUBLIC_SCREENSHOT_USER_EMAIL=test@boardsesh.com` and `EXPO_PUBLIC_SCREENSHOT_USER_PASSWORD=test` with the local screenshot mode if automatic fixture login is needed. The local backend must have its development authentication secret configured. Select the same board, angle, language, and rendering mode in both runs.
+
+The `performance.now()` values exported by this RN version can be monotonic uptime values. Derive durations by subtracting marks within the same launch; do not interpret a raw mark as milliseconds since process creation or compare raw marks across launches. A visible Home commit is also distinct from the native screen displaying its pixels.
+
+The runner records completed overlay filenames from the app's existing `board-thumbnails` cache. Unique trailing hashes distinguish frame/color signatures, while full filenames include board configuration, style, and resolution. These are render-cache observations, not counts of retained objects or exact climb UUIDs. Keep allocation inspection separate from the launch and navigation measurements.
+
+The supported Debug exclusion follows [Expo's autolinking configuration](https://docs.expo.dev/modules/autolinking/). Interpret [React Native DevTools profiles](https://reactnative.dev/docs/react-native-devtools) alongside native tools; JavaScript timings do not replace displayed-frame measurements.
+
+For post-profiling smoke validation, reuse the verified export without another build or Expo's implicit Metro selection:
+
+```sh
+BOARDSESH_IOS_SIMULATOR_UDID=<simulator-udid> \
+BOARDSESH_IOS_SMOKE_APP_PATH=/path/to/run/app/Boardsesh.app \
+vp run check:mobile-simulator
+```
+
+This opt-in mode validates the existing executable and bundle identity, installs in place, and launches the plist's bundle identifier on the leased device before the normal log smoke check. Leave `BOARDSESH_IOS_SMOKE_APP_PATH` unset for the usual build-and-launch flow. A Debug export still requires its selected Metro server to be running.

--- a/docs/ios-profiling.md
+++ b/docs/ios-profiling.md
@@ -36,7 +36,11 @@ The run manifest records the source commit, tracked patch, untracked source hash
 
 Debug navigation runs two warm-up four-tab loops followed by five measured loops. JavaScript callback gaps and React render durations are attribution evidence, not native UI FPS. The capture checks `Tracing.start` in a fresh process and records whether a trace completes. React renderer profiles and native `sample` remain explicit fallbacks; unavailable tracing is recorded, never called a completed trace.
 
+Debug capture selects an exact app identifier from Metro's registered runtimes and refuses ambiguous targets or debugger URLs outside the selected localhost port. A transport timeout or an unfinished trace aborts the run: tracing overhead must not silently remain active during the measured loops. A Watchman binary can be installed while its operating-system watcher still fails; retain that startup as invalid, preserve unrelated watchers, and verify the source identity again after recovery.
+
 Release captures include ten process-cold, warm-cache launches and twenty browsing/background cycles in one process. Startup artifacts are written to the app's local Documents directory by `EXPO_PUBLIC_PROFILE_STARTUP=1`. Each launch must produce a new runtime ID. The host measures when the deferred artifact export becomes observable, which includes polling and export delay; it is not time to first displayed frame. The JS timestamps and native runtime markers retain separate clock labels.
+
+The selected source ref must include the mobile startup collector, introduced separately from the tooling in [the feedback/startup PR](https://github.com/boardsesh/boardsesh/pull/5328). The runner checks this prerequisite before a native build. The collector is opt-in, keeps one mark per phase, and replaces a fixed local export file rather than appending telemetry.
 
 Memory sampling uses physical footprint at settled Home after each browsing/background cycle. A missing footprint or changed process invalidates the memory sequence. Run retained-object/allocation inspection separately and record distinct climb/render keys before changing any cache limit or claiming a leak. A simulator result does not establish a phone performance budget.
 

--- a/packages/db/scripts/seed-ios-performance.ts
+++ b/packages/db/scripts/seed-ios-performance.ts
@@ -1,0 +1,105 @@
+/** Local-only, additive fixtures for the iOS performance comparison. */
+import { createHash } from 'node:crypto';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { and, asc, eq, inArray } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { boardClimbs, playlistClimbs, playlistOwnership, playlists, users } from '../src/schema/index';
+
+async function main() {
+  const databaseUrl = process.env.BOARDSESH_PROFILE_DATABASE_URL;
+  if (!databaseUrl || !['localhost', '127.0.0.1', '[::1]'].includes(new URL(databaseUrl).hostname)) {
+    throw new Error('Set BOARDSESH_PROFILE_DATABASE_URL to the explicitly selected loopback fixture database.');
+  }
+  const connection = postgres(databaseUrl, { max: 1 });
+  const db = drizzle(connection);
+  try {
+    const [testUser] = await db.select({ id: users.id }).from(users).where(eq(users.email, 'test@boardsesh.com'));
+    if (!testUser) throw new Error('The local test@boardsesh.com fixture account must exist first.');
+    const climbs = await db
+      .select({ uuid: boardClimbs.uuid, name: boardClimbs.name, layoutId: boardClimbs.layoutId })
+      .from(boardClimbs)
+      .where(and(eq(boardClimbs.boardType, 'tension'), eq(boardClimbs.isDraft, false), eq(boardClimbs.isListed, true)))
+      .orderBy(asc(boardClimbs.uuid))
+      .limit(12);
+    if (climbs.length < 12) throw new Error('Load the real Tension climb catalogue before seeding.');
+    const communityOwnerId = 'ios-performance-community-fixture-v1';
+    const fixedTimestamp = new Date('2026-09-08T00:00:00Z');
+    const fixtureUuids: string[] = [];
+    await db.transaction(async (transaction) => {
+      await transaction
+        .insert(users)
+        .values({
+          id: communityOwnerId,
+          name: 'Local performance crew',
+          email: 'ios-performance-fixture@example.invalid',
+          createdAt: fixedTimestamp,
+          updatedAt: fixedTimestamp,
+        })
+        .onConflictDoNothing();
+      for (const shelf of ['owned', 'community'] as const) {
+        for (let index = 0; index < 200; index++) {
+          const ordinal = String(index + 1).padStart(3, '0');
+          const uuid = `ios-performance-v1-${shelf}-${ordinal}`;
+          fixtureUuids.push(uuid);
+          await transaction
+            .insert(playlists)
+            .values({
+              uuid,
+              boardType: 'tension',
+              layoutId: null,
+              name: `Performance ${shelf} ${ordinal}`,
+              description: 'Local deterministic fixture with real Tension climbs.',
+              isPublic: shelf === 'community',
+              createdAt: new Date(fixedTimestamp.getTime() + index * 1000),
+              updatedAt: new Date(fixedTimestamp.getTime() + index * 1000),
+            })
+            .onConflictDoNothing();
+          const [playlist] = await transaction
+            .select({ id: playlists.id })
+            .from(playlists)
+            .where(eq(playlists.uuid, uuid));
+          if (!playlist) throw new Error(`Fixture insert missing: ${uuid}`);
+          await transaction
+            .insert(playlistOwnership)
+            .values({
+              playlistId: playlist.id,
+              userId: shelf === 'owned' ? testUser.id : communityOwnerId,
+              role: 'owner',
+            })
+            .onConflictDoNothing();
+          await transaction
+            .insert(playlistClimbs)
+            .values(
+              climbs.map((climb, position) => ({
+                playlistId: playlist.id,
+                climbUuid: climb.uuid,
+                angle: 40,
+                position,
+              })),
+            )
+            .onConflictDoNothing();
+        }
+      }
+    });
+    const seededPlaylists = await db
+      .select({ uuid: playlists.uuid })
+      .from(playlists)
+      .where(inArray(playlists.uuid, fixtureUuids));
+    if (seededPlaylists.length !== 400) throw new Error('Incomplete fixture set.');
+    const identity = { version: 1, boardType: 'tension', angle: 40, owned: 200, community: 200, climbs, fixtureUuids };
+    const artifact = { ...identity, sha256: createHash('sha256').update(JSON.stringify(identity)).digest('hex') };
+    const outputDirectory = resolve(process.cwd(), '.boardsesh');
+    mkdirSync(outputDirectory, { recursive: true });
+    writeFileSync(resolve(outputDirectory, 'ios-performance-fixtures.json'), JSON.stringify(artifact, null, 2));
+    console.log(`Local fixture ready: 200 owned + 200 community playlists, 12 real climbs each; ${artifact.sha256}`);
+  } finally {
+    await connection.end();
+  }
+}
+
+void main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/index.test.tsx
@@ -103,7 +103,9 @@ vi.mock('@react-native-async-storage/async-storage', () => ({
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('expo-router', () => ({ router: { push: vi.fn() }, useFocusEffect: () => undefined }));
-vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) }));
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0 }),
+}));
 
 // Reanimated primitives the hub touches → inert stubs. Animated.ScrollView just
 // renders its children so the in-body sections (and our error block) are in DOM.
@@ -128,7 +130,11 @@ vi.mock('react-native', () => ({
     onPress?: () => void;
     accessibilityLabel?: string;
   }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
-  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1, absoluteFill: {} },
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+    hairlineWidth: 1,
+    absoluteFill: {},
+  },
   Platform: { OS: 'ios' },
 }));
 
@@ -147,8 +153,12 @@ vi.mock('../../../../src/providers/auth-provider', () => ({
 vi.mock('../../../../src/providers/toast-provider', () => ({
   useToast: () => toast,
 }));
-vi.mock('../../../../src/lib/graphql/use-auth-token', () => ({ useAuthToken: () => ({ data: 'token' }) }));
-vi.mock('../../../../src/lib/graphql/hooks', () => ({ useProfile: () => ({ data: { id: 'me' } }) }));
+vi.mock('../../../../src/lib/graphql/use-auth-token', () => ({
+  useAuthToken: () => ({ data: 'token' }),
+}));
+vi.mock('../../../../src/lib/graphql/hooks', () => ({
+  useProfile: () => ({ data: { id: 'me' } }),
+}));
 vi.mock('../../../../src/lib/graphql/use-active-board', () => ({
   useActiveBoard: () => ({ data: { boardType: 'kilter', layoutId: 1, sizeId: 10, angle: 40 } }),
 }));
@@ -232,8 +242,14 @@ vi.mock('../../../../src/components/SectionHeader', () => ({
 }));
 // The form sheet exposes a submit button driving onSubmit with fixed form
 // values, so the test can trigger the create flow without the real sheet UI.
-const FORM_VALUES = { name: 'Crimps', description: '', color: undefined, icon: undefined, isPublic: false };
-vi.mock('../../../../src/components/playlist', () => ({
+const FORM_VALUES = {
+  name: 'Crimps',
+  description: '',
+  color: undefined,
+  icon: undefined,
+  isPublic: false,
+};
+vi.mock('../../../../src/components/playlist/PlaylistCard', () => ({
   PlaylistCard: ({
     name,
     metaLabel,
@@ -251,6 +267,8 @@ vi.mock('../../../../src/components/playlist', () => ({
       createElement('span', null, metaLabel ? `${name} ${metaLabel}` : name),
       onTogglePin ? createElement('button', { 'aria-label': `pin-${name}`, onClick: onTogglePin }, 'pin') : null,
     ),
+}));
+vi.mock('../../../../src/components/playlist', () => ({
   PlaylistFormSheet: ({
     visible,
     submitError,
@@ -275,6 +293,23 @@ vi.mock('../../../../src/components/playlist', () => ({
 vi.mock('../../../../src/components/HorizontalScrollSection', () => ({
   HorizontalScrollSection: ({ children, title }: { children?: ReactNode; title: string }) =>
     createElement('section', { 'data-scroll-section': title }, createElement('h2', null, title), children),
+}));
+vi.mock('../../../../src/components/playlist/PlaylistShelf', () => ({
+  PlaylistShelf: ({
+    items,
+    renderItem,
+    title,
+  }: {
+    items: PlaylistItem[];
+    renderItem: (entry: { item: PlaylistItem; index: number }) => ReactNode;
+    title: string;
+  }) =>
+    createElement(
+      'section',
+      { 'data-scroll-section': title },
+      createElement('h2', null, title),
+      items.map((item, index) => createElement('div', { key: item.uuid }, renderItem({ item, index }))),
+    ),
 }));
 // The chrome exposes the create button so the test can open + submit the flow.
 vi.mock('../../../../src/components/chrome', () => ({
@@ -382,7 +417,13 @@ describe('DiscoverLibrary error handling', () => {
 
   it('renders for-you smart cards and community playlists', () => {
     communityHook.popular = [
-      { uuid: 'community', name: 'Setter picks', climbCount: 7, creatorId: 'creator-2', creatorName: 'Jess' },
+      {
+        uuid: 'community',
+        name: 'Setter picks',
+        climbCount: 7,
+        creatorId: 'creator-2',
+        creatorName: 'Jess',
+      },
     ];
 
     const { getByText } = renderHub();
@@ -434,7 +475,13 @@ describe('DiscoverLibrary error handling', () => {
       { uuid: 'owned', name: 'Project drawer', climbCount: 5, isPinnedByMe: false },
     ];
     communityHook.popular = [
-      { uuid: 'community', name: 'Setter picks', climbCount: 7, creatorId: 'creator-2', creatorName: 'Jess' },
+      {
+        uuid: 'community',
+        name: 'Setter picks',
+        climbCount: 7,
+        creatorId: 'creator-2',
+        creatorName: 'Jess',
+      },
     ];
 
     const { container, getByText } = renderHub();
@@ -457,7 +504,13 @@ describe('DiscoverLibrary error handling', () => {
   it('renders for-you smart cards when generated discover playlists are empty', () => {
     userHook.playlists = [{ uuid: 'owned', name: 'Project drawer', climbCount: 5, isPinnedByMe: false }];
     communityHook.popular = [
-      { uuid: 'community', name: 'Setter picks', climbCount: 7, creatorId: 'creator-2', creatorName: 'Jess' },
+      {
+        uuid: 'community',
+        name: 'Setter picks',
+        climbCount: 7,
+        creatorId: 'creator-2',
+        creatorName: 'Jess',
+      },
     ];
 
     const { getByText } = renderHub();
@@ -481,7 +534,13 @@ describe('DiscoverLibrary error handling', () => {
 
   it('shows pin controls on community playlist cards', async () => {
     communityHook.popular = [
-      { uuid: 'community', name: 'Setter picks', climbCount: 7, creatorId: 'creator-2', creatorName: 'Jess' },
+      {
+        uuid: 'community',
+        name: 'Setter picks',
+        climbCount: 7,
+        creatorId: 'creator-2',
+        creatorName: 'Jess',
+      },
     ];
     pinPlaylist.mockResolvedValue(true);
 
@@ -560,6 +619,20 @@ describe('DiscoverLibrary error handling', () => {
     expect(queryByText('Pinned 5')).toBeNull();
   });
 
+  it('deduplicates appended owned pages while excluding pinned playlists from the shelf', () => {
+    pinnedHook.pinned = [{ uuid: 'pinned', name: 'Pinned list', climbCount: 2, isPinnedByMe: true }];
+    userHook.playlists = [
+      { uuid: 'pinned', name: 'Pinned list', climbCount: 2, isPinnedByMe: true },
+      { uuid: 'owned', name: 'Owned list', climbCount: 5 },
+      { uuid: 'owned', name: 'Owned list', climbCount: 5 },
+      { uuid: 'later', name: 'Later page', climbCount: 1 },
+    ];
+    const { container } = renderHub();
+    const shelf = container.querySelector('[data-scroll-section="library.allPlaylists.title"]');
+    expect(shelf?.querySelectorAll('[data-card="Owned list"]')).toHaveLength(1);
+    expect(shelf?.querySelector('[data-card="Pinned list"]')).toBeNull();
+    expect(shelf?.querySelector('[data-card="Later page"]')).not.toBeNull();
+  });
   it('caps the pinned grid at eight playlists', () => {
     pinnedHook.pinned = Array.from({ length: 9 }, (_, index) => ({
       uuid: `pinned-${index}`,

--- a/packages/mobile/app/(tabs)/discover/index.tsx
+++ b/packages/mobile/app/(tabs)/discover/index.tsx
@@ -6,6 +6,7 @@ import { router, useFocusEffect } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { FAB } from 'react-native-paper';
+import type { ListRenderItemInfo } from '@shopify/flash-list';
 import {
   useDiscoverPlaylists,
   useUserPlaylists,
@@ -23,7 +24,9 @@ import { offlineReasonFor } from '../../../src/hooks/use-offline-query-state';
 import { Button } from '../../../src/components/Button';
 import { SectionHeader } from '../../../src/components/SectionHeader';
 import { HorizontalScrollSection } from '../../../src/components/HorizontalScrollSection';
-import { PlaylistCard, PlaylistFormSheet, type PlaylistFormValues } from '../../../src/components/playlist';
+import { PlaylistFormSheet, type PlaylistFormValues } from '../../../src/components/playlist';
+import { DiscoverPlaylistCard, DiscoverSmartPlaylistCard } from '../../../src/components/playlist/DiscoverPlaylistCard';
+import { PlaylistShelf } from '../../../src/components/playlist/PlaylistShelf';
 import { DiscoverTopChrome } from '../../../src/components/chrome';
 import { SMART_PLAYLISTS, type SmartPlaylistPresentation } from '../../../src/lib/smart-playlists';
 import { useAuth } from '../../../src/providers/auth-provider';
@@ -51,6 +54,8 @@ const FOR_YOU_SMART_PLAYLIST_TYPES: SmartPlaylistType[] = [
   'RECOMMENDED_FRESH',
 ];
 
+const NO_RECENT_PLAYLIST_CANDIDATES: Playlist[] = [];
+
 const PINNED_SMART_PLAYLISTS_STORAGE_PREFIX = 'boardsesh_pinned_smart_playlists_v1';
 
 function isForYouSmartPlaylistType(value: unknown): value is SmartPlaylistType {
@@ -77,6 +82,10 @@ function parsePinnedSmartPlaylistTypes(raw: string | null): SmartPlaylistType[] 
 
 function pinnedSmartPlaylistsStorageKey(userId: string): string {
   return `${PINNED_SMART_PLAYLISTS_STORAGE_PREFIX}_${userId}`;
+}
+
+function playlistKey(playlist: { uuid: string }): string {
+  return playlist.uuid;
 }
 
 export default function DiscoverLibrary() {
@@ -129,6 +138,9 @@ export default function DiscoverLibrary() {
     playlists: userPlaylists,
     isLoading: userLoading,
     isLoadingMore: userLoadingMore,
+    hasMore: userHasMore,
+    hasLoadMoreError: userLoadMoreError,
+    retryLoadMore: retryLoadMoreUser,
     hasError: userError,
     loadMore: loadMoreUser,
     refetch: refetchUser,
@@ -143,7 +155,7 @@ export default function DiscoverLibrary() {
     token: effectiveToken,
     boardType: filterBoardType,
     layoutId: filterLayoutId,
-    candidatePlaylists: [],
+    candidatePlaylists: NO_RECENT_PLAYLIST_CANDIDATES,
   });
 
   // Community playlists (popular + recent streams, merged).
@@ -152,6 +164,7 @@ export default function DiscoverLibrary() {
     recent: communityRecent,
     isLoading: communityLoading,
     isLoadingMore: communityLoadingMore,
+    hasMore: communityHasMore,
     hasError: communityError,
     loadMore: loadMoreCommunity,
     refetch: refetchCommunity,
@@ -282,7 +295,12 @@ export default function DiscoverLibrary() {
   const hasVisiblePinnedItems = visiblePinnedSmartCards.length + visiblePinnedPlaylists.length > 0;
 
   const unpinnedUserPlaylists = useMemo(() => {
-    return userPlaylists.filter((playlist) => !pinnedPlaylistUuids.has(playlist.uuid));
+    const seen = new Set<string>();
+    return userPlaylists.filter((playlist) => {
+      if (pinnedPlaylistUuids.has(playlist.uuid) || seen.has(playlist.uuid)) return false;
+      seen.add(playlist.uuid);
+      return true;
+    });
   }, [pinnedPlaylistUuids, userPlaylists]);
 
   const goToPlaylist = useCallback((uuid: string) => {
@@ -373,22 +391,50 @@ export default function DiscoverLibrary() {
     [pinPlaylist, refetchPinned, refetchUser, showToast, t, unpinPlaylist],
   );
 
-  // Pin / unpin straight from a playlist card. The shared-hook arrays aren't
-  // ours to mutate optimistically, so refetch both lists once the mutation lands
-  // and let the pinned ordering + icon re-derive.
-  const handleToggleCardPin = useCallback(
-    (playlist: Playlist) => {
-      void togglePlaylistPin(playlist.uuid, playlist.isPinnedByMe);
-    },
-    [togglePlaylistPin],
+  const renderOwnedPlaylist = useCallback(
+    ({ item: playlist, index }: ListRenderItemInfo<Playlist>) => (
+      <DiscoverPlaylistCard
+        uuid={playlist.uuid}
+        name={playlist.name}
+        climbCount={playlist.climbCount}
+        color={playlist.color}
+        icon={playlist.icon}
+        variant="scroll"
+        index={index}
+        onOpen={goToPlaylist}
+        isPinned={playlist.isPinnedByMe}
+        onPin={togglePlaylistPin}
+      />
+    ),
+    [goToPlaylist, togglePlaylistPin],
   );
 
-  const handleToggleDiscoverPin = useCallback(
-    (playlistUuid: string) => {
-      void togglePlaylistPin(playlistUuid, pinnedPlaylistUuids.has(playlistUuid));
-    },
-    [pinnedPlaylistUuids, togglePlaylistPin],
+  const renderCommunityPlaylist = useCallback(
+    ({ item: playlist, index }: ListRenderItemInfo<DiscoverablePlaylist>) => (
+      <DiscoverPlaylistCard
+        uuid={playlist.uuid}
+        name={playlist.name}
+        climbCount={playlist.climbCount}
+        color={playlist.color}
+        icon={playlist.icon}
+        variant="scroll"
+        index={index}
+        metaLabel={t('library.communityByline', {
+          creatorName: playlist.creatorName,
+          climbCount: t('detail.climbCount', { count: playlist.climbCount }),
+        })}
+        onOpen={goToPlaylist}
+        isPinned={isAuthenticated && pinnedPlaylistUuids.has(playlist.uuid)}
+        onPin={isAuthenticated ? togglePlaylistPin : undefined}
+      />
+    ),
+    [goToPlaylist, isAuthenticated, pinnedPlaylistUuids, t, togglePlaylistPin],
   );
+  const communityInvalidation = useMemo(
+    () => ({ isAuthenticated, pinnedPlaylistUuids, t }),
+    [isAuthenticated, pinnedPlaylistUuids, t],
+  );
+  const openAllPlaylists = useCallback(() => router.push('/(tabs)/discover/all'), []);
 
   // Refresh owned + pinned when returning to the tab (e.g. after editing,
   // deleting, or pinning from a detail screen). Skip the first focus so we don't
@@ -481,31 +527,33 @@ export default function DiscoverLibrary() {
             <View style={styles.grid}>
               {visiblePinnedSmartCards.map(({ preset, count }, index) => (
                 <View key={preset.type} style={styles.gridItem}>
-                  <PlaylistCard
+                  <DiscoverSmartPlaylistCard
+                    smartType={preset.type}
                     name={t(preset.titleI18nKey)}
                     climbCount={count}
                     color={preset.color}
                     icon={preset.icon}
                     variant="grid"
                     index={index}
-                    onPress={() => goToSmartPlaylist(preset.type)}
+                    onOpen={goToSmartPlaylist}
                     isPinned={pinnedSmartPlaylistTypeSet.has(preset.type)}
-                    onTogglePin={smartPinsHydrated ? () => handleToggleSmartPin(preset.type) : undefined}
+                    onPin={smartPinsHydrated ? handleToggleSmartPin : undefined}
                   />
                 </View>
               ))}
               {visiblePinnedPlaylists.map((playlist, index) => (
                 <View key={playlist.uuid} style={styles.gridItem}>
-                  <PlaylistCard
+                  <DiscoverPlaylistCard
+                    uuid={playlist.uuid}
                     name={playlist.name}
                     climbCount={playlist.climbCount}
                     color={playlist.color}
                     icon={playlist.icon}
                     variant="grid"
                     index={visiblePinnedSmartCards.length + index}
-                    onPress={() => goToPlaylist(playlist.uuid)}
+                    onOpen={goToPlaylist}
                     isPinned={playlist.isPinnedByMe}
-                    onTogglePin={() => handleToggleCardPin(playlist)}
+                    onPin={togglePlaylistPin}
                   />
                 </View>
               ))}
@@ -515,36 +563,26 @@ export default function DiscoverLibrary() {
 
         {/* My Playlists — user's own playlists, excluding the pinned grid above. */}
         {isAuthenticated && (userLoading || unpinnedUserPlaylists.length > 0) ? (
-          <HorizontalScrollSection
+          <PlaylistShelf
             title={t('library.allPlaylists.title')}
             actionLabel={userPlaylists.length > 0 ? t('library.allPlaylists.seeAll') : undefined}
-            onActionPress={userPlaylists.length > 0 ? () => router.push('/(tabs)/discover/all') : undefined}
+            onActionPress={userPlaylists.length > 0 ? openAllPlaylists : undefined}
             loading={userLoading && unpinnedUserPlaylists.length === 0}
             isLoadingMore={userLoadingMore}
-            onEndReached={loadMoreUser}
-          >
-            {unpinnedUserPlaylists.map((playlist, index) => (
-              <PlaylistCard
-                key={playlist.uuid}
-                name={playlist.name}
-                climbCount={playlist.climbCount}
-                color={playlist.color}
-                icon={playlist.icon}
-                variant="scroll"
-                index={index}
-                onPress={() => goToPlaylist(playlist.uuid)}
-                isPinned={playlist.isPinnedByMe}
-                onTogglePin={() => handleToggleCardPin(playlist)}
-              />
-            ))}
-          </HorizontalScrollSection>
+            hasMore={userHasMore || userLoadMoreError}
+            onEndReached={userLoadMoreError ? retryLoadMoreUser : loadMoreUser}
+            items={unpinnedUserPlaylists}
+            renderItem={renderOwnedPlaylist}
+            keyExtractor={playlistKey}
+          />
         ) : null}
 
         {/* For You — the same smart-playlist cards as web, in mobile product order. */}
         {isAuthenticated && userId && (smartCountsLoading || forYouSmartCards.length > 0) ? (
           <HorizontalScrollSection title={t('library.sections.forYou')} loading={smartCountsLoading}>
             {forYouSmartCards.map(({ preset, count }, index) => (
-              <PlaylistCard
+              <DiscoverSmartPlaylistCard
+                smartType={preset.type}
                 key={preset.type}
                 name={t(preset.titleI18nKey)}
                 climbCount={count}
@@ -552,9 +590,9 @@ export default function DiscoverLibrary() {
                 icon={preset.icon}
                 variant="scroll"
                 index={index}
-                onPress={() => goToSmartPlaylist(preset.type)}
+                onOpen={goToSmartPlaylist}
                 isPinned={pinnedSmartPlaylistTypeSet.has(preset.type)}
-                onTogglePin={smartPinsHydrated ? () => handleToggleSmartPin(preset.type) : undefined}
+                onPin={smartPinsHydrated ? handleToggleSmartPin : undefined}
               />
             ))}
           </HorizontalScrollSection>
@@ -562,31 +600,17 @@ export default function DiscoverLibrary() {
 
         {/* Community Playlists — user-made public playlists. */}
         {communityLoading || communityItems.length > 0 ? (
-          <HorizontalScrollSection
+          <PlaylistShelf
             title={t('library.sections.community')}
             loading={communityLoading && communityItems.length === 0}
             isLoadingMore={communityLoadingMore}
+            hasMore={communityHasMore}
             onEndReached={loadMoreCommunity}
-          >
-            {communityItems.map((playlist, index) => (
-              <PlaylistCard
-                key={playlist.uuid}
-                name={playlist.name}
-                climbCount={playlist.climbCount}
-                color={playlist.color}
-                icon={playlist.icon}
-                variant="scroll"
-                metaLabel={t('library.communityByline', {
-                  creatorName: playlist.creatorName,
-                  climbCount: t('detail.climbCount', { count: playlist.climbCount }),
-                })}
-                index={index}
-                onPress={() => goToPlaylist(playlist.uuid)}
-                isPinned={isAuthenticated && pinnedPlaylistUuids.has(playlist.uuid)}
-                onTogglePin={isAuthenticated ? () => handleToggleDiscoverPin(playlist.uuid) : undefined}
-              />
-            ))}
-          </HorizontalScrollSection>
+            items={communityItems}
+            renderItem={renderCommunityPlaylist}
+            keyExtractor={playlistKey}
+            extraData={communityInvalidation}
+          />
         ) : null}
 
         {/* Load error: a section's first page failed and the hub is empty.

--- a/packages/mobile/app/(tabs)/home/index.tsx
+++ b/packages/mobile/app/(tabs)/home/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FlatList, Pressable, RefreshControl, StyleSheet, View } from 'react-native';
-import { FlashList, type FlashListRef } from '@shopify/flash-list';
+import { FlashList, type FlashListRef, type ListRenderItemInfo } from '@shopify/flash-list';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
@@ -43,6 +43,10 @@ import { navigateToSessionFeedItem } from '../../../src/lib/session-feed-navigat
 import { iosSystemColors } from '../../../src/theme/ios-colors';
 import { borderRadius, spacing } from '../../../src/theme/tokens';
 import { BETA_CARD_HEIGHT, BETA_CARD_WIDTH } from '../../../src/components/play-drawer/BetaVideoCard';
+
+import { HomeStartupCommit } from '../../../src/lib/profiling/HomeStartupCommit';
+import { STARTUP_PROFILING_ENABLED } from '../../../src/lib/profiling/startup-profile';
+import { homeEmptyStartupOutcome } from '../../../src/lib/profiling/startup-collector';
 
 const RECENT_BETA_LIMIT = 20;
 const SHELF_GAP = spacing[3];
@@ -243,14 +247,17 @@ export default function HomeTab() {
   // the single signal that re-invokes it. A churning `renderItem` would force
   // FlashList to re-render regardless of `extraData` (perf playbook rule 3).
   const renderItem = useCallback(
-    ({ item }: { item: SessionFeedItem }) => (
-      <SessionFeedCard
-        session={item}
-        voteSummary={summaryMapRef.current.get(voteSummaryKey(item.socialEntityType, item.socialEntityId))}
-        onOpenComments={handleOpenComments}
-        onPress={handleSessionPress}
-        onOpenClimb={handleOpenClimb}
-      />
+    ({ item, target }: ListRenderItemInfo<SessionFeedItem>) => (
+      <>
+        {STARTUP_PROFILING_ENABLED && target === 'Cell' ? <HomeStartupCommit outcome="content" /> : null}
+        <SessionFeedCard
+          session={item}
+          voteSummary={summaryMapRef.current.get(voteSummaryKey(item.socialEntityType, item.socialEntityId))}
+          onOpenComments={handleOpenComments}
+          onPress={handleSessionPress}
+          onOpenClimb={handleOpenClimb}
+        />
+      </>
     ),
     [handleOpenComments, handleSessionPress, handleOpenClimb],
   );
@@ -379,6 +386,7 @@ export default function HomeTab() {
   if (!isAuthenticated) {
     return (
       <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
+        {STARTUP_PROFILING_ENABLED ? <HomeStartupCommit outcome="empty" /> : null}
         <Icon name="people" size={48} color={systemColors.tertiaryLabel} />
         <Text variant="headline" style={styles.emptyTitle}>
           {t('mobile.home.signInTitle')}
@@ -420,51 +428,64 @@ export default function HomeTab() {
           />
         }
         ListEmptyComponent={
-          feedOffline.isBlocked && feedOffline.reason ? (
-            <OfflineState reason={feedOffline.reason} onRetry={handleRefresh} />
-          ) : feed.isLoading || !scopeReady ? (
-            <ActivitySkeletonList skeletonKeys={INITIAL_FEED_SKELETON_KEYS} />
-          ) : feed.isError ? (
-            <View style={styles.feedState}>
-              <Icon name="error" size={32} color={iosSystemColors.systemRed} />
-              <Text variant="headline" style={styles.emptyTitle}>
-                {t('errors.loadActivity')}
-              </Text>
-              <View style={styles.emptyCta}>
-                <Button title={tCommon('actions.retry')} onPress={() => void feed.refetch()} />
+          <>
+            {STARTUP_PROFILING_ENABLED ? (
+              <HomeStartupCommit
+                outcome={homeEmptyStartupOutcome({
+                  authenticated: isAuthenticated,
+                  blockedReason: feedOffline.isBlocked ? feedOffline.reason : null,
+                  loading: feed.isLoading,
+                  scopeReady,
+                  error: feed.isError,
+                })}
+              />
+            ) : null}
+            {feedOffline.isBlocked && feedOffline.reason ? (
+              <OfflineState reason={feedOffline.reason} onRetry={handleRefresh} />
+            ) : feed.isLoading || !scopeReady ? (
+              <ActivitySkeletonList skeletonKeys={INITIAL_FEED_SKELETON_KEYS} />
+            ) : feed.isError ? (
+              <View style={styles.feedState}>
+                <Icon name="error" size={32} color={iosSystemColors.systemRed} />
+                <Text variant="headline" style={styles.emptyTitle}>
+                  {t('errors.loadActivity')}
+                </Text>
+                <View style={styles.emptyCta}>
+                  <Button title={tCommon('actions.retry')} onPress={() => void feed.refetch()} />
+                </View>
               </View>
-            </View>
-          ) : mode === 'gym' && selectedBoard != null ? (
-            <View style={styles.feedState}>
-              <Icon name="boards" size={48} color={systemColors.tertiaryLabel} />
-              <Text variant="headline" style={styles.emptyTitle}>
-                {t('mobile.home.boardEmptyTitle', { board: selectedBoard.gymName ?? selectedBoard.name })}
-              </Text>
-              <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.emptyBody}>
-                {t('mobile.home.boardEmptyBody')}
-              </Text>
-              <View style={styles.emptyCta}>
-                <Button title={t('mobile.home.boardEmptyCta')} onPress={handleBrowseEveryone} />
+            ) : mode === 'gym' && selectedBoard != null ? (
+              <View style={styles.feedState}>
+                <Icon name="boards" size={48} color={systemColors.tertiaryLabel} />
+                <Text variant="headline" style={styles.emptyTitle}>
+                  {t('mobile.home.boardEmptyTitle', { board: selectedBoard.gymName ?? selectedBoard.name })}
+                </Text>
+                <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.emptyBody}>
+                  {t('mobile.home.boardEmptyBody')}
+                </Text>
+                <View style={styles.emptyCta}>
+                  <Button title={t('mobile.home.boardEmptyCta')} onPress={handleBrowseEveryone} />
+                </View>
               </View>
-            </View>
-          ) : mode === 'crew' ? (
-            <View style={styles.feedState}>
-              <Icon name="people" size={48} color={systemColors.tertiaryLabel} />
-              <Text variant="headline" style={styles.emptyTitle}>
-                {t('mobile.home.emptyTitle')}
-              </Text>
-              <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.emptyBody}>
-                {t('mobile.home.emptyBody')}
-              </Text>
-            </View>
-          ) : (
-            <View style={styles.feedState}>
-              <Icon name="people" size={48} color={systemColors.tertiaryLabel} />
-              <Text variant="headline" style={styles.emptyTitle}>
-                {t('emptyStates.noRecentActivity')}
-              </Text>
-            </View>
-          )
+            ) : mode === 'crew' ? (
+              <View style={styles.feedState}>
+                <Icon name="people" size={48} color={systemColors.tertiaryLabel} />
+                <Text variant="headline" style={styles.emptyTitle}>
+                  {t('mobile.home.emptyTitle')}
+                </Text>
+                <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.emptyBody}>
+                  {t('mobile.home.emptyBody')}
+                </Text>
+              </View>
+            ) : (
+              <View style={styles.feedState}>
+                <Icon name="people" size={48} color={systemColors.tertiaryLabel} />
+                <Text variant="headline" style={styles.emptyTitle}>
+                  {t('emptyStates.noRecentActivity')}
+                </Text>
+              </View>
+            )}
+          </>
         }
         ListFooterComponent={
           feed.isFetchingNextPage ? <ActivitySkeletonList skeletonKeys={NEXT_PAGE_FEED_SKELETON_KEYS} /> : null

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -14,7 +14,8 @@ import '../src/lib/analytics-bootstrap';
 // isInitialized() when a screen mounts and throws if it changes afterwards — so
 // this cannot become a hook or an effect. See observe-bootstrap.ts.
 import '../src/lib/observe-bootstrap';
-import { useCallback, useEffect, useRef, useMemo, useState, type ReactNode } from 'react';
+import { markStartup } from '../src/lib/profiling/startup-profile';
+import { useCallback, useEffect, useLayoutEffect, useRef, useMemo, useState, type ReactNode } from 'react';
 import { LogBox, Pressable, StyleSheet, View } from 'react-native';
 // Navigation theme comes from expo-router's vendored React Navigation. Expo
 // SDK 57's expo-router is not compatible with a separately-installed
@@ -108,6 +109,7 @@ import { getPreference, removePreference, setPreference } from '../src/lib/prefe
 // OnCreate registers the Glide trim-on-UI_HIDDEN callback. No-op on iOS.
 import '../modules/memory-trim/src/index';
 
+markStartup('root.module.ready');
 void SplashScreen.preventAutoHideAsync();
 
 // The screenshots build is a Debug dev-client (__DEV__ true) so it can load its
@@ -517,14 +519,24 @@ function RootLayout() {
   // the cold launch the native pruner runs on (#3647).
   useDiskCacheSweep();
 
+  useLayoutEffect(() => {
+    markStartup('root.commit');
+  }, []);
+
   useEffect(() => {
+    markStartup('fonts.start');
     let cancelled = false;
+    let fontOutcome: 'ready' | 'error' = 'ready';
     void loadRequiredFonts()
       .catch((error: unknown) => {
+        fontOutcome = 'error';
         reportError(error);
       })
       .finally(() => {
-        if (!cancelled) setFontsReady(true);
+        if (!cancelled) {
+          markStartup('fonts.ready', fontOutcome);
+          setFontsReady(true);
+        }
       });
     return () => {
       cancelled = true;
@@ -554,7 +566,11 @@ function RootLayout() {
       console.warn(`[root-ready] authReady=${String(authReady)} fontsReady=${String(fontsReady)}`);
     }
     if (!authReady || !fontsReady) return;
-    void SplashScreen.hideAsync();
+    markStartup('splash.hide.request');
+    void SplashScreen.hideAsync().then(
+      () => markStartup('splash.hide.resolved', 'ready'),
+      () => markStartup('splash.hide.resolved', 'error'),
+    );
   }, [authReady, fontsReady]);
 
   return (

--- a/packages/mobile/metro-watchman.cjs
+++ b/packages/mobile/metro-watchman.cjs
@@ -1,0 +1,13 @@
+const { spawnSync } = require('node:child_process');
+
+/** Opt-in only: preserve Expo defaults and fail clearly when Watchman is absent. */
+function configureWatchman(config, env = process.env, run = spawnSync) {
+  if (env.BOARDSESH_METRO_USE_WATCHMAN !== '1') return;
+  const watchman = run('watchman', ['--version'], { encoding: 'utf8', timeout: 5000 });
+  if (watchman.status !== 0) {
+    throw new Error('BOARDSESH_METRO_USE_WATCHMAN=1 requires an available Watchman installation.');
+  }
+  config.resolver.useWatchman = true;
+}
+
+module.exports = { configureWatchman };

--- a/packages/mobile/metro.config.js
+++ b/packages/mobile/metro.config.js
@@ -4,6 +4,7 @@
 // unchanged.
 const { getSentryExpoConfig } = require('@sentry/react-native/metro');
 const path = require('path');
+const { configureWatchman } = require('./metro-watchman.cjs');
 const { applyExpoWebResponseHeaders } = require('./expo-web-response-headers.cjs');
 const { resolveWebRuntimeModulePath } = require('./metro-web-runtime-resolution.cjs');
 
@@ -13,6 +14,8 @@ const monorepoRoot = path.resolve(projectRoot, '../..');
 const config = getSentryExpoConfig(projectRoot);
 
 config.watchFolders = [monorepoRoot];
+
+configureWatchman(config);
 
 function escapedPathPattern(filePath) {
   return path

--- a/packages/mobile/src/components/HorizontalScrollSection.tsx
+++ b/packages/mobile/src/components/HorizontalScrollSection.tsx
@@ -32,8 +32,8 @@ const DEFAULT_MIN_HEIGHT = 160;
 
 /**
  * Horizontal card scroller with a section title and an optional "See all"
- * affordance. Uses a ScrollView (the loaded card count per shelf is bounded)
- * and fires `onEndReached` as the content scrolls within
+ * affordance for fixed, small shelves. Growing playlist shelves use PlaylistShelf.
+ * Fires `onEndReached` as the content scrolls within
  * `END_REACHED_THRESHOLD` of the right edge. Generic over its children —
  * playlist shelves on Discover and the beta-links shelf on profiles share it.
  */

--- a/packages/mobile/src/components/playlist/DiscoverPlaylistCard.tsx
+++ b/packages/mobile/src/components/playlist/DiscoverPlaylistCard.tsx
@@ -1,0 +1,40 @@
+import { memo, useCallback } from 'react';
+import type { SmartPlaylistType } from '@boardsesh/graphql/operations/playlists';
+import { PlaylistCard, type PlaylistCardProps } from './PlaylistCard';
+
+type CardDisplayProps = Omit<PlaylistCardProps, 'onPress' | 'onTogglePin'>;
+export type DiscoverPlaylistCardProps = CardDisplayProps & {
+  uuid: string;
+  onOpen: (uuid: string) => void;
+  onPin?: (uuid: string, isPinned: boolean) => void;
+};
+
+/** Scalars keep refreshed objects and parent renders out of memoized cards. */
+export const DiscoverPlaylistCard = memo(function DiscoverPlaylistCard({
+  uuid,
+  onOpen,
+  onPin,
+  ...display
+}: DiscoverPlaylistCardProps) {
+  const isPinned = !!display.isPinned;
+  const handleOpen = useCallback(() => onOpen(uuid), [onOpen, uuid]);
+  const handlePin = useCallback(() => onPin?.(uuid, isPinned), [onPin, uuid, isPinned]);
+  return <PlaylistCard {...display} onPress={handleOpen} onTogglePin={onPin ? handlePin : undefined} />;
+});
+
+export type DiscoverSmartPlaylistCardProps = CardDisplayProps & {
+  smartType: SmartPlaylistType;
+  onOpen: (smartType: SmartPlaylistType) => void;
+  onPin?: (smartType: SmartPlaylistType) => void;
+};
+
+export const DiscoverSmartPlaylistCard = memo(function DiscoverSmartPlaylistCard({
+  smartType,
+  onOpen,
+  onPin,
+  ...display
+}: DiscoverSmartPlaylistCardProps) {
+  const handleOpen = useCallback(() => onOpen(smartType), [onOpen, smartType]);
+  const handlePin = useCallback(() => onPin?.(smartType), [onPin, smartType]);
+  return <PlaylistCard {...display} onPress={handleOpen} onTogglePin={onPin ? handlePin : undefined} />;
+});

--- a/packages/mobile/src/components/playlist/PlaylistShelf.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistShelf.tsx
@@ -1,0 +1,147 @@
+import { useCallback, useMemo, useRef } from 'react';
+import { View, StyleSheet, useWindowDimensions, type NativeScrollEvent, type NativeSyntheticEvent } from 'react-native';
+import { FlashList, type ListRenderItem } from '@shopify/flash-list';
+import { SectionHeader } from '../SectionHeader';
+import { ActivityIndicator } from '../ActivityIndicator';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing } from '../../theme/tokens';
+import { textStyles as fallbackTextStyles } from '../../theme/typography';
+
+export type PlaylistShelfProps<PlaylistItem> = {
+  title: string;
+  items: readonly PlaylistItem[];
+  renderItem: ListRenderItem<PlaylistItem>;
+  keyExtractor: (item: PlaylistItem, index: number) => string;
+  extraData?: unknown;
+  loading?: boolean;
+  isLoadingMore?: boolean;
+  hasMore: boolean;
+  onEndReached: () => void;
+  actionLabel?: string;
+  onActionPress?: () => void;
+};
+
+export function playlistShelfHeight(fontScale: number, nameLineHeight: number, metaLineHeight: number): number {
+  // Match PlaylistCard's fixed preview, two gaps and Text's 1.5 scaling cap.
+  return 120 + 2 * spacing[2] + Math.ceil((nameLineHeight + metaLineHeight) * Math.min(fontScale, 1.5));
+}
+
+const KEEP_SCROLL_OFFSET = { disabled: true };
+
+function CardSeparator() {
+  return <View style={styles.separator} />;
+}
+function LoadingFooter() {
+  return (
+    <View style={styles.footer}>
+      <ActivityIndicator size="small" />
+    </View>
+  );
+}
+
+/** A bounded horizontal viewport. Data remains paginated in the shared hooks. */
+export function PlaylistShelf<PlaylistItem>({
+  title,
+  items,
+  renderItem,
+  keyExtractor,
+  extraData,
+  loading,
+  isLoadingMore,
+  hasMore,
+  onEndReached,
+  actionLabel,
+  onActionPress,
+}: PlaylistShelfProps<PlaylistItem>) {
+  const { fontScale } = useWindowDimensions();
+  const { textStyles } = useTheme();
+  const height = playlistShelfHeight(
+    fontScale,
+    textStyles.subheadline.lineHeight ?? fallbackTextStyles.subheadline.lineHeight,
+    textStyles.caption1.lineHeight ?? fallbackTextStyles.caption1.lineHeight,
+  );
+  const listStyle = useMemo(() => ({ height }), [height]);
+  const interaction = useRef({ armed: false, dragging: false, momentum: false });
+  const handleBeginDrag = useCallback(() => {
+    interaction.current = { armed: !loading && !isLoadingMore, dragging: true, momentum: false };
+  }, [loading, isLoadingMore]);
+  const handleEndDrag = useCallback(() => {
+    interaction.current.dragging = false;
+  }, []);
+  const handleMomentumBegin = useCallback(() => {
+    interaction.current.momentum = true;
+  }, []);
+  const handleMomentumEnd = useCallback(() => {
+    interaction.current.momentum = false;
+    interaction.current.armed = false;
+  }, []);
+  const requestPage = useCallback(() => {
+    const current = interaction.current;
+    if (!current.armed || (!current.dragging && !current.momentum)) return;
+    if (!hasMore || loading || isLoadingMore) {
+      current.armed = false;
+      return;
+    }
+    // Consume before invoking: append, dedup, and layout callbacks cannot drain
+    // pages during this gesture. A new drag permits retries after a failed page.
+    current.armed = false;
+    onEndReached();
+  }, [hasMore, loading, isLoadingMore, onEndReached]);
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
+      // Also inspect user scrolls so another drag can retry at an unchanged end
+      // after a duplicate page or failure (FlashList may not emit onEndReached again).
+      if (contentSize.width - contentOffset.x - layoutMeasurement.width < 200) requestPage();
+    },
+    [requestPage],
+  );
+  return (
+    <View style={styles.section}>
+      <SectionHeader title={title} actionLabel={actionLabel} onActionPress={onActionPress} />
+      {loading ? (
+        <View style={[styles.loading, listStyle]}>
+          <ActivityIndicator size="small" />
+        </View>
+      ) : (
+        <View style={listStyle}>
+          <FlashList
+            horizontal
+            data={items}
+            renderItem={renderItem}
+            keyExtractor={keyExtractor}
+            extraData={extraData}
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.content}
+            ItemSeparatorComponent={CardSeparator}
+            ListFooterComponent={isLoadingMore ? LoadingFooter : null}
+            drawDistance={240}
+            maintainVisibleContentPosition={KEEP_SCROLL_OFFSET}
+            onEndReached={requestPage}
+            onEndReachedThreshold={0.5}
+            onScroll={handleScroll}
+            onScrollBeginDrag={handleBeginDrag}
+            onScrollEndDrag={handleEndDrag}
+            onMomentumScrollBegin={handleMomentumBegin}
+            onMomentumScrollEnd={handleMomentumEnd}
+            scrollEventThrottle={16}
+          />
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: { marginBottom: spacing[2] },
+  content: { paddingHorizontal: spacing[4] },
+  separator: { width: spacing[4] },
+  loading: { alignItems: 'center', justifyContent: 'center' },
+  footer: {
+    width: 48,
+    height: 120,
+    marginLeft: spacing[4],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/packages/mobile/src/components/playlist/__tests__/discover-playlist-card.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/discover-playlist-card.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { createElement } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PlaylistCardProps } from '../PlaylistCard';
+
+const cardRender = vi.hoisted(() => vi.fn());
+vi.mock('../PlaylistCard', () => ({
+  PlaylistCard: (props: PlaylistCardProps) => {
+    cardRender(props);
+    return createElement(
+      'div',
+      null,
+      createElement('button', { onClick: props.onPress }, props.name),
+      props.onTogglePin ? createElement('button', { onClick: props.onTogglePin }, 'pin') : null,
+    );
+  },
+}));
+import { DiscoverPlaylistCard, DiscoverSmartPlaylistCard } from '../DiscoverPlaylistCard';
+
+beforeEach(() => cardRender.mockClear());
+describe('Discover playlist callback adapters', () => {
+  it('does not render unchanged cards when a parent refreshes its objects', () => {
+    const onOpen = vi.fn();
+    const onPin = vi.fn();
+    const props = {
+      uuid: 'first',
+      name: 'First',
+      climbCount: 5,
+      variant: 'scroll' as const,
+      isPinned: false,
+      onOpen,
+      onPin,
+    };
+    const view = render(<DiscoverPlaylistCard {...props} />);
+    const initialCalls = cardRender.mock.calls.length;
+    view.rerender(<DiscoverPlaylistCard {...{ ...props }} />);
+    expect(cardRender).toHaveBeenCalledTimes(initialCalls);
+  });
+  it('recycled cards call the new identifier and pin state', () => {
+    const onOpen = vi.fn();
+    const onPin = vi.fn();
+    const view = render(
+      <DiscoverPlaylistCard
+        uuid="first"
+        name="First"
+        climbCount={1}
+        variant="scroll"
+        isPinned={false}
+        onOpen={onOpen}
+        onPin={onPin}
+      />,
+    );
+    view.rerender(
+      <DiscoverPlaylistCard
+        uuid="second"
+        name="Second"
+        climbCount={2}
+        variant="scroll"
+        isPinned
+        onOpen={onOpen}
+        onPin={onPin}
+      />,
+    );
+    fireEvent.click(view.getByText('Second'));
+    fireEvent.click(view.getByText('pin'));
+    expect(onOpen).toHaveBeenCalledWith('second');
+    expect(onPin).toHaveBeenCalledWith('second', true);
+  });
+  it('updates changed actions and removes pin interaction after sign-out', () => {
+    const oldOpen = vi.fn();
+    const newOpen = vi.fn();
+    const onPin = vi.fn();
+    const view = render(
+      <DiscoverPlaylistCard uuid="first" name="First" climbCount={1} variant="scroll" onOpen={oldOpen} onPin={onPin} />,
+    );
+    view.rerender(<DiscoverPlaylistCard uuid="first" name="First" climbCount={1} variant="scroll" onOpen={newOpen} />);
+    fireEvent.click(view.getByText('First'));
+    expect(newOpen).toHaveBeenCalledWith('first');
+    expect(oldOpen).not.toHaveBeenCalled();
+    expect(view.queryByText('pin')).toBeNull();
+  });
+  it('smart hydration and recycling bind the current smart type', () => {
+    const onOpen = vi.fn();
+    const onPin = vi.fn();
+    const view = render(
+      <DiscoverSmartPlaylistCard smartType="LIKED_CLIMBS" name="Liked" climbCount={1} variant="grid" onOpen={onOpen} />,
+    );
+    expect(view.queryByText('pin')).toBeNull();
+    view.rerender(
+      <DiscoverSmartPlaylistCard
+        smartType="PROJECTS"
+        name="Projects"
+        climbCount={2}
+        variant="grid"
+        onOpen={onOpen}
+        onPin={onPin}
+      />,
+    );
+    fireEvent.click(view.getByText('Projects'));
+    fireEvent.click(view.getByText('pin'));
+    expect(onOpen).toHaveBeenCalledWith('PROJECTS');
+    expect(onPin).toHaveBeenCalledWith('PROJECTS');
+  });
+  it('updates translated display text without recreating unchanged action props', () => {
+    const onOpen = vi.fn();
+    const onPin = vi.fn();
+    const view = render(
+      <DiscoverSmartPlaylistCard
+        smartType="PROJECTS"
+        name="Projects"
+        climbCount={2}
+        variant="grid"
+        onOpen={onOpen}
+        onPin={onPin}
+      />,
+    );
+    const first = cardRender.mock.lastCall?.[0] as PlaylistCardProps;
+    view.rerender(
+      <DiscoverSmartPlaylistCard
+        smartType="PROJECTS"
+        name="Projets"
+        climbCount={2}
+        variant="grid"
+        onOpen={onOpen}
+        onPin={onPin}
+      />,
+    );
+    const translated = cardRender.mock.lastCall?.[0] as PlaylistCardProps;
+    expect(view.getByText('Projets')).toBeTruthy();
+    expect(translated.onPress).toBe(first.onPress);
+    expect(translated.onTogglePin).toBe(first.onTogglePin);
+  });
+});

--- a/packages/mobile/src/components/playlist/__tests__/playlist-shelf.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-shelf.test.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import { createElement, type ReactNode } from 'react';
+import { render, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+interface ShelfListProps {
+  data: { uuid: string }[];
+  onEndReached: () => void;
+  onScrollBeginDrag: () => void;
+  onScrollEndDrag: () => void;
+  onMomentumScrollBegin: () => void;
+  onMomentumScrollEnd: () => void;
+  onScroll: (event: {
+    nativeEvent: {
+      contentOffset: { x: number };
+      contentSize: { width: number };
+      layoutMeasurement: { width: number };
+    };
+  }) => void;
+  keyExtractor: (item: { uuid: string }) => string;
+  renderItem: unknown;
+  extraData: unknown;
+  drawDistance: number;
+}
+const list = vi.hoisted(() => ({ current: null as ShelfListProps | null }));
+vi.mock('@shopify/flash-list', () => ({
+  FlashList: (props: ShelfListProps) => {
+    list.current = props;
+    return createElement('div', { 'data-count': props.data.length });
+  },
+}));
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  useWindowDimensions: () => ({ fontScale: 1, width: 390, height: 844 }),
+}));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 2: 8, 4: 16 } }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    textStyles: { subheadline: { lineHeight: 20 }, caption1: { lineHeight: 16 } },
+  }),
+}));
+vi.mock('../../SectionHeader', () => ({ SectionHeader: () => null }));
+vi.mock('../../ActivityIndicator', () => ({ ActivityIndicator: () => null }));
+import { PlaylistShelf, playlistShelfHeight } from '../PlaylistShelf';
+
+const keyExtractor = (item: { uuid: string }) => item.uuid;
+const renderItem = () => null;
+const nearEnd = {
+  nativeEvent: {
+    contentOffset: { x: 950 },
+    contentSize: { width: 1400 },
+    layoutMeasurement: { width: 390 },
+  },
+};
+function callbacks(): ShelfListProps {
+  if (!list.current) throw new Error('No list mounted.');
+  return list.current;
+}
+beforeEach(() => {
+  list.current = null;
+});
+describe('playlist shelf pagination', () => {
+  it('loads one page per user end-reach and never drains appended data', () => {
+    const loadMore = vi.fn();
+    const initial = [{ uuid: 'first' }];
+    const props = {
+      title: 'Owned',
+      items: initial,
+      renderItem,
+      keyExtractor,
+      hasMore: true,
+      onEndReached: loadMore,
+    };
+    const view = render(<PlaylistShelf {...props} />);
+    act(() => callbacks().onEndReached());
+    expect(loadMore).not.toHaveBeenCalled();
+    act(() => {
+      callbacks().onScrollBeginDrag();
+      callbacks().onScroll(nearEnd);
+      callbacks().onEndReached();
+    });
+    expect(loadMore).toHaveBeenCalledTimes(1);
+    view.rerender(<PlaylistShelf {...props} items={[...initial, { uuid: 'second' }]} />);
+    act(() => {
+      callbacks().onEndReached();
+      callbacks().onScroll(nearEnd);
+    });
+    expect(loadMore).toHaveBeenCalledTimes(1);
+    act(() => {
+      callbacks().onScrollBeginDrag();
+      callbacks().onScroll(nearEnd);
+    });
+    expect(loadMore).toHaveBeenCalledTimes(2);
+  });
+  it('allows another gesture to retry after failure or a duplicate-only page', () => {
+    const loadMore = vi.fn();
+    const props = {
+      title: 'Owned',
+      items: [{ uuid: 'first' }],
+      renderItem,
+      keyExtractor,
+      hasMore: true,
+      onEndReached: loadMore,
+    };
+    const view = render(<PlaylistShelf {...props} />);
+    act(() => {
+      callbacks().onScrollBeginDrag();
+      callbacks().onEndReached();
+    });
+    view.rerender(<PlaylistShelf {...props} isLoadingMore />);
+    act(() => {
+      callbacks().onScrollBeginDrag();
+      callbacks().onScroll(nearEnd);
+    });
+    expect(loadMore).toHaveBeenCalledTimes(1);
+    view.rerender(<PlaylistShelf {...props} items={[{ uuid: 'first' }]} />);
+    act(() => {
+      callbacks().onScrollBeginDrag();
+      callbacks().onScroll(nearEnd);
+      callbacks().onScroll(nearEnd);
+    });
+    expect(loadMore).toHaveBeenCalledTimes(2);
+  });
+  it('does not rearm while a page is pending or fetch solely from its append', () => {
+    const loadMore = vi.fn();
+    const props = {
+      title: 'Owned',
+      items: [{ uuid: 'first' }],
+      renderItem,
+      keyExtractor,
+      hasMore: true,
+      onEndReached: loadMore,
+    };
+    const view = render(<PlaylistShelf {...props} />);
+    act(() => {
+      callbacks().onScrollBeginDrag();
+      callbacks().onEndReached();
+    });
+    view.rerender(<PlaylistShelf {...props} isLoadingMore />);
+    act(() => {
+      callbacks().onScrollBeginDrag();
+      callbacks().onScroll(nearEnd);
+      callbacks().onScrollEndDrag();
+      callbacks().onMomentumScrollBegin();
+    });
+    view.rerender(<PlaylistShelf {...props} items={[...props.items, { uuid: 'second' }]} />);
+    act(() => callbacks().onEndReached());
+    expect(loadMore).toHaveBeenCalledTimes(1);
+  });
+  it('does not fetch an exhausted stream or fetch after a settled gesture', () => {
+    const loadMore = vi.fn();
+    const props = {
+      title: 'Owned',
+      items: [{ uuid: 'first' }],
+      renderItem,
+      keyExtractor,
+      hasMore: false,
+      onEndReached: loadMore,
+    };
+    const view = render(<PlaylistShelf {...props} />);
+    act(() => {
+      callbacks().onScrollBeginDrag();
+      callbacks().onScroll(nearEnd);
+    });
+    expect(loadMore).not.toHaveBeenCalled();
+    view.rerender(<PlaylistShelf {...props} hasMore />);
+    act(() => {
+      callbacks().onScrollEndDrag();
+      callbacks().onMomentumScrollEnd();
+      callbacks().onScroll(nearEnd);
+    });
+    expect(loadMore).not.toHaveBeenCalled();
+  });
+  it('loads at the end of momentum using the same gesture budget', () => {
+    const loadMore = vi.fn();
+    render(
+      <PlaylistShelf
+        title="Owned"
+        items={[{ uuid: 'first' }]}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        hasMore
+        onEndReached={loadMore}
+      />,
+    );
+    act(() => {
+      callbacks().onScrollBeginDrag();
+      callbacks().onScrollEndDrag();
+      callbacks().onMomentumScrollBegin();
+      callbacks().onScroll(nearEnd);
+      callbacks().onEndReached();
+    });
+    expect(loadMore).toHaveBeenCalledTimes(1);
+  });
+  it.each([20, 100, 200])('retains all %i items and passes a bounded draw window to FlashList', (count) => {
+    const items = Array.from({ length: count }, (_, index) => ({ uuid: String(index) }));
+    const extraData = { pinned: true };
+    render(
+      <PlaylistShelf
+        title="Owned"
+        items={items}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        extraData={extraData}
+        hasMore
+        onEndReached={vi.fn()}
+      />,
+    );
+    expect(callbacks().data).toBe(items);
+    expect(callbacks().drawDistance).toBe(240);
+    expect(callbacks().renderItem).toBe(renderItem);
+    expect(callbacks().extraData).toBe(extraData);
+    expect(callbacks().keyExtractor(items[count - 1])).toBe(String(count - 1));
+  });
+  it('reserves room for card text up to the shared Text scaling cap', () => {
+    expect(playlistShelfHeight(1, 20, 16)).toBe(172);
+    expect(playlistShelfHeight(1.5, 20, 16)).toBe(190);
+    expect(playlistShelfHeight(3, 20, 16)).toBe(190);
+  });
+});

--- a/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
+++ b/packages/mobile/src/components/user-drawer/FeedbackSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type RefObject } from 'react';
+import { memo, useEffect, useMemo, useRef, useState, type RefObject } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
@@ -14,6 +14,7 @@ import { useAuth } from '../../providers/auth-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
 import { spacing, borderRadius } from '../../theme/tokens';
+import { FeedbackMetadataCollector, type FeedbackMetadataReader } from '../../lib/feedback/FeedbackMetadataCollector';
 import { useSubmitMobileAppFeedback } from '../../lib/feedback/use-submit-app-feedback';
 import { clearScreenshotUploadCache, uploadFeedbackScreenshots } from '../../lib/feedback/screenshot-upload';
 import { runBleAdvertisementRecon } from '../../lib/ble/advertisement-recon';
@@ -29,6 +30,8 @@ const STAR_RATING_VALUES = [1, 2, 3, 4, 5] as const;
 type FeedbackSheetProps = {
   sheetRef: RefObject<ManagedSheetHandle | null>;
   mode: FeedbackSheetMode;
+  visible: boolean;
+  onClose: () => void;
   /**
    * Show a "Join Discord" link below the submit button. Used on the login screen,
    * where a stuck user has no other route to help; off everywhere else (the user
@@ -37,20 +40,29 @@ type FeedbackSheetProps = {
   showDiscordLink?: boolean;
 };
 
-export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: FeedbackSheetProps) {
+export const FeedbackSheet = memo(function FeedbackSheet({
+  sheetRef,
+  mode,
+  visible,
+  onClose,
+  showDiscordLink = false,
+}: FeedbackSheetProps) {
   const { t } = useTranslation('settings');
   // The screenshot strings live in `common`, shared with the QA verdict sheet.
   const { t: tCommon } = useTranslation('common');
   const { systemColors, brandColors } = useTheme();
   const { showToast } = useToast();
   const { isAuthenticated } = useAuth();
-  const { mutateAsync, isPending, reset } = useSubmitMobileAppFeedback();
+  const metadataReaderRef = useRef<FeedbackMetadataReader | null>(null);
+  const { mutateAsync, isPending, reset } = useSubmitMobileAppFeedback(metadataReaderRef);
   const [selectedRating, setSelectedRating] = useState<number | null>(null);
   const [comment, setComment] = useState('');
   const [captureBleDiag, setCaptureBleDiag] = useState(false);
   const [contactConsent, setContactConsent] = useState(true);
   const [screenshotUris, setScreenshotUris] = useState<string[]>([]);
   const [isUploading, setIsUploading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const submittingRef = useRef(false);
 
   const isBugReport = mode === 'bug';
   // The upload endpoint needs a bearer token, so a signed-out reporter gets the
@@ -75,181 +87,197 @@ export function FeedbackSheet({ sheetRef, mode, showDiscordLink = false }: Feedb
   const snapPoints = useMemo(() => (isBugReport ? ['62%', '88%'] : ['44%', '72%']), [isBugReport]);
 
   const handleDismiss = () => {
-    sheetRef.current?.dismiss();
+    onClose();
   };
 
   const handleSubmit = async () => {
-    if (!canSubmit || isPending || isUploading) return;
-
-    // Uploaded before the report so it carries keys the backend can resolve. A
-    // failed upload leaves the typed report and the picked shots untouched.
-    let screenshotKeys: string[] = [];
-    if (screenshotUris.length > 0) {
-      setIsUploading(true);
-      try {
-        screenshotKeys = await uploadFeedbackScreenshots(screenshotUris);
-      } catch {
-        showToast(tCommon('screenshots.uploadFailed'), 'error');
-        return;
-      } finally {
-        setIsUploading(false);
-      }
-    }
-
+    if (!canSubmit || submittingRef.current) return;
+    submittingRef.current = true;
+    setIsSubmitting(true);
     try {
-      // Fire the opt-in Bluetooth scan-recon alongside the report. It scans
-      // (no connect) and ships each in-range board's raw advertisement payload
-      // to PostHog so we can find where bare-name boxes stash their serial. The
-      // correlation id groups this one scan's events; joining to the specific bug
-      // report is by person + timestamp (the report goes to the backend, not
-      // PostHog). Runs independently of the sheet lifecycle; never blocks the
-      // submit or surfaces its own errors.
-      if (isBugReport && captureBleDiag) {
-        const reconCorrelationId = `bug-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
-        void runBleAdvertisementRecon(reconCorrelationId).catch(() => {});
+      // Uploaded before the report so it carries keys the backend can resolve. A
+      // failed upload leaves the typed report and the picked shots untouched.
+      let screenshotKeys: string[] = [];
+      if (screenshotUris.length > 0) {
+        setIsUploading(true);
+        try {
+          screenshotKeys = await uploadFeedbackScreenshots(screenshotUris);
+        } catch {
+          showToast(tCommon('screenshots.uploadFailed'), 'error');
+          return;
+        } finally {
+          setIsUploading(false);
+        }
       }
-      await mutateAsync({
-        source: isBugReport ? 'drawer-bug' : 'drawer-feedback',
-        rating: isBugReport ? null : selectedRating,
-        comment: trimmedComment.length > 0 ? trimmedComment : null,
-        contactConsent: isBugReport ? contactConsent : null,
-        screenshotKeys: screenshotKeys.length > 0 ? screenshotKeys : null,
-      });
-      sheetRef.current?.dismiss();
-      showToast(isBugReport ? t('feedbackDialog.successBug') : t('feedbackDialog.successRating'), 'success');
-      setSelectedRating(null);
-      setComment('');
-      setContactConsent(true);
-      setScreenshotUris([]);
-      // The report is filed, so the uploaded objects now belong to it. The next
-      // one must upload its own rather than reuse these.
-      clearScreenshotUploadCache();
-    } catch {
-      showToast(t('feedbackDialog.errorRating'), 'error');
+
+      try {
+        // Fire the opt-in Bluetooth scan-recon alongside the report. It scans
+        // (no connect) and ships each in-range board's raw advertisement payload
+        // to PostHog so we can find where bare-name boxes stash their serial. The
+        // correlation id groups this one scan's events; joining to the specific bug
+        // report is by person + timestamp (the report goes to the backend, not
+        // PostHog). Runs independently of the sheet lifecycle; never blocks the
+        // submit or surfaces its own errors.
+        if (isBugReport && captureBleDiag) {
+          const reconCorrelationId = `bug-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+          void runBleAdvertisementRecon(reconCorrelationId).catch(() => {});
+        }
+        await mutateAsync({
+          source: isBugReport ? 'drawer-bug' : 'drawer-feedback',
+          rating: isBugReport ? null : selectedRating,
+          comment: trimmedComment.length > 0 ? trimmedComment : null,
+          contactConsent: isBugReport ? contactConsent : null,
+          screenshotKeys: screenshotKeys.length > 0 ? screenshotKeys : null,
+        });
+        onClose();
+        showToast(isBugReport ? t('feedbackDialog.successBug') : t('feedbackDialog.successRating'), 'success');
+        setSelectedRating(null);
+        setComment('');
+        setContactConsent(true);
+        setScreenshotUris([]);
+        // The report is filed, so the uploaded objects now belong to it. The next
+        // one must upload its own rather than reuse these.
+        clearScreenshotUploadCache();
+      } catch {
+        showToast(t('feedbackDialog.errorRating'), 'error');
+      }
+    } finally {
+      submittingRef.current = false;
+      setIsSubmitting(false);
     }
   };
 
   return (
-    <ModalSheet ref={sheetRef} snapPoints={snapPoints} scrollable contentContainerStyle={styles.content}>
-      <View style={styles.headerRow}>
-        <Text variant="title3" style={styles.title}>
-          {title}
-        </Text>
-        <PressableSurface
-          onPress={handleDismiss}
-          feedback="opacity"
-          hitSlop={8}
-          accessibilityRole="button"
-          accessibilityLabel={t('feedbackDialog.closeAria')}
-          style={styles.closeButton}
-        >
-          <Icon name="close" size={20} color={systemColors.secondaryLabel} />
-        </PressableSurface>
-      </View>
-
-      {!isBugReport ? (
-        <View style={styles.starRow}>
-          {STAR_RATING_VALUES.map((starRating) => {
-            const selected = selectedRating !== null && starRating <= selectedRating;
-            return (
-              <PressableSurface
-                key={starRating}
-                onPress={() => setSelectedRating(starRating)}
-                feedback="scale"
-                hitSlop={6}
-                accessibilityRole="button"
-                accessibilityLabel={t('feedbackForm.starRating', { count: starRating })}
-                accessibilityState={{ selected }}
-                style={styles.starButton}
-              >
-                <Icon name={selected ? 'star.fill' : 'star'} size={34} color={brandColors.warning} />
-              </PressableSurface>
-            );
-          })}
+    <>
+      {visible || isSubmitting ? <FeedbackMetadataCollector readerRef={metadataReaderRef} /> : null}
+      <ModalSheet
+        ref={sheetRef}
+        visible={visible}
+        onClose={onClose}
+        snapPoints={snapPoints}
+        scrollable
+        contentContainerStyle={styles.content}
+      >
+        <View style={styles.headerRow}>
+          <Text variant="title3" style={styles.title}>
+            {title}
+          </Text>
+          <PressableSurface
+            onPress={handleDismiss}
+            feedback="opacity"
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel={t('feedbackDialog.closeAria')}
+            style={styles.closeButton}
+          >
+            <Icon name="close" size={20} color={systemColors.secondaryLabel} />
+          </PressableSurface>
         </View>
-      ) : null}
 
-      <BottomSheetTextInput
-        style={[
-          styles.input,
-          {
-            backgroundColor: systemColors.fill,
-            borderColor: systemColors.separator,
-            color: systemColors.label,
-          },
-        ]}
-        placeholder={inputPlaceholder}
-        placeholderTextColor={systemColors.tertiaryLabel}
-        value={comment}
-        onChangeText={setComment}
-        multiline
-        maxLength={COMMENT_MAX_LENGTH}
-        textAlignVertical="top"
-      />
+        {!isBugReport ? (
+          <View style={styles.starRow}>
+            {STAR_RATING_VALUES.map((starRating) => {
+              const selected = selectedRating !== null && starRating <= selectedRating;
+              return (
+                <PressableSurface
+                  key={starRating}
+                  onPress={() => setSelectedRating(starRating)}
+                  feedback="scale"
+                  hitSlop={6}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('feedbackForm.starRating', { count: starRating })}
+                  accessibilityState={{ selected }}
+                  style={styles.starButton}
+                >
+                  <Icon name={selected ? 'star.fill' : 'star'} size={34} color={brandColors.warning} />
+                </PressableSurface>
+              );
+            })}
+          </View>
+        ) : null}
 
-      {isBugReport && remainingBugChars > 0 ? (
-        <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.helperText}>
-          {t('feedbackForm.remainingChars', { count: remainingBugChars })}
-        </Text>
-      ) : null}
-
-      {isBugReport ? (
-        <View style={[styles.recordingCard, { backgroundColor: systemColors.secondaryBackground }]}>
-          <SessionRecordingSwitchRow
-            label={t('feedbackForm.sessionRecordingLabel')}
-            description={t('feedbackForm.sessionRecordingDescription')}
-          />
-          <SwitchRow
-            label={t('feedbackForm.bluetoothBugLabel')}
-            description={t('feedbackForm.bluetoothBugDescription')}
-            value={captureBleDiag}
-            onValueChange={setCaptureBleDiag}
-          />
-        </View>
-      ) : null}
-
-      {canAttachScreenshots ? (
-        <ScreenshotPicker uris={screenshotUris} onChange={setScreenshotUris} disabled={isPending || isUploading} />
-      ) : null}
-
-      {isBugReport && isAuthenticated ? (
-        <View style={[styles.recordingCard, { backgroundColor: systemColors.secondaryBackground }]}>
-          <SwitchRow
-            label={t('feedbackForm.contactConsentLabel')}
-            description={t('feedbackForm.contactConsentDescription')}
-            value={contactConsent}
-            onValueChange={setContactConsent}
-          />
-        </View>
-      ) : null}
-
-      <Button
-        title={submitLabel}
-        onPress={() => {
-          void handleSubmit();
-        }}
-        variant="filled"
-        size="large"
-        disabled={!canSubmit || isUploading}
-        loading={isPending || isUploading}
-        style={styles.submitButton}
-      />
-
-      {showDiscordLink ? (
-        <Button
-          title={t('feedbackDialog.joinDiscord')}
-          onPress={() => {
-            void openDiscordInvite('login');
-          }}
-          variant="text"
-          size="large"
-          icon="open.external"
-          tintColor={brandColors.primary}
+        <BottomSheetTextInput
+          style={[
+            styles.input,
+            {
+              backgroundColor: systemColors.fill,
+              borderColor: systemColors.separator,
+              color: systemColors.label,
+            },
+          ]}
+          placeholder={inputPlaceholder}
+          placeholderTextColor={systemColors.tertiaryLabel}
+          value={comment}
+          onChangeText={setComment}
+          multiline
+          maxLength={COMMENT_MAX_LENGTH}
+          textAlignVertical="top"
         />
-      ) : null}
-    </ModalSheet>
+
+        {isBugReport && remainingBugChars > 0 ? (
+          <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.helperText}>
+            {t('feedbackForm.remainingChars', { count: remainingBugChars })}
+          </Text>
+        ) : null}
+
+        {isBugReport ? (
+          <View style={[styles.recordingCard, { backgroundColor: systemColors.secondaryBackground }]}>
+            <SessionRecordingSwitchRow
+              label={t('feedbackForm.sessionRecordingLabel')}
+              description={t('feedbackForm.sessionRecordingDescription')}
+            />
+            <SwitchRow
+              label={t('feedbackForm.bluetoothBugLabel')}
+              description={t('feedbackForm.bluetoothBugDescription')}
+              value={captureBleDiag}
+              onValueChange={setCaptureBleDiag}
+            />
+          </View>
+        ) : null}
+
+        {canAttachScreenshots ? (
+          <ScreenshotPicker uris={screenshotUris} onChange={setScreenshotUris} disabled={isPending || isUploading} />
+        ) : null}
+
+        {isBugReport && isAuthenticated ? (
+          <View style={[styles.recordingCard, { backgroundColor: systemColors.secondaryBackground }]}>
+            <SwitchRow
+              label={t('feedbackForm.contactConsentLabel')}
+              description={t('feedbackForm.contactConsentDescription')}
+              value={contactConsent}
+              onValueChange={setContactConsent}
+            />
+          </View>
+        ) : null}
+
+        <Button
+          title={submitLabel}
+          onPress={() => {
+            void handleSubmit();
+          }}
+          variant="filled"
+          size="large"
+          disabled={!canSubmit || isUploading}
+          loading={isPending || isUploading}
+          style={styles.submitButton}
+        />
+
+        {showDiscordLink ? (
+          <Button
+            title={t('feedbackDialog.joinDiscord')}
+            onPress={() => {
+              void openDiscordInvite('login');
+            }}
+            variant="text"
+            size="large"
+            icon="open.external"
+            tintColor={brandColors.primary}
+          />
+        ) : null}
+      </ModalSheet>
+    </>
   );
-}
+});
 
 const styles = StyleSheet.create({
   content: {

--- a/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
+++ b/packages/mobile/src/components/user-drawer/UserDrawerProvider.tsx
@@ -55,6 +55,7 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
   const feedbackSheetRef = useRef<ManagedSheetHandle>(null);
   const qaVerdictSheetRef = useRef<ManagedSheetHandle>(null);
   const [feedbackMode, setFeedbackMode] = useState<FeedbackSheetMode>('rating');
+  const [feedbackVisible, setFeedbackVisible] = useState(false);
 
   // Mirror the latest focused-route segments into a ref so the callbacks below
   // stay referentially stable (no `segments` in their deps). Assigning during
@@ -117,7 +118,11 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
   }, [confirmSignOut]);
 
   const presentFeedback = useCallback(() => {
-    feedbackSheetRef.current?.present();
+    setFeedbackVisible(true);
+  }, []);
+
+  const closeFeedback = useCallback(() => {
+    setFeedbackVisible(false);
   }, []);
 
   const navigateToQaPick = useCallback(() => {
@@ -179,7 +184,12 @@ export function UserDrawerProvider({ children }: { children: ReactNode }) {
           and presenting it only after the route has fully unmounted (the route's
           close(after) sequencing) keeps it on top with no concurrent-presentation
           deadlock. */}
-      <FeedbackSheet sheetRef={feedbackSheetRef} mode={feedbackMode} />
+      <FeedbackSheet
+        sheetRef={feedbackSheetRef}
+        mode={feedbackMode}
+        visible={feedbackVisible}
+        onClose={closeFeedback}
+      />
       {/* Same root-hosting rule as FeedbackSheet above: a native sheet rendered
           inside the transparentModal drawer route would present behind it. */}
       <QaVerdictSheet sheetRef={qaVerdictSheetRef} />

--- a/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.lifecycle.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.lifecycle.test.tsx
@@ -1,0 +1,340 @@
+// @vitest-environment jsdom
+import { it, expect, vi, beforeEach } from 'vitest';
+import { render, renderHook, fireEvent, act } from '@testing-library/react';
+import { createElement, createRef, useSyncExternalStore, Profiler, useState, type ReactNode } from 'react';
+import type { ManagedSheetHandle } from '../../../providers/sheet-presentation-provider';
+
+type ViewMockProps = { children?: ReactNode };
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  View: ({ children }: ViewMockProps) => createElement('div', {}, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+type ModalSheetMockProps = { children?: ReactNode; visible?: boolean; onClose?: () => void };
+const nativeSheet = vi.hoisted(() => ({ close: undefined as (() => void) | undefined }));
+vi.mock('../../ModalSheet', () => ({
+  ModalSheet: ({ children, visible, onClose }: ModalSheetMockProps) => {
+    nativeSheet.close = onClose;
+    return createElement('div', { 'data-modal-sheet': String(visible) }, children);
+  },
+}));
+
+type TextMockProps = { children?: ReactNode };
+vi.mock('../../Text', () => ({
+  Text: ({ children }: TextMockProps) => createElement('span', {}, children),
+}));
+
+vi.mock('../../Icon', () => ({
+  Icon: () => createElement('span', { 'data-icon': 'true' }),
+}));
+
+type ButtonMockProps = { title: string; onPress?: () => void; disabled?: boolean; loading?: boolean };
+vi.mock('../../Button', () => ({
+  Button: ({ title, onPress, disabled }: ButtonMockProps) =>
+    createElement('button', { onClick: onPress, disabled, 'data-button': title }),
+}));
+
+type PressableMockProps = { children?: ReactNode; onPress?: () => void; accessibilityLabel?: string };
+vi.mock('../../PressableSurface', () => ({
+  PressableSurface: ({ children, onPress, accessibilityLabel }: PressableMockProps) =>
+    createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+}));
+
+// The picker owns the photo library + compression; the sheet only cares that it
+// hands back URIs and that the keys reach the mutation.
+type ScreenshotPickerMockProps = { uris: string[]; onChange: (uris: string[]) => void; disabled?: boolean };
+vi.mock('../../feedback/ScreenshotPicker', () => ({
+  ScreenshotPicker: ({ uris, onChange, disabled }: ScreenshotPickerMockProps) =>
+    createElement('button', {
+      'data-screenshot-picker': uris.join(','),
+      disabled,
+      onClick: () => onChange([...uris, `file:///shot-${uris.length}.jpg`]),
+    }),
+}));
+
+const uploadFeedbackScreenshots = vi.hoisted(() => vi.fn());
+const clearScreenshotUploadCache = vi.hoisted(() => vi.fn());
+vi.mock('../../../lib/feedback/screenshot-upload', () => ({ uploadFeedbackScreenshots, clearScreenshotUploadCache }));
+
+vi.mock('../../settings/SessionRecordingSwitchRow', () => ({
+  SessionRecordingSwitchRow: () => createElement('div', { 'data-testid': 'session-recording-switch' }),
+}));
+
+// Real tokens.ts pulls in ios-colors.ts, which reads Platform.OS at module load —
+// stub the constants FeedbackSheet actually consumes instead of widening the
+// react-native mock to support that transitive chain.
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24 },
+  borderRadius: { lg: 12 },
+}));
+
+type SwitchRowMockProps = { label: string; value: boolean; onValueChange: (next: boolean) => void };
+vi.mock('../../SwitchRow', () => ({
+  SwitchRow: ({ label, value, onValueChange }: SwitchRowMockProps) =>
+    createElement('button', {
+      'data-switch': label,
+      'data-value': String(value),
+      onClick: () => onValueChange(!value),
+    }),
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { secondaryLabel: '#888', fill: '#eee', separator: '#ccc', label: '#000', tertiaryLabel: '#aaa' },
+    brandColors: { warning: '#f90', primary: '#60f' },
+  }),
+}));
+
+const showToast = vi.hoisted(() => vi.fn());
+vi.mock('../../../providers/toast-provider', () => ({
+  useToast: () => ({ showToast }),
+}));
+
+const auth = vi.hoisted(() => ({ isAuthenticated: true }));
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: auth.isAuthenticated }),
+}));
+
+const request = vi.hoisted(() => vi.fn().mockResolvedValue({ submitAppFeedback: true }));
+vi.mock('../../../lib/graphql/client', () => ({ getHttpClient: () => ({ request }) }));
+vi.mock('expo-application', () => ({ nativeApplicationVersion: '2.5.0', nativeBuildVersion: '1' }));
+
+const metadata = vi.hoisted(() => ({
+  pathname: '/home',
+  sessionId: 'session-before',
+  climbUuid: 'climb-before',
+  boardName: 'kilter',
+  revision: 0,
+  listeners: new Set<() => void>(),
+  subscriptions: 0,
+}));
+function subscribeMetadata(listener: () => void) {
+  metadata.listeners.add(listener);
+  metadata.subscriptions++;
+  return () => {
+    metadata.listeners.delete(listener);
+    metadata.subscriptions--;
+  };
+}
+function useMetadataRevision() {
+  useSyncExternalStore(subscribeMetadata, () => metadata.revision);
+}
+function updateMetadata() {
+  metadata.revision++;
+  for (const listener of metadata.listeners) listener();
+}
+vi.mock('expo-router', () => ({
+  usePathname: () => {
+    useMetadataRevision();
+    return metadata.pathname;
+  },
+}));
+vi.mock('../../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => {
+    useMetadataRevision();
+    return { data: { boardType: metadata.boardName, layoutId: 1, sizeId: 2, setIds: '1', angle: 40 } };
+  },
+}));
+const queueActions = { getQueueSnapshot: () => ({ currentClimbQueueItem: { climb: { uuid: metadata.climbUuid } } }) };
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueue: () => {
+    throw new Error('Full queue subscription is forbidden');
+  },
+  useQueueActions: () => queueActions,
+  useQueueSessionId: () => {
+    useMetadataRevision();
+    return { sessionId: metadata.sessionId };
+  },
+}));
+
+vi.mock('../../../lib/ble/advertisement-recon', () => ({
+  runBleAdvertisementRecon: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../lib/discord', () => ({
+  openDiscordInvite: vi.fn(),
+}));
+
+vi.mock('@expo/ui/community/bottom-sheet', () => ({
+  BottomSheetTextInput: ({
+    value,
+    onChangeText,
+    placeholder,
+  }: {
+    value?: string;
+    onChangeText?: (text: string) => void;
+    placeholder?: string;
+  }) =>
+    createElement('input', {
+      value: value ?? '',
+      placeholder,
+      onChange: (event: { target: { value: string } }) => onChangeText?.(event.target.value),
+    }),
+}));
+
+import { FeedbackSheet } from '../FeedbackSheet';
+import { useSubmitMobileAppFeedback } from '../../../lib/feedback/use-submit-app-feedback';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const closeRequested = vi.fn();
+function Host({ initialVisible = false }: { initialVisible?: boolean }) {
+  const [visible, setVisible] = useState(initialVisible);
+  const sheetRef = createRef<ManagedSheetHandle>();
+  return (
+    <>
+      <button onClick={() => setVisible(true)}>Open feedback</button>
+      <FeedbackSheet
+        sheetRef={sheetRef}
+        mode="bug"
+        visible={visible}
+        onClose={() => {
+          closeRequested();
+          setVisible(false);
+        }}
+      />
+    </>
+  );
+}
+function mountFeedback(initialVisible = false) {
+  const onRender = vi.fn();
+  const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  const rendered = render(
+    <QueryClientProvider client={queryClient}>
+      <Profiler id="feedback" onRender={onRender}>
+        <Host initialVisible={initialVisible} />
+      </Profiler>
+    </QueryClientProvider>,
+  );
+  return { ...rendered, onRender };
+}
+
+beforeEach(() => {
+  request.mockReset().mockResolvedValue({ submitAppFeedback: true });
+  uploadFeedbackScreenshots.mockReset().mockResolvedValue(['screenshot-key']);
+  closeRequested.mockClear();
+  showToast.mockClear();
+  metadata.pathname = '/home';
+  metadata.sessionId = 'session-before';
+  metadata.climbUuid = 'climb-before';
+  metadata.boardName = 'kilter';
+});
+
+it('unsubscribes while closed, keeps drafts, and does not reopen after native dismissal', async () => {
+  const { onRender, getByText, getByPlaceholderText, container } = mountFeedback();
+  expect(metadata.subscriptions).toBe(0);
+  const closedRenders = onRender.mock.calls.length;
+  act(() => {
+    metadata.pathname = '/discover';
+    updateMetadata();
+  });
+  expect(onRender).toHaveBeenCalledTimes(closedRenders);
+  fireEvent.click(getByText('Open feedback'));
+  expect(metadata.subscriptions).toBe(3);
+  fireEvent.change(getByPlaceholderText('feedbackForm.bugPlaceholder'), {
+    target: { value: 'Keep this draft on close' },
+  });
+  act(() => nativeSheet.close?.());
+  expect(metadata.subscriptions).toBe(0);
+  expect(container.querySelector('[data-modal-sheet="false"]')).not.toBeNull();
+  act(() => {
+    metadata.pathname = '/climbs';
+    updateMetadata();
+  });
+  expect(container.querySelector('[data-modal-sheet="false"]')).not.toBeNull();
+  fireEvent.click(getByText('Open feedback'));
+  expect((getByPlaceholderText('feedbackForm.bugPlaceholder') as HTMLInputElement).value).toBe(
+    'Keep this draft on close',
+  );
+});
+
+it('reads current board, route, session, and queue after a dismissed screenshot upload', async () => {
+  let finishUpload: (keys: string[]) => void = () => {};
+  uploadFeedbackScreenshots.mockReturnValueOnce(
+    new Promise<string[]>((resolve) => {
+      finishUpload = resolve;
+    }),
+  );
+  let finishMutation: (response: { submitAppFeedback: boolean }) => void = () => {};
+  request.mockReturnValueOnce(
+    new Promise<{ submitAppFeedback: boolean }>((resolve) => {
+      finishMutation = resolve;
+    }),
+  );
+  const { getByPlaceholderText, container } = mountFeedback(true);
+  fireEvent.change(getByPlaceholderText('feedbackForm.bugPlaceholder'), {
+    target: { value: 'The board disappeared during the climb' },
+  });
+  fireEvent.click(container.querySelector('[data-screenshot-picker]')!);
+  fireEvent.click(container.querySelector('[data-button="feedbackDialog.submitBug"]')!);
+  expect(uploadFeedbackScreenshots).toHaveBeenCalledTimes(1);
+  act(() => nativeSheet.close?.());
+  expect(metadata.subscriptions).toBe(3);
+  act(() => {
+    metadata.pathname = '/climbs';
+    metadata.sessionId = 'session-after';
+    metadata.climbUuid = 'climb-after';
+    metadata.boardName = 'tension';
+    updateMetadata();
+  });
+  // Queue-only change: no metadata render publishes a new reader closure.
+  metadata.climbUuid = 'queue-only-latest';
+  await act(async () => {
+    finishUpload(['screenshot-key']);
+  });
+  await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+  expect(request.mock.calls[0][1]).toMatchObject({
+    input: {
+      boardName: 'tension',
+      screenshotKeys: ['screenshot-key'],
+      context: { url: '/climbs', sessionId: 'session-after', climbUuid: 'queue-only-latest' },
+    },
+  });
+  expect(metadata.subscriptions).toBe(3);
+  await act(async () => {
+    finishMutation({ submitAppFeedback: true });
+  });
+  await vi.waitFor(() => expect(metadata.subscriptions).toBe(0));
+  expect(container.querySelector('[data-modal-sheet="false"]')).not.toBeNull();
+});
+
+it('retains attachments and draft after an upload failure and allows retry', async () => {
+  uploadFeedbackScreenshots.mockRejectedValueOnce(new Error('upload failed'));
+  const { getByPlaceholderText, container } = mountFeedback(true);
+  fireEvent.change(getByPlaceholderText('feedbackForm.bugPlaceholder'), {
+    target: { value: 'Keep the screenshot for retry' },
+  });
+  fireEvent.click(container.querySelector('[data-screenshot-picker]')!);
+  fireEvent.click(container.querySelector('[data-button="feedbackDialog.submitBug"]')!);
+  await vi.waitFor(() => expect(showToast).toHaveBeenCalledWith('screenshots.uploadFailed', 'error'));
+  expect(request).not.toHaveBeenCalled();
+  expect(container.querySelector('[data-screenshot-picker="file:///shot-0.jpg"]')).not.toBeNull();
+  fireEvent.click(container.querySelector('[data-button="feedbackDialog.submitBug"]')!);
+  await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+});
+
+it('refuses submission before metadata is mounted instead of filing stale context', async () => {
+  const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  const { result } = renderHook(() => useSubmitMobileAppFeedback({ current: null }), {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  });
+  await act(async () => {
+    await expect(
+      result.current.mutateAsync({
+        source: 'drawer-bug',
+        rating: null,
+        comment: 'The route was unavailable',
+        contactConsent: false,
+        screenshotKeys: null,
+      }),
+    ).rejects.toThrow('Feedback metadata is not ready');
+  });
+  expect(request).not.toHaveBeenCalled();
+});

--- a/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/FeedbackSheet.test.tsx
@@ -100,6 +100,8 @@ const feedbackMutation = vi.hoisted(() => ({
   isPending: false,
   reset: vi.fn(),
 }));
+vi.mock('../../../lib/feedback/FeedbackMetadataCollector', () => ({ FeedbackMetadataCollector: () => null }));
+
 vi.mock('../../../lib/feedback/use-submit-app-feedback', () => ({
   useSubmitMobileAppFeedback: () => feedbackMutation,
 }));
@@ -142,20 +144,22 @@ describe('FeedbackSheet bug report contact consent', () => {
 
   it('defaults contact consent to on (opt-out) for an authenticated bug report', () => {
     const sheetRef = createRef<ManagedSheetHandle>();
-    const { container } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    const { container } = render(<FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="bug" />);
     expect(switchRow(container)?.getAttribute('data-value')).toBe('true');
   });
 
   it('does not render the consent switch when unauthenticated', () => {
     auth.isAuthenticated = false;
     const sheetRef = createRef<ManagedSheetHandle>();
-    const { container } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    const { container } = render(<FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="bug" />);
     expect(switchRow(container)).toBeNull();
   });
 
   it('submits contactConsent true by default without the user touching the switch', async () => {
     const sheetRef = createRef<ManagedSheetHandle>();
-    const { container, getByPlaceholderText } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    const { container, getByPlaceholderText } = render(
+      <FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="bug" />,
+    );
     fireEvent.change(getByPlaceholderText('feedbackForm.bugPlaceholder'), {
       target: { value: 'the board disconnects on start' },
     });
@@ -166,7 +170,9 @@ describe('FeedbackSheet bug report contact consent', () => {
 
   it('respects an explicit opt-out when the reporter flips the switch off', async () => {
     const sheetRef = createRef<ManagedSheetHandle>();
-    const { container, getByPlaceholderText } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    const { container, getByPlaceholderText } = render(
+      <FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="bug" />,
+    );
     fireEvent.click(switchRow(container)!);
     expect(switchRow(container)?.getAttribute('data-value')).toBe('false');
 
@@ -180,7 +186,9 @@ describe('FeedbackSheet bug report contact consent', () => {
 
   it('resets the switch back to on after a successful submit, even from an opt-out', async () => {
     const sheetRef = createRef<ManagedSheetHandle>();
-    const { container, getByPlaceholderText } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    const { container, getByPlaceholderText } = render(
+      <FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="bug" />,
+    );
     fireEvent.click(switchRow(container)!);
     expect(switchRow(container)?.getAttribute('data-value')).toBe('false');
 
@@ -194,12 +202,12 @@ describe('FeedbackSheet bug report contact consent', () => {
 
   it('resets the switch back to on when the sheet mode changes away and back', () => {
     const sheetRef = createRef<ManagedSheetHandle>();
-    const { container, rerender } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    const { container, rerender } = render(<FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="bug" />);
     fireEvent.click(switchRow(container)!);
     expect(switchRow(container)?.getAttribute('data-value')).toBe('false');
 
-    rerender(<FeedbackSheet sheetRef={sheetRef} mode="rating" />);
-    rerender(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    rerender(<FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="rating" />);
+    rerender(<FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="bug" />);
     expect(switchRow(container)?.getAttribute('data-value')).toBe('true');
   });
 });
@@ -221,26 +229,28 @@ describe('FeedbackSheet screenshots', () => {
 
   it('offers the picker on an authenticated bug report', () => {
     const sheetRef = createRef<ManagedSheetHandle>();
-    const { container } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    const { container } = render(<FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="bug" />);
     expect(picker(container)).not.toBeNull();
   });
 
   it('hides it when signed out — the upload endpoint needs a bearer token', () => {
     auth.isAuthenticated = false;
     const sheetRef = createRef<ManagedSheetHandle>();
-    const { container } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    const { container } = render(<FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="bug" />);
     expect(picker(container)).toBeNull();
   });
 
   it('hides it on the star-rating form, which files no issue to illustrate', () => {
     const sheetRef = createRef<ManagedSheetHandle>();
-    const { container } = render(<FeedbackSheet sheetRef={sheetRef} mode="rating" />);
+    const { container } = render(<FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="rating" />);
     expect(picker(container)).toBeNull();
   });
 
   it('uploads the picked shots and sends their keys with the report', async () => {
     const sheetRef = createRef<ManagedSheetHandle>();
-    const { container, getByPlaceholderText } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    const { container, getByPlaceholderText } = render(
+      <FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="bug" />,
+    );
     fireEvent.click(picker(container)!);
     typeReport(getByPlaceholderText);
     fireEvent.click(container.querySelector('[data-button="feedbackDialog.submitBug"]')!);
@@ -254,7 +264,9 @@ describe('FeedbackSheet screenshots', () => {
 
   it('sends no keys at all when nothing was attached', async () => {
     const sheetRef = createRef<ManagedSheetHandle>();
-    const { container, getByPlaceholderText } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    const { container, getByPlaceholderText } = render(
+      <FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="bug" />,
+    );
     typeReport(getByPlaceholderText);
     fireEvent.click(container.querySelector('[data-button="feedbackDialog.submitBug"]')!);
 
@@ -265,7 +277,9 @@ describe('FeedbackSheet screenshots', () => {
 
   it('clears the strip after a successful submit', async () => {
     const sheetRef = createRef<ManagedSheetHandle>();
-    const { container, getByPlaceholderText } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    const { container, getByPlaceholderText } = render(
+      <FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="bug" />,
+    );
     fireEvent.click(picker(container)!);
     typeReport(getByPlaceholderText);
     fireEvent.click(container.querySelector('[data-button="feedbackDialog.submitBug"]')!);
@@ -275,19 +289,21 @@ describe('FeedbackSheet screenshots', () => {
 
   it('clears the strip when the sheet mode changes away and back', () => {
     const sheetRef = createRef<ManagedSheetHandle>();
-    const { container, rerender } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    const { container, rerender } = render(<FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="bug" />);
     fireEvent.click(picker(container)!);
     expect(picker(container)?.getAttribute('data-screenshot-picker')).toBe('file:///shot-0.jpg');
 
-    rerender(<FeedbackSheet sheetRef={sheetRef} mode="rating" />);
-    rerender(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    rerender(<FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="rating" />);
+    rerender(<FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="bug" />);
     expect(picker(container)?.getAttribute('data-screenshot-picker')).toBe('');
   });
 
   it('keeps the typed report and the shots when the upload fails', async () => {
     uploadFeedbackScreenshots.mockRejectedValue(new Error('offline'));
     const sheetRef = createRef<ManagedSheetHandle>();
-    const { container, getByPlaceholderText } = render(<FeedbackSheet sheetRef={sheetRef} mode="bug" />);
+    const { container, getByPlaceholderText } = render(
+      <FeedbackSheet sheetRef={sheetRef} visible onClose={() => {}} mode="bug" />,
+    );
     fireEvent.click(picker(container)!);
     typeReport(getByPlaceholderText);
     fireEvent.click(container.querySelector('[data-button="feedbackDialog.submitBug"]')!);

--- a/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { createElement, type ReactNode } from 'react';
+import { createElement, useEffect, type ReactNode } from 'react';
 
 const browser = vi.hoisted(() => ({ openBrowserAsync: vi.fn().mockResolvedValue(undefined) }));
 const routerMock = vi.hoisted(() => ({ push: vi.fn(), back: vi.fn() }));
@@ -204,8 +204,10 @@ vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
 vi.mock('../FeedbackSheet', () => ({
-  FeedbackSheet: ({ sheetRef }: { sheetRef?: { current: { present: () => void } | null } }) => {
-    if (sheetRef) sheetRef.current = { present: feedbackPresent };
+  FeedbackSheet: ({ visible }: { visible: boolean }) => {
+    useEffect(() => {
+      if (visible) feedbackPresent();
+    }, [visible]);
     return null;
   },
 }));

--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -14,6 +14,9 @@ import { fileURLToPath } from 'node:url';
 const reportErrorMock = vi.hoisted(() => vi.fn());
 vi.mock('../../lib/error-reporting', () => ({ reportError: reportErrorMock }));
 
+const markStartupMock = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/profiling/startup-profile', () => ({ markStartup: markStartupMock }));
+
 const trackMock = vi.hoisted(() => vi.fn());
 vi.mock('../../lib/analytics', () => ({ track: trackMock }));
 // Only vacuumDatabase is stubbed; everything else in the engine stays real, since
@@ -365,6 +368,7 @@ describe('initializeDatabase connection PRAGMAs', () => {
     setDatabaseHandle(null);
     reportErrorMock.mockClear();
     trackMock.mockClear();
+    markStartupMock.mockClear();
     dbDir = mkdtempSync(join(tmpdir(), 'bs-conn-'));
     dbPath = join(dbDir, 'boardsesh.db');
     fileDb = createTestDatabase(dbPath) as unknown as TestSqliteDb & SQLiteDatabase;
@@ -469,6 +473,7 @@ describe('initializeDatabase lock contention (#4104)', () => {
     setDatabaseHandle(null);
     reportErrorMock.mockClear();
     trackMock.mockClear();
+    markStartupMock.mockClear();
     dbDir = mkdtempSync(join(tmpdir(), 'bs-lock-'));
     realDb = createTestDatabase(join(dbDir, 'boardsesh.db'));
   });
@@ -489,6 +494,9 @@ describe('initializeDatabase lock contention (#4104)', () => {
     // until onInit resolves, so waiting for retries here would be a black screen.
     await expect(initializeDatabase(contended.db)).resolves.toBeUndefined();
 
+    expect(markStartupMock).toHaveBeenCalledWith('sqlite.initial.gate', 'degraded');
+    expect(markStartupMock).toHaveBeenCalledWith('sqlite.recovery.start');
+    expect(markStartupMock).not.toHaveBeenCalledWith('sqlite.recovery.end', 'ready');
     expect(contended.failures()).toBe(1);
     expect(getDatabaseHandle()).toBeNull();
     // A launch that is still retrying is not yet newsworthy.
@@ -508,6 +516,7 @@ describe('initializeDatabase lock contention (#4104)', () => {
     contended.unlock();
     await vi.advanceTimersByTimeAsync(FIRST_RETRY_DELAY_MS);
 
+    expect(markStartupMock).toHaveBeenCalledWith('sqlite.recovery.end', 'ready');
     expect(getDatabaseHandle()).toBe(contended.db);
     expect(reportErrorMock).not.toHaveBeenCalled();
   });

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -26,6 +26,7 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { reportError } from '../lib/error-reporting';
 import { track } from '../lib/analytics';
 import { setSchemaReady } from './schema-ready';
+import { markStartup } from '../lib/profiling/startup-profile';
 import { measureDatabaseBytes } from './storage-usage';
 
 export const DATABASE_NAME = 'boardsesh.db';
@@ -227,6 +228,7 @@ async function attemptInitialization(db: SQLiteDatabase): Promise<InitOutcome> {
  * handle degrades exactly like the old permanent failure did, then recovers.
  */
 function beginInitialization(db: SQLiteDatabase): Promise<void> {
+  markStartup('sqlite.initial.start');
   let releaseLaunch: () => void = () => {};
   const launchGate = new Promise<void>((resolve) => {
     releaseLaunch = resolve;
@@ -257,10 +259,12 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
 
       // Unblock the provider once, whatever the first attempt did.
       if (attempts === 1) {
+        markStartup('sqlite.initial.gate', outcome.status === 'ready' ? 'ready' : 'degraded');
         releaseLaunch();
       }
 
       if (outcome.status === 'ready') {
+        if (attempts > 1) markStartup('sqlite.recovery.end', 'ready');
         // Only a chain that survived a GENUINE lock failure recovered from
         // contention. A chain whose only failure was against a superseded (closed)
         // handle worked around a remount, not a lock — firing the event for it
@@ -301,6 +305,7 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
       // already been handed the resolved launch promise, so schema readiness stayed
       // false for the rest of the session.
       if (superseded && !outcome.retryable && supersededRestarts < MAX_SUPERSEDED_RESTARTS) {
+        markStartup('sqlite.recovery.start');
         supersededRestarts += 1;
         continue;
       }
@@ -314,6 +319,7 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
         Date.now() + retryDelayMs >= deadline;
 
       if (outOfRoad) {
+        if (attempts > 1) markStartup('sqlite.recovery.end', 'error');
         if (__DEV__) {
           console.warn(
             `[SQLite] initializeDatabase failed in phase "${outcome.phase}" after ${attempts} attempt(s); ` +
@@ -345,6 +351,7 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
         return;
       }
 
+      markStartup('sqlite.recovery.start');
       await delay(retryDelayMs);
     }
   })();

--- a/packages/mobile/src/lib/feedback/FeedbackMetadataCollector.tsx
+++ b/packages/mobile/src/lib/feedback/FeedbackMetadataCollector.tsx
@@ -1,0 +1,26 @@
+import { useLayoutEffect, type RefObject } from 'react';
+import { usePathname } from 'expo-router';
+import { useActiveBoard } from '../graphql/use-active-board';
+import { useQueueActions, useQueueSessionId } from '../../providers/queue-provider';
+import type { BuildMobileFeedbackEnrichmentArgs } from './feedback-enrichment';
+
+export type FeedbackMetadataReader = () => BuildMobileFeedbackEnrichmentArgs;
+
+/** Only mounted while reporting. Route changes update this bridge, not the form. */
+export function FeedbackMetadataCollector({ readerRef }: { readerRef: RefObject<FeedbackMetadataReader | null> }) {
+  const { data: activeBoard } = useActiveBoard();
+  const { getQueueSnapshot } = useQueueActions();
+  const { sessionId } = useQueueSessionId();
+  const pathname = usePathname();
+
+  useLayoutEffect(() => {
+    readerRef.current = () => ({
+      activeBoard,
+      currentClimbQueueItem: getQueueSnapshot().currentClimbQueueItem,
+      sessionId,
+      pathname,
+    });
+  }, [activeBoard, getQueueSnapshot, pathname, readerRef, sessionId]);
+
+  return null;
+}

--- a/packages/mobile/src/lib/feedback/use-submit-app-feedback.ts
+++ b/packages/mobile/src/lib/feedback/use-submit-app-feedback.ts
@@ -1,6 +1,7 @@
 import { Platform } from 'react-native';
 import * as Application from 'expo-application';
-import { usePathname } from 'expo-router';
+import type { RefObject } from 'react';
+import type { FeedbackMetadataReader } from './FeedbackMetadataCollector';
 import { useMutation } from '@tanstack/react-query';
 import {
   SUBMIT_APP_FEEDBACK,
@@ -9,8 +10,6 @@ import {
 } from '@boardsesh/graphql/operations';
 import type { SubmitAppFeedbackInput } from '@boardsesh/shared-schema';
 import { getHttpClient } from '../graphql/client';
-import { useActiveBoard } from '../graphql/use-active-board';
-import { useQueue, useQueueSessionId } from '../../providers/queue-provider';
 import { buildMobileFeedbackEnrichment } from './feedback-enrichment';
 
 export type MobileSubmitAppFeedbackPayload = Omit<
@@ -41,20 +40,14 @@ async function submitMobileAppFeedback(payload: SubmitAppFeedbackInput): Promise
   return response.submitAppFeedback;
 }
 
-export function useSubmitMobileAppFeedback() {
-  const activeBoardQuery = useActiveBoard();
-  const queueContext = useQueue();
-  const { sessionId } = useQueueSessionId();
-  const pathname = usePathname();
-
+export function useSubmitMobileAppFeedback(readerRef: RefObject<FeedbackMetadataReader | null>) {
   return useMutation({
     mutationFn: (payload: MobileSubmitAppFeedbackPayload): Promise<boolean> => {
-      const enrichment = buildMobileFeedbackEnrichment({
-        activeBoard: activeBoardQuery.data,
-        currentClimbQueueItem: queueContext.state.currentClimbQueueItem,
-        sessionId,
-        pathname,
-      });
+      const readMetadata = readerRef.current;
+      if (!readMetadata) return Promise.reject(new Error('Feedback metadata is not ready'));
+      // Read at mutation time, after screenshot upload. The bridge stays mounted
+      // throughout submission, even if the reporter dismisses the native sheet.
+      const enrichment = buildMobileFeedbackEnrichment(readMetadata());
       return submitMobileAppFeedback({
         ...payload,
         ...enrichment,

--- a/packages/mobile/src/lib/profiling/HomeStartupCommit.tsx
+++ b/packages/mobile/src/lib/profiling/HomeStartupCommit.tsx
@@ -1,0 +1,11 @@
+import { useLayoutEffect } from 'react';
+import { markStartup } from './startup-profile';
+import type { StartupOutcome } from './startup-collector';
+
+/** Mounted beside the actual row/empty state, never beside a loading placeholder. */
+export function HomeStartupCommit({ outcome }: { outcome: StartupOutcome | null }) {
+  useLayoutEffect(() => {
+    if (outcome) markStartup('home.useful.commit', outcome);
+  }, [outcome]);
+  return null;
+}

--- a/packages/mobile/src/lib/profiling/__tests__/startup-collector.test.ts
+++ b/packages/mobile/src/lib/profiling/__tests__/startup-collector.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { createStartupCollector, homeEmptyStartupOutcome } from '../startup-collector';
+
+describe('local startup collector', () => {
+  it('does not read clocks or retain marks while disabled', () => {
+    const collector = createStartupCollector(false, () => {
+      throw new Error('unexpected clock');
+    });
+    expect(collector.mark('root.commit')).toBe(false);
+    expect(collector.snapshot()).toEqual([]);
+  });
+
+  it('keeps the first commit and isolates returned snapshots', () => {
+    let timestamp = 1;
+    const collector = createStartupCollector(true, () => timestamp++);
+    expect(collector.mark('home.useful.commit', 'offline')).toBe(true);
+    for (let render = 0; render < 200; render++) collector.mark('home.useful.commit', 'content');
+    collector.snapshot()[0].timestampMs = 999;
+    expect(collector.snapshot()).toEqual([{ name: 'home.useful.commit', timestampMs: 1, outcome: 'offline' }]);
+  });
+
+  it('keeps SQLite initial gate and recovery separate', () => {
+    let timestamp = 1;
+    const collector = createStartupCollector(true, () => timestamp++);
+    collector.mark('sqlite.initial.start');
+    collector.mark('sqlite.initial.gate', 'degraded');
+    collector.mark('sqlite.recovery.start');
+    collector.mark('auth.initial.start');
+    collector.mark('sqlite.recovery.end', 'ready');
+    expect(collector.snapshot().map(({ name }) => name)).toEqual([
+      'sqlite.initial.start',
+      'sqlite.initial.gate',
+      'sqlite.recovery.start',
+      'auth.initial.start',
+      'sqlite.recovery.end',
+    ]);
+  });
+});
+
+describe('Home useful empty-state outcome', () => {
+  const loaded = { authenticated: true, blockedReason: null, loading: false, scopeReady: true, error: false };
+  it('excludes unresolved scope and loading skeletons', () => {
+    expect(homeEmptyStartupOutcome({ ...loaded, loading: true })).toBeNull();
+    expect(homeEmptyStartupOutcome({ ...loaded, scopeReady: false })).toBeNull();
+    expect(homeEmptyStartupOutcome({ ...loaded, loading: true, error: true })).toBeNull();
+  });
+  it('records empty, offline, and error content matching rendered precedence', () => {
+    expect(homeEmptyStartupOutcome(loaded)).toBe('empty');
+    expect(homeEmptyStartupOutcome({ ...loaded, authenticated: false, loading: true })).toBe('empty');
+    expect(homeEmptyStartupOutcome({ ...loaded, error: true })).toBe('error');
+    expect(homeEmptyStartupOutcome({ ...loaded, blockedReason: 'offline', loading: true })).toBe('offline');
+    expect(homeEmptyStartupOutcome({ ...loaded, blockedReason: 'error', loading: true })).toBe('error');
+  });
+});

--- a/packages/mobile/src/lib/profiling/__tests__/startup-profile.test.ts
+++ b/packages/mobile/src/lib/profiling/__tests__/startup-profile.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { write, createDirectory } = vi.hoisted(() => ({ write: vi.fn(), createDirectory: vi.fn() }));
+vi.mock('expo-file-system', () => ({
+  Directory: class {
+    create = createDirectory;
+  },
+  File: class {
+    write = write;
+  },
+  Paths: { document: 'documents' },
+}));
+
+type ProfileHandle = { snapshot: () => { runId: string; marks: { name: string }[] }; flush: () => Promise<void> };
+const profilingGlobal = globalThis as typeof globalThis & { __boardseshStartupProfile?: ProfileHandle };
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.useFakeTimers();
+  write.mockReset();
+  createDirectory.mockReset();
+  delete profilingGlobal.__boardseshStartupProfile;
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  delete profilingGlobal.__boardseshStartupProfile;
+});
+
+describe('startup artifact lifecycle', () => {
+  it('does not expose a profiling global, timer, or file in normal builds', async () => {
+    vi.stubEnv('EXPO_PUBLIC_PROFILE_STARTUP', undefined);
+    const { markStartup } = await import('../startup-profile');
+    markStartup('home.useful.commit', 'content');
+    expect(profilingGlobal.__boardseshStartupProfile).toBeUndefined();
+    expect(vi.getTimerCount()).toBe(0);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('defers export beyond the measured commit and skips duplicate revisions', async () => {
+    vi.stubEnv('EXPO_PUBLIC_PROFILE_STARTUP', '1');
+    const { markStartup } = await import('../startup-profile');
+    markStartup('home.useful.commit', 'content');
+    expect(write).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(write).toHaveBeenCalledTimes(1);
+    const artifact = JSON.parse(write.mock.calls[0][0] as string) as { runId: string; marks: { name: string }[] };
+    expect(artifact.runId).not.toBe('');
+    expect(artifact.marks.map(({ name }) => name)).toEqual(['collector.loaded', 'home.useful.commit']);
+    markStartup('home.useful.commit', 'empty');
+    await profilingGlobal.__boardseshStartupProfile?.flush();
+    expect(write).toHaveBeenCalledTimes(1);
+    markStartup('sqlite.recovery.end', 'ready');
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(write).toHaveBeenCalledTimes(2);
+  });
+
+  it('exports incomplete launches and tolerates unavailable local disk', async () => {
+    vi.stubEnv('EXPO_PUBLIC_PROFILE_STARTUP', '1');
+    write.mockImplementationOnce(() => {
+      throw new Error('disk unavailable');
+    });
+    await import('../startup-profile');
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(write).toHaveBeenCalledTimes(1);
+    await profilingGlobal.__boardseshStartupProfile?.flush();
+    expect(write).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/mobile/src/lib/profiling/startup-collector.ts
+++ b/packages/mobile/src/lib/profiling/startup-collector.ts
@@ -1,0 +1,62 @@
+/** Local attribution only. These JS marks are never host launch timestamps. */
+export type StartupMarkName =
+  | 'collector.loaded'
+  | 'root.module.ready'
+  | 'root.commit'
+  | 'fonts.start'
+  | 'fonts.ready'
+  | 'sqlite.initial.start'
+  | 'sqlite.initial.gate'
+  | 'sqlite.recovery.start'
+  | 'sqlite.recovery.end'
+  | 'auth.initial.start'
+  | 'auth.initial.ready'
+  | 'splash.hide.request'
+  | 'splash.hide.resolved'
+  | 'home.useful.commit';
+export type StartupOutcome =
+  | 'ready'
+  | 'error'
+  | 'degraded'
+  | 'authenticated'
+  | 'anonymous'
+  | 'content'
+  | 'empty'
+  | 'offline';
+export type StartupMark = { name: StartupMarkName; timestampMs: number; outcome?: StartupOutcome };
+
+export function createStartupCollector(enabled: boolean, now: () => number) {
+  // One entry per fixed phase: retries, navigation, and StrictMode cannot grow it.
+  const marks = new Map<StartupMarkName, StartupMark>();
+  return {
+    mark(name: StartupMarkName, outcome?: StartupOutcome): boolean {
+      if (!enabled || marks.has(name)) return false;
+      marks.set(name, { name, timestampMs: now(), ...(outcome ? { outcome } : {}) });
+      return true;
+    },
+    snapshot(): StartupMark[] {
+      return [...marks.values()].map((mark) => ({ ...mark }));
+    },
+  };
+}
+
+/** Mirrors Home's visible empty-state precedence; skeletons are not useful. */
+export function homeEmptyStartupOutcome({
+  authenticated,
+  blockedReason,
+  loading,
+  scopeReady,
+  error,
+}: {
+  authenticated: boolean;
+  blockedReason: string | null;
+  loading: boolean;
+  scopeReady: boolean;
+  error: boolean;
+}): StartupOutcome | null {
+  if (!authenticated) return 'empty';
+  if (blockedReason) return blockedReason === 'error' ? 'error' : 'offline';
+  if (loading || !scopeReady) return null;
+  if (error) return 'error';
+  return 'empty';
+}

--- a/packages/mobile/src/lib/profiling/startup-profile.ts
+++ b/packages/mobile/src/lib/profiling/startup-profile.ts
@@ -1,0 +1,85 @@
+import { createStartupCollector, type StartupMarkName, type StartupOutcome } from './startup-collector';
+
+export const STARTUP_PROFILING_ENABLED = process.env.EXPO_PUBLIC_PROFILE_STARTUP === '1';
+const collector = createStartupCollector(STARTUP_PROFILING_ENABLED, () => performance.now());
+const runId = STARTUP_PROFILING_ENABLED ? `${Date.now()}-${Math.random().toString(36).slice(2, 10)}` : '';
+let exportTimer: ReturnType<typeof setTimeout> | undefined;
+let exportInFlight: Promise<void> | undefined;
+let exportedRevision = -1;
+
+const RN_TIMING_KEYS = [
+  'startTime',
+  'initializeRuntimeStart',
+  'executeJavaScriptBundleEntryPointStart',
+  'endTime',
+] as const;
+
+function snapshot() {
+  const runtimePerformance = performance as typeof performance & {
+    rnStartupTiming?: Partial<Record<(typeof RN_TIMING_KEYS)[number], number | null>>;
+  };
+  // Copy explicit getters: RN's platform object has no enumerable own fields.
+  const rnStartupTiming = Object.fromEntries(
+    RN_TIMING_KEYS.map((key) => {
+      const timestamp = runtimePerformance.rnStartupTiming?.[key];
+      return [key, typeof timestamp === 'number' && Number.isFinite(timestamp) ? timestamp : null];
+    }),
+  );
+  return {
+    schemaVersion: 1,
+    runId,
+    jsClock: 'RN performance.now monotonic milliseconds; compare differences within one run only',
+    nativeClock: 'RN startup timing milliseconds; RN time origin; unavailable fields are null',
+    hostClock: 'not collected; do not subtract host launch timestamps from these marks',
+    rnStartupTiming,
+    marks: collector.snapshot(),
+  };
+}
+
+async function flush(): Promise<void> {
+  if (!STARTUP_PROFILING_ENABLED) return;
+  if (exportInFlight) {
+    await exportInFlight;
+    return flush();
+  }
+  const captured = snapshot();
+  if (exportedRevision === captured.marks.length) return;
+  exportInFlight = (async () => {
+    const { Directory, File, Paths } = await import('expo-file-system');
+    const directory = new Directory(Paths.document, 'boardsesh-profile');
+    directory.create({ intermediates: true, idempotent: true });
+    // A fixed file bounds disk usage across process-cold launches. The runner
+    // copies it after each launch and rejects a stale runId from a previous run.
+    new File(directory, 'startup-latest.json').write(JSON.stringify(captured, null, 2));
+    exportedRevision = captured.marks.length;
+  })();
+  try {
+    await exportInFlight;
+  } finally {
+    exportInFlight = undefined;
+  }
+}
+
+function scheduleExport(delayMs: number) {
+  if (exportTimer) clearTimeout(exportTimer);
+  exportTimer = setTimeout(() => {
+    exportTimer = undefined;
+    // Local diagnostics must never change startup behavior if disk export fails.
+    void flush().catch(() => {});
+  }, delayMs);
+}
+
+export function markStartup(name: StartupMarkName, outcome?: StartupOutcome): void {
+  if (!collector.mark(name, outcome)) return;
+  if (name === 'home.useful.commit' || name === 'sqlite.recovery.end') scheduleExport(1_000);
+}
+
+if (STARTUP_PROFILING_ENABLED) {
+  const profilingGlobal = globalThis as typeof globalThis & {
+    __boardseshStartupProfile?: { snapshot: typeof snapshot; flush: typeof flush };
+  };
+  profilingGlobal.__boardseshStartupProfile = { snapshot, flush };
+  markStartup('collector.loaded');
+  // Export incomplete starts too, without disk work in the ordinary launch path.
+  scheduleExport(10_000);
+}

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-virtual-wall.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-virtual-wall.test.tsx
@@ -58,6 +58,7 @@ const bluetooth = vi.hoisted(() => {
       connect: vi.fn(async () => true),
       disconnect: vi.fn(async () => {}),
       sendFramesToBoard: vi.fn<SendFramesToBoard>(async () => true),
+      consumeBackgroundAdoptSendGate: vi.fn(() => false),
       pickerState: null as PickerState | null,
       reconnectSerialForCurrentBoard: null,
       connectInitialSendRef: { current: null as { frames: string; mirrored: boolean; colorSignature: string } | null },

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -1,3 +1,4 @@
+import { markStartup } from '../lib/profiling/startup-profile';
 import { createContext, useContext, useEffect, useMemo, useRef, useState, useCallback, type ReactNode } from 'react';
 import { AppState, Platform } from 'react-native';
 import { useSegments, Redirect } from 'expo-router';
@@ -696,6 +697,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
   }, [checkAuth]);
 
   useEffect(() => {
+    markStartup('auth.initial.start');
     // Belt-and-braces: checkAuth already resolves its own rejections, but keep
     // the invocation from producing an unhandled rejection if that ever changes.
     void checkAuth();
@@ -1017,6 +1019,7 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
 
   useEffect(() => {
     if (!isLoading) {
+      markStartup('auth.initial.ready', authStateRef.current.isAuthenticated ? 'authenticated' : 'anonymous');
       onReadyRef.current?.();
     }
   }, [isLoading]);

--- a/scripts/__tests__/ios-profiling-tools.test.ts
+++ b/scripts/__tests__/ios-profiling-tools.test.ts
@@ -1,0 +1,360 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { exportBuiltApp } from '../lib/ios-build-export';
+import { resolveMetroHostname } from '../lib/metro-host';
+import { acquireSimulatorLease, guardSimulatorCommand, selectSimulatorUdid } from '../lib/ios-simulator-lease';
+import {
+  assertMatchingIdentity,
+  hasUsefulStartupArtifact,
+  validateCaptureFiles,
+  type IosAppIdentity,
+} from '../lib/ios-profile-identity';
+import { extractIosDeviceArgs } from '../mobile-ios-run';
+import { parseProfileArgs } from '../mobile-profile-ios';
+
+const scratch: string[] = [];
+const udid = '561A4D7D-12C6-4B27-A956-A69C4436F4BE';
+function directory(): string {
+  const path = mkdtempSync(join(tmpdir(), 'boardsesh-profile-test-'));
+  scratch.push(path);
+  return path;
+}
+afterEach(() => {
+  for (const path of scratch.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe('Metro host resolution', () => {
+  it.each([['--host', 'localhost'], ['--host=localhost'], ['--localhost']])('advertises loopback for %j', (...args) => {
+    const fallback = vi.fn(() => ({ hostname: 'host.ts.net', source: 'tailscale' as const }));
+    expect(resolveMetroHostname(args, fallback).hostname).toBe('localhost');
+    expect(fallback).not.toHaveBeenCalled();
+  });
+  it('keeps the default resolver for LAN', () => {
+    expect(resolveMetroHostname(['--lan'], () => ({ hostname: 'host.ts.net', source: 'tailscale' })).hostname).toBe(
+      'host.ts.net',
+    );
+  });
+});
+
+describe('validated build exports', () => {
+  it('never publishes a stale product after a failed build', () => {
+    const root = directory();
+    const built = join(root, 'built.app');
+    const exported = join(root, 'out/Boardsesh.app');
+    mkdirSync(built);
+    mkdirSync(exported, { recursive: true });
+    writeFileSync(join(built, 'Info.plist'), 'plist');
+    writeFileSync(join(built, 'Boardsesh'), 'stale');
+    writeFileSync(join(exported, 'Boardsesh'), 'previous good');
+    expect(() => exportBuiltApp(65, built, join(root, 'out'))).toThrow(/refusing any pre-existing/);
+    expect(readFileSync(join(exported, 'Boardsesh'), 'utf8')).toBe('previous good');
+  });
+  it('preserves the prior export when a successful build produced an incomplete app', () => {
+    const root = directory();
+    mkdirSync(join(root, 'out/Boardsesh.app'), { recursive: true });
+    writeFileSync(join(root, 'out/Boardsesh.app/Boardsesh'), 'previous');
+    expect(() => exportBuiltApp(0, join(root, 'missing.app'), join(root, 'out'))).toThrow(/complete/);
+    expect(readFileSync(join(root, 'out/Boardsesh.app/Boardsesh'), 'utf8')).toBe('previous');
+  });
+  it('publishes a validated successful build', () => {
+    const root = directory();
+    const built = join(root, 'built.app');
+    mkdirSync(built);
+    writeFileSync(join(built, 'Info.plist'), 'plist');
+    writeFileSync(join(built, 'Boardsesh'), 'new');
+    const destination = exportBuiltApp(0, built, join(root, 'out'));
+    expect(readFileSync(join(destination, 'Boardsesh'), 'utf8')).toBe('new');
+  });
+});
+
+describe('simulator ownership', () => {
+  it('refuses foreign active ownership, including old leases', () => {
+    const root = directory();
+    const leases = join(root, 'leases');
+    const lease = acquireSimulatorLease(udid, root, leases);
+    expect(() => acquireSimulatorLease(udid, directory(), leases)).toThrow(/leased by/);
+    lease.release();
+    expect(existsSync(join(leases, `${udid}.lock`))).toBe(false);
+  });
+  it('allows explicit inherited ownership without releasing its parent', () => {
+    const root = directory();
+    const leases = join(root, 'leases');
+    const parent = acquireSimulatorLease(udid, root, leases);
+    const child = acquireSimulatorLease(udid, root, leases, parent.owner.token);
+    child.release();
+    expect(existsSync(join(leases, `${udid}.lock`))).toBe(true);
+    parent.release();
+  });
+  it('does not steal an incomplete lease', () => {
+    const root = directory();
+    const leases = join(root, 'leases');
+    mkdirSync(join(leases, `${udid}.lock`), { recursive: true });
+    expect(() => acquireSimulatorLease(udid, root, leases)).toThrow(/incomplete lease/);
+  });
+  it('rejects ambiguous booted selection at the command boundary', () => {
+    expect(() => guardSimulatorCommand('xcrun', ['simctl', 'shutdown', 'booted'], directory())).toThrow(
+      /explicit UDID/,
+    );
+  });
+  it('does not select the only booted simulator when a different device was requested', () => {
+    const devices = [{ udid, name: 'Someone else simulator', state: 'Booted' }];
+    expect(() => selectSimulatorUdid(devices, 'Owned simulator')).toThrow(/Select exactly one/);
+    expect(selectSimulatorUdid(devices, udid)).toBe(udid);
+  });
+  it('leaves Android Maestro commands alone', () => {
+    expect(() => guardSimulatorCommand('maestro', ['--device', 'emulator-5554', 'test'], directory())).not.toThrow();
+  });
+});
+
+const identity: IosAppIdentity = {
+  bundleIdentifier: 'app',
+  executableUuid: 'uuid',
+  executableSha256: 'binary',
+  embeddedBundleSha256: 'bundle',
+};
+describe('capture validity', () => {
+  it.each(['executableUuid', 'executableSha256', 'embeddedBundleSha256', 'bundleIdentifier'] as const)(
+    'rejects a changed %s',
+    (field) => {
+      expect(() => assertMatchingIdentity(identity, { ...identity, [field]: 'foreign' })).toThrow(/identity changed/);
+    },
+  );
+  it('rejects incomplete captures', () => {
+    expect(() => validateCaptureFiles({}, { valid: false })).toThrow(/incomplete/);
+    expect(() => validateCaptureFiles({}, {})).toThrow(/incomplete/);
+    expect(() => validateCaptureFiles(null, { valid: true })).toThrow(/missing/);
+    expect(() => validateCaptureFiles({}, { valid: true })).toThrow(/incomplete/);
+  });
+  it('requires an explicit simulator for profiling', () => {
+    expect(() => parseProfileArgs(['--udid', 'booted'])).toThrow(/explicitly owned/);
+    expect(parseProfileArgs(['--udid', udid, '--configuration', 'Debug', '--port', '8097']).port).toBe(8097);
+  });
+  it.each([['--device', udid], ['-d', udid], [`--device=${udid}`]])('normalizes Expo device flags %j', (...flags) => {
+    expect(extractIosDeviceArgs(['--no-bundler', ...flags])).toEqual({ requested: udid, remaining: ['--no-bundler'] });
+  });
+});
+
+const require = createRequire(import.meta.url);
+const { configureWatchman } = require('../../packages/mobile/metro-watchman.cjs') as {
+  configureWatchman: (
+    config: { resolver: { useWatchman: boolean | null } },
+    env: Record<string, string>,
+    run: () => { status: number | null },
+  ) => void;
+};
+describe('Watchman opt-in', () => {
+  it('does not probe or alter Expo defaults when disabled', () => {
+    const config = { resolver: { useWatchman: null } };
+    const probe = vi.fn(() => ({ status: 0 }));
+    configureWatchman(config, {}, probe);
+    expect(config.resolver.useWatchman).toBeNull();
+    expect(probe).not.toHaveBeenCalled();
+  });
+  it('fails explicitly when Watchman is unavailable', () => {
+    expect(() =>
+      configureWatchman({ resolver: { useWatchman: null } }, { BOARDSESH_METRO_USE_WATCHMAN: '1' }, () => ({
+        status: null,
+      })),
+    ).toThrow(/available Watchman/);
+  });
+  it('enables available Watchman only when requested', () => {
+    const config = { resolver: { useWatchman: null } };
+    configureWatchman(config, { BOARDSESH_METRO_USE_WATCHMAN: '1' }, () => ({ status: 0 }));
+    expect(config.resolver.useWatchman).toBe(true);
+  });
+});
+
+describe('complete comparison sample counts', () => {
+  const navigation = Array.from({ length: 20 }, (_, index) => ({
+    loop: Math.floor(index / 4) + 1,
+    route: ['home', 'climbs', 'discover', 'profile'][index % 4],
+    observation: { gaps: [16.7] },
+    routeConfirmed: true,
+    nativeSampleComplete: true,
+  }));
+  const debug = { configuration: 'Debug', warmupLoops: 2, measuredLoops: 5, navigation };
+  const verdict = { valid: true, completed: true, configuration: 'Debug' };
+  it('accepts all five measured loops after two warmups', () => {
+    expect(() => validateCaptureFiles(debug, verdict)).not.toThrow();
+  });
+  it('rejects missing loops and callback observations', () => {
+    expect(() => validateCaptureFiles({ ...debug, navigation: navigation.slice(1) }, verdict)).toThrow(
+      /Incomplete Debug/,
+    );
+    expect(() =>
+      validateCaptureFiles(
+        { ...debug, navigation: navigation.map((entry) => ({ ...entry, observation: { gaps: [] } })) },
+        verdict,
+      ),
+    ).toThrow(/Invalid navigation/);
+  });
+  it('rejects missing Release launches and memory samples even with a successful verdict', () => {
+    expect(() =>
+      validateCaptureFiles(
+        { configuration: 'Release', launches: [], memory: [] },
+        { valid: true, completed: true, configuration: 'Release' },
+      ),
+    ).toThrow(/Incomplete Release/);
+  });
+});
+
+function releaseCapture() {
+  return {
+    configuration: 'Release',
+    launches: Array.from({ length: 10 }, (_, index) => ({
+      trial: index + 1,
+      hostExportObservedMs: 2500,
+      artifact: {
+        runId: `runtime-${index + 1}`,
+        marks: [{ name: 'home.useful.commit', timestampMs: 1500, outcome: 'content' }],
+      },
+    })),
+    memory: Array.from({ length: 20 }, (_, index) => ({ cycle: index + 1, pid: 1234, footprintMiB: 250 })),
+  };
+}
+const releaseVerdict = { valid: true, completed: true, configuration: 'Release' };
+
+describe('Release artifact integrity', () => {
+  it('accepts ten distinct useful launches and twenty cycles in one process', () => {
+    expect(() => validateCaptureFiles(releaseCapture(), releaseVerdict)).not.toThrow();
+  });
+  it.each(['content', 'empty', 'offline', 'error'])('accepts the visible %s outcome', (outcome) => {
+    expect(
+      hasUsefulStartupArtifact({ runId: 'runtime', marks: [{ name: 'home.useful.commit', timestampMs: 0, outcome }] }),
+    ).toBe(true);
+  });
+  it.each([null, {}, [], { runId: 'runtime' }, { runId: 'runtime', marks: [null] }])(
+    'rejects malformed artifact %j',
+    (artifact) => {
+      expect(hasUsefulStartupArtifact(artifact)).toBe(false);
+      const recorded = releaseCapture();
+      expect(() =>
+        validateCaptureFiles(
+          {
+            ...recorded,
+            launches: recorded.launches.map((launch, index) => (index === 0 ? { ...launch, artifact } : launch)),
+          },
+          releaseVerdict,
+        ),
+      ).toThrow(/Invalid or stale/);
+    },
+  );
+  it.each(['', ' ', '\t\n'])('rejects empty runtime identity %j', (runId) => {
+    const recorded = releaseCapture();
+    recorded.launches[0].artifact.runId = runId;
+    expect(() => validateCaptureFiles(recorded, releaseVerdict)).toThrow(/Invalid or stale/);
+  });
+  it.each([NaN, Infinity, -Infinity, -1, undefined, null, '1500'])(
+    'rejects invalid useful timestamp %j',
+    (timestampMs) => {
+      const recorded = releaseCapture();
+      const artifact = {
+        runId: 'runtime-first',
+        marks: [{ name: 'home.useful.commit', timestampMs, outcome: 'content' }],
+      };
+      expect(hasUsefulStartupArtifact(artifact)).toBe(false);
+      expect(() =>
+        validateCaptureFiles(
+          { ...recorded, launches: [{ ...recorded.launches[0], artifact }, ...recorded.launches.slice(1)] },
+          releaseVerdict,
+        ),
+      ).toThrow(/Invalid or stale/);
+    },
+  );
+  it.each([
+    [],
+    [{ name: 'root.commit', timestampMs: 10 }],
+    [{ name: 'home.useful.commit', timestampMs: 10, outcome: 'loading' }],
+    [{ name: 'home.useful.commit', timestampMs: 10 }],
+    [
+      { name: 'home.useful.commit', timestampMs: 10, outcome: 'content' },
+      { name: 'home.useful.commit', timestampMs: 20, outcome: 'empty' },
+    ],
+  ])('rejects missing, loading, or ambiguous useful commits %j', (...marks) => {
+    // Vitest spreads array table rows; restore the artifact marks array.
+    const recorded = releaseCapture();
+    expect(() =>
+      validateCaptureFiles(
+        {
+          ...recorded,
+          launches: [
+            { ...recorded.launches[0], artifact: { runId: 'runtime-first', marks } },
+            ...recorded.launches.slice(1),
+          ],
+        },
+        releaseVerdict,
+      ),
+    ).toThrow(/Invalid or stale/);
+  });
+  it('rejects a reused launch runtime and a changed memory process', () => {
+    const stale = releaseCapture();
+    stale.launches[1].artifact.runId = stale.launches[0].artifact.runId;
+    expect(() => validateCaptureFiles(stale, releaseVerdict)).toThrow(/Invalid or stale/);
+    const switched = releaseCapture();
+    switched.memory[10].pid += 1;
+    expect(() => validateCaptureFiles(switched, releaseVerdict)).toThrow(/changed process/);
+  });
+});
+
+function debugCapture() {
+  return {
+    configuration: 'Debug',
+    warmupLoops: 2,
+    measuredLoops: 5,
+    capability: { react: { available: true, complete: true }, nativeSample: { complete: true } },
+    navigation: Array.from({ length: 20 }, (_, index) => ({
+      loop: Math.floor(index / 4) + 1,
+      route: ['home', 'climbs', 'discover', 'profile'][index % 4],
+      routeConfirmed: true,
+      nativeSampleComplete: false,
+      observation: { gaps: [16.7] },
+    })),
+  };
+}
+const debugVerdict = { valid: true, completed: true, configuration: 'Debug' };
+
+describe('Debug attribution and navigation integrity', () => {
+  it('accepts complete React attribution without native sampling', () => {
+    expect(() => validateCaptureFiles(debugCapture(), debugVerdict)).not.toThrow();
+  });
+  it('accepts all complete in-scenario native samples as an explicit React fallback', () => {
+    const recorded = debugCapture();
+    recorded.capability.react = { available: false, complete: false };
+    for (const observation of recorded.navigation) observation.nativeSampleComplete = true;
+    expect(() => validateCaptureFiles(recorded, debugVerdict)).not.toThrow();
+  });
+  it.each([false, undefined, 'true'])('rejects an unconfirmed destination %j', (routeConfirmed) => {
+    const recorded = debugCapture();
+    expect(() =>
+      validateCaptureFiles(
+        {
+          ...recorded,
+          navigation: recorded.navigation.map((observation, index) =>
+            index === 7 ? { ...observation, routeConfirmed } : observation,
+          ),
+        },
+        debugVerdict,
+      ),
+    ).toThrow(/Invalid navigation/);
+  });
+  it.each([
+    {},
+    { react: { available: true } },
+    { react: { available: true, complete: false }, nativeSample: { complete: true } },
+    { react: { available: false, complete: true } },
+  ])('rejects missing attribution despite an idle terminal sample %j', (capability) => {
+    expect(() => validateCaptureFiles({ ...debugCapture(), capability }, debugVerdict)).toThrow(
+      /neither complete React/,
+    );
+  });
+  it('rejects one incomplete scenario when React attribution is unavailable', () => {
+    const recorded = debugCapture();
+    recorded.capability.react = { available: false, complete: false };
+    for (const observation of recorded.navigation) observation.nativeSampleComplete = true;
+    recorded.navigation[12].nativeSampleComplete = false;
+    expect(() => validateCaptureFiles(recorded, debugVerdict)).toThrow(/neither complete React/);
+  });
+});

--- a/scripts/__tests__/mobile-ios-run.test.ts
+++ b/scripts/__tests__/mobile-ios-run.test.ts
@@ -217,18 +217,15 @@ describe('acquireBuildLock', () => {
     expect(existsSync(paths.lockPath)).toBe(false);
   });
 
-  it('replaces stale lock directories', () => {
+  it('does not steal an old lock from a potentially live build', () => {
     const tempDir = makeTempDir();
     const paths = makePaths(tempDir);
     mkdirSync(paths.lockPath, { recursive: true });
     const staleTime = new Date(clock.now() - 13 * 60 * 60 * 1000);
     utimesSync(paths.lockPath, staleTime, staleTime);
 
-    const lock = acquireBuildLock(paths, nodeFileSystem, clock);
-
-    expect(lock.path).toBe(paths.lockPath);
-    expect(readFileSync(join(paths.lockPath, 'owner.txt'), 'utf8')).toContain('sharedBuildPath=');
-    lock.release();
+    expect(() => acquireBuildLock(paths, nodeFileSystem, clock)).toThrow(/another Boardsesh iOS build/);
+    expect(existsSync(paths.lockPath)).toBe(true);
   });
 });
 

--- a/scripts/__tests__/mobile-profile-capture.test.ts
+++ b/scripts/__tests__/mobile-profile-capture.test.ts
@@ -1,0 +1,139 @@
+import http from 'node:http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  CdpClient,
+  distribution,
+  physicalFootprintMiB,
+  selectDebuggerTarget,
+  usefulStartup,
+} from '../mobile-profile-capture';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('profiling measurement validity', () => {
+  it('rejects stale, loading, and malformed startup artifacts', () => {
+    const artifact = { runId: 'current', marks: [{ name: 'home.useful.commit', timestampMs: 12, outcome: 'content' }] };
+    expect(usefulStartup(artifact, 'previous')).toBe(true);
+    expect(usefulStartup(artifact, 'current')).toBe(false);
+    expect(usefulStartup({ ...artifact, marks: [{ name: 'root.commit', timestampMs: 1 }] }, null)).toBe(false);
+    expect(usefulStartup(null, null)).toBe(false);
+    for (const outcome of ['empty', 'offline', 'error'])
+      expect(
+        usefulStartup({ ...artifact, marks: [{ name: 'home.useful.commit', timestampMs: 12, outcome }] }, null),
+      ).toBe(true);
+  });
+  it('distinguishes physical footprint from RSS and peak footprint', () => {
+    expect(physicalFootprintMiB('Physical footprint:         195.7M\nPhysical footprint (peak): 294.3M')).toBe(195.7);
+    expect(physicalFootprintMiB('Physical footprint: 1.5G')).toBe(1536);
+    expect(physicalFootprintMiB('Physical footprint: 1024K')).toBe(1);
+    expect(physicalFootprintMiB('RSS: 123M\nPhysical footprint (peak): 294.3M')).toBeNull();
+  });
+  it('retains individual sample order and reports nearest-rank distributions', () => {
+    expect(distribution([3, 1, 2])).toEqual({ samples: [3, 1, 2], count: 3, min: 1, median: 2, p95: 3, max: 3 });
+    expect(distribution([]).median).toBeNull();
+  });
+});
+
+describe('Metro debugger target selection', () => {
+  const selectedApp = 'com.boardsesh.app';
+  const runtime = {
+    appId: selectedApp,
+    title: 'Boardsesh [React Native Bridgeless]',
+    webSocketDebuggerUrl: 'ws://localhost:8097/inspector/debug?device=owned&page=1',
+  };
+
+  it('selects the actual React Native title without requiring the word Hermes', () => {
+    expect(selectDebuggerTarget([runtime], selectedApp)).toBe(runtime);
+  });
+
+  it('uses the exact app identifier instead of a Hermes title or a shared prefix', () => {
+    const developmentRuntime = {
+      ...runtime,
+      appId: 'com.boardsesh.app.dev',
+      title: 'Hermes React Native',
+      webSocketDebuggerUrl: 'ws://localhost:8097/inspector/debug?device=foreign&page=1',
+    };
+    expect(selectDebuggerTarget([developmentRuntime, runtime], selectedApp)).toBe(runtime);
+    expect(selectDebuggerTarget([runtime, developmentRuntime], developmentRuntime.appId)).toBe(developmentRuntime);
+    expect(selectDebuggerTarget([developmentRuntime], selectedApp)).toBeUndefined();
+  });
+
+  it('refuses multiple registered runtimes for the same application', () => {
+    const secondRuntime = {
+      ...runtime,
+      webSocketDebuggerUrl: 'ws://localhost:8097/inspector/debug?device=second&page=1',
+    };
+    expect(() => selectDebuggerTarget([runtime, secondRuntime], selectedApp)).toThrow(/Multiple runtimes.*ambiguous/);
+  });
+
+  it('ignores malformed entries without selecting an unrelated application', () => {
+    expect(
+      selectDebuggerTarget(
+        [
+          null,
+          'Hermes',
+          42,
+          {},
+          { appId: selectedApp },
+          { appId: selectedApp, webSocketDebuggerUrl: 123 },
+          { ...runtime, appId: 'com.example.app' },
+        ],
+        selectedApp,
+      ),
+    ).toBeUndefined();
+  });
+
+  it.each([null, undefined, {}, 'Hermes'])('rejects a malformed target-list response: %j', (targets) => {
+    expect(() => selectDebuggerTarget(targets, selectedApp)).toThrow(/Invalid Metro debugger target list/);
+  });
+});
+
+describe('CDP connection ownership and Origin', () => {
+  it.each(['ws://other-host.example:8097/inspector/debug', 'ws://localhost:8081/inspector/debug'])(
+    'rejects a debugger endpoint outside the selected Metro: %s',
+    async (endpoint) => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          json: async () => [{ appId: 'com.boardsesh.app', webSocketDebuggerUrl: endpoint }],
+        })),
+      );
+      await expect(CdpClient.connect(8097)).rejects.toThrow(/outside the selected local Metro/);
+    },
+  );
+
+  it("supplies Metro's required localhost Origin to the actual WebSocket handshake", async () => {
+    const port = 8097;
+    const endpoint = `ws://localhost:${port}/inspector/debug?device=fixture&page=1`;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        json: async () => [
+          {
+            appId: 'com.boardsesh.app.dev',
+            title: 'Boardsesh [React Native Bridgeless]',
+            webSocketDebuggerUrl: endpoint,
+          },
+        ],
+      })),
+    );
+    // Exercise the pinned ws constructor, intercepting only its HTTP transport.
+    // This catches an omitted Origin without binding a port or using Metro/RN.
+    const interceptedTransport = new Error('Fixture intercepted the HTTP upgrade before network I/O.');
+    let upgradeOptions: unknown;
+    vi.spyOn(http, 'request').mockImplementation((options: unknown) => {
+      upgradeOptions = options;
+      throw interceptedTransport;
+    });
+    await expect(CdpClient.connect(port, 'com.boardsesh.app.dev')).rejects.toBe(interceptedTransport);
+    expect(upgradeOptions).toMatchObject({
+      host: 'localhost',
+      port: String(port),
+      path: '/inspector/debug?device=fixture&page=1',
+      headers: { Origin: `http://localhost:${port}`, Upgrade: 'websocket' },
+    });
+  });
+});

--- a/scripts/lib/ios-build-export.ts
+++ b/scripts/lib/ios-build-export.ts
@@ -1,0 +1,40 @@
+import { cpSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+export function assertSuccessfulBuild(status: number, appPath: string): void {
+  if (status !== 0)
+    throw new Error(`Xcode build failed (exit ${status}); refusing any pre-existing .app at ${appPath}.`);
+  if (!existsSync(join(appPath, 'Info.plist')) || !existsSync(join(appPath, 'Boardsesh'))) {
+    throw new Error(`Xcode did not produce a complete Boardsesh.app at ${appPath}.`);
+  }
+  if (statSync(join(appPath, 'Boardsesh')).size === 0) throw new Error('Built executable is empty.');
+}
+
+/** Publish only a fully copied product; rollback preserves the last good export. */
+export function exportBuiltApp(status: number, appPath: string, appOut: string): string {
+  assertSuccessfulBuild(status, appPath);
+  mkdirSync(appOut, { recursive: true });
+  const destination = join(appOut, 'Boardsesh.app');
+  const stage = join(appOut, `.Boardsesh-${randomUUID()}.app`);
+  const previous = join(appOut, `.Boardsesh-previous-${randomUUID()}.app`);
+  try {
+    cpSync(appPath, stage, { recursive: true });
+    assertSuccessfulBuild(0, stage);
+    // Ensure the copy has the same executable before replacing a working export.
+    if (!readFileSync(join(stage, 'Boardsesh')).equals(readFileSync(join(appPath, 'Boardsesh')))) {
+      throw new Error('Staged executable differs from the built executable.');
+    }
+    if (existsSync(destination)) renameSync(destination, previous);
+    try {
+      renameSync(stage, destination);
+    } catch (error) {
+      if (existsSync(previous)) renameSync(previous, destination);
+      throw error;
+    }
+    rmSync(previous, { recursive: true, force: true });
+    return destination;
+  } finally {
+    rmSync(stage, { recursive: true, force: true });
+  }
+}

--- a/scripts/lib/ios-profile-identity.ts
+++ b/scripts/lib/ios-profile-identity.ts
@@ -1,0 +1,165 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface IosAppIdentity {
+  bundleIdentifier: string;
+  executableUuid: string;
+  executableSha256: string;
+  embeddedBundleSha256: string | null;
+}
+
+export function fileSha256(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+export function readAppIdentity(appPath: string, configuration: 'Debug' | 'Release'): IosAppIdentity {
+  const plist = (key: string) =>
+    execFileSync('plutil', ['-extract', key, 'raw', '-o', '-', join(appPath, 'Info.plist')], {
+      encoding: 'utf8',
+    }).trim();
+  const executable = join(appPath, plist('CFBundleExecutable'));
+  const uuid = execFileSync('xcrun', ['dwarfdump', '--uuid', executable], { encoding: 'utf8' })
+    .split('\n')
+    .map((line) => /UUID: ([0-9A-F-]+) \(([^)]+)\)/i.exec(line))
+    .filter((match) => match !== null)
+    .map((match) => `${match[1]} (${match[2]})`)
+    .sort()
+    .join(', ');
+  if (!uuid) throw new Error(`Executable has no UUID: ${executable}`);
+  const bundlePath = join(appPath, 'main.jsbundle');
+  if (configuration === 'Release' && !existsSync(bundlePath))
+    throw new Error('Release profiling requires an embedded bundle.');
+  return {
+    bundleIdentifier: plist('CFBundleIdentifier'),
+    executableUuid: uuid,
+    executableSha256: fileSha256(executable),
+    embeddedBundleSha256: existsSync(bundlePath) ? fileSha256(bundlePath) : null,
+  };
+}
+
+export function assertMatchingIdentity(expected: IosAppIdentity, actual: IosAppIdentity): void {
+  for (const field of ['bundleIdentifier', 'executableUuid', 'executableSha256', 'embeddedBundleSha256'] as const) {
+    if (expected[field] !== actual[field])
+      throw new Error(`Installed app identity changed: ${field}. Capture is invalid.`);
+  }
+}
+
+function objectRecord(candidate: unknown): Record<string, unknown> | null {
+  return candidate !== null && typeof candidate === 'object' && !Array.isArray(candidate)
+    ? (candidate as Record<string, unknown>)
+    : null;
+}
+
+/** A useful Home commit must come from a complete, identifiable runtime artifact. */
+export function hasUsefulStartupArtifact(artifact: unknown): boolean {
+  const recorded = objectRecord(artifact);
+  if (typeof recorded?.runId !== 'string' || recorded.runId.trim().length === 0 || !Array.isArray(recorded.marks))
+    return false;
+  let usefulMarks = 0;
+  for (const candidate of recorded.marks) {
+    const mark = objectRecord(candidate);
+    if (
+      typeof mark?.name !== 'string' ||
+      typeof mark.timestampMs !== 'number' ||
+      !Number.isFinite(mark.timestampMs) ||
+      mark.timestampMs < 0
+    )
+      return false;
+    if (mark.name === 'home.useful.commit') {
+      if (typeof mark.outcome !== 'string' || !['content', 'empty', 'offline', 'error'].includes(mark.outcome))
+        return false;
+      usefulMarks += 1;
+    }
+  }
+  // Duplicate first-useful marks are ambiguous, even if one looks plausible.
+  return usefulMarks === 1;
+}
+
+export function validateCaptureFiles(measurements: unknown, validity: unknown): void {
+  const recorded = objectRecord(measurements);
+  const verdict = objectRecord(validity);
+  if (!recorded) throw new Error('Measurements are missing.');
+  if (verdict?.valid !== true || verdict.completed !== true || verdict.configuration !== recorded.configuration) {
+    throw new Error(
+      'Capture did not explicitly report a completed matching configuration; retain artifacts as incomplete.',
+    );
+  }
+  if (recorded.configuration === 'Release') {
+    if (
+      !Array.isArray(recorded.launches) ||
+      recorded.launches.length !== 10 ||
+      !Array.isArray(recorded.memory) ||
+      recorded.memory.length !== 20
+    ) {
+      throw new Error('Incomplete Release capture: expected ten launches and twenty memory cycles.');
+    }
+    const runtimeIds = new Set<string>();
+    for (const [index, trial] of recorded.launches.entries()) {
+      const launch = objectRecord(trial);
+      const artifact = objectRecord(launch?.artifact);
+      if (
+        launch?.trial !== index + 1 ||
+        !hasUsefulStartupArtifact(artifact) ||
+        typeof artifact?.runId !== 'string' ||
+        runtimeIds.has(artifact.runId) ||
+        typeof launch.hostExportObservedMs !== 'number' ||
+        !Number.isFinite(launch.hostExportObservedMs) ||
+        launch.hostExportObservedMs < 0
+      ) {
+        throw new Error('Invalid or stale launch sample.');
+      }
+      runtimeIds.add(artifact.runId);
+    }
+    const memoryPid = objectRecord(recorded.memory[0])?.pid;
+    for (const [index, observation] of recorded.memory.entries()) {
+      const sample = objectRecord(observation);
+      if (
+        sample?.cycle !== index + 1 ||
+        typeof memoryPid !== 'number' ||
+        !Number.isInteger(memoryPid) ||
+        memoryPid <= 0 ||
+        sample.pid !== memoryPid ||
+        typeof sample.footprintMiB !== 'number' ||
+        !Number.isFinite(sample.footprintMiB) ||
+        sample.footprintMiB <= 0
+      ) {
+        throw new Error('Invalid memory sample or changed process.');
+      }
+    }
+  } else if (recorded.configuration === 'Debug') {
+    if (
+      recorded.warmupLoops !== 2 ||
+      recorded.measuredLoops !== 5 ||
+      !Array.isArray(recorded.navigation) ||
+      recorded.navigation.length !== 20
+    ) {
+      throw new Error('Incomplete Debug capture: expected two warmups and five measured four-tab loops.');
+    }
+    const capabilities = objectRecord(recorded.capability);
+    const react = objectRecord(capabilities?.react);
+    const completeReactAttribution = react?.available === true && react.complete === true;
+    const completeScenarioSamples = recorded.navigation.every(
+      (observation) => objectRecord(observation)?.nativeSampleComplete === true,
+    );
+    if (!completeReactAttribution && !completeScenarioSamples) {
+      throw new Error('Debug capture has neither complete React attribution nor complete in-scenario native samples.');
+    }
+    const routes = ['home', 'climbs', 'discover', 'profile'];
+    for (const [index, observation] of recorded.navigation.entries()) {
+      const sample = objectRecord(observation);
+      const timing = objectRecord(sample?.observation);
+      if (
+        sample?.loop !== Math.floor(index / 4) + 1 ||
+        sample.route !== routes[index % 4] ||
+        sample.routeConfirmed !== true ||
+        !Array.isArray(timing?.gaps) ||
+        timing.gaps.length === 0 ||
+        !timing.gaps.every((gap) => typeof gap === 'number' && Number.isFinite(gap) && gap >= 0)
+      ) {
+        throw new Error('Invalid navigation sample or missing callback observations.');
+      }
+    }
+  } else throw new Error('Unknown profiling configuration.');
+}

--- a/scripts/lib/ios-simulator-lease.ts
+++ b/scripts/lib/ios-simulator-lease.ts
@@ -1,0 +1,142 @@
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export interface SimulatorLeaseOwner {
+  token: string;
+  pid: number;
+  worktree: string;
+  udid: string;
+  startedAt: string;
+}
+
+export function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+export function acquireSimulatorLease(
+  udid: string,
+  worktree: string,
+  directory = join(homedir(), 'Library', 'Caches', 'boardsesh', 'simulator-leases'),
+  inheritedToken = process.env.BOARDSESH_SIMULATOR_LEASE_TOKEN,
+): { owner: SimulatorLeaseOwner; release(): void } {
+  if (!/^[0-9a-f-]{36}$/i.test(udid))
+    throw new Error('A simulator lease requires an explicit UDID; "booted" is unsafe.');
+  const leasePath = join(directory, `${udid.toUpperCase()}.lock`);
+  mkdirSync(directory, { recursive: true });
+  const owner: SimulatorLeaseOwner = {
+    token: randomUUID(),
+    pid: process.pid,
+    worktree: realpathSync(worktree),
+    udid,
+    startedAt: new Date().toISOString(),
+  };
+  try {
+    mkdirSync(leasePath);
+  } catch {
+    let existing: SimulatorLeaseOwner;
+    try {
+      existing = JSON.parse(readFileSync(join(leasePath, 'owner.json'), 'utf8')) as SimulatorLeaseOwner;
+    } catch {
+      throw new Error(`Simulator ${udid} has an incomplete lease at ${leasePath}; refusing to steal it.`);
+    }
+    if (
+      existing.token === inheritedToken &&
+      existing.udid.toUpperCase() === udid.toUpperCase() &&
+      processIsAlive(existing.pid)
+    ) {
+      return { owner: existing, release() {} };
+    }
+    // Never steal a live lease, even when a long run exceeds a time threshold.
+    if (processIsAlive(existing.pid)) {
+      throw new Error(`Simulator ${udid} is leased by ${existing.worktree} (PID ${existing.pid}).`);
+    }
+    throw new Error(
+      `Simulator ${udid} has a stopped owner. Remove only the stale lease at ${leasePath} before retrying.`,
+    );
+  }
+  writeFileSync(join(leasePath, 'owner.json'), JSON.stringify(owner));
+  return {
+    owner,
+    release() {
+      try {
+        const current = JSON.parse(readFileSync(join(leasePath, 'owner.json'), 'utf8')) as SimulatorLeaseOwner;
+        if (current.token === owner.token) rmSync(leasePath, { recursive: true });
+      } catch {
+        /* Already released. */
+      }
+    },
+  };
+}
+
+const heldLeases = new Map<string, ReturnType<typeof acquireSimulatorLease>>();
+
+export function holdSimulatorLease(udid: string, worktree: string): void {
+  const selected = process.env.BOARDSESH_IOS_SIMULATOR_UDID;
+  if (selected && selected.toUpperCase() !== udid.toUpperCase()) {
+    throw new Error(`Requested simulator ${udid} differs from selected simulator ${selected}.`);
+  }
+  if (heldLeases.has(udid)) return;
+  const lease = acquireSimulatorLease(udid, worktree);
+  heldLeases.set(udid, lease);
+  process.once('exit', () => lease.release());
+}
+
+/** Shared boundary for screenshot, status-bar, launch, navigation and shutdown. */
+export function guardSimulatorCommand(command: string, args: readonly string[], worktree: string): void {
+  if (command === 'maestro') {
+    const deviceIndex = args.indexOf('--device');
+    if (deviceIndex >= 0 && /^[0-9a-f-]{36}$/i.test(args[deviceIndex + 1])) {
+      holdSimulatorLease(args[deviceIndex + 1], worktree);
+    }
+    return;
+  }
+  if (command !== 'xcrun' || args[0] !== 'simctl') return;
+  if (['list', 'help', 'create'].includes(args[1])) return;
+  const device = args[2];
+  if (!device) throw new Error('Simulator action is missing its explicit UDID.');
+  holdSimulatorLease(device, worktree);
+}
+
+export function resolveSimulatorUdid(requested = process.env.BOARDSESH_IOS_SIMULATOR_UDID): string {
+  const listing = JSON.parse(
+    execFileSync('xcrun', ['simctl', 'list', 'devices', 'available', '--json'], {
+      encoding: 'utf8',
+    }),
+  ) as { devices: Record<string, { udid: string; name: string; state: string }[]> };
+  return selectSimulatorUdid(Object.values(listing.devices).flat(), requested);
+}
+
+export function selectSimulatorUdid(
+  devices: readonly { udid: string; name: string; state: string }[],
+  requested?: string,
+): string {
+  const matches = requested
+    ? devices.filter((device) => device.udid.toUpperCase() === requested.toUpperCase() || device.name === requested)
+    : devices.filter((device) => device.state === 'Booted');
+  if (matches.length !== 1)
+    throw new Error('Select exactly one simulator with BOARDSESH_IOS_SIMULATOR_UDID or --device.');
+  return matches[0].udid;
+}
+
+/** Shell wrappers execute their entire flow under one inherited lease. */
+export function leaseEnvironment(
+  udid: string,
+  worktree: string,
+): {
+  env: NodeJS.ProcessEnv;
+  release(): void;
+} {
+  const lease = acquireSimulatorLease(udid, resolve(worktree));
+  return {
+    env: { ...process.env, BOARDSESH_IOS_SIMULATOR_UDID: udid, BOARDSESH_SIMULATOR_LEASE_TOKEN: lease.owner.token },
+    release: () => lease.release(),
+  };
+}

--- a/scripts/lib/metro-host.ts
+++ b/scripts/lib/metro-host.ts
@@ -1,0 +1,18 @@
+import { resolveTailscaleHostname, type TailscaleHostResolution } from './tailscale-hostname';
+
+/** Binding and the manifest's advertised bundle hostname must agree. */
+export function resolveMetroHostname(
+  args: readonly string[],
+  resolveDefault: () => TailscaleHostResolution = resolveTailscaleHostname,
+): TailscaleHostResolution {
+  let host: string | undefined;
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    if (argument === '--localhost') host = 'localhost';
+    else if (argument === '--lan') host = 'lan';
+    else if (argument === '--tunnel') host = 'tunnel';
+    else if (argument === '--host') host = args[++index];
+    else if (argument.startsWith('--host=')) host = argument.slice('--host='.length);
+  }
+  return host === 'localhost' ? { hostname: 'localhost', source: 'env' } : resolveDefault();
+}

--- a/scripts/mobile-build-sim-app.ts
+++ b/scripts/mobile-build-sim-app.ts
@@ -26,12 +26,22 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { exportBuiltApp } from './lib/ios-build-export';
+import {
+  acquireBuildLock,
+  createMobileIosCachePaths,
+  ensureSharedBuildCache,
+  nodeFileSystem,
+  systemClock,
+} from './mobile-ios-run';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ROOT_DIR = process.env.BOARDSESH_PROFILE_SOURCE_DIR
+  ? resolve(process.env.BOARDSESH_PROFILE_SOURCE_DIR)
+  : resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const MOBILE_DIR = resolve(ROOT_DIR, 'packages', 'mobile');
 const IOS_DIR = resolve(MOBILE_DIR, 'ios');
 const DERIVED_DATA_DIR = resolve(IOS_DIR, 'build');
@@ -178,7 +188,7 @@ function ensureNativeProject(clean: boolean): void {
     return;
   }
   if (existsSync(WORKSPACE_PATH)) {
-    if (screenshotNativeProjectNeedsRefresh()) {
+    if (process.env.BOARDSESH_PROFILE_BUILD !== '1' && screenshotNativeProjectNeedsRefresh()) {
       expoPrebuild(true);
       return;
     }
@@ -254,37 +264,52 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
   // Tells app.config.ts to register ./plugins/with-screenshot-dev-menu, which
   // bakes dev-menu suppression into Info.plist so the dev-client chrome can't
   // cover the captured screens on a cold relaunch. Read at prebuild time.
-  process.env.BOARDSESH_SCREENSHOT_BUILD = '1';
+  if (process.env.BOARDSESH_PROFILE_BUILD !== '1') process.env.BOARDSESH_SCREENSHOT_BUILD = '1';
 
   try {
-    ensureNativeProject(options.clean);
-    podInstall();
+    const paths = createMobileIosCachePaths(process.env, MOBILE_DIR);
+    const lock = acquireBuildLock(paths, nodeFileSystem, systemClock);
+    try {
+      ensureNativeProject(options.clean);
+      if (process.env.BOARDSESH_PROFILE_BUILD === '1' && options.configuration === 'Debug') {
+        const port = Number(process.env.BOARDSESH_METRO_PORT ?? '8081');
+        if (!Number.isInteger(port) || port < 1 || port > 65535) throw new Error('Invalid profiling Metro port.');
+        const delegatePath = join(IOS_DIR, 'Boardsesh', 'AppDelegate.swift');
+        const delegate = readFileSync(delegatePath, 'utf8').replace(
+          /^\s*RCTBundleURLProvider\.sharedSettings\(\)\.jsLocation = "localhost:\d+"\n/gm,
+          '',
+        );
+        const marker = 'return RCTBundleURLProvider.sharedSettings().jsBundleURL';
+        if (!delegate.includes(marker)) throw new Error('Could not configure profiling AppDelegate bundle URL.');
+        writeFileSync(
+          delegatePath,
+          delegate.replace(
+            marker,
+            `RCTBundleURLProvider.sharedSettings().jsLocation = "localhost:${port}"\n    ${marker}`,
+          ),
+        );
+      }
+      ensureSharedBuildCache(paths, nodeFileSystem, systemClock);
+      podInstall();
 
-    let status = xcodebuild(options.configuration);
-    const appPath = builtAppPath(options.configuration);
-    if (status !== 0 && !existsSync(appPath)) {
-      // RN New Architecture codegen ("Generate Specs") can race the compile on a
-      // cold/clean build ("Build input file cannot be found: …/ReactCodegen/
-      // *-generated.mm"). The specs land during that first attempt, so a second
-      // build finds them — the well-known "build twice on a clean checkout"
-      // quirk that bites every fresh CI runner. Retry once.
-      console.log(
-        `${LOG} First build failed without producing the .app (likely the cold-build codegen race); retrying once...`,
-      );
-      status = xcodebuild(options.configuration);
+      let status = xcodebuild(options.configuration);
+      const appPath = builtAppPath(options.configuration);
+      if (status !== 0) {
+        // RN New Architecture codegen ("Generate Specs") can race the compile on a
+        // cold/clean build ("Build input file cannot be found: …/ReactCodegen/
+        // *-generated.mm"). The specs land during that first attempt, so a second
+        // build finds them — the well-known "build twice on a clean checkout"
+        // quirk that bites every fresh CI runner. Retry once.
+        console.log(`${LOG} First build failed; retrying once for the cold-build codegen race...`);
+        status = xcodebuild(options.configuration);
+      }
+
+      const destination = exportBuiltApp(status, appPath, options.appOut);
+      console.log(`${LOG} Built ${options.configuration} simulator app -> ${destination}`);
+      return 0;
+    } finally {
+      lock.release();
     }
-
-    if (!existsSync(appPath)) {
-      console.error(`${LOG} FAILED: ${appPath} not found after build (exit ${status}).`);
-      return status === 0 ? 1 : status;
-    }
-
-    mkdirSync(options.appOut, { recursive: true });
-    const destination = join(options.appOut, APP_NAME);
-    rmSync(destination, { force: true, recursive: true });
-    cpSync(appPath, destination, { recursive: true });
-    console.log(`${LOG} Built ${options.configuration} simulator app -> ${destination}`);
-    return 0;
   } catch (error) {
     console.error(`${LOG} FAILED: ${error instanceof Error ? error.message : String(error)}`);
     return 1;

--- a/scripts/mobile-dev-start.ts
+++ b/scripts/mobile-dev-start.ts
@@ -6,9 +6,11 @@ import { createServer } from 'node:net';
 import { resolve, dirname, join, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { resolveTailscaleHostname } from './lib/tailscale-hostname';
+import { resolveMetroHostname } from './lib/metro-host';
 
-const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ROOT_DIR = process.env.BOARDSESH_PROFILE_SOURCE_DIR
+  ? resolve(process.env.BOARDSESH_PROFILE_SOURCE_DIR)
+  : resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const METRO_DEFAULT_PORT = 8081;
 const METRO_MAX_PORT = 8099;
 const BOARDSESH_DIR = join(ROOT_DIR, '.boardsesh');
@@ -158,7 +160,7 @@ async function main() {
   const branchName = resolveCurrentBranchName();
   const commitSha = runGitCommand(['rev-parse', '--short', 'HEAD']);
   const qaNotes = resolveQaNotes(cliQaNotesPath);
-  const tailscale = resolveTailscaleHostname();
+  const tailscale = resolveMetroHostname(passthroughArgs);
   const metroPort = await resolveMetroPort(passthroughArgs);
   const metroPassthroughArgs = withMetroPort(passthroughArgs, metroPort);
   const startedAt = new Date().toISOString();
@@ -199,7 +201,9 @@ async function main() {
 
   // Bind Metro on 0.0.0.0 (Expo's --host lan) so devices on the same Tailnet can
   // reach the bundler. Respect a user-supplied --host so manual overrides win.
-  const userPassedHost = metroPassthroughArgs.some((arg) => arg === '--host' || arg.startsWith('--host='));
+  const userPassedHost = metroPassthroughArgs.some(
+    (arg) => arg === '--host' || arg.startsWith('--host=') || ['--localhost', '--lan', '--tunnel'].includes(arg),
+  );
   // We ship a custom dev client (EAS preview-build flow); Metro must serve the
   // dev-client bundle, not the Expo Go one. Opt out by passing --go.
   const userPickedClient = passthroughArgs.some(

--- a/scripts/mobile-ios-run.ts
+++ b/scripts/mobile-ios-run.ts
@@ -1,12 +1,15 @@
 /// <reference types="node" />
 
-import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { leaseEnvironment, resolveSimulatorUdid } from './lib/ios-simulator-lease';
 import {
   existsSync,
   lstatSync,
   mkdirSync,
   readdirSync,
   readlinkSync,
+  readFileSync,
   renameSync,
   rmSync,
   rmdirSync,
@@ -20,7 +23,6 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const MOBILE_DIR = resolve(ROOT_DIR, 'packages', 'mobile');
 const DEFAULT_CACHE_DIR = join(homedir(), 'Library', 'Caches', 'boardsesh', 'xcode', 'packages-mobile-ios', 'build');
-const LOCK_STALE_MS = 12 * 60 * 60 * 1000;
 
 export interface MobileIosCachePaths {
   mobileDir: string;
@@ -42,6 +44,7 @@ export interface FileSystemOps {
   rmdir(path: string): void;
   symlink(target: string, path: string): void;
   writeFile(path: string, contents: string): void;
+  readFile(path: string): string;
 }
 
 export interface Runner {
@@ -83,6 +86,7 @@ export const nodeFileSystem: FileSystemOps = {
   rmdir: rmdirSync,
   symlink: symlinkSync,
   writeFile: writeFileSync,
+  readFile: (path) => readFileSync(path, 'utf8'),
 };
 
 export const nodeRunner: Runner = {
@@ -194,28 +198,52 @@ export function acquireBuildLock(paths: MobileIosCachePaths, fs: FileSystemOps, 
   try {
     fs.mkdirExclusive(paths.lockPath);
   } catch {
-    if (isStaleLock(paths.lockPath, fs, clock)) {
-      fs.rm(paths.lockPath);
-      fs.mkdirExclusive(paths.lockPath);
-    } else {
-      throw new Error(
-        `another Boardsesh iOS build is using the shared cache at ${paths.sharedBuildPath}. ` +
-          `Wait for it to finish, then rerun this command.`,
-      );
-    }
+    throw new Error(
+      `another Boardsesh iOS build is using the shared cache at ${paths.sharedBuildPath}. ` +
+        `Wait for it to finish. A stopped owner's lock must be inspected and removed explicitly: ${paths.lockPath}`,
+    );
   }
 
-  fs.writeFile(
-    join(paths.lockPath, 'owner.txt'),
-    [`pid=${process.pid}`, `startedAt=${clock.isoNow()}`, `sharedBuildPath=${paths.sharedBuildPath}`, ''].join('\n'),
-  );
+  const ownerToken = randomUUID();
+  const ownerPath = join(paths.lockPath, 'owner.txt');
+  const ownerContents = [
+    `token=${ownerToken}`,
+    `pid=${process.pid}`,
+    `startedAt=${clock.isoNow()}`,
+    `sharedBuildPath=${paths.sharedBuildPath}`,
+    '',
+  ].join('\n');
+  fs.writeFile(ownerPath, ownerContents);
 
   return {
     path: paths.lockPath,
     release() {
-      fs.rm(paths.lockPath);
+      if (fs.exists(ownerPath) && fs.readFile(ownerPath) === ownerContents) fs.rm(paths.lockPath);
     },
   };
+}
+
+export function extractIosDeviceArgs(args: readonly string[]): { requested: string | undefined; remaining: string[] } {
+  let requested: string | undefined;
+  const remaining: string[] = [];
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index];
+    if (argument === '--device' || argument === '-d') {
+      const candidate = args[++index];
+      if (!candidate || candidate.startsWith('-')) throw new Error('Pass an explicit device name or UDID.');
+      requested = candidate;
+    } else if (argument.startsWith('--device=')) requested = argument.slice('--device='.length);
+    else remaining.push(argument);
+  }
+  return { requested, remaining };
+}
+
+function isPhysicalDevice(requested: string): boolean {
+  const listing = execFileSync('xcrun', ['xctrace', 'list', 'devices'], { encoding: 'utf8', timeout: 15000 });
+  const physicalSection = listing.split('== Simulators ==')[0];
+  return physicalSection
+    .split('\n')
+    .some((line) => line.includes(`(${requested})`) || line.startsWith(`${requested} (`));
 }
 
 export function main(): number {
@@ -223,27 +251,44 @@ export function main(): number {
 
   try {
     validateExpoRunIosArgs(passthroughArgs);
-    const paths = createMobileIosCachePaths();
-    ensureIosProject(paths, nodeFileSystem, nodeRunner);
-    const cacheResult = ensureSharedBuildCache(paths, nodeFileSystem, systemClock);
-
-    console.log(`[mobile:ios] Shared Xcode build cache: ${cacheResult.sharedBuildPath}`);
-    if (cacheResult.importedExistingBuild) {
-      console.log('[mobile:ios] Imported existing packages/mobile/ios/build into the shared cache.');
-    }
-    if (cacheResult.movedAsidePath) {
-      console.log(`[mobile:ios] Preserved existing worktree build output at ${cacheResult.movedAsidePath}`);
-    }
-
-    const lock = acquireBuildLock(paths, nodeFileSystem, systemClock);
+    const { requested, remaining } = extractIosDeviceArgs(passthroughArgs);
+    let simulator: ReturnType<typeof leaseEnvironment>;
     try {
-      const status = nodeRunner.run('vp', ['exec', 'expo', 'run:ios', ...passthroughArgs], {
-        cwd: paths.mobileDir,
-        env: { ...process.env },
-      });
-      return status ?? 1;
+      const udid = resolveSimulatorUdid(requested);
+      simulator = leaseEnvironment(udid, ROOT_DIR);
+      remaining.push('--device', udid);
+    } catch (error) {
+      if (!requested || !isPhysicalDevice(requested)) throw error;
+      // Physical iPhone builds cannot interfere with a simulator lease.
+      simulator = { env: { ...process.env }, release() {} };
+      remaining.push('--device', requested);
+    }
+
+    try {
+      const paths = createMobileIosCachePaths();
+      const lock = acquireBuildLock(paths, nodeFileSystem, systemClock);
+      try {
+        ensureIosProject(paths, nodeFileSystem, nodeRunner);
+        const cacheResult = ensureSharedBuildCache(paths, nodeFileSystem, systemClock);
+
+        console.log(`[mobile:ios] Shared Xcode build cache: ${cacheResult.sharedBuildPath}`);
+        if (cacheResult.importedExistingBuild) {
+          console.log('[mobile:ios] Imported existing packages/mobile/ios/build into the shared cache.');
+        }
+        if (cacheResult.movedAsidePath) {
+          console.log(`[mobile:ios] Preserved existing worktree build output at ${cacheResult.movedAsidePath}`);
+        }
+
+        const status = nodeRunner.run('vp', ['exec', 'expo', 'run:ios', ...remaining], {
+          cwd: paths.mobileDir,
+          env: simulator.env,
+        });
+        return status ?? 1;
+      } finally {
+        lock.release();
+      }
     } finally {
-      lock.release();
+      simulator.release();
     }
   } catch (error) {
     console.error(`[mobile:ios] FAILED: ${error instanceof Error ? error.message : String(error)}`);
@@ -256,16 +301,6 @@ function isEmptyDirectory(path: string, fs: FileSystemOps): boolean {
     const stats = fs.lstat(path);
     if (!stats.isDirectory() || stats.isSymbolicLink()) return false;
     return fs.readdir(path).length === 0;
-  } catch {
-    return false;
-  }
-}
-
-function isStaleLock(path: string, fs: FileSystemOps, clock: Clock): boolean {
-  try {
-    const stats = fs.lstat(path);
-    if (!stats.isDirectory()) return false;
-    return typeof stats.mtimeMs === 'number' && clock.now() - stats.mtimeMs > LOCK_STALE_MS;
   } catch {
     return false;
   }

--- a/scripts/mobile-ios-shots.ts
+++ b/scripts/mobile-ios-shots.ts
@@ -1,3 +1,4 @@
+import { guardSimulatorCommand } from './lib/ios-simulator-lease';
 /// <reference types="node" />
 
 /**
@@ -219,6 +220,7 @@ function parseShotsArgs(argv: readonly string[]): ShotsOptions {
 }
 
 function simctl(args: string[], env: NodeJS.ProcessEnv = process.env): { status: number; stdout: string } {
+  guardSimulatorCommand('xcrun', ['simctl', ...args], ROOT_DIR);
   const result = runCapture('xcrun', ['simctl', ...args], { env });
   return { status: result.status, stdout: result.stdout };
 }
@@ -311,6 +313,7 @@ function runMaestroFlowFile(udid: string, flowYaml: string, env: NodeJS.ProcessE
   const dir = mkdtempSync(join(tmpdir(), 'boardsesh-ios-nav-'));
   const flowFile = join(dir, 'flow.yaml');
   try {
+    guardSimulatorCommand('maestro', ['--device', udid], ROOT_DIR);
     writeFileSync(flowFile, flowYaml, 'utf8');
     return runInherit('maestro', ['--device', udid, 'test', flowFile], { env, cwd: dir });
   } finally {
@@ -350,6 +353,7 @@ function runFlow(udid: string, options: ShotsOptions, env: NodeJS.ProcessEnv): v
   const password = process.env.SCREENSHOT_USER_PASSWORD ?? DEFAULT_USER_PASSWORD;
   const captureDir = mkdtempSync(join(tmpdir(), 'boardsesh-ios-flow-'));
   try {
+    guardSimulatorCommand('maestro', ['--device', udid], ROOT_DIR);
     console.log(`${LOG} Running Maestro flow ${options.flow} on ${udid}...`);
     const status = runInherit(
       'maestro',
@@ -419,7 +423,7 @@ function assertDarwinWithSimctl(): void {
 
 function attachToSimulator(device: string): DeviceInfo {
   assertDarwinWithSimctl();
-  const booted = resolveBootedIosDevice(device);
+  const booted = resolveBootedIosDevice(process.env.BOARDSESH_IOS_SIMULATOR_UDID ?? device);
   if (!booted) {
     throw new Error('No booted simulator — start one with `vp run mobile:ios-shots` (in the background) first.');
   }
@@ -449,10 +453,9 @@ function runNavigateSubcommand(options: ShotsOptions): number {
 }
 
 function killMetro(): void {
-  const result = runCapture('lsof', ['-nP', `-iTCP:${METRO_PORT}`, '-sTCP:LISTEN', '-t']);
-  const pids = result.stdout.split(/\s+/).filter(Boolean);
-  for (const pid of pids) runCapture('kill', [pid]);
-  if (pids.length > 0) console.log(`${LOG} Stopped Metro on port ${METRO_PORT}.`);
+  // Only the process that spawned Metro owns its ChildProcess handle. Never kill
+  // arbitrary listeners discovered by port: they may belong to another checkout.
+  console.log(`${LOG} Stop Metro through the process that started it (Ctrl-C).`);
 }
 
 function runShutdownSubcommand(options: ShotsOptions): number {
@@ -525,16 +528,8 @@ async function runFullPipeline(options: ShotsOptions): Promise<number> {
   applyCleanStatusBar(device.udid);
 
   console.log(`${LOG} Installing ${appPath} on ${device.name}...`);
-  simctl(['uninstall', device.udid, APP_ID]); // ignore failure (not installed yet)
   const install = simctl(['install', device.udid, appPath]);
   if (install.status !== 0) throw new Error(`simctl install exited ${install.status}`);
-  if (!options.keepKeychain) {
-    // The shared keychain group (group.com.boardsesh.app) survives uninstall, so a
-    // stale token from a prior --backend local run would auth against the wrong
-    // backend. A clean keychain forces a fresh sign-in with the baked creds.
-    console.log(`${LOG} Resetting simulator keychain (clears any stale auth token)...`);
-    simctl(['keychain', device.udid, 'reset']);
-  }
 
   if (portInUse(METRO_PORT)) {
     throw new Error(`port ${METRO_PORT} is already in use; stop it (another Metro would serve the wrong bundle).`);

--- a/scripts/mobile-profile-capture.ts
+++ b/scripts/mobile-profile-capture.ts
@@ -505,7 +505,7 @@ export async function main(argv = process.argv.slice(2)) {
       limitations: [
         'Simulator only; device validation required.',
         'No native FPS claim.',
-        'Pending supplemental captures: allocation inspection, distinct render keys, and 20/100/200 shelf populations.',
+        'Pending supplemental captures: allocation inspection, exact distinct climb IDs, and 20/100/200 shelf populations.',
       ],
     });
     return 0;

--- a/scripts/mobile-profile-capture.ts
+++ b/scripts/mobile-profile-capture.ts
@@ -1,0 +1,521 @@
+/// <reference types="node" />
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { performance } from 'node:perf_hooks';
+import { hasUsefulStartupArtifact } from './lib/ios-profile-identity';
+import { guardSimulatorCommand, holdSimulatorLease } from './lib/ios-simulator-lease';
+
+const require = createRequire(import.meta.url);
+const expoRequire = createRequire(require.resolve('@expo/cli/package.json'));
+// Expo already pins ws; its Origin option is required by Metro's inspector proxy.
+const InspectorWebSocket = expoRequire('ws') as new (url: string, options: { origin: string }) => WebSocket;
+
+interface CaptureOptions {
+  runDir: string;
+  udid: string;
+  appId: string;
+  configuration: 'Debug' | 'Release';
+  port: number;
+}
+interface StartupArtifact {
+  runId: string;
+  marks: { name: string; timestampMs: number; outcome?: string }[];
+}
+export function distribution(samples: number[]) {
+  const sorted = [...samples].sort((left, right) => left - right);
+  const percentile = (fraction: number) => sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)] ?? null;
+  return {
+    samples,
+    count: samples.length,
+    min: sorted[0] ?? null,
+    median: percentile(0.5),
+    p95: percentile(0.95),
+    max: sorted.at(-1) ?? null,
+  };
+}
+export function physicalFootprintMiB(report: string): number | null {
+  const match = report.match(/^Physical footprint:\s+([\d.]+)([KMG])(?:B)?/m);
+  if (!match) return null;
+  return Number(match[1]) * (match[2] === 'G' ? 1024 : match[2] === 'K' ? 1 / 1024 : 1);
+}
+export function usefulStartup(artifact: unknown, previousRunId: string | null): artifact is StartupArtifact {
+  return hasUsefulStartupArtifact(artifact) && (artifact as StartupArtifact).runId !== previousRunId;
+}
+export function readRenderKeys(container: string) {
+  const directory = join(container, 'Library', 'Caches', 'board-thumbnails');
+  const renderKeys = existsSync(directory)
+    ? readdirSync(directory)
+        .filter((name) => /^v\d+_.*\.png$/.test(name))
+        .sort()
+    : [];
+  return {
+    renderKeys,
+    renderedClimbSignatures: [...new Set(renderKeys.map((key) => key.split('_').at(-1) ?? ''))].sort((left, right) =>
+      left.localeCompare(right),
+    ),
+    meaning:
+      'Completed on-disk overlay cache keys, with distinct frame/color signatures; these are not retained-object or UUID counts.',
+  };
+}
+
+const pause = (milliseconds: number) => new Promise<void>((resolvePause) => setTimeout(resolvePause, milliseconds));
+function save(directory: string, name: string, artifact: unknown) {
+  writeFileSync(join(directory, name), JSON.stringify(artifact, null, 2));
+}
+function simctl(options: CaptureOptions, args: string[]): string {
+  guardSimulatorCommand('xcrun', ['simctl', ...args], process.cwd());
+  return execFileSync('xcrun', ['simctl', ...args], {
+    encoding: 'utf8',
+    timeout: 30_000,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+function previousStartupRunId(options: CaptureOptions): string | null {
+  try {
+    const container = simctl(options, ['get_app_container', options.udid, options.appId, 'data']);
+    const artifact = JSON.parse(
+      readFileSync(join(container, 'Documents', 'boardsesh-profile', 'startup-latest.json'), 'utf8'),
+    ) as Partial<StartupArtifact>;
+    return typeof artifact.runId === 'string' ? artifact.runId : null;
+  } catch {
+    return null;
+  }
+}
+function launch(options: CaptureOptions): number {
+  const output = simctl(options, ['launch', options.udid, options.appId]);
+  const pid = Number(output.match(/:\s*(\d+)\s*$/)?.[1]);
+  if (!Number.isInteger(pid) || pid <= 0) throw new Error(`Could not identify launched app PID: ${output}`);
+  return pid;
+}
+function terminate(options: CaptureOptions) {
+  try {
+    simctl(options, ['terminate', options.udid, options.appId]);
+  } catch (error) {
+    if (!String(error).includes('not running') && !String(error).includes('found nothing to terminate')) throw error;
+  }
+}
+function navigate(options: CaptureOptions, route: string) {
+  const assertion =
+    route === 'home' || route === 'climbs'
+      ? `    id: ${route}-screen`
+      : `    text: '${route === 'discover' ? 'My Playlists' : 'Progress'}'`;
+  const flowPath = join(options.runDir, `navigate-${route}.yaml`);
+  writeFileSync(
+    flowPath,
+    `appId: ${options.appId}\n---\n- openLink: com.boardsesh.app://${route}\n- tapOn:\n    text: Open\n    optional: true\n- waitForAnimationToEnd\n- extendedWaitUntil:\n    visible:\n  ${assertion}\n    timeout: 15000\n`,
+  );
+  const args = ['--device', options.udid, 'test', flowPath];
+  guardSimulatorCommand('maestro', args, process.cwd());
+  const navigation = spawnSync('maestro', args, { timeout: 60_000, stdio: 'pipe' });
+  writeFileSync(
+    join(options.runDir, `navigate-${route}.log`),
+    Buffer.concat([navigation.stdout ?? Buffer.alloc(0), navigation.stderr ?? Buffer.alloc(0)]),
+  );
+  if (navigation.status !== 0) throw new Error(`Navigation to ${route} was not confirmed; capture is incomplete.`);
+}
+
+function screenshot(options: CaptureOptions, name: string) {
+  simctl(options, ['io', options.udid, 'screenshot', join(options.runDir, name)]);
+}
+async function waitForStartup(options: CaptureOptions, previousRunId: string | null) {
+  const container = simctl(options, ['get_app_container', options.udid, options.appId, 'data']);
+  const path = join(container, 'Documents', 'boardsesh-profile', 'startup-latest.json');
+  const deadline = performance.now() + 45_000;
+  while (performance.now() < deadline) {
+    try {
+      const artifact: unknown = JSON.parse(readFileSync(path, 'utf8'));
+      if (usefulStartup(artifact, previousRunId)) return artifact;
+    } catch {
+      /* File may not exist yet, or writer may be replacing it. */
+    }
+    await pause(100);
+  }
+  throw new Error('No fresh useful Home commit artifact within 45 seconds.');
+}
+
+export interface DebuggerTarget {
+  appId: string;
+  webSocketDebuggerUrl: string;
+}
+export function selectDebuggerTarget(candidates: unknown, appId: string): DebuggerTarget | undefined {
+  if (!Array.isArray(candidates)) throw new Error('Invalid Metro debugger target list.');
+  const matching = candidates.filter(
+    (target): target is DebuggerTarget =>
+      target !== null &&
+      typeof target === 'object' &&
+      target.appId === appId &&
+      typeof target.webSocketDebuggerUrl === 'string',
+  );
+  if (matching.length > 1) throw new Error(`Multiple runtimes for ${appId}; refusing an ambiguous capture.`);
+  return matching[0];
+}
+
+class CdpProtocolError extends Error {}
+
+export class CdpClient {
+  private sequence = 0;
+  private pending = new Map<
+    number,
+    { resolve(result: unknown): void; reject(error: Error): void; timer: ReturnType<typeof setTimeout> }
+  >();
+  readonly events: { method: string; params?: Record<string, unknown> }[] = [];
+  constructor(private socket: WebSocket) {
+    socket.addEventListener('message', (event) => {
+      const response = JSON.parse(String(event.data)) as {
+        id?: number;
+        result?: unknown;
+        error?: unknown;
+        method?: string;
+        params?: Record<string, unknown>;
+      };
+      if (response.id !== undefined) {
+        const request = this.pending.get(response.id);
+        if (!request) return;
+        clearTimeout(request.timer);
+        this.pending.delete(response.id);
+        if (response.error) request.reject(new CdpProtocolError(JSON.stringify(response.error)));
+        else request.resolve(response.result);
+      } else if (response.method && this.events.length < 100_000)
+        this.events.push({ method: response.method, params: response.params });
+    });
+  }
+  static async connect(port: number, appId = 'com.boardsesh.app') {
+    let runtime: DebuggerTarget | undefined;
+    const deadline = Date.now() + 10000;
+    while (!runtime && Date.now() < deadline) {
+      const targets: unknown = await (
+        await fetch(`http://localhost:${port}/json/list`, { signal: AbortSignal.timeout(5000) })
+      ).json();
+      runtime = selectDebuggerTarget(targets, appId);
+      if (!runtime) await pause(250);
+    }
+    if (!runtime) throw new Error(`No registered debugger runtime for ${appId}.`);
+    const socketUrl = new URL(runtime.webSocketDebuggerUrl);
+    if (!['localhost', '127.0.0.1'].includes(socketUrl.hostname) || Number(socketUrl.port) !== port)
+      throw new Error('Debugger target points outside the selected local Metro.');
+    const socket = new InspectorWebSocket(runtime.webSocketDebuggerUrl, { origin: `http://localhost:${port}` });
+    await new Promise<void>((resolveOpen, reject) => {
+      const timer = setTimeout(() => reject(new Error('CDP connection timeout.')), 5000);
+      socket.addEventListener(
+        'open',
+        () => {
+          clearTimeout(timer);
+          resolveOpen();
+        },
+        { once: true },
+      );
+      socket.addEventListener(
+        'error',
+        () => {
+          clearTimeout(timer);
+          reject(new Error('CDP connection failed.'));
+        },
+        { once: true },
+      );
+    });
+    return new CdpClient(socket);
+  }
+  call(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    const id = ++this.sequence;
+    return new Promise((resolveResult, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${method} timed out.`));
+      }, 10_000);
+      this.pending.set(id, { resolve: resolveResult, reject, timer });
+      this.socket.send(JSON.stringify({ id, method, params }));
+    });
+  }
+  async evaluate(expression: string): Promise<unknown> {
+    const response = (await this.call('Runtime.evaluate', { expression, returnByValue: true, awaitPromise: true })) as {
+      result?: { value?: unknown };
+      exceptionDetails?: unknown;
+    };
+    if (response.exceptionDetails) throw new Error(JSON.stringify(response.exceptionDetails));
+    return response.result?.value;
+  }
+  close() {
+    for (const request of this.pending.values()) {
+      clearTimeout(request.timer);
+      request.reject(new Error('CDP closed.'));
+    }
+    this.pending.clear();
+    this.socket.close();
+  }
+}
+
+async function initializeDebugNavigation(cdp: CdpClient) {
+  const ready = await cdp.evaluate(`(() => {
+    for (const definition of __r.getModules().values()) {
+      if (!definition.isInitialized) continue;
+      const exported = definition.publicModule?.exports;
+      if (!exported || typeof exported !== 'object') continue;
+      if (typeof exported.router?.navigate === 'function') globalThis.__boardseshCaptureRouter = exported.router;
+      if (typeof exported.store?.getRouteInfo === 'function') globalThis.__boardseshCaptureRouterStore = exported.store;
+    }
+    return !!globalThis.__boardseshCaptureRouter && !!globalThis.__boardseshCaptureRouterStore;
+  })()`);
+  if (!ready) throw new Error('Initialized Expo Router navigation/state APIs unavailable.');
+}
+async function navigateDebug(cdp: CdpClient, route: string, settleMs: number) {
+  await cdp.evaluate(`__boardseshCaptureRouter.navigate(${JSON.stringify('/' + route)}); true`);
+  await pause(settleMs);
+  const pathname = await cdp.evaluate('__boardseshCaptureRouterStore.getRouteInfo().pathname');
+  if (pathname !== '/' + route)
+    throw new Error(`Expected /${route}, observed ${String(pathname)}; navigation capture invalid.`);
+}
+
+async function captureDebug(options: CaptureOptions) {
+  const previousRunId = previousStartupRunId(options);
+  terminate(options);
+  const pid = launch(options);
+  await waitForStartup(options, previousRunId);
+  const cdp = await CdpClient.connect(options.port, options.appId);
+  const capability: Record<string, unknown> = {};
+  const navigation: unknown[] = [];
+  let tracingStarted = false;
+  try {
+    // A capability probe in a fresh process; an incomplete trace is never a pass.
+    try {
+      await cdp.call('Tracing.start');
+      tracingStarted = true;
+      await pause(250);
+      await cdp.call('Tracing.end');
+      const deadline = Date.now() + 10_000;
+      while (!cdp.events.some((event) => event.method === 'Tracing.tracingComplete') && Date.now() < deadline)
+        await pause(50);
+      const complete = cdp.events.some((event) => event.method === 'Tracing.tracingComplete');
+      const chunks = cdp.events.filter((event) => event.method === 'Tracing.dataCollected');
+      capability.tracing = { complete, chunks: chunks.length };
+      save(options.runDir, 'tracing-probe.json', cdp.events);
+      if (!complete) throw new Error('Tracing did not finish; refusing measurements with uncertain tracing overhead.');
+      tracingStarted = false;
+    } catch (error) {
+      capability.tracing = { complete: false, reason: String(error) };
+      if (tracingStarted || !(error instanceof CdpProtocolError)) {
+        await cdp.call('Tracing.end').catch(() => undefined);
+        throw error;
+      }
+    }
+    await initializeDebugNavigation(cdp);
+    const routes = ['home', 'climbs', 'discover', 'profile'];
+    for (let loop = 0; loop < 2; loop++)
+      for (const route of routes) {
+        await navigateDebug(cdp, route, 2000);
+      }
+    const rendererId = await cdp.evaluate(
+      `(() => { const hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__; return hook?.rendererInterfaces ? [...hook.rendererInterfaces.keys()].find(id => hook.rendererInterfaces.get(id).startProfiling) ?? null : null; })()`,
+    );
+    capability.react = { available: typeof rendererId === 'number', complete: false };
+    if (typeof rendererId === 'number')
+      await cdp.evaluate(
+        `__REACT_DEVTOOLS_GLOBAL_HOOK__.rendererInterfaces.get(${rendererId}).startProfiling(true); true`,
+      );
+    for (let loop = 1; loop <= 5; loop++) {
+      for (const route of routes) {
+        await cdp.evaluate(
+          `(() => { globalThis.__boardseshCapture = { gaps: [], longTasks: [], previous: performance.now() }; const state = __boardseshCapture; state.observer = new PerformanceObserver(list => { for (const entry of list.getEntries()) if(state.longTasks.length < 1000) state.longTasks.push(entry.duration); }); state.observer.observe({entryTypes:['longtask']}); const frame = () => { const now = performance.now(); if(state.gaps.length < 2000) state.gaps.push(now-state.previous); state.previous=now; state.frame=requestAnimationFrame(frame); }; state.frame=requestAnimationFrame(frame); return true; })()`,
+        );
+        const sampleStartedAt = performance.now();
+        let sampleCompleted: Promise<boolean> | undefined;
+        if (typeof rendererId !== 'number') {
+          const nativeSample = spawn(
+            'sample',
+            [String(pid), '5', '-file', join(options.runDir, `navigation-${loop}-${route}.sample.txt`)],
+            { stdio: 'ignore' },
+          );
+          sampleCompleted = new Promise<boolean>((resolveSample) => {
+            nativeSample.once('error', () => resolveSample(false));
+            nativeSample.once('exit', (status) => resolveSample(status === 0));
+          });
+        }
+        await navigateDebug(cdp, route, 4000);
+        const navigationConfirmedAt = performance.now();
+        const nativeSampleComplete = sampleCompleted
+          ? (await sampleCompleted) && navigationConfirmedAt - sampleStartedAt <= 5000
+          : false;
+        const observation = await cdp.evaluate(
+          `(() => { const state=__boardseshCapture; cancelAnimationFrame(state.frame); state.observer.disconnect(); return { gaps:state.gaps, longTasks:state.longTasks }; })()`,
+        );
+        navigation.push({
+          loop,
+          route,
+          routeConfirmed: true,
+          nativeSampleComplete,
+          sampleStartedAt,
+          navigationConfirmedAt,
+          observation,
+        });
+        save(options.runDir, 'navigation.json', navigation);
+        screenshot(options, `navigation-${loop}-${route}.png`);
+        console.log(`[mobile:profile] Debug loop ${loop}/5 ${route}`);
+      }
+    }
+    if (typeof rendererId === 'number') {
+      await cdp.evaluate(`__REACT_DEVTOOLS_GLOBAL_HOOK__.rendererInterfaces.get(${rendererId}).stopProfiling(); true`);
+      const profile = await cdp.evaluate(
+        `__REACT_DEVTOOLS_GLOBAL_HOOK__.rendererInterfaces.get(${rendererId}).getProfilingData()`,
+      );
+      save(options.runDir, 'react-profile.json', profile);
+      const reactProfile = profile as { dataForRoots?: { commitData?: unknown[] }[] };
+      const complete = reactProfile.dataForRoots?.some((root) => (root.commitData?.length ?? 0) > 0) ?? false;
+      capability.react = { available: true, complete };
+      if (!complete) throw new Error('React profiling returned no commits.');
+      const names = await cdp.evaluate(
+        `(() => { const renderer=__REACT_DEVTOOLS_GLOBAL_HOOK__.rendererInterfaces.get(${rendererId}); const profile=renderer.getProfilingData(); const ids=new Set(profile.dataForRoots.flatMap(root=>root.commitData.flatMap(commit=>commit.fiberActualDurations.map(pair=>pair[0])))); return [...ids].map(id=>[id,renderer.getDisplayNameForElementID(id)]); })()`,
+      );
+      save(options.runDir, 'react-names.json', names);
+    }
+    const samplePath = join(options.runDir, 'debug-native.sample.txt');
+    const sample = spawnSync('sample', [String(pid), '1', '-file', samplePath], { timeout: 15_000, stdio: 'pipe' });
+    const nativeSampleComplete =
+      sample.status === 0 && existsSync(samplePath) && readFileSync(samplePath, 'utf8').includes('Call graph:');
+    capability.nativeSample = { complete: nativeSampleComplete };
+    if (
+      typeof rendererId !== 'number' &&
+      !navigation.every((entry) => (entry as { nativeSampleComplete: boolean }).nativeSampleComplete)
+    )
+      throw new Error('Neither React attribution nor complete in-scenario native samples are available.');
+    return {
+      configuration: 'Debug',
+      warmupLoops: 2,
+      measuredLoops: 5,
+      navigation,
+      capability,
+      timingMeaning: 'JS callback gaps and React render durations, not native FPS.',
+    };
+  } finally {
+    try {
+      await cdp.evaluate(
+        `(() => { const state=globalThis.__boardseshCapture; if(state) { cancelAnimationFrame(state.frame); state.observer?.disconnect(); } for(const renderer of globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__?.rendererInterfaces?.values() ?? []) renderer.stopProfiling?.(); delete globalThis.__boardseshCapture; return true; })()`,
+      );
+    } catch {
+      /* The owned runtime may have exited; never hide the capture failure. */
+    }
+    cdp.close();
+  }
+}
+
+async function captureRelease(options: CaptureOptions) {
+  const launches: unknown[] = [];
+  let previousRunId: string | null = null;
+  // First fixture login/cache population is excluded from the ten warm-cache launches.
+  previousRunId = previousStartupRunId(options);
+  terminate(options);
+  launch(options);
+  const warmup = await waitForStartup(options, previousRunId);
+  previousRunId = warmup.runId;
+  navigate(options, 'home');
+  await pause(3000);
+  const hostExportObservedMs: number[] = [];
+  for (let trial = 1; trial <= 10; trial++) {
+    terminate(options);
+    await pause(500);
+    const hostStart = performance.now();
+    const pid = launch(options);
+    const artifact = await waitForStartup(options, previousRunId);
+    const observedMs = performance.now() - hostStart;
+    hostExportObservedMs.push(observedMs);
+    previousRunId = artifact.runId;
+    save(options.runDir, `startup-${trial}.json`, artifact);
+    screenshot(options, `launch-${trial}.png`);
+    launches.push({ trial, pid, hostExportObservedMs: observedMs, artifact });
+    save(options.runDir, 'launches.json', launches);
+    console.log(
+      `[mobile:profile] Release launch ${trial}/10: local useful-commit export observed ${Math.round(observedMs)} ms`,
+    );
+    await pause(2000);
+  }
+  const pid = launch(options);
+  const memory: {
+    cycle: number;
+    pid: number;
+    footprintMiB: number | null;
+    renderKeys: ReturnType<typeof readRenderKeys>;
+  }[] = [];
+  const appContainer = simctl(options, ['get_app_container', options.udid, options.appId, 'data']);
+  const initialRenderKeys = readRenderKeys(appContainer);
+  const flowPath = join(options.runDir, 'browse-cycle.yaml');
+  writeFileSync(
+    flowPath,
+    `appId: ${options.appId}\n---\n- repeat:\n    times: 3\n    commands:\n      - swipe:\n          start: 50%,75%\n          end: 50%,30%\n          duration: 400\n- waitForAnimationToEnd\n`,
+  );
+  for (let cycle = 1; cycle <= 20; cycle++) {
+    navigate(options, 'climbs');
+    await pause(1000);
+    const args = ['--device', options.udid, 'test', flowPath];
+    guardSimulatorCommand('maestro', args, process.cwd());
+    const browsing = spawnSync('maestro', args, { timeout: 60_000, stdio: 'pipe' });
+    writeFileSync(
+      join(options.runDir, `browse-${cycle}.log`),
+      Buffer.concat([browsing.stdout ?? Buffer.alloc(0), browsing.stderr ?? Buffer.alloc(0)]),
+    );
+    if (browsing.status !== 0) throw new Error(`Browsing cycle ${cycle} failed; incomplete memory run.`);
+    simctl(options, ['launch', options.udid, 'com.apple.Preferences']);
+    await pause(2000);
+    if (launch(options) !== pid) throw new Error('Memory run app process changed; samples cannot be compared.');
+    navigate(options, 'home');
+    await pause(3000);
+    const samplePath = join(options.runDir, `memory-${cycle}.sample.txt`);
+    const sampled = spawnSync('sample', [String(pid), '1', '-file', samplePath], { timeout: 15_000, stdio: 'pipe' });
+    if (sampled.status !== 0 || !existsSync(samplePath)) throw new Error(`Native memory sample ${cycle} failed.`);
+    const footprintMiB = physicalFootprintMiB(readFileSync(samplePath, 'utf8'));
+    if (footprintMiB === null || !Number.isFinite(footprintMiB))
+      throw new Error(`Physical footprint missing in sample ${cycle}.`);
+    memory.push({ cycle, pid, footprintMiB, renderKeys: readRenderKeys(appContainer) });
+    save(options.runDir, 'memory.json', memory);
+    console.log(`[mobile:profile] Release memory cycle ${cycle}/20: ${memory.at(-1)?.footprintMiB} MiB`);
+  }
+  return {
+    configuration: 'Release',
+    initialRenderKeys,
+    launches,
+    memory,
+    hostExportObservedMs: distribution(hostExportObservedMs),
+    hostTimingMeaning:
+      'Host launch to local useful-commit artifact observation; includes deferred export and polling, not first displayed frame.',
+    memoryMeaning:
+      'Same-process physical footprint at settled Home after browsing/background; allocation attribution and distinct render-key counts require separate capture.',
+  };
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const flags = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) flags.set(argv[index], argv[index + 1]);
+  const options: CaptureOptions = {
+    runDir: resolve(flags.get('--run-dir') ?? '.boardsesh/ios-profile-capture'),
+    udid: flags.get('--udid') ?? '',
+    appId: flags.get('--app-id') ?? 'com.boardsesh.app',
+    configuration: flags.get('--configuration') === 'Debug' ? 'Debug' : 'Release',
+    port: Number(flags.get('--port') ?? '8097'),
+  };
+  mkdirSync(options.runDir, { recursive: true });
+  holdSimulatorLease(options.udid, process.cwd());
+  try {
+    const measurements =
+      options.configuration === 'Debug' ? await captureDebug(options) : await captureRelease(options);
+    save(options.runDir, 'measurements.json', measurements);
+    save(options.runDir, 'capture-validity.json', {
+      valid: true,
+      completed: true,
+      configuration: options.configuration,
+      limitations: [
+        'Simulator only; device validation required.',
+        'No native FPS claim.',
+        'Pending supplemental captures: allocation inspection, distinct render keys, and 20/100/200 shelf populations.',
+      ],
+    });
+    return 0;
+  } catch (error) {
+    save(options.runDir, 'capture-validity.json', { valid: false, completed: false, error: String(error) });
+    console.error(error);
+    return 1;
+  }
+}
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)
+  void main().then((status) => {
+    process.exitCode = status;
+  });

--- a/scripts/mobile-profile-ios.ts
+++ b/scripts/mobile-profile-ios.ts
@@ -1,0 +1,373 @@
+/// <reference types="node" />
+
+import { spawn, spawnSync, execFileSync, type ChildProcess } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, openSync, closeSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { leaseEnvironment, resolveSimulatorUdid } from './lib/ios-simulator-lease';
+import { assertMatchingIdentity, fileSha256, readAppIdentity, validateCaptureFiles } from './lib/ios-profile-identity';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+export interface ProfileOptions {
+  udid: string;
+  sourceRef: string;
+  configuration: 'Debug' | 'Release';
+  port: number;
+  runDir: string;
+  checkout: string | null;
+  fixtureManifest: string;
+}
+
+export function parseProfileArgs(argv: readonly string[]): ProfileOptions {
+  const options: ProfileOptions = {
+    udid: process.env.BOARDSESH_IOS_SIMULATOR_UDID ?? '',
+    sourceRef: 'HEAD',
+    configuration: 'Release',
+    port: 8097,
+    runDir: join(ROOT, '.boardsesh', `ios-profile-${new Date().toISOString().replace(/[:.]/g, '-')}`),
+    checkout: null,
+    fixtureManifest: join(ROOT, '.boardsesh/ios-performance-fixtures.json'),
+  };
+  const args = argv.filter((argument) => argument !== '--');
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const argument = args[index + 1];
+    if (!argument || argument.startsWith('--')) throw new Error(`${flag} requires a value.`);
+    if (flag === '--udid') options.udid = argument;
+    else if (flag === '--source-ref') options.sourceRef = argument;
+    else if (flag === '--configuration' && (argument === 'Debug' || argument === 'Release'))
+      options.configuration = argument;
+    else if (flag === '--port') options.port = Number(argument);
+    else if (flag === '--run-dir') options.runDir = resolve(argument);
+    else if (flag === '--checkout') options.checkout = resolve(argument);
+    else if (flag === '--fixtures') options.fixtureManifest = resolve(argument);
+    else throw new Error(`Unknown option or invalid value: ${flag} ${argument}`);
+  }
+  if (!/^[0-9a-f-]{36}$/i.test(options.udid)) throw new Error('--udid must identify an explicitly owned simulator.');
+  if (!Number.isInteger(options.port) || options.port < 1 || options.port > 65535) throw new Error('Invalid --port.');
+  return options;
+}
+
+function run(command: string, args: string[], cwd: string, env: NodeJS.ProcessEnv): void {
+  const result = spawnSync(command, args, { cwd, env, stdio: 'inherit' });
+  if (result.status !== 0) throw new Error(`${command} failed with exit ${result.status ?? 1}.`);
+}
+
+export function assertCapturePrerequisites(env: NodeJS.ProcessEnv = process.env): void {
+  const maestro = spawnSync('maestro', ['--version'], { env, encoding: 'utf8', timeout: 15000 });
+  if (maestro.status !== 0) {
+    throw new Error(
+      'Maestro is unavailable or cannot find Java. Set JAVA_HOME to an installed JDK and verify maestro --version before building.',
+    );
+  }
+}
+
+async function assertFreePort(port: number): Promise<void> {
+  await new Promise<void>((resolvePort, reject) => {
+    const server = createServer();
+    server.once('error', () => reject(new Error(`Port ${port} is occupied; refusing to reuse or stop another Metro.`)));
+    server.listen(port, '127.0.0.1', () => server.close(() => resolvePort()));
+  });
+}
+
+async function waitForOwnedMetro(port: number, checkout: string, metro: ChildProcess): Promise<void> {
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    if (metro.exitCode !== null) throw new Error('Owned Metro exited before becoming ready.');
+    try {
+      const response = await fetch(`http://localhost:${port}/_boardsesh/metro-info`, {
+        signal: AbortSignal.timeout(2000),
+      });
+      const metadata = (await response.json()) as { rootDir?: string };
+      if (metadata.rootDir === checkout) return;
+      if (response.ok) throw new Error('Metro source identity differs from the profiling checkout.');
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('source identity')) throw error;
+    }
+    await new Promise((resolvePoll) => setTimeout(resolvePoll, 500));
+  }
+  throw new Error('Metro readiness timed out.');
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<number> {
+  const options = parseProfileArgs(argv);
+  if (process.platform !== 'darwin') throw new Error('iOS profiling requires macOS and Xcode.');
+  // Local fixtures only. Never silently send the screenshot account to production.
+  const apiUrl = process.env.EXPO_PUBLIC_BACKEND_URL ?? '';
+  if (!/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/.test(apiUrl)) {
+    throw new Error('Set EXPO_PUBLIC_BACKEND_URL to the seeded local backend before profiling.');
+  }
+  if (!existsSync(options.fixtureManifest))
+    throw new Error('Seed local profiling fixtures and pass their manifest with --fixtures.');
+  const fixtures = JSON.parse(readFileSync(options.fixtureManifest, 'utf8')) as {
+    owned?: number;
+    community?: number;
+    climbs?: unknown[];
+  };
+  if (
+    (fixtures.owned ?? 0) < 200 ||
+    (fixtures.community ?? 0) < 200 ||
+    !Array.isArray(fixtures.climbs) ||
+    fixtures.climbs.length === 0
+  ) {
+    throw new Error('Profiling requires at least 200 owned and 200 community playlists with real climbs.');
+  }
+  assertCapturePrerequisites();
+  if (existsSync(join(options.runDir, 'manifest.json')))
+    throw new Error('Run directory already has a manifest. Use a fresh run directory.');
+  mkdirSync(options.runDir, { recursive: true });
+  const checkout = options.checkout ?? join(options.runDir, 'source');
+  const udid = resolveSimulatorUdid(options.udid);
+  const lease = leaseEnvironment(udid, ROOT);
+  const env: NodeJS.ProcessEnv = {
+    ...lease.env,
+    BOARDSESH_PROFILE_BUILD: '1',
+    BOARDSESH_PROFILE_SOURCE_DIR: checkout,
+    BOARDSESH_SCREENSHOT_BUILD: undefined,
+    EXPO_PUBLIC_PROFILE_STARTUP: '1',
+    BOARDSESH_METRO_PORT: String(options.port),
+    TAILSCALE_HOSTNAME: 'localhost',
+    REACT_NATIVE_PACKAGER_HOSTNAME: 'localhost',
+    CI: '1',
+    BOARDSESH_IOS_BUILD_CACHE_DIR: join(options.runDir, 'native-cache', 'build'),
+  };
+  const manifest: Record<string, unknown> = {
+    version: 1,
+    startedAt: new Date().toISOString(),
+    sourceCheckout: checkout,
+    configuration: options.configuration,
+    udid,
+    metroPort: options.configuration === 'Debug' ? options.port : null,
+    clocks: {
+      host: 'host monotonic observation; command overhead included',
+      js: 'runtime performance.now; never subtract from host timestamps',
+    },
+    fixtureManifestSha256: fileSha256(options.fixtureManifest),
+    fixtureManifest: options.fixtureManifest,
+    fixtureEnvironment: Object.fromEntries(
+      [
+        'EXPO_PUBLIC_BACKEND_URL',
+        'EXPO_PUBLIC_SCREENSHOT_MODE',
+        'EXPO_PUBLIC_SCREENSHOT_THEME',
+        'EXPO_PUBLIC_SCREENSHOT_LOCALE',
+        'EXPO_PUBLIC_SCREENSHOT_BOARDS',
+        'EXPO_PUBLIC_SCREENSHOT_RENDER_MODE',
+      ].map((name) => [name, env[name] ?? null]),
+    ),
+    fallbackCaptures: ['React renderer commit profile', 'native sample'],
+    status: 'preparing',
+    ownedPids: [],
+  };
+  const save = () => writeFileSync(join(options.runDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+  let metro: ChildProcess | undefined;
+  try {
+    save();
+    if (!options.checkout) run('git', ['worktree', 'add', '--detach', checkout, options.sourceRef], ROOT, env);
+    if (!existsSync(join(checkout, 'packages/mobile/src/lib/profiling/startup-profile.ts'))) {
+      throw new Error(
+        'This source needs the companion startup instrumentation (src/lib/profiling/startup-profile.ts) before native profiling builds.',
+      );
+    }
+    // Profiling must never reuse a previously generated native project.
+    if (existsSync(join(checkout, 'packages/mobile/ios')))
+      throw new Error('Profiling checkout already has ios/. Use a fresh dedicated checkout.');
+    manifest.sourceCommit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: checkout, encoding: 'utf8' }).trim();
+    manifest.sourceDiff = execFileSync('git', ['diff', '--binary', 'HEAD'], {
+      cwd: checkout,
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+    }).trim();
+    manifest.sourceStatus = execFileSync('git', ['status', '--porcelain'], { cwd: checkout, encoding: 'utf8' });
+    const untrackedPaths = execFileSync('git', ['ls-files', '--others', '--exclude-standard', '-z'], {
+      cwd: checkout,
+      encoding: 'utf8',
+    })
+      .split('\0')
+      .filter(Boolean);
+    manifest.untrackedSourceHashes = Object.fromEntries(
+      untrackedPaths.map((path) => [path, fileSha256(join(checkout, path))]),
+    );
+    if (options.configuration === 'Debug') {
+      const packagePath = join(checkout, 'packages/mobile/package.json');
+      const packageJson = JSON.parse(readFileSync(packagePath, 'utf8')) as {
+        expo: { autolinking: { ios?: { exclude?: string[] } } };
+      };
+      const iosOptions = packageJson.expo.autolinking.ios ?? {};
+      const excludedModules = ['expo-dev-client', 'expo-dev-launcher', 'expo-dev-menu', 'expo-dev-menu-interface'];
+      packageJson.expo.autolinking.ios = {
+        ...iosOptions,
+        exclude: [...new Set([...(iosOptions.exclude ?? []), ...excludedModules])],
+      };
+      writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+      manifest.debugAutolinkingExclusions = excludedModules;
+    }
+    if (!existsSync(join(checkout, 'node_modules'))) run('vp', ['install'], checkout, env);
+    // Compute through the installed API, preserving the full source attribution artifact.
+    const fingerprintPath = join(options.runDir, 'native-fingerprint.json');
+    run(
+      'vp',
+      [
+        'exec',
+        'node',
+        '-e',
+        'require("@expo/fingerprint").createFingerprintAsync(process.cwd(), { platforms: ["ios"] }).then(result => require("node:fs").writeFileSync(process.argv[1], JSON.stringify(result)))',
+        fingerprintPath,
+      ],
+      join(checkout, 'packages/mobile'),
+      env,
+    );
+    manifest.nativeFingerprint = (JSON.parse(readFileSync(fingerprintPath, 'utf8')) as { hash: string }).hash;
+    manifest.status = 'building';
+    save();
+    run(
+      'vp',
+      [
+        'exec',
+        'tsx',
+        join(ROOT, 'scripts/mobile-build-sim-app.ts'),
+        '--app-out',
+        join(options.runDir, 'app'),
+        '--configuration',
+        options.configuration,
+      ],
+      checkout,
+      {
+        ...env,
+        BOARDSESH_PROFILE_SOURCE_DIR: checkout,
+      },
+    );
+    manifest.generatedInputs = Object.fromEntries(
+      [
+        'packages/mobile/package.json',
+        'packages/mobile/ios/Boardsesh/AppDelegate.swift',
+        'packages/mobile/ios/Podfile.lock',
+        'packages/mobile/ios/Podfile.properties.json',
+      ]
+        .filter((path) => existsSync(join(checkout, path)))
+        .map((path) => [path, fileSha256(join(checkout, path))]),
+    );
+    writeFileSync(
+      join(options.runDir, 'build-inputs.patch'),
+      execFileSync('git', ['diff', '--binary', 'HEAD'], {
+        cwd: checkout,
+        encoding: 'utf8',
+        maxBuffer: 16 * 1024 * 1024,
+      }),
+    );
+    if (options.configuration === 'Debug') {
+      const pods = readFileSync(join(checkout, 'packages/mobile/ios/Podfile.lock'), 'utf8');
+      if (/ExpoDevLauncher|EXDevLauncher|expo-dev-launcher|ExpoDevMenu|EXDevMenu|expo-dev-menu/.test(pods)) {
+        throw new Error('Profiling Debug build still contains Expo launcher/menu native modules.');
+      }
+    }
+    const appPath = join(options.runDir, 'app/Boardsesh.app');
+    const identity = readAppIdentity(appPath, options.configuration);
+    manifest.appIdentity = identity;
+    const simctl = (args: string[]) => execFileSync('xcrun', ['simctl', ...args], { env, encoding: 'utf8' }).trim();
+    const deviceListing = simctl(['list', 'devices', '--json']);
+    manifest.deviceListing = JSON.parse(deviceListing) as unknown;
+    const listing = JSON.parse(deviceListing) as { devices: Record<string, { udid: string; state: string }[]> };
+    if (
+      Object.values(listing.devices)
+        .flat()
+        .find((device) => device.udid === udid)?.state !== 'Booted'
+    )
+      simctl(['boot', udid]);
+    simctl(['bootstatus', udid, '-b']);
+    simctl(['install', udid, appPath]);
+    const installedPath = simctl(['get_app_container', udid, identity.bundleIdentifier, 'app']);
+    assertMatchingIdentity(identity, readAppIdentity(installedPath, options.configuration));
+    if (options.configuration === 'Debug') {
+      await assertFreePort(options.port);
+      const log = openSync(join(options.runDir, 'metro.log'), 'w');
+      try {
+        metro = spawn(
+          'vp',
+          [
+            'exec',
+            'tsx',
+            join(ROOT, 'scripts/mobile-dev-start.ts'),
+            '--host',
+            'localhost',
+            '--port',
+            String(options.port),
+          ],
+          {
+            cwd: checkout,
+            env,
+            stdio: ['ignore', log, log],
+            detached: true,
+          },
+        );
+      } finally {
+        closeSync(log);
+      }
+      manifest.ownedPids = [metro.pid];
+      save();
+      await waitForOwnedMetro(options.port, checkout, metro);
+    }
+    manifest.status = 'capturing';
+    save();
+    run(
+      'vp',
+      [
+        'exec',
+        'tsx',
+        join(ROOT, 'scripts/mobile-profile-capture.ts'),
+        '--run-dir',
+        options.runDir,
+        '--udid',
+        udid,
+        '--app-id',
+        identity.bundleIdentifier,
+        '--configuration',
+        options.configuration,
+        '--port',
+        String(options.port),
+        '--app-path',
+        appPath,
+      ],
+      checkout,
+      env,
+    );
+    assertMatchingIdentity(
+      identity,
+      readAppIdentity(simctl(['get_app_container', udid, identity.bundleIdentifier, 'app']), options.configuration),
+    );
+    validateCaptureFiles(
+      JSON.parse(readFileSync(join(options.runDir, 'measurements.json'), 'utf8')) as unknown,
+      JSON.parse(readFileSync(join(options.runDir, 'capture-validity.json'), 'utf8')) as unknown,
+    );
+    manifest.status = 'complete';
+    return 0;
+  } catch (error) {
+    manifest.status = 'invalid';
+    manifest.failure = error instanceof Error ? error.message : String(error);
+    console.error(manifest.failure);
+    return 1;
+  } finally {
+    if (metro?.pid && metro.exitCode === null && metro.signalCode === null) {
+      try {
+        process.kill(-metro.pid, 'SIGTERM');
+      } catch {
+        /* Owned process already exited. */
+      }
+    }
+    lease.release();
+    manifest.finishedAt = new Date().toISOString();
+    save();
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main()
+    .then((status) => {
+      process.exitCode = status;
+    })
+    .catch((error: unknown) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    });
+}

--- a/scripts/mobile-screenshot.sh
+++ b/scripts/mobile-screenshot.sh
@@ -9,6 +9,13 @@ if ! command -v xcrun &>/dev/null || ! xcrun simctl list devices &>/dev/null 2>&
   exit 0
 fi
 
+# Resolve once and hold ownership across the entire command, including launch/logs.
+if [ -z "${BOARDSESH_SIMULATOR_LEASE_TOKEN:-}" ]; then
+  cd "$ROOT_DIR"
+  exec vp exec tsx scripts/mobile-simulator-lease.ts bash "$SCRIPT_DIR/mobile-screenshot.sh" "$@"
+fi
+vp exec tsx "$SCRIPT_DIR/mobile-simulator-lease.ts" --assert-only
+
 DELAY=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -40,7 +47,7 @@ mkdir -p "$SCREENSHOT_DIR"
 TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 SCREENSHOT_PATH="$SCREENSHOT_DIR/mobile-${TIMESTAMP}.png"
 
-xcrun simctl io booted screenshot "$SCREENSHOT_PATH"
+xcrun simctl io "$BOARDSESH_IOS_SIMULATOR_UDID" screenshot "$SCREENSHOT_PATH"
 
 echo "[mobile-screenshot] Saved: .boardsesh/screenshots/mobile-${TIMESTAMP}.png"
 exit 0

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -1,3 +1,4 @@
+import { guardSimulatorCommand } from './lib/ios-simulator-lease';
 /// <reference types="node" />
 
 /**
@@ -434,11 +435,13 @@ export interface DeviceInfo {
 }
 
 function runInherit(command: string, args: string[], env: NodeJS.ProcessEnv, cwd: string = ROOT_DIR): number {
+  guardSimulatorCommand(command, args, ROOT_DIR);
   const result = spawnSync(command, args, { cwd, env, stdio: 'inherit' });
   return result.status ?? 1;
 }
 
 function runCapture(command: string, args: string[]): { status: number; stdout: string } {
+  guardSimulatorCommand(command, args, ROOT_DIR);
   const result = spawnSync(command, args, { encoding: 'utf8' });
   return { status: result.status ?? 1, stdout: result.stdout ?? '' };
 }
@@ -544,6 +547,20 @@ export function resolveAppStoreLocaleTargets(appLocales: readonly Locale[]): App
 
 export function findOrCreateIosDevice(screenshotDevice: IosScreenshotDevice): DeviceInfo {
   const devices = listSimulatorDevices();
+  const selectedUdid = process.env.BOARDSESH_IOS_SIMULATOR_UDID;
+  if (selectedUdid) {
+    const selectedDevice = devices.find((device) => device.udid.toUpperCase() === selectedUdid.toUpperCase());
+    if (!selectedDevice) throw new Error(`Selected simulator ${selectedUdid} is unavailable.`);
+    if (
+      screenshotDevice.name !== selectedDevice.name &&
+      screenshotDevice.name.toUpperCase() !== selectedUdid.toUpperCase()
+    ) {
+      throw new Error(
+        `Screenshot device ${screenshotDevice.name} differs from leased simulator ${selectedDevice.name}. Pass the leased device explicitly.`,
+      );
+    }
+    return selectedDevice;
+  }
   const booted = devices.find((device) => device.name === screenshotDevice.name && device.state === 'Booted');
   if (booted) return booted;
   const existing = devices.find((device) => device.name === screenshotDevice.name);
@@ -577,13 +594,15 @@ export function findOrCreateIosDevice(screenshotDevice: IosScreenshotDevice): De
  * still isn't unique. Returns null when nothing is booted.
  */
 export function resolveBootedIosDevice(name?: string): DeviceInfo | null {
+  name = process.env.BOARDSESH_IOS_SIMULATOR_UDID ?? name;
   const booted = listSimulatorDevices().filter((device) => device.state === 'Booted');
   if (booted.length === 0) return null;
-  if (booted.length === 1) return booted[0];
   if (name) {
-    const named = booted.filter((device) => device.name === name);
+    const named = booted.filter((device) => device.name === name || device.udid === name);
     if (named.length === 1) return named[0];
+    throw new Error(`Requested simulator ${name} is not uniquely booted.`);
   }
+  if (booted.length === 1) return booted[0];
   throw new Error(
     `Multiple booted simulators (${booted.map((device) => device.name).join(', ')}); pass --device "<name>" to pick one.`,
   );
@@ -905,25 +924,12 @@ function captureIosDevice(
   applyCleanStatusBar(device.udid);
 
   console.log(`${LOG} Installing ${appPath} on ${device.name} for ${localeTarget.appLocale}...`);
-  // Uninstall first so the run starts from a clean container (fresh AsyncStorage,
-  // so no stale active board). The dev-client + Metro path drops Maestro's
-  // `clearState`, which can't run before the bundle has loaded — the uninstall +
-  // install gives the same fresh-data guarantee.
-  runCapture('xcrun', ['simctl', 'uninstall', device.udid, APP_ID]);
+  // Install in place to preserve app data and the simulator keychain.
   const install = runCapture('xcrun', ['simctl', 'install', device.udid, appPath]);
   if (install.status !== 0) {
     console.error(`${LOG} FAILED: simctl install exited ${install.status}.`);
     return install.status;
   }
-
-  // Reset the simulator keychain so the app's auto-sign-in re-authenticates
-  // against the target backend. The auth token lives in a shared keychain access
-  // group (group.com.boardsesh.app) that survives both an app uninstall and the
-  // fresh install above — so without this a stale token (e.g. from a previous
-  // --backend local run) is reused and the app talks to the wrong backend with an
-  // invalid session. A clean keychain forces a fresh sign-in with the baked creds.
-  console.log(`${LOG} Resetting simulator keychain (clears any stale auth token)...`);
-  runCapture('xcrun', ['simctl', 'keychain', device.udid, 'reset']);
 
   const captureDir = mkdtempSync(join(tmpdir(), 'boardsesh-shots-'));
   try {

--- a/scripts/mobile-simulator-check.sh
+++ b/scripts/mobile-simulator-check.sh
@@ -10,6 +10,13 @@ if ! command -v xcrun &>/dev/null || ! xcrun simctl list devices &>/dev/null 2>&
   exit 0
 fi
 
+# Resolve once and hold ownership across the entire command, including launch/logs.
+if [ -z "${BOARDSESH_SIMULATOR_LEASE_TOKEN:-}" ]; then
+  cd "$ROOT_DIR"
+  exec vp exec tsx scripts/mobile-simulator-lease.ts bash "$SCRIPT_DIR/mobile-simulator-check.sh" "$@"
+fi
+vp exec tsx "$SCRIPT_DIR/mobile-simulator-lease.ts" --assert-only
+
 if [ ! -d "$MOBILE_DIR" ]; then
   echo "[mobile-sim] FAILED: packages/mobile/ not found at $MOBILE_DIR"
   exit 1
@@ -17,11 +24,18 @@ fi
 
 cd "$ROOT_DIR"
 
-echo "[mobile-sim] Building and launching on iOS simulator (shared-cache expo run:ios)..."
-
-if ! tsx scripts/mobile-ios-run.ts 2>&1; then
-  echo "[mobile-sim] FAILED: mobile iOS build exited with an error"
-  exit 1
+if [ -n "${BOARDSESH_IOS_SMOKE_APP_PATH:-}" ]; then
+  echo "[mobile-sim] Installing and launching the selected existing simulator app..."
+  if ! vp exec tsx scripts/mobile-simulator-smoke.ts "$BOARDSESH_IOS_SMOKE_APP_PATH" 2>&1; then
+    echo "[mobile-sim] FAILED: existing simulator app validation or launch failed"
+    exit 1
+  fi
+else
+  echo "[mobile-sim] Building and launching on iOS simulator (shared-cache expo run:ios)..."
+  if ! tsx scripts/mobile-ios-run.ts 2>&1; then
+    echo "[mobile-sim] FAILED: mobile iOS build exited with an error"
+    exit 1
+  fi
 fi
 
 mkdir -p "$ROOT_DIR/.boardsesh"
@@ -30,7 +44,7 @@ LOG_FILE="$ROOT_DIR/.boardsesh/mobile-device.log"
 
 echo "[mobile-sim] Capturing 30s of device logs..."
 
-xcrun simctl spawn booted log stream \
+xcrun simctl spawn "$BOARDSESH_IOS_SIMULATOR_UDID" log stream \
   --predicate 'subsystem == "com.boardsesh.app"' \
   --timeout 30 \
   > "$LOG_FILE" 2>&1 || true

--- a/scripts/mobile-simulator-lease.ts
+++ b/scripts/mobile-simulator-lease.ts
@@ -1,0 +1,25 @@
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { leaseEnvironment, resolveSimulatorUdid } from './lib/ios-simulator-lease';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const [command, ...args] = process.argv.slice(2).filter((argument) => argument !== '--');
+if (!command) throw new Error('Expected a command to run while holding the simulator lease.');
+const inheritedToken = process.env.BOARDSESH_SIMULATOR_LEASE_TOKEN;
+if (command === '--assert-only' && (!inheritedToken || !process.env.BOARDSESH_IOS_SIMULATOR_UDID)) {
+  throw new Error('An inherited simulator lease requires both its token and exact UDID.');
+}
+const lease = leaseEnvironment(resolveSimulatorUdid(), root);
+try {
+  if (command === '--assert-only') {
+    if (lease.env.BOARDSESH_SIMULATOR_LEASE_TOKEN !== inheritedToken) {
+      throw new Error('The inherited simulator lease token is stale or invalid.');
+    }
+  } else {
+    const result = spawnSync(command, args, { cwd: root, env: lease.env, stdio: 'inherit' });
+    process.exitCode = result.status ?? 1;
+  }
+} finally {
+  lease.release();
+}

--- a/scripts/mobile-simulator-smoke.ts
+++ b/scripts/mobile-simulator-smoke.ts
@@ -1,0 +1,33 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assertMatchingIdentity, readAppIdentity } from './lib/ios-profile-identity';
+import { guardSimulatorCommand, resolveSimulatorUdid } from './lib/ios-simulator-lease';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const appPath = process.argv[2];
+if (!appPath) throw new Error('Pass the existing simulator app export for the smoke check.');
+const configuration = existsSync(join(appPath, 'main.jsbundle')) ? 'Release' : 'Debug';
+const identity = readAppIdentity(resolve(appPath), configuration);
+const udid = resolveSimulatorUdid();
+const simctl = (args: string[]) => {
+  guardSimulatorCommand('xcrun', ['simctl', ...args], root);
+  return execFileSync('xcrun', ['simctl', ...args], { encoding: 'utf8' }).trim();
+};
+const listing = JSON.parse(simctl(['list', 'devices', '--json'])) as {
+  devices: Record<string, { udid: string; state: string }[]>;
+};
+if (
+  Object.values(listing.devices)
+    .flat()
+    .find((device) => device.udid === udid)?.state !== 'Booted'
+) {
+  simctl(['boot', udid]);
+}
+simctl(['bootstatus', udid, '-b']);
+simctl(['install', udid, resolve(appPath)]);
+const installedPath = simctl(['get_app_container', udid, identity.bundleIdentifier, 'app']);
+assertMatchingIdentity(identity, readAppIdentity(installedPath, configuration));
+simctl(['launch', udid, identity.bundleIdentifier]);
+console.log(`[mobile-sim] Launched verified ${configuration} export ${identity.bundleIdentifier} on ${udid}.`);

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "//": "Typechecks the repo-root scripts, which were previously never validated by CI — `vp run typecheck` only covered packages/*. Wired in via the `typecheck:scripts` task. Scoped to the Discord feedback pipeline, the dev-db discovery watchdog and the board-art geometry generator for now; widen `include` as other scripts are made type-clean.",
+  "//": "Typechecks the repo-root scripts wired into typecheck:scripts, including the Discord feedback pipeline, development tooling, board-art generation, Railway configuration, and iOS profiling/build/simulator ownership tools with their regression tests.",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
@@ -31,6 +31,23 @@
     "railway-apply.ts",
     "railway-apply.test.ts",
     "../infra/railway/config.ts",
-    "../infra/railway/plan.ts"
+    "../infra/railway/plan.ts",
+    "mobile-profile-capture.ts",
+    "mobile-profile-ios.ts",
+    "mobile-simulator-lease.ts",
+    "mobile-simulator-smoke.ts",
+    "lib/ios-profile-identity.ts",
+    "lib/ios-simulator-lease.ts",
+    "lib/ios-build-export.ts",
+    "lib/metro-host.ts",
+    "mobile-ios-run.ts",
+    "mobile-build-sim-app.ts",
+    "mobile-dev-start.ts",
+    "mobile-screenshots.ts",
+    "mobile-ios-shots.ts",
+    "__tests__/ios-profiling-tools.test.ts",
+    "__tests__/mobile-ios-run.test.ts",
+    "__tests__/mobile-screenshots.test.ts",
+    "__tests__/mobile-profile-capture.test.ts"
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -999,6 +999,10 @@ export default defineConfig({
         command: 'tsx scripts/mobile-ios-run.ts',
         cache: false,
       },
+      'mobile:profile:ios': {
+        command: 'tsx scripts/mobile-profile-ios.ts',
+        cache: false,
+      },
       'mobile:screenshot': {
         command: 'bash scripts/mobile-screenshot.sh',
         cache: false,


### PR DESCRIPTION
## Summary

Closed feedback forms stop subscribing to navigation and queue updates while preserving drafts. Reports read current route, board, session, and climb metadata through screenshot upload and submission. Opt-in local startup marks attribute existing readiness gates without moving them.

Author verification: 9,351 mobile tests, mobile/repository typechecks, iOS/Android bundles, native Release smoke test, screenshot check, and lint/format passed. Independent implementation review completed. Five measured Debug tab loops recorded closed FeedbackSheet renders falling from 20 to zero. Native drawer opening, draft preservation, drag dismissal, and subsequent navigation passed. Upload/retry/current-metadata behavior is covered by tests. Startup gates and cache policy are unchanged.

Stack: [tooling #5327](https://github.com/boardsesh/boardsesh/pull/5327) → [feedback/startup #5328](https://github.com/boardsesh/boardsesh/pull/5328) → [Discover #5329](https://github.com/boardsesh/boardsesh/pull/5329). Separate PR bases keep each implementation diff focused.

Controlled results and limitations: [performance follow-up](https://github.com/boardsesh/boardsesh/blob/codex/ios-discover-performance/docs/ios-performance-follow-up-2026-09-08.md).

## Release Notes

Your feedback draft stays ready when you reopen it, without slowing browsing.

## Test plan

1. Report a bug → type a draft → close.
2. Reopen Report a bug → your draft remains.
3. Attach a screenshot → submit → confirmation appears.

## Risk

Risk: 2/5 — feedback lifecycle and optional local diagnostics.
