### PR TITLE
fix(mobile): stop serving a SQLite connection the provider closed

### DIFF
--- a/packages/mobile/src/components/connectivity/use-connectivity-banner.ts
+++ b/packages/mobile/src/components/connectivity/use-connectivity-banner.ts
@@ -92,9 +92,10 @@ export function useConnectivityBanner(): ConnectivityBannerModel {
   const connectivity = useConnectivity();
   const router = useRouter();
   const { isAuthenticated } = useAuth();
-  // The SQLite handle is null until migrations land and goes null again on
-  // sign-out, and neither is a React state change on its own — the readiness
-  // store is what makes re-reading it a subscription rather than a guess.
+  // The SQLite handle is null until migrations land, and null again from the
+  // moment `SQLiteProvider` tears a connection down until the replacement one is
+  // migrated (#5292), and neither is a React state change on its own — the
+  // readiness store is what makes re-reading it a subscription rather than a guess.
   const schemaReady = useOfflineSchemaReady();
   const outbox = useOutboxSummary(schemaReady ? getDatabaseHandle() : null);
 

--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -38,6 +38,7 @@ import {
   initializeDatabase,
   INIT_RETRY_DELAYS_MS,
   setDatabaseHandle,
+  releaseDatabaseHandle,
 } from '../connection';
 import { isSchemaReady } from '../schema-ready';
 import { resetDatabaseInitializationForTests } from '../testing';
@@ -434,7 +435,13 @@ describe('initializeDatabase lock contention (#4104)', () => {
   // `error` may be a function to vary the throw per failure (attempt N is contended,
   // attempt N+1 is a closed handle).
   function createContendedDatabase(
-    options: { error?: Error | ((failureCount: number) => Error); onFailure?: (failureCount: number) => void } = {},
+    options: {
+      error?: Error | ((failureCount: number) => Error);
+      onFailure?: (failureCount: number) => void;
+      // The same hook for an attempt that is going to SUCCEED: a remount landing
+      // during the winning attempt is the production case, not just the contended one.
+      onExec?: (source: string) => void;
+    } = {},
   ) {
     const { error = new Error(LOCK_ERROR_MESSAGE) } = options;
     const failureFor = (failureCount: number) => (typeof error === 'function' ? error(failureCount) : error);
@@ -443,6 +450,7 @@ describe('initializeDatabase lock contention (#4104)', () => {
 
     const wrapper = {
       execAsync: async (source: string): Promise<void> => {
+        options.onExec?.(source);
         if (locked && /pending_mutations/i.test(source)) {
           failures += 1;
           // Lets a test land a remount WHILE this attempt is in flight, which is the
@@ -737,5 +745,102 @@ describe('initializeDatabase lock contention (#4104)', () => {
     await retryMount;
 
     expect(getDatabaseHandle()).toBe(healthy.db);
+  });
+
+  // #5292: the success-path counterpart to the exhausted-window case above. A chain
+  // that WON kept the single-flight guard forever, so the next mount was handed the
+  // resolved promise, the handle was never republished, and every local read went on
+  // hitting the connection SQLiteProvider had closed ("Access to closed resource",
+  // ~249 users/30d). The remount triggers are production ones — the root error
+  // boundary's retry, Android activity recreation — not just Fast Refresh.
+  it('re-publishes the connection a remount opened', async () => {
+    const first = createContendedDatabase();
+    first.unlock();
+    await initializeDatabase(first.db);
+    expect(getDatabaseHandle()).toBe(first.db);
+
+    // The remount: SQLiteProvider closed first.db and opened second.db, calling
+    // onInit again with it.
+    const second = createContendedDatabase();
+    second.unlock();
+    await initializeDatabase(second.db);
+
+    expect(getDatabaseHandle()).toBe(second.db);
+    expect(isSchemaReady()).toBe(true);
+  });
+
+  it('retracts the closed connection when the remount starts, not when its migrations land', async () => {
+    vi.useFakeTimers();
+    const first = createContendedDatabase();
+    first.unlock();
+    await initializeDatabase(first.db);
+    expect(getDatabaseHandle()).toBe(first.db);
+
+    // The replacement connection is contended, so its own init cannot publish for at
+    // least one backoff. The old handle still has to go the instant onInit is called
+    // for the new one: the teardown that closed first.db is landing right now, and
+    // the sync scheduler and mutation drainer read the handle from outside React,
+    // where nothing tells them a remount happened. Asserted BEFORE any await —
+    // republishing on success alone would leave that whole window serving a corpse.
+    const second = createContendedDatabase();
+    const remount = initializeDatabase(second.db);
+    expect(getDatabaseHandle()).toBeNull();
+    expect(isSchemaReady()).toBe(false);
+
+    await remount;
+    second.unlock();
+    await vi.advanceTimersByTimeAsync(FIRST_RETRY_DELAY_MS);
+
+    expect(getDatabaseHandle()).toBe(second.db);
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('retargets when the remount lands during the attempt that wins', async () => {
+    const second = createContendedDatabase();
+    second.unlock();
+    let remounted = false;
+    // The remount lands mid-attempt, so this chain publishes a connection that is
+    // already being torn down. It has to notice on the way out and initialize the
+    // replacement itself: the remount was handed this promise, so nothing else will.
+    const first = createContendedDatabase({
+      // Fires on the mutation-queue DDL — the same seam the contended tests use, and
+      // late enough that `initializeDatabase` has finished assigning the single-flight
+      // guard, so this really is a remount arriving into a running chain.
+      onExec: (source) => {
+        if (remounted || !/pending_mutations/i.test(source)) return;
+        remounted = true;
+        void initializeDatabase(second.db);
+      },
+    });
+    first.unlock();
+
+    await initializeDatabase(first.db);
+    await vi.waitFor(() => {
+      expect(getDatabaseHandle()).toBe(second.db);
+    });
+
+    expect(isSchemaReady()).toBe(true);
+    expect(reportErrorMock).not.toHaveBeenCalled();
+    // Working around a remount is not recovering from contention — no lock was ever
+    // held, so the recovery event must stay quiet (#4325).
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores a teardown for a connection a newer mount has already replaced', () => {
+    const first = createContendedDatabase();
+    const second = createContendedDatabase();
+    setDatabaseHandle(second.db);
+
+    // An effect cleanup can run after the replacement connection has published
+    // itself. Retracting unconditionally here would switch offline storage off for a
+    // database that is perfectly alive.
+    releaseDatabaseHandle(first.db);
+    expect(getDatabaseHandle()).toBe(second.db);
+    expect(isSchemaReady()).toBe(true);
+
+    // ...and the teardown that DOES own the published handle still retracts it.
+    releaseDatabaseHandle(second.db);
+    expect(getDatabaseHandle()).toBeNull();
+    expect(isSchemaReady()).toBe(false);
   });
 });

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -63,6 +63,24 @@ export function getDatabaseHandle(): SQLiteDatabase | null {
 }
 
 /**
+ * Retracts the published handle when the connection behind it is being closed.
+ *
+ * `SQLiteProvider`'s effect teardown calls `db.closeAsync()`, and until #5292 nothing
+ * told this module about it: `getDatabaseHandle()` kept serving the closed connection
+ * and every local read threw `Access to closed resource` (~249 users/30d). Called from
+ * the provider's own teardown so the handle goes null BEFORE the close lands, rather
+ * than leaving a window where a non-React reader (sync scheduler, mutation drainer)
+ * picks up a dead connection.
+ *
+ * Identity-checked: an effect cleanup can run after a newer connection has already
+ * published itself, and retracting unconditionally would switch offline storage off
+ * for a database that is perfectly alive.
+ */
+export function releaseDatabaseHandle(db: SQLiteDatabase): void {
+  if (databaseHandle === db) setDatabaseHandle(null);
+}
+
+/**
  * How many times the whole setup sequence is attempted before giving up, and the
  * hard wall-clock ceiling across all of them.
  *
@@ -189,6 +207,13 @@ export function initializeDatabase(db: SQLiteDatabase): Promise<void> {
   // Recorded on EVERY call, including the remount that only gets the shared promise
   // back, so the in-flight chain can retarget onto the live connection.
   latestDatabase = db;
+  // A second connection arriving means `SQLiteProvider` has torn the previous one
+  // down — its teardown closes it (expo-sqlite `build/hooks.js`), and the close can
+  // land before or after this call. Retract synchronously, before the first await, so
+  // from the instant `onInit` runs for the new connection no reader can be handed the
+  // old one (#5292). The chain below republishes once the new connection's migrations
+  // are in place.
+  if (databaseHandle !== null && databaseHandle !== db) setDatabaseHandle(null);
   activeInitialization ??= beginInitialization(db);
   return activeInitialization;
 }
@@ -264,6 +289,23 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
       }
 
       if (outcome.status === 'ready') {
+        // A remount landed between the publish inside `attemptInitialization` and this
+        // line, so the connection just prepared is already closed. The remount was
+        // handed this (about to resolve) promise and nothing else will initialize its
+        // connection, so retarget here instead of returning and leaving offline
+        // storage dead for the session. Spends a superseded refund, not retry budget:
+        // no lock was contended, the file is simply behind a newer connection.
+        if (latestDatabase !== null && latestDatabase !== target && supersededRestarts < MAX_SUPERSEDED_RESTARTS) {
+          markStartup('sqlite.recovery.start');
+          supersededRestarts += 1;
+          continue;
+        }
+        // Drop the single-flight guard on the way out. Holding it past a successful
+        // chain is what made #5292 permanent: the next mount was handed this resolved
+        // promise, `setDatabaseHandle` never ran again, and the handle stayed pinned to
+        // a connection `SQLiteProvider` had since closed. Nothing awaits between here
+        // and the `return`, so no mount can slip in after the clear and be stranded.
+        activeInitialization = null;
         if (attempts > 1) markStartup('sqlite.recovery.end', 'ready');
         // Only a chain that survived a GENUINE lock failure recovered from
         // contention. A chain whose only failure was against a superseded (closed)

--- a/packages/mobile/src/db/index.ts
+++ b/packages/mobile/src/db/index.ts
@@ -5,6 +5,7 @@ export {
   initializeDatabase,
   setDatabaseHandle,
   getDatabaseHandle,
+  releaseDatabaseHandle,
   clearUserData,
   purgeLocalDataForSignOut,
   type SignOutPurgeResult,

--- a/packages/mobile/src/providers/__tests__/database-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/database-provider.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+// #5292: SQLiteProvider's effect teardown closes its connection, and nothing told the
+// module-level handle about it — `getDatabaseHandle()` went on serving a closed
+// connection to the sync scheduler and mutation drainer, neither of which is inside
+// React and neither of which can see a remount. Driven through the provider's own
+// lifecycle rather than by calling the retraction directly, because what has to hold
+// is an ordering: the handle is gone by the time the close lands.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+
+vi.mock('../../lib/error-reporting', () => ({ reportError: vi.fn() }));
+vi.mock('../../lib/profiling/startup-profile', () => ({ markStartup: vi.fn() }));
+vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
+
+// The real engine runs SQL, and its node:sqlite test adapter cannot be bundled into
+// this file's jsdom environment. Everything about the DDL is covered against the REAL
+// schema in db/__tests__/connection.test.ts; what this suite needs from the setup
+// sequence is only that it succeeds, so the handle gets published and the teardown has
+// something to retract.
+vi.mock('@boardsesh/offline-sync', () => ({
+  configureMainConnection: vi.fn(async () => {}),
+  ensureMutationQueueTable: vi.fn(async () => {}),
+  runMigrations: vi.fn(async () => {}),
+  classifySqliteLockError: () => ({ locked: false, code: null }),
+  applyBusyTimeout: vi.fn(async () => {}),
+  beginImmediateWrite: vi.fn(async () => {}),
+  deleteUserCheckpoints: vi.fn(async () => {}),
+  deleteAllSyncMeta: vi.fn(async () => {}),
+  vacuumDatabase: vi.fn(async () => true),
+  getUnfinishedDownloadScopeKeys: vi.fn(async () => []),
+  claimAbandonedDownloadTerminal: vi.fn(() => true),
+  purgeNamespaceForScopeKey: vi.fn(async () => {}),
+  OFFLINE_DB_BUSY_TIMEOUT_MS: 5_000,
+  BOARD_DATA_TABLES: [],
+}));
+
+// Everything the fake provider below has to hand back to the test. vi.hoisted because
+// the mock factory is hoisted above this file's imports, so it cannot close over an
+// ordinary top-level const.
+const sqlite = vi.hoisted(() => ({
+  // A distinct object per mount, exactly like `openDatabaseAsync` — the identity is
+  // what the retraction checks.
+  openConnection: (): unknown => ({ connection: 'unset' }),
+  // What `getDatabaseHandle()` returned at the moment the provider closed a
+  // connection. Null means the retraction won the race, which is the point.
+  closes: [] as { database: unknown; handleAtClose: unknown }[],
+  readHandle: (): unknown => null,
+}));
+
+// Stands in for expo-sqlite's own provider (`build/hooks.js`): the effect opens a
+// connection, awaits `onInit`, publishes it through context, and closes it on
+// teardown. That open → onInit → close shape is the bug.
+vi.mock('expo-sqlite', async () => {
+  const { createContext, createElement, useContext, useEffect, useRef, useState } = await import('react');
+  const SQLiteContext = createContext<unknown>(null);
+
+  function SQLiteProvider({ children, onInit }: { children?: unknown; onInit: (db: never) => Promise<void> }) {
+    const databaseRef = useRef<unknown>(null);
+    const [, setOpened] = useState(false);
+
+    useEffect(() => {
+      async function setup(): Promise<void> {
+        const database = sqlite.openConnection();
+        await onInit(database as never);
+        databaseRef.current = database;
+        setOpened(true);
+      }
+      void setup();
+      return () => {
+        const database = databaseRef.current;
+        databaseRef.current = null;
+        setOpened(false);
+        if (database === null) return;
+        // expo-sqlite's teardown is `async function teardown(db) { await
+        // db.closeAsync(); }` — started from the cleanup, settled a microtask later.
+        // Recording the handle at THAT point is the assertion that matters: whatever
+        // order React runs the cleanups in, no reader may still be holding this
+        // connection once it is actually closed.
+        void Promise.resolve().then(() => {
+          sqlite.closes.push({ database, handleAtClose: sqlite.readHandle() });
+        });
+      };
+    }, [onInit]);
+
+    if (databaseRef.current === null) return null;
+    return createElement(SQLiteContext.Provider, { value: databaseRef.current }, children as never);
+  }
+
+  return { SQLiteProvider, useSQLiteContext: () => useContext(SQLiteContext) };
+});
+
+import { DatabaseProvider } from '../database-provider';
+import { getDatabaseHandle, setDatabaseHandle } from '../../db/connection';
+import { isSchemaReady } from '../../db/schema-ready';
+import { resetDatabaseInitializationForTests } from '../../db/testing';
+
+beforeEach(() => {
+  resetDatabaseInitializationForTests();
+  setDatabaseHandle(null);
+  sqlite.closes.length = 0;
+  sqlite.readHandle = () => getDatabaseHandle();
+  let opened = 0;
+  sqlite.openConnection = () => {
+    opened += 1;
+    return { connection: opened };
+  };
+});
+
+describe('DatabaseProvider', () => {
+  it('retracts the handle before the connection is closed', async () => {
+    const view = render(
+      <DatabaseProvider>
+        <div data-testid="child" />
+      </DatabaseProvider>,
+    );
+
+    await waitFor(() => {
+      expect(getDatabaseHandle()).not.toBeNull();
+    });
+    const published = getDatabaseHandle();
+
+    view.unmount();
+
+    expect(getDatabaseHandle()).toBeNull();
+    expect(isSchemaReady()).toBe(false);
+    // The provider really did close the connection it had published, and by the time
+    // that close landed the handle no longer pointed at it. Without the retraction a
+    // reader here gets a connection that throws `Access to closed resource`.
+    await waitFor(() => {
+      expect(sqlite.closes).toEqual([{ database: published, handleAtClose: null }]);
+    });
+  });
+});

--- a/packages/mobile/src/providers/database-provider.tsx
+++ b/packages/mobile/src/providers/database-provider.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from 'react';
-import { SQLiteProvider } from 'expo-sqlite';
-import { DATABASE_NAME, initializeDatabase } from '../db';
+import { useEffect, type ReactNode } from 'react';
+import { SQLiteProvider, useSQLiteContext } from 'expo-sqlite';
+import { DATABASE_NAME, initializeDatabase, releaseDatabaseHandle } from '../db';
 
 function handleDatabaseError(error: Error): void {
   if (__DEV__) {
@@ -8,9 +8,32 @@ function handleDatabaseError(error: Error): void {
   }
 }
 
+/**
+ * Renders nothing; exists to hang the handle retraction off `SQLiteProvider`'s own
+ * lifecycle.
+ *
+ * The provider's effect teardown closes the connection (expo-sqlite
+ * `build/hooks.js`), and it does so asynchronously — `await db.closeAsync()`, started
+ * from the cleanup. Every cleanup in the torn-down subtree runs in that same
+ * synchronous commit, so retracting from here lands before the close itself does,
+ * whichever order React visits them in. Without it the window between the close and
+ * the replacement connection's migrations belongs to whoever reads
+ * `getDatabaseHandle()` — the sync scheduler and mutation drainer, neither of which is
+ * inside React and neither of which can see the provider remount (#5292).
+ *
+ * Mounted as a sibling of `children` rather than wrapping them: it must not add a
+ * component boundary to the tree every screen renders under.
+ */
+function DatabaseHandleLifecycle() {
+  const database = useSQLiteContext();
+  useEffect(() => () => releaseDatabaseHandle(database), [database]);
+  return null;
+}
+
 export function DatabaseProvider({ children }: { children: ReactNode }) {
   return (
     <SQLiteProvider databaseName={DATABASE_NAME} onInit={initializeDatabase} onError={handleDatabaseError}>
+      <DatabaseHandleLifecycle />
       {children}
     </SQLiteProvider>
   );


### PR DESCRIPTION
## Summary

`getDatabaseHandle()` kept handing out the SQLite connection `SQLiteProvider` had already closed, so every local read after a provider remount threw `Access to closed resource` — offline search, climb detail and the local ticks list came back empty or errored (~249 unique users in 30 days; Sentry BOARDSESH-G1/CF/CW/DH). The remount triggers are production ones: the root `ErrorBoundary`'s retry remounts the whole tree including `DatabaseProvider`, and Android activity recreation on a config change outside `configChanges` rebuilds the React root while JS module state survives.

The issue's description names only half the cause. Nothing published null on teardown — true — but `initializeDatabase` also single-flights on `activeInitialization` and only cleared that guard on the failure path. So a remount got the already-resolved promise back, `setDatabaseHandle` never ran again, and the handle stayed pinned to the dead connection for the rest of the process. Retracting alone would have turned a recoverable stale handle into offline storage that is dead for the session, so the fix re-runs the init chain rather than just re-publishing. Re-running matters for a second reason: `PRAGMA busy_timeout` is per connection, so a re-published handle that skipped `configureMainConnection` would fault into the SQLITE_BUSY family (#5302).

What changed:

- `releaseDatabaseHandle(db)` retracts the handle from `SQLiteProvider`'s own teardown, identity-checked so a late cleanup cannot retract a newer connection. `DatabaseHandleLifecycle` (a null-render child inside the provider) hangs it off `useSQLiteContext()`; every cleanup in the torn-down subtree runs in one synchronous commit, and the real close is `await db.closeAsync()`, so the retraction lands first. The web fork is untouched.
- `initializeDatabase` retracts synchronously the instant a second connection arrives, so no reader can be handed the old one between `onInit(db2)` and the new connection's migrations.
- The init chain clears `activeInitialization` when it wins, and a remount landing between the publish and the clear retargets onto the live connection (spending a superseded refund, not retry budget) instead of being stranded.
- Every `getDatabaseHandle()` caller already null-checks, so no consumer changed.

Author-side verification: `vp run typecheck:mobile`, `vp run test:mobile` (863 files / 9356 tests green), `vp run check:mobile-bundle`, `vp check` (0 errors). Each of the five guards was mutation-tested — the fix reverted one line at a time, the matching test confirmed red, everything else green.

Follow-ups, deliberately not in this PR:

- Connection-handover telemetry (how often a remount hands the chain a new connection) would need a new `SHARED_EVENTS` constant in `@boardsesh/analytics` and would widen this past the mobile package. Worth filing: it would settle the Android-config-change vs error-boundary-retry split, which is currently unknowable from the Sentry data.
- #5302 (SQLITE_BUSY family) is not fixed here. This change removes one way to reach it — a republished connection that never ran `configureMainConnection` — because the replacement connection now goes through the full init chain, PRAGMAs included. Any remaining busy errors there are genuine contention.

Fixes #5292

## Release Notes

- Offline search and your logbook stop coming up empty after the app reloads itself

## Test plan

1. Open the app offline, search climbs — results appear.
2. Force a reload (rotate, or change system font size).
3. Search again offline — results still appear, not empty.
4. Open Logbook — your ticks are still listed.
5. Open a climb from the list — detail loads.

## Risk

Risk: 3/5 — mobile-only lifecycle change on the shared offline SQLite handle; every reader already null-checks, and it touches no schema or writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
