### PR TITLE
fix(backend): support both favorites rollout schemas

### DIFF
--- a/docs/favorites-rollout.md
+++ b/docs/favorites-rollout.md
@@ -1,0 +1,23 @@
+# Climb-wide favorites rollout
+
+Favorites belong to `(user_id, climb_uuid)`. Deploy this in two ordered changes so an app update cannot require a backend that has not arrived, and a database migration cannot reject the backend that is still serving requests.
+
+## 1. Backend compatibility
+
+Deploy the compatibility PR completely before merging #4256. It accepts both legacy board/angle inputs and UUID-only requests. Favorites reads ignore board and angle and return distinct UUIDs. Mutations take a transaction-scoped advisory lock per user and climb, check existing rows across angles, and use untargeted `ON CONFLICT DO NOTHING`. This works with either the original four-column unique index or the future two-column unique index.
+
+Inserts still populate the non-null legacy columns. The board comes from the catalog when available, falling back to the old input for unknown climbs; angle retains the input or defaults to zero. These columns are storage metadata, not favorite identity. The existing sync payload and three-part deletion IDs remain unchanged in this release, so current SQLite clients continue syncing.
+
+This step has no database migration and does not change mobile query documents. During its own rolling deployment, older instances can still create angle duplicates under the existing index. The later migration archives and collapses those rows. Do not apply the unique-index migration until every serving backend instance runs compatible writers.
+
+## 2. Storage and client update (#4256)
+
+Once backend compatibility is deployed successfully, merge #4256. Keep the compatibility mutation implementation while the new index and client changes roll out. New mobile code can arrive before this second backend deployment because the compatibility backend already accepts UUID-only operations. The migration can arrive before this second backend deployment because the compatibility writer never targets the obsolete conflict key.
+
+The Postgres migration archives duplicate favorites before deduplication and suppresses deletion tombstones during that process. SQLite migration 6 changes the local primary key to `climb_uuid`, preserving shipped migration 5. The client accepts both historical three-part and new UUID deletion IDs, with timestamp protection for a later re-add.
+
+After step 2, rollback targets must retain the compatibility backend. Reverting to an earlier writer while the new unique index is installed can raise `23505` or fail conflict-target inference. Column and wire-field removal remain a separate cleanup in #4246 after the client population is accounted for.
+
+## Verification
+
+Backend integration tests run both payload formats against the legacy index, both indexes together, and the new index alone. They cover concurrent adds and toggles, old duplicate rows, account isolation, and non-null values needed by older sync clients. GraphQL validation covers shipped non-null variables and new UUID-only documents.

