### PR TITLE
fix(mobile): keep climb thumbnails painted through player transitions

### DIFF
--- a/docs/react-native-performance.md
+++ b/docs/react-native-performance.md
@@ -317,6 +317,14 @@ uptime (#3803). Four contracts keep them in check:
   `memoryWarning` event is a _last_ resort, not a foreground lever: iOS delivers it only after an
   allocation has already failed. Re-decodes from disk (no network).
 
+**Phone player transitions retain thumbnails.** Opening `/play` must keep the underlying
+list's image layers mounted. Although the player has an opaque backing, its opening and closing
+animations expose the list; an interactive swipe exposes it while `/play` is still focused.
+Unmounting on route focus leaves blank thumbnails until their images decode again. Keep the
+existing image instances throughout the transition, including a cancelled swipe. This retains
+the mounted list thumbnails while the player is open; list virtualization, cache limits,
+app-background cleanup, and inactive-iPad-tab cleanup continue to bound image memory.
+
 **Why:** On-device profiling (Pixel 8 Pro, Android 16) showed ~248 MB native heap idle on the feed
 and the play-drawer carousel piling a native-res (~7 MB RGBA) overlay per swiped climb into the
 cache. Display-sizing + recycling cut carousel browse-growth ~19%; background-blanking cut the

--- a/packages/mobile/src/components/board-art-visibility-context.ts
+++ b/packages/mobile/src/components/board-art-visibility-context.ts
@@ -1,8 +1,8 @@
 import { createContext, useContext } from 'react';
 
 // Whether board art in this subtree is on a currently-visible surface. Default
-// `true`, so any board art rendered outside a provider — every iPhone, the
-// always-visible iPad sidebar cell + play pane, and unit tests — always paints.
+// `true`, so board art rendered outside a provider — the iPad sidebar cell +
+// play pane, root player, and unit tests — always paints while foregrounded.
 //
 // A per-tab `BoardArtVisibilityProvider` flips this to `false` for an INACTIVE
 // iPad tab. The iPad shell keeps every tab mounted (`detachInactiveScreens={false}`

--- a/packages/mobile/src/providers/__tests__/board-art-visibility-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/board-art-visibility-provider.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
-import { createElement } from 'react';
+import { createElement, type ReactNode } from 'react';
 
 const segments = vi.hoisted(() => ({ value: ['(tabs)', 'home'] as readonly string[] }));
 vi.mock('expo-router', () => ({ useSegments: () => segments.value }));
@@ -9,8 +9,22 @@ vi.mock('expo-router', () => ({ useSegments: () => segments.value }));
 const deviceLayout = vi.hoisted(() => ({ isPad: true }));
 vi.mock('../../hooks/use-device-layout', () => ({ useDeviceLayout: () => ({ isPad: deviceLayout.isPad }) }));
 
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('expo-image', () => ({
+  Image: ({ source }: { source: { uri: string } }) => createElement('img', { src: source.uri }),
+}));
+
+const appVisibility = vi.hoisted(() => ({ backgrounded: false }));
+vi.mock('../../lib/app-visibility', () => ({ useIsAppBackgrounded: () => appVisibility.backgrounded }));
+
 import { BoardArtVisibilityProvider, type BoardArtTab } from '../board-art-visibility-provider';
 import { useBoardArtVisible } from '../../components/board-art-visibility-context';
+import { LayeredClimbImage } from '../../components/LayeredClimbImage';
 
 function VisibleProbe() {
   return createElement('span', { 'data-visible': String(useBoardArtVisible()) });
@@ -28,6 +42,7 @@ describe('BoardArtVisibilityProvider', () => {
   beforeEach(() => {
     deviceLayout.isPad = true;
     segments.value = ['(tabs)', 'home'];
+    appVisibility.backgrounded = false;
   });
 
   it('reports visible on the focused iPad tab', () => {
@@ -49,7 +64,7 @@ describe('BoardArtVisibilityProvider', () => {
     expect(readVisible(container)).toBe('true');
   });
 
-  it('hides every tab while a root modal / player route is focused', () => {
+  it('hides iPad tab art while the player route is focused', () => {
     segments.value = ['play'];
     const { container } = renderWithin('climbs');
     expect(readVisible(container)).toBe('false');
@@ -62,21 +77,52 @@ describe('BoardArtVisibilityProvider', () => {
     expect(readVisible(container)).toBe('true');
   });
 
-  // The player paints its own opaque backing over the whole tab shell, so the tab's
-  // list thumbnails are occluded but still mounted — pinning their decoded bitmaps
-  // through the app's peak board-art moment (the player's own full-res board is live,
-  // and remixing from it opens the create board too). #3804.
-  it('hides tab board art on iPhone while the player is up', () => {
+  it('keeps phone tab board art visible while the player is up', () => {
     deviceLayout.isPad = false;
     segments.value = ['play'];
     const { container } = renderWithin('climbs');
-    expect(readVisible(container)).toBe('false');
+    expect(readVisible(container)).toBe('true');
   });
 
-  // Over-blanking guards. Both of these are root/pushed surfaces that float over a
-  // still-VISIBLE list, so blanking under them would be a user-facing regression —
-  // which is why occlusion is an allowlist of opaque-backed routes rather than
-  // "no tab is active".
+  it('preserves phone image instances through repeated player opens and closes', () => {
+    deviceLayout.isPad = false;
+    segments.value = ['(tabs)', 'climbs'];
+    const renderThumbnail = () =>
+      createElement(BoardArtVisibilityProvider, {
+        tab: 'climbs',
+        children: createElement(LayeredClimbImage, {
+          overlayUri: 'file:///overlay.png',
+          backgroundPaths: ['/bundled/kilter.webp'],
+        }),
+      });
+    const { container, rerender } = render(renderThumbnail());
+    const backgroundImage = container.querySelector('img[src="file:///bundled/kilter.webp"]');
+    const overlayImage = container.querySelector('img[src="file:///overlay.png"]');
+    expect(backgroundImage).not.toBeNull();
+    expect(overlayImage).not.toBeNull();
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      for (const nextSegments of [['play'], ['(tabs)', 'climbs']]) {
+        segments.value = nextSegments;
+        rerender(renderThumbnail());
+        expect(container.querySelectorAll('img')).toHaveLength(2);
+        expect(container.querySelector('img[src="file:///bundled/kilter.webp"]')).toBe(backgroundImage);
+        expect(container.querySelector('img[src="file:///overlay.png"]')).toBe(overlayImage);
+      }
+    }
+
+    // Keeping art through navigation must not disable app-background cleanup.
+    segments.value = ['play'];
+    appVisibility.backgrounded = true;
+    rerender(renderThumbnail());
+    expect(container.querySelector('img')).toBeNull();
+
+    appVisibility.backgrounded = false;
+    rerender(renderThumbnail());
+    expect(container.querySelectorAll('img')).toHaveLength(2);
+  });
+
+  // These drawers can leave the underlying list visible too.
   it('stays visible on iPhone under the user drawer', () => {
     deviceLayout.isPad = false;
     segments.value = ['user-drawer'];
@@ -93,7 +139,7 @@ describe('BoardArtVisibilityProvider', () => {
 
   it('still blanks an inactive iPad tab under the user drawer', () => {
     // iPad behaviour is unchanged: a root modal leaves no tab active, so every tab
-    // blanks via the iPad branch regardless of the new player check.
+    // blanks via the iPad branch.
     segments.value = ['user-drawer'];
     const { container } = renderWithin('climbs');
     expect(readVisible(container)).toBe('false');

--- a/packages/mobile/src/providers/board-art-visibility-provider.tsx
+++ b/packages/mobile/src/providers/board-art-visibility-provider.tsx
@@ -2,7 +2,7 @@ import { type ReactNode } from 'react';
 import { useSegments } from 'expo-router';
 import { BoardArtVisibilityContext } from '../components/board-art-visibility-context';
 import { useDeviceLayout } from '../hooks/use-device-layout';
-import { isPlayerRoute, tabsActiveSegment } from '../lib/route-segments';
+import { tabsActiveSegment } from '../lib/route-segments';
 
 // The top-level tab names ((tabs)/<name>). Typing the `tab` prop as this union
 // (not a bare string) makes a typo in a layout's `tab="…"` a compile error rather
@@ -10,45 +10,24 @@ import { isPlayerRoute, tabsActiveSegment } from '../lib/route-segments';
 export type BoardArtTab = 'climbs' | 'discover' | 'home' | 'profile' | 'record' | 'wall';
 
 /**
- * Wraps one tab's stack so its board art blanks while that art is not on screen.
- * Two independent hidden cases, because they have different cost/benefit:
+ * Releases board art in non-focused iPad tabs. The iPad shell keeps every tab
+ * mounted (`detachInactiveScreens={false}`), so hidden image views would retain
+ * decoded bitmaps for the life of the session. Clearing the image cache only
+ * releases cache copies, not bitmaps a mounted view still holds (#3803).
  *
- * 1. **The player is up — every device.** `/play` is a `transparentModal` that
- *    paints its OWN opaque backing (app/_layout.tsx), so the whole tab shell
- *    behind it is fully occluded while still mounted — pinning every list
- *    thumbnail's decoded bitmap for as long as the player is open. Blanking here
- *    is invisible by construction (nothing behind the player is on screen) and
- *    it is the app's peak board-art moment: the player's own full-res board is
- *    live on top, and remixing from it opens the create board as well (#3804).
- *    The player itself renders OUTSIDE every provider (it is a root route, not
- *    under `(tabs)`), so its board keeps painting — as do the root-mounted queue
- *    accessory and the iPad sidebar/detail pane.
- *
- * 2. **An inactive tab — iPad only.** The iPad shell keeps every tab mounted
- *    (`detachInactiveScreens={false}`), so without this an inactive tab's
- *    `LayeredClimbImage` views retain their decoded bitmaps off-screen for the
- *    life of the session — `Image.clearMemoryCache()` reclaims only unreferenced
- *    cache copies, not bitmaps a mounted view still holds (#3803). iPhone is
- *    opted out of THIS case only: its tabs already freeze/detach on blur, and
- *    re-decoding on every tab return would flash the thumbnails for no memory
- *    win. Case 1 is a much rarer transition for a much larger working set, so it
- *    applies on iPhone too.
- *
- * Anything hidden re-decodes from the disk cache in tens of ms when shown again.
+ * Phones keep their images mounted through navigation. The player has an opaque
+ * backing, but its opening/closing animations reveal the list beneath it. During
+ * swipe dismissal `/play` stays focused until the player is offscreen, so hiding
+ * on route focus would expose blank thumbnails while their images reload.
+ * App-background cleanup remains owned by LayeredClimbImage on every device.
  */
 export function BoardArtVisibilityProvider({ tab, children }: { tab: BoardArtTab; children: ReactNode }) {
   const { isPad } = useDeviceLayout();
   const segments = useSegments();
-  // Case 1. Deliberately keyed on the player route specifically, NOT on
-  // `tabsActiveSegment(segments) === null` — that would also fire for the
-  // `user-drawer` root modal and for a tab's own `create` drawer, both of which
-  // float over a still-VISIBLE list. Blanking under those would be a user-facing
-  // regression, so occlusion stays an explicit allowlist of opaque-backed surfaces.
-  const occludedByPlayer = isPlayerRoute(segments);
-  // Case 2: visible only while THIS tab is the focused top-level destination
+  // On iPad, visible only while THIS tab is the focused top-level destination
   // (segment 1). A pushed sub-route of the tab keeps it active (`tabsActiveSegment`
   // still returns the tab name). The value is a primitive boolean, so the provider
   // needs no memo (react/jsx-no-constructed-context-values).
-  const visible = !occludedByPlayer && (!isPad || tabsActiveSegment(segments) === tab);
+  const visible = !isPad || tabsActiveSegment(segments) === tab;
   return <BoardArtVisibilityContext.Provider value={visible}>{children}</BoardArtVisibilityContext.Provider>;
 }


### PR DESCRIPTION
## Summary

Opening the player hid the phone climb list's image layers immediately. The opening and dismissal animations expose that list, leaving blank thumbnails until the images decoded again. Keep the existing images mounted throughout player navigation, including interactive dismissal.

App-background cleanup, inactive-iPad-tab cleanup, image-cache limits, and list virtualization stay unchanged. Updated the performance guidance and added a regression test that checks the same background and overlay image instances survive repeated opens and closes.

Validation: the two new regression assertions failed before the fix; all 9,325 mobile tests, mobile and full workspace typechecks, iOS and Android bundle checks, repository lint/format checks, and staged checks pass. Repository lint reports existing warnings but no errors. Device gesture QA remains pending: this Linux environment has no iOS simulator or accelerated Android emulator.

Independent code-review subagent: no actionable findings; independently reran the 35 focused image tests successfully. GitHub's separate Claude review job could not review the change because the account's weekly quota is exhausted until September 12 at 07:00 UTC.

## Release Notes

Return from a climb to your list without thumbnails flashing.

## Test plan

1. Climbs tab → open a climb; thumbnails stay visible during opening.
2. Close the player; list thumbnails appear immediately without flashing.
3. Slowly swipe down; revealed list thumbnails stay painted.
4. Cancel the swipe; the revealed thumbnails remain painted.
5. Android: press Back; thumbnails and scroll position remain unchanged.

## Risk

Risk: 2/5 — isolated visibility change with regression tests; mounted list thumbnails remain in memory while the player is open, with existing background and inactive-tab cleanup preserved.