--- a/packages/backend/src/__tests__/favorites-rollout-compat.test.ts
+++ b/packages/backend/src/__tests__/favorites-rollout-compat.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { and, eq, sql } from 'drizzle-orm';
+import { buildSchema, graphql } from 'graphql';
+import { typeDefs, type ConnectionContext } from '@boardsesh/shared-schema';
+import * as dbSchema from '@boardsesh/db/schema';
+import { db } from '../db/client';
+import { favoriteMutations } from '../graphql/resolvers/favorites/mutations';
+import { favoriteQueries } from '../graphql/resolvers/favorites/queries';
+
+type IndexShape = 'legacy' | 'dual' | 'uuid';
+const USER_ID = 'favorites-rollout-user';
+const OTHER_USER_ID = 'favorites-rollout-other';
+const CLIMB_UUID = 'favorites-rollout-climb';
+const graphSchema = buildSchema(typeDefs.join('\n'));
+
+function context(userId = USER_ID): ConnectionContext {
+  return {
+    connectionId: 'favorites-rollout-connection',
+    isAuthenticated: true,
+    userId,
+    sessionId: null,
+    controllerId: null,
+    controllerApiKey: null,
+  } as unknown as ConnectionContext;
+}
+
+async function resetIndex(shape: IndexShape): Promise<void> {
+  await db.execute(sql`TRUNCATE user_favorites, sync_deletions RESTART IDENTITY CASCADE`);
+  await db.execute(sql`DROP INDEX IF EXISTS unique_user_favorite`);
+  await db.execute(sql`DROP INDEX IF EXISTS unique_user_favorite_legacy`);
+  if (shape === 'legacy') {
+    await db.execute(
+      sql`CREATE UNIQUE INDEX unique_user_favorite ON user_favorites(user_id, board_name, climb_uuid, angle)`,
+    );
+  } else {
+    await db.execute(sql`CREATE UNIQUE INDEX unique_user_favorite ON user_favorites(user_id, climb_uuid)`);
+    if (shape === 'dual') {
+      await db.execute(
+        sql`CREATE UNIQUE INDEX unique_user_favorite_legacy ON user_favorites(user_id, board_name, climb_uuid, angle)`,
+      );
+    }
+  }
+}
+
+async function favorites(userId = USER_ID) {
+  return db.select().from(dbSchema.userFavorites).where(eq(dbSchema.userFavorites.userId, userId));
+}
+
+beforeEach(async () => {
+  for (const userId of [USER_ID, OTHER_USER_ID]) {
+    await db
+      .insert(dbSchema.users)
+      .values({ id: userId, email: `${userId}@test.com` })
+      .onConflictDoNothing();
+  }
+  await db.execute(sql`
+    INSERT INTO board_climbs(uuid, board_type, layout_id, setter_username, name, description, frames, is_listed)
+    VALUES (${CLIMB_UUID}, 'kilter', 1, 'setter', 'Rollout climb', '', 'p1r1', true)
+    ON CONFLICT (uuid) DO NOTHING
+  `);
+});
+
+describe.each<IndexShape>(['legacy', 'dual', 'uuid'])('favorites with the %s index shape', (shape) => {
+  beforeEach(() => resetIndex(shape));
+
+  it('accepts UUID-only adds and preserves the non-null legacy sync columns', async () => {
+    await favoriteMutations.addFavorite(undefined, { input: { climbUuid: CLIMB_UUID } }, context());
+    const rows = await favorites();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ climbUuid: CLIMB_UUID, boardName: 'kilter', angle: 0 });
+  });
+
+  it('accepts queued legacy inputs at another angle without duplicating or violating either key', async () => {
+    await favoriteMutations.addFavorite(
+      undefined,
+      { input: { climbUuid: CLIMB_UUID, boardName: 'kilter', angle: 40 } },
+      context(),
+    );
+    await favoriteMutations.addFavorite(
+      undefined,
+      { input: { climbUuid: CLIMB_UUID, boardName: 'tension', angle: 25 } },
+      context(),
+    );
+    expect(await favorites()).toHaveLength(1);
+    expect(
+      await favoriteQueries.favorites(
+        undefined,
+        { climbUuids: [CLIMB_UUID], boardName: 'tension', angle: 25 },
+        context(),
+      ),
+    ).toEqual([CLIMB_UUID]);
+  });
+
+  it('toggles an existing favorite off from another board and angle', async () => {
+    await favoriteMutations.addFavorite(
+      undefined,
+      { input: { climbUuid: CLIMB_UUID, boardName: 'kilter', angle: 40 } },
+      context(),
+    );
+    expect(
+      await favoriteMutations.toggleFavorite(
+        undefined,
+        { input: { climbUuid: CLIMB_UUID, boardName: 'tension', angle: 25 } },
+        context(),
+      ),
+    ).toEqual({ favorited: false });
+    expect(await favorites()).toHaveLength(0);
+  });
+
+  it('serializes concurrent adds across legacy and UUID-only payloads', async () => {
+    await Promise.all(
+      Array.from({ length: 8 }, (_, index) =>
+        favoriteMutations.addFavorite(
+          undefined,
+          {
+            input:
+              index % 2 ? { climbUuid: CLIMB_UUID } : { climbUuid: CLIMB_UUID, boardName: 'kilter', angle: index * 5 },
+          },
+          context(),
+        ),
+      ),
+    );
+    expect(await favorites()).toHaveLength(1);
+  });
+
+  it('serializes concurrent toggles so an even number leaves no favorite', async () => {
+    const results = await Promise.all(
+      Array.from({ length: 6 }, () =>
+        favoriteMutations.toggleFavorite(undefined, { input: { climbUuid: CLIMB_UUID } }, context()),
+      ),
+    );
+    expect(results.filter((result) => result.favorited)).toHaveLength(3);
+    expect(await favorites()).toHaveLength(0);
+  });
+
+  it('keeps removals idempotent and scoped to the signed-in user', async () => {
+    for (const userId of [USER_ID, OTHER_USER_ID]) {
+      await favoriteMutations.addFavorite(undefined, { input: { climbUuid: CLIMB_UUID } }, context(userId));
+    }
+    for (let repeat = 0; repeat < 2; repeat++) {
+      expect(await favoriteMutations.removeFavorite(undefined, { input: { climbUuid: CLIMB_UUID } }, context())).toBe(
+        true,
+      );
+    }
+    expect(await favorites()).toHaveLength(0);
+    expect(await favorites(OTHER_USER_ID)).toHaveLength(1);
+  });
+
+  it.each(['legacy', 'uuid'])('executes %s GraphQL documents and inputs', async (format) => {
+    const input =
+      format === 'legacy' ? { boardName: 'kilter', climbUuid: CLIMB_UUID, angle: 40 } : { climbUuid: CLIMB_UUID };
+    const mutation = await graphql({
+      schema: graphSchema,
+      source: 'mutation Toggle($input: ToggleFavoriteInput!) { toggleFavorite(input: $input) { favorited } }',
+      variableValues: { input },
+      rootValue: {
+        toggleFavorite: (args: { input: typeof input }) => favoriteMutations.toggleFavorite(undefined, args, context()),
+      },
+    });
+    expect(mutation.errors).toBeUndefined();
+    expect(mutation.data?.toggleFavorite).toEqual({ favorited: true });
+    const query = await graphql({
+      schema: graphSchema,
+      source:
+        format === 'legacy'
+          ? 'query Favorites($boardName: String!, $climbUuids: [String!]!, $angle: Int!) { favorites(boardName: $boardName, climbUuids: $climbUuids, angle: $angle) }'
+          : 'query Favorites($climbUuids: [String!]!) { favorites(climbUuids: $climbUuids) }',
+      variableValues: { boardName: 'tension', climbUuids: [CLIMB_UUID], angle: 25 },
+      rootValue: {
+        favorites: (args: { climbUuids: string[]; boardName?: string; angle?: number }) =>
+          favoriteQueries.favorites(undefined, args, context()),
+      },
+    });
+    expect(query.errors).toBeUndefined();
+    expect(query.data?.favorites).toEqual([CLIMB_UUID]);
+  });
+});
+
+describe('pre-migration duplicate favorites', () => {
+  beforeEach(async () => {
+    await resetIndex('legacy');
+    await db.insert(dbSchema.userFavorites).values(
+      [40, 50].map((angle) => ({
+        userId: USER_ID,
+        climbUuid: CLIMB_UUID,
+        boardName: 'kilter',
+        angle,
+      })),
+    );
+  });
+
+  it('returns one UUID while leaving duplicates for the archive migration', async () => {
+    expect(await favoriteQueries.favorites(undefined, { climbUuids: [CLIMB_UUID] }, context())).toEqual([CLIMB_UUID]);
+    await favoriteMutations.addFavorite(undefined, { input: { climbUuid: CLIMB_UUID } }, context());
+    expect(await favorites()).toHaveLength(2);
+  });
+
+  it('removes all variants when the climber removes the heart', async () => {
+    expect(await favoriteMutations.toggleFavorite(undefined, { input: { climbUuid: CLIMB_UUID } }, context())).toEqual({
+      favorited: false,
+    });
+    expect(await favorites()).toHaveLength(0);
+  });
+
+  it('preserves historical deletion IDs until the separate migration', async () => {
+    await favoriteMutations.removeFavorite(undefined, { input: { climbUuid: CLIMB_UUID } }, context());
+    const deletions = await db
+      .select({ recordId: dbSchema.syncDeletions.recordId })
+      .from(dbSchema.syncDeletions)
+      .where(and(eq(dbSchema.syncDeletions.userId, USER_ID), eq(dbSchema.syncDeletions.tableName, 'user_favorites')));
+    expect(deletions.map((deletion) => deletion.recordId).sort()).toEqual([
+      `kilter:${CLIMB_UUID}:40`,
+      `kilter:${CLIMB_UUID}:50`,
+    ]);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/favorites/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/favorites/mutations.ts
@@ -1,4 +1,4 @@
-import { eq, and } from 'drizzle-orm';
+import { eq, and, sql } from 'drizzle-orm';
 import type {
   ConnectionContext,
   ToggleFavoriteInput,
@@ -15,14 +15,77 @@ import {
   RemoveFavoriteInputSchema,
 } from '../../../validation/schemas';
 
+// Separate advisory-lock namespace ("FAVS"). The transaction lock serializes
+// one user's writes to one climb across backend instances, even before the
+// database has a unique (user_id, climb_uuid) index. Hash collisions only
+// serialize unrelated favorites; they cannot mix their rows.
+const FAVORITE_LOCK_NAMESPACE = 0x46415653;
+
+async function writeFavorite(
+  userId: string,
+  input: AddFavoriteInput,
+  operation: 'add' | 'remove' | 'toggle',
+): Promise<boolean> {
+  return db.transaction(async (transaction) => {
+    const lockKey = JSON.stringify([userId, input.climbUuid]);
+    await transaction.execute(sql`SELECT pg_advisory_xact_lock(${FAVORITE_LOCK_NAMESPACE}, hashtext(${lockKey}))`);
+    const favoriteKey = and(
+      eq(dbSchema.userFavorites.userId, userId),
+      eq(dbSchema.userFavorites.climbUuid, input.climbUuid),
+    );
+
+    if (operation === 'remove') {
+      await transaction.delete(dbSchema.userFavorites).where(favoriteKey);
+      return false;
+    }
+
+    const [existingFavorite] = await transaction
+      .select({ id: dbSchema.userFavorites.id })
+      .from(dbSchema.userFavorites)
+      .where(favoriteKey)
+      .limit(1);
+    if (existingFavorite) {
+      if (operation === 'toggle') {
+        // Remove every old angle variant; a heart belongs to the climb.
+        await transaction.delete(dbSchema.userFavorites).where(favoriteKey);
+        return false;
+      }
+      return true;
+    }
+
+    const [climb] = await transaction
+      .select({ boardType: dbSchema.boardClimbs.boardType })
+      .from(dbSchema.boardClimbs)
+      .where(eq(dbSchema.boardClimbs.uuid, input.climbUuid))
+      .limit(1);
+    const inserted = await transaction
+      .insert(dbSchema.userFavorites)
+      .values({
+        userId,
+        climbUuid: input.climbUuid,
+        // Old Postgres and SQLite schemas require both fields. The catalog's
+        // board also keeps legacy list/export readers working through rollout.
+        // Unknown catalog climbs remain accepted, as they were before this change.
+        boardName: climb?.boardType ?? input.boardName ?? '',
+        angle: input.angle ?? 0,
+      })
+      // Do not name either unique key: this writer must work with the old
+      // four-column index, the new two-column index, or both during rollout.
+      .onConflictDoNothing()
+      .returning({ id: dbSchema.userFavorites.id });
+
+    if (operation === 'toggle' && inserted.length === 0) {
+      // An older backend that does not take the lock can still race us while
+      // this compatibility release rolls out. Reconcile an insert conflict
+      // as the second toggle instead of reporting a heart we did not add.
+      await transaction.delete(dbSchema.userFavorites).where(favoriteKey);
+      return false;
+    }
+    return true;
+  });
+}
+
 export const favoriteMutations = {
-  /**
-   * Toggle favorite status for a climb
-   * If favorited, removes the favorite; if not favorited, adds it.
-   * The insert-first upsert keeps concurrent toggles race-free: exactly one of
-   * two racing calls wins the INSERT (unique_user_favorite), the other falls
-   * through to the DELETE branch instead of hitting a unique violation.
-   */
   toggleFavorite: async (
     _: unknown,
     { input }: { input: ToggleFavoriteInput },
@@ -30,81 +93,17 @@ export const favoriteMutations = {
   ): Promise<ToggleFavoriteResult> => {
     requireAuthenticated(ctx);
     validateInput(ToggleFavoriteInputSchema, input, 'input');
-
-    const userId = ctx.userId!;
-
-    const inserted = await db
-      .insert(dbSchema.userFavorites)
-      .values({
-        userId,
-        boardName: input.boardName,
-        climbUuid: input.climbUuid,
-        angle: input.angle,
-      })
-      .onConflictDoNothing({
-        target: [
-          dbSchema.userFavorites.userId,
-          dbSchema.userFavorites.boardName,
-          dbSchema.userFavorites.climbUuid,
-          dbSchema.userFavorites.angle,
-        ],
-      })
-      .returning({ id: dbSchema.userFavorites.id });
-
-    if (inserted.length > 0) {
-      return { favorited: true };
-    }
-
-    await db
-      .delete(dbSchema.userFavorites)
-      .where(
-        and(
-          eq(dbSchema.userFavorites.userId, userId),
-          eq(dbSchema.userFavorites.boardName, input.boardName),
-          eq(dbSchema.userFavorites.climbUuid, input.climbUuid),
-          eq(dbSchema.userFavorites.angle, input.angle),
-        ),
-      );
-    return { favorited: false };
+    return { favorited: await writeFavorite(ctx.userId!, input, 'toggle') };
   },
 
-  /**
-   * Add a climb to favorites. Idempotent: ON CONFLICT (user_id, board_name,
-   * climb_uuid, angle) DO NOTHING. Safe for the mobile offline mutation queue to
-   * replay — a second add for the same (user, board, climb, angle) is a no-op,
-   * never a duplicate row. Always returns true.
-   */
+  // Idempotent across board/angle variants and safe for queued offline retries.
   addFavorite: async (_: unknown, { input }: { input: AddFavoriteInput }, ctx: ConnectionContext): Promise<boolean> => {
     requireAuthenticated(ctx);
     validateInput(AddFavoriteInputSchema, input, 'input');
-
-    const userId = ctx.userId!;
-
-    await db
-      .insert(dbSchema.userFavorites)
-      .values({
-        userId,
-        boardName: input.boardName,
-        climbUuid: input.climbUuid,
-        angle: input.angle,
-      })
-      .onConflictDoNothing({
-        target: [
-          dbSchema.userFavorites.userId,
-          dbSchema.userFavorites.boardName,
-          dbSchema.userFavorites.climbUuid,
-          dbSchema.userFavorites.angle,
-        ],
-      });
-
+    await writeFavorite(ctx.userId!, input, 'add');
     return true;
   },
 
-  /**
-   * Remove a climb from favorites. Idempotent: deleting a row that doesn't exist
-   * is a no-op, so the offline mutation queue can replay an unfavorite safely
-   * without inverting state (unlike toggleFavorite). Always returns true.
-   */
   removeFavorite: async (
     _: unknown,
     { input }: { input: RemoveFavoriteInput },
@@ -112,20 +111,7 @@ export const favoriteMutations = {
   ): Promise<boolean> => {
     requireAuthenticated(ctx);
     validateInput(RemoveFavoriteInputSchema, input, 'input');
-
-    const userId = ctx.userId!;
-
-    await db
-      .delete(dbSchema.userFavorites)
-      .where(
-        and(
-          eq(dbSchema.userFavorites.userId, userId),
-          eq(dbSchema.userFavorites.boardName, input.boardName),
-          eq(dbSchema.userFavorites.climbUuid, input.climbUuid),
-          eq(dbSchema.userFavorites.angle, input.angle),
-        ),
-      );
-
+    await writeFavorite(ctx.userId!, input, 'remove');
     return true;
   },
 };

--- a/packages/backend/src/graphql/resolvers/favorites/queries.ts
+++ b/packages/backend/src/graphql/resolvers/favorites/queries.ts
@@ -3,38 +3,33 @@ import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, validateInput } from '../shared/helpers';
-import { BoardNameSchema, FavoritesQueryClimbUuidsSchema } from '../../../validation/schemas';
+import { FavoritesQueryClimbUuidsSchema } from '../../../validation/schemas';
 
 export const favoriteQueries = {
   /**
-   * Get favorite climb UUIDs for the authenticated user
-   * Filters by board name, angle, and optionally by a list of climb UUIDs
+   * Get favorite climb UUIDs for the authenticated user.
+   *
+   * Favorites are keyed by (user_id, climb_uuid), so the answer is the same
+   * whichever board or angle the caller is looking at. `boardName` and `angle`
+   * are still accepted (older binaries pass them) and ignored.
    */
   favorites: async (
     _: unknown,
-    { boardName, climbUuids, angle }: { boardName: string; climbUuids: string[]; angle: number },
+    { climbUuids }: { boardName?: string | null; climbUuids: string[]; angle?: number | null },
     ctx: ConnectionContext,
   ): Promise<string[]> => {
     if (!ctx.isAuthenticated || !ctx.userId) {
       return [];
     }
 
-    validateInput(BoardNameSchema, boardName, 'boardName');
     validateInput(FavoritesQueryClimbUuidsSchema, climbUuids, 'climbUuids');
 
     const favorites = await db
-      .select({ climbUuid: dbSchema.userFavorites.climbUuid })
+      .selectDistinct({ climbUuid: dbSchema.userFavorites.climbUuid })
       .from(dbSchema.userFavorites)
-      .where(
-        and(
-          eq(dbSchema.userFavorites.userId, ctx.userId),
-          eq(dbSchema.userFavorites.boardName, boardName),
-          eq(dbSchema.userFavorites.angle, angle),
-          inArray(dbSchema.userFavorites.climbUuid, climbUuids),
-        ),
-      );
+      .where(and(eq(dbSchema.userFavorites.userId, ctx.userId), inArray(dbSchema.userFavorites.climbUuid, climbUuids)));
 
-    return favorites.map((f) => f.climbUuid);
+    return favorites.map((favorite) => favorite.climbUuid);
   },
 
   /**

--- a/packages/backend/src/validation/schemas/favorites.ts
+++ b/packages/backend/src/validation/schemas/favorites.ts
@@ -2,24 +2,30 @@ import { z } from 'zod';
 import { ExternalUUIDSchema, BoardNameSchema } from './primitives';
 
 /**
- * Toggle favorite input validation schema
+ * Favorite input validation schemas.
+ *
+ * Favorites are keyed by (userId, climbUuid). `boardName` and `angle` are still
+ * accepted — binaries that shipped before the re-keying send them, and so do
+ * favorite mutations already sitting in a device's offline outbox. They are
+ * ignored for identity and retained as storage hints during rollout. Removal
+ * follows separately after shipped clients have been accounted for.
  */
 export const ToggleFavoriteInputSchema = z.object({
-  boardName: BoardNameSchema,
+  boardName: z.string().optional().nullable(),
   climbUuid: ExternalUUIDSchema,
-  angle: z.number().int(),
+  angle: z.number().int().optional().nullable(),
 });
 
 export const AddFavoriteInputSchema = z.object({
-  boardName: BoardNameSchema,
+  boardName: z.string().optional().nullable(),
   climbUuid: ExternalUUIDSchema,
-  angle: z.number().int(),
+  angle: z.number().int().optional().nullable(),
 });
 
 export const RemoveFavoriteInputSchema = z.object({
-  boardName: BoardNameSchema,
+  boardName: z.string().optional().nullable(),
   climbUuid: ExternalUUIDSchema,
-  angle: z.number().int(),
+  angle: z.number().int().optional().nullable(),
 });
 
 /**

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -939,15 +939,16 @@ input DeleteAccountInput {
 # ============================================
 
 """
-Input for toggling a climb as favorite.
+Input for toggling a climb as favorite. Favorites are keyed by climb UUID —
+a climb stays hearted whichever board config or angle you switch to.
 """
 input ToggleFavoriteInput {
-  "Board type"
-  boardName: String!
+  "Legacy storage hint; ignored for favorite identity. Kept for shipped clients."
+  boardName: String
   "Climb UUID to favorite/unfavorite"
   climbUuid: String!
-  "Board angle"
-  angle: Int!
+  "Legacy storage hint; ignored for favorite identity. Kept for shipped clients."
+  angle: Int
 }
 
 """
@@ -962,24 +963,24 @@ type ToggleFavoriteResult {
 Input for adding a climb to favorites (idempotent, sync-safe).
 """
 input AddFavoriteInput {
-  "Board type"
-  boardName: String!
+  "Legacy storage hint; ignored for favorite identity. Kept for shipped clients."
+  boardName: String
   "Climb UUID to favorite"
   climbUuid: String!
-  "Board angle"
-  angle: Int!
+  "Legacy storage hint; ignored for favorite identity. Kept for shipped clients."
+  angle: Int
 }
 
 """
 Input for removing a climb from favorites (idempotent, sync-safe).
 """
 input RemoveFavoriteInput {
-  "Board type"
-  boardName: String!
+  "Legacy storage hint; ignored for favorite identity. Kept for shipped clients."
+  boardName: String
   "Climb UUID to unfavorite"
   climbUuid: String!
-  "Board angle"
-  angle: Int!
+  "Legacy storage hint; ignored for favorite identity. Kept for shipped clients."
+  angle: Int
 }
 
 # ============================================
@@ -5570,7 +5571,7 @@ type Query {
   Check which climbs from a list are favorited by the current user.
   Returns array of favorited climb UUIDs.
   """
-  favorites(boardName: String!, climbUuids: [String!]!, angle: Int!): [String!]!
+  favorites(boardName: String, climbUuids: [String!]!, angle: Int): [String!]!
 
   """
   Get count of favorited climbs per board for the current user.

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -137,10 +137,10 @@ export type AddCommentInput = {
 
 /** Input for adding a climb to favorites (idempotent, sync-safe). */
 export type AddFavoriteInput = {
-  /** Board angle */
-  angle: Scalars['Int']['input'];
-  /** Board type */
-  boardName: Scalars['String']['input'];
+  /** Legacy storage hint; ignored for favorite identity. Kept for shipped clients. */
+  angle?: InputMaybe<Scalars['Int']['input']>;
+  /** Legacy storage hint; ignored for favorite identity. Kept for shipped clients. */
+  boardName?: InputMaybe<Scalars['String']['input']>;
   /** Climb UUID to favorite */
   climbUuid: Scalars['String']['input'];
 };
@@ -5972,8 +5972,8 @@ export type QueryEventsReplayArgs = {
 
 /** Root query type for all read operations. */
 export type QueryFavoritesArgs = {
-  angle: Scalars['Int']['input'];
-  boardName: Scalars['String']['input'];
+  angle?: InputMaybe<Scalars['Int']['input']>;
+  boardName?: InputMaybe<Scalars['String']['input']>;
   climbUuids: Array<Scalars['String']['input']>;
 };
 
@@ -6623,10 +6623,10 @@ export type RemoveClimbFromPlaylistInput = {
 
 /** Input for removing a climb from favorites (idempotent, sync-safe). */
 export type RemoveFavoriteInput = {
-  /** Board angle */
-  angle: Scalars['Int']['input'];
-  /** Board type */
-  boardName: Scalars['String']['input'];
+  /** Legacy storage hint; ignored for favorite identity. Kept for shipped clients. */
+  angle?: InputMaybe<Scalars['Int']['input']>;
+  /** Legacy storage hint; ignored for favorite identity. Kept for shipped clients. */
+  boardName?: InputMaybe<Scalars['String']['input']>;
   /** Climb UUID to unfavorite */
   climbUuid: Scalars['String']['input'];
 };
@@ -8158,12 +8158,15 @@ export type TickStatus =
 
 export type TimePeriod = 'all' | 'day' | 'hour' | 'month' | 'week' | 'year';
 
-/** Input for toggling a climb as favorite. */
+/**
+ * Input for toggling a climb as favorite. Favorites are keyed by climb UUID —
+ * a climb stays hearted whichever board config or angle you switch to.
+ */
 export type ToggleFavoriteInput = {
-  /** Board angle */
-  angle: Scalars['Int']['input'];
-  /** Board type */
-  boardName: Scalars['String']['input'];
+  /** Legacy storage hint; ignored for favorite identity. Kept for shipped clients. */
+  angle?: InputMaybe<Scalars['Int']['input']>;
+  /** Legacy storage hint; ignored for favorite identity. Kept for shipped clients. */
+  boardName?: InputMaybe<Scalars['String']['input']>;
   /** Climb UUID to favorite/unfavorite */
   climbUuid: Scalars['String']['input'];
 };
@@ -12577,7 +12580,7 @@ export type QueryResolvers<
     Array<ResolversTypes['String']>,
     ParentType,
     ContextType,
-    RequireFields<QueryFavoritesArgs, 'angle' | 'boardName' | 'climbUuids'>
+    RequireFields<QueryFavoritesArgs, 'climbUuids'>
   >;
   findSimilarGyms?: Resolver<
     Array<ResolversTypes['SimilarGym']>,

--- a/packages/shared-schema/src/schema/favorites.ts
+++ b/packages/shared-schema/src/schema/favorites.ts
@@ -4,15 +4,16 @@ export const favoritesTypeDefs = /* GraphQL */ `
   # ============================================
 
   """
-  Input for toggling a climb as favorite.
+  Input for toggling a climb as favorite. Favorites are keyed by climb UUID —
+  a climb stays hearted whichever board config or angle you switch to.
   """
   input ToggleFavoriteInput {
-    "Board type"
-    boardName: String!
+    "Legacy storage hint; ignored for favorite identity. Kept for shipped clients."
+    boardName: String
     "Climb UUID to favorite/unfavorite"
     climbUuid: String!
-    "Board angle"
-    angle: Int!
+    "Legacy storage hint; ignored for favorite identity. Kept for shipped clients."
+    angle: Int
   }
 
   """
@@ -27,23 +28,23 @@ export const favoritesTypeDefs = /* GraphQL */ `
   Input for adding a climb to favorites (idempotent, sync-safe).
   """
   input AddFavoriteInput {
-    "Board type"
-    boardName: String!
+    "Legacy storage hint; ignored for favorite identity. Kept for shipped clients."
+    boardName: String
     "Climb UUID to favorite"
     climbUuid: String!
-    "Board angle"
-    angle: Int!
+    "Legacy storage hint; ignored for favorite identity. Kept for shipped clients."
+    angle: Int
   }
 
   """
   Input for removing a climb from favorites (idempotent, sync-safe).
   """
   input RemoveFavoriteInput {
-    "Board type"
-    boardName: String!
+    "Legacy storage hint; ignored for favorite identity. Kept for shipped clients."
+    boardName: String
     "Climb UUID to unfavorite"
     climbUuid: String!
-    "Board angle"
-    angle: Int!
+    "Legacy storage hint; ignored for favorite identity. Kept for shipped clients."
+    angle: Int
   }
 `;

--- a/packages/shared-schema/src/schema/queries.ts
+++ b/packages/shared-schema/src/schema/queries.ts
@@ -174,7 +174,7 @@ export const queriesTypeDefs = /* GraphQL */ `
     Check which climbs from a list are favorited by the current user.
     Returns array of favorited climb UUIDs.
     """
-    favorites(boardName: String!, climbUuids: [String!]!, angle: Int!): [String!]!
+    favorites(boardName: String, climbUuids: [String!]!, angle: Int): [String!]!
 
     """
     Get count of favorited climbs per board for the current user.

--- a/packages/shared-schema/src/types/favorites.ts
+++ b/packages/shared-schema/src/types/favorites.ts
@@ -1,9 +1,11 @@
-// Favorites types
+// Favorites use (userId, climbUuid) for identity. Optional boardName/angle
+// remain storage hints during rollout so shipped clients and queued offline
+// mutations keep working against both database schemas.
 
 export type ToggleFavoriteInput = {
-  boardName: string;
+  boardName?: string | null;
   climbUuid: string;
-  angle: number;
+  angle?: number | null;
 };
 
 export type ToggleFavoriteResult = {
@@ -11,13 +13,13 @@ export type ToggleFavoriteResult = {
 };
 
 export type AddFavoriteInput = {
-  boardName: string;
+  boardName?: string | null;
   climbUuid: string;
-  angle: number;
+  angle?: number | null;
 };
 
 export type RemoveFavoriteInput = {
-  boardName: string;
+  boardName?: string | null;
   climbUuid: string;
-  angle: number;
+  angle?: number | null;
 };

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -134,10 +134,10 @@ export type AddCommentInput = {
 
 /** Input for adding a climb to favorites (idempotent, sync-safe). */
 export type AddFavoriteInput = {
-  /** Board angle */
-  angle: Scalars['Int']['input'];
-  /** Board type */
-  boardName: Scalars['String']['input'];
+  /** Legacy storage hint; ignored for favorite identity. Kept for shipped clients. */
+  angle?: InputMaybe<Scalars['Int']['input']>;
+  /** Legacy storage hint; ignored for favorite identity. Kept for shipped clients. */
+  boardName?: InputMaybe<Scalars['String']['input']>;
   /** Climb UUID to favorite */
   climbUuid: Scalars['String']['input'];
 };
@@ -5969,8 +5969,8 @@ export type QueryEventsReplayArgs = {
 
 /** Root query type for all read operations. */
 export type QueryFavoritesArgs = {
-  angle: Scalars['Int']['input'];
-  boardName: Scalars['String']['input'];
+  angle?: InputMaybe<Scalars['Int']['input']>;
+  boardName?: InputMaybe<Scalars['String']['input']>;
   climbUuids: Array<Scalars['String']['input']>;
 };
 
@@ -6620,10 +6620,10 @@ export type RemoveClimbFromPlaylistInput = {
 
 /** Input for removing a climb from favorites (idempotent, sync-safe). */
 export type RemoveFavoriteInput = {
-  /** Board angle */
-  angle: Scalars['Int']['input'];
-  /** Board type */
-  boardName: Scalars['String']['input'];
+  /** Legacy storage hint; ignored for favorite identity. Kept for shipped clients. */
+  angle?: InputMaybe<Scalars['Int']['input']>;
+  /** Legacy storage hint; ignored for favorite identity. Kept for shipped clients. */
+  boardName?: InputMaybe<Scalars['String']['input']>;
   /** Climb UUID to unfavorite */
   climbUuid: Scalars['String']['input'];
 };
@@ -8155,12 +8155,15 @@ export type TickStatus =
 
 export type TimePeriod = 'all' | 'day' | 'hour' | 'month' | 'week' | 'year';
 
-/** Input for toggling a climb as favorite. */
+/**
+ * Input for toggling a climb as favorite. Favorites are keyed by climb UUID —
+ * a climb stays hearted whichever board config or angle you switch to.
+ */
 export type ToggleFavoriteInput = {
-  /** Board angle */
-  angle: Scalars['Int']['input'];
-  /** Board type */
-  boardName: Scalars['String']['input'];
+  /** Legacy storage hint; ignored for favorite identity. Kept for shipped clients. */
+  angle?: InputMaybe<Scalars['Int']['input']>;
+  /** Legacy storage hint; ignored for favorite identity. Kept for shipped clients. */
+  boardName?: InputMaybe<Scalars['String']['input']>;
   /** Climb UUID to favorite/unfavorite */
   climbUuid: Scalars['String']['input'];
 };


### PR DESCRIPTION
## Summary

Accept UUID-only favorite requests before #4256 updates mobile clients, and keep backend writes working before and after that PR installs the new unique index. This prerequisite must be fully deployed before #4256 merges.

Favorite mutations serialize writes per user and climb with a transaction-scoped advisory lock and use untargeted conflict handling. Legacy board/angle payloads still validate, while new payloads may contain only `climbUuid`. Inserts keep legacy fields non-null and derive the stored board from the catalog when possible. Favorite-status queries return distinct climb UUIDs independently of board or angle.

This PR changes no database schema or shipped mobile query documents. Existing sync payloads and deletion IDs are preserved. The rollout order and rollback boundary are documented in `docs/favorites-rollout.md`.

Validation: full workspace typecheck passes. The rollout matrix passed 27 integration tests, and existing backend sync suites passed 31 tests. Lint and pre-commit checks pass with no errors. The matrix exercises old, combined, and new indexes; both GraphQL payload formats; concurrent writes; account isolation; and pre-migration duplicate rows.

## Release Notes

- Your hearts follow the climb across angles.

## Test plan

1. Sign in → heart a climb → the heart fills.
2. Change angle → reopen the climb → its heart stays filled.
3. Tap the filled heart → reopen climb → heart stays empty.

## Risk

Risk: 4/5 — changes favorite writes and prepares a staged database rollout.
