### PR TITLE
fix(mobile): stabilize play drawer sizing on open

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -393,6 +393,14 @@ defer the heavy content one `requestAnimationFrame` — the present runs nativel
 content fills in mid-slide. See `app/play.tsx`. Don't use `InteractionManager` for this: it
 waits out the whole transition and is disabled in screenshot mode.
 
+The player board also waits for the scroll viewport, title header, and Logbook header
+measurements before its one-frame defer starts. The carousel keeps its flex container
+mounted for measurement, but mounts images and prefetch only after it can contain-fit the
+board. Give both the image and zoom wrapper explicit dimensions: a cached image painted
+at an implicit size can visibly grow when layout corrects it during the native slide.
+Keep this measurement gate in screenshot mode too. Once mounted, ordinary resizing and
+climb changes reuse the carousel without restarting the opening placeholder.
+
 ## Worked examples
 
 - **Queue / Board / LogAscent / Angle / ClimbActions / AddBetaVideo** — secondary, opened on

--- a/packages/mobile/src/components/play-drawer/DeferredBoard.tsx
+++ b/packages/mobile/src/components/play-drawer/DeferredBoard.tsx
@@ -12,11 +12,11 @@ type BoardRenderData = {
 };
 
 type DeferredBoardProps = {
-  /** Drives the single-frame defer gate. While the route commits its first frame
-   *  this is false and a sized placeholder stands in for the board; one
-   *  requestAnimationFrame later it flips true and the interactive carousel
-   *  mounts, so the present animation runs natively over the placeholder. */
+  /** Closing resets the defer gate; reopening starts with a sized placeholder. */
   open: boolean;
+  /** The viewport and headers have measured, so the board's flex allocation
+   *  no longer depends on the first-screen fallback dimensions. */
+  layoutReady: boolean;
   boardName: BoardName;
   boardRenderData: BoardRenderData;
   layoutId: number;
@@ -42,19 +42,19 @@ type DeferredBoardProps = {
 
 /**
  * Defers mounting the interactive {@link SwipeBoardCarousel} until one frame
- * after the play drawer opens. The carousel mounts 2× `BoardImageNative` plus a
- * pinch/swipe/zoom gesture composition; rendering all of that synchronously the
- * moment the route commits blocks the present animation for ~0.5–1s (the
+ * after the open drawer's viewport and headers have measured. The carousel mounts
+ * 2× `BoardImageNative` plus a pinch/swipe/zoom gesture composition; rendering all
+ * of that synchronously when the route commits blocks the present animation for ~0.5–1s (the
  * user-reported stall). A single `requestAnimationFrame` gate lets the sheet
  * animate open immediately over a board-sized placeholder, then mounts the board
  * a frame later — and unlike `runAfterInteractions` a rAF can't be starved by the
  * sub-sheet hosts churning the interaction queue (the old 350ms-fallback stall,
  * which `docs/mobile-sheets-vs-routes.md` explicitly forbids for this).
  *
- * The gate is keyed on the OPEN TRANSITION (`open`), not on the displayed
- * climb's uuid, so once the drawer is open, swiping to next/prev climbs renders
- * the board immediately with no placeholder flash — the carousel stays mounted
- * across in-drawer swipes.
+ * The gate depends on opening and initial layout readiness, not the displayed
+ * climb's uuid or subsequent positive dimensions. Swiping to next/prev climbs
+ * renders the board immediately with no placeholder flash — the carousel stays
+ * mounted across in-drawer swipes.
  *
  * The placeholder fills the board's flex box (`flex: 1`, the same box the
  * contained carousel lays out into) so the first-screen layout is identical
@@ -62,16 +62,16 @@ type DeferredBoardProps = {
  */
 export const DeferredBoard = memo(function DeferredBoard({
   open,
+  layoutReady,
   boardRenderData,
   ...carouselProps
 }: DeferredBoardProps) {
-  // Gate on the open transition only so the board stays mounted across in-drawer
-  // swipes once the drawer is open. A single rAF fires after the route commits
-  // its first frame; it can't be starved the way the interaction queue can, so
-  // there's no "blank board until you reopen" fallback to wait out.
-  const ready = useDeferredUntilFrame(open);
+  // Let the viewport and header measurements reach layout before mounting the
+  // carousel. Otherwise a cached image can paint at the fallback size and visibly
+  // grow mid-presentation. Readiness stays true across swipes and positive resizes.
+  const ready = useDeferredUntilFrame(open && layoutReady);
 
-  if (!ready) {
+  if (!open || !layoutReady || !ready) {
     return (
       <View
         style={styles.placeholder}

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -1277,6 +1277,8 @@ export function PlayDrawer({
             <ScrollView
               ref={scrollRef}
               nestedScrollEnabled
+              showsVerticalScrollIndicator={false}
+              showsHorizontalScrollIndicator={false}
               // No top/bottom rubber-band: at the top, a downward drag is the
               // dismiss (the drawer translates) — a simultaneous scroll bounce would
               // fight it and read as double movement.
@@ -1379,6 +1381,7 @@ export function PlayDrawer({
                         {boardRenderData ? (
                           <DeferredBoard
                             open={isSheetOpen}
+                            layoutReady={sheetViewportHeight > 0 && headerBottomY > 0 && logbookHeaderHeight > 0}
                             boardName={boardName as BoardName}
                             boardRenderData={boardRenderData}
                             layoutId={layoutId}

--- a/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
+++ b/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
@@ -1,12 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  View,
-  StyleSheet,
-  useWindowDimensions,
-  PixelRatio,
-  type LayoutChangeEvent,
-  type ViewStyle,
-} from 'react-native';
+import { View, StyleSheet, useWindowDimensions, PixelRatio, type LayoutChangeEvent } from 'react-native';
 import Animated, {
   useAnimatedStyle,
   useDerivedValue,
@@ -15,7 +8,6 @@ import Animated, {
   type SharedValue,
 } from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { useTranslation } from 'react-i18next';
 import { computePeekOffset, type PeekDirection } from '@boardsesh/play-view';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { BoardImageNative } from '../BoardImageNative';
@@ -99,7 +91,6 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
   swipeTranslateX,
   swipeIsAnimating,
 }: SwipeBoardCarouselProps) {
-  const { t } = useTranslation('session');
   const { width: screenWidth } = useWindowDimensions();
   // Measured box the board is laid out into. The board is sized to *fit* this
   // box (contain) so the play drawer's full-screen first view can keep the
@@ -117,19 +108,6 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
   const boardBox = useMemo(
     () => computeContainedBoardSize(containerSize.width, containerSize.height, aspectRatio),
     [containerSize, aspectRatio],
-  );
-  const boardStyle = useMemo<ViewStyle | undefined>(
-    () => (boardBox ? { width: boardBox.width, height: boardBox.height } : undefined),
-    [boardBox],
-  );
-  // Render the per-climb holds overlay at the displayed pixel size, not the
-  // board's native ~1080px. The board photo stays full-res (backgroundVariant
-  // "full"); only the overlay shrinks. Without this, swiping through climbs
-  // piles a native-res (~7 MB RGBA) overlay per climb into expo-image's memory
-  // cache. Clamped to native width inside useNativeClimbRender (never upscales).
-  const overlayRenderWidth = useMemo(
-    () => (boardBox ? Math.round(boardBox.width * PixelRatio.get()) : undefined),
-    [boardBox],
   );
   // The carousel works in board-width units: a letterboxed (narrower) board
   // must slide off by its own width and the peek board must enter edge-adjacent.
@@ -253,9 +231,24 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
 
   const isScreenshotMode = process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1';
 
+  // Keep measuring the flex box, but never mount images at an implicit/full-width
+  // size. Cached photos can paint before onLayout reaches JS, making the later
+  // contain-fit correction look like a zoom during the native opening animation.
+  if (!boardBox) {
+    return (
+      <GestureDetector gesture={composedGesture}>
+        <View style={styles.container} onLayout={handleLayout} testID="play-drawer-board-container" />
+      </GestureDetector>
+    );
+  }
+
+  // Only request display-sized overlays once layout is known. The shared photo
+  // stays full-res; useNativeClimbRender clamps the overlay to native resolution.
+  const overlayRenderWidth = Math.round(boardBox.width * PixelRatio.get());
+
   return (
     <GestureDetector gesture={composedGesture}>
-      <View style={styles.container} onLayout={handleLayout}>
+      <View style={styles.container} onLayout={handleLayout} testID="play-drawer-board-container">
         {isScreenshotMode ? (
           // Screenshot mode: render the board in PLAIN (non-reanimated) Views.
           // The swipe/zoom `Animated.View` wrappers promote the board to a render
@@ -266,7 +259,7 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
           // board-presence sheet (no carousel) already captures reliably, confirming
           // the carousel layer is the culprit. overlayTestID anchors on the painted
           // holds overlay.
-          <View style={[styles.boardWrapper, boardBox ? { width: boardBox.width } : null]}>
+          <View style={[styles.boardWrapper, boardBox]}>
             <BoardImageNative
               frames={currentFrameOverride ?? currentFrames}
               boardName={boardName}
@@ -279,7 +272,7 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
               renderWidth={overlayRenderWidth}
               backgroundVariant="full"
               recyclingKey={currentFrames}
-              style={boardStyle}
+              style={boardBox}
               overlayTestID="play-drawer-board-overlay"
               // The one board a climber is actually looking at: `surface: 'play'`
               // on render-failure telemetry, and the only surface that watches
@@ -288,8 +281,8 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
             />
           </View>
         ) : (
-          <Animated.View style={[styles.boardWrapper, boardBox ? { width: boardBox.width } : null, currentStyle]}>
-            <Animated.View style={animatedZoomStyle}>
+          <Animated.View style={[styles.boardWrapper, boardBox, currentStyle]}>
+            <Animated.View style={[boardBox, animatedZoomStyle]}>
               <BoardImageNative
                 frames={currentFrameOverride ?? currentFrames}
                 boardName={boardName}
@@ -304,7 +297,7 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
                 // Climb identity (not the per-frame override) so the overlay
                 // recycles on swipe-to-new-climb, not on every playback frame.
                 recyclingKey={currentFrames}
-                style={boardStyle}
+                style={boardBox}
                 // During a swipe commit the current board's frames swap to the
                 // climb the peek was showing; that overlay is already cached, so an
                 // instant (no-fade) swap lands it before the reset uncovers it —
@@ -336,7 +329,7 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
               // Climb identity (peekFrames is the neighbour's frames, not a
               // per-frame override) so the peek overlay recycles per climb.
               recyclingKey={peekFrames}
-              style={boardStyle}
+              style={boardBox}
             />
           )}
         </Animated.View>

--- a/packages/mobile/src/components/play-drawer/__tests__/deferred-board.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/deferred-board.test.tsx
@@ -36,6 +36,7 @@ vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#8
 import { DeferredBoard } from '../DeferredBoard';
 
 const baseProps = {
+  layoutReady: true,
   boardName: 'kilter' as const,
   boardRenderData: { boardWidth: 1080, boardHeight: 1920 },
   layoutId: 1,
@@ -72,6 +73,7 @@ describe('DeferredBoard', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it('shows a board-sized placeholder before the deferred frame fires', () => {
@@ -90,6 +92,62 @@ describe('DeferredBoard', () => {
     expect(container.querySelector('[data-testid="deferred-board-placeholder"]')).toBeNull();
     const board = container.querySelector('[data-testid="swipe-board"]');
     expect(board?.getAttribute('data-frames')).toBe('p1145r15');
+  });
+
+  it('waits for delayed layout, then defers one frame after the measured commit', () => {
+    const { container, rerender } = render(
+      createElement(DeferredBoard, { ...baseProps, open: true, layoutReady: false }),
+    );
+    flushFrame();
+    expect(container.querySelector('[data-testid="swipe-board"]')).toBeNull();
+    expect(requestFrame).not.toHaveBeenCalled();
+
+    rerender(createElement(DeferredBoard, { ...baseProps, open: true }));
+    expect(container.querySelector('[data-testid="deferred-board-placeholder"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="swipe-board"]')).toBeNull();
+
+    flushFrame();
+    expect(container.querySelector('[data-testid="swipe-board"]')).toBeTruthy();
+  });
+
+  it('does not mount when layout arrives after the drawer closes', () => {
+    const { container, rerender } = render(
+      createElement(DeferredBoard, { ...baseProps, open: true, layoutReady: false }),
+    );
+    rerender(createElement(DeferredBoard, { ...baseProps, open: false }));
+    flushFrame();
+
+    expect(container.querySelector('[data-testid="swipe-board"]')).toBeNull();
+    expect(requestFrame).not.toHaveBeenCalled();
+  });
+
+  it('keeps the carousel mounted when board geometry changes after opening', () => {
+    const { container, rerender } = render(createElement(DeferredBoard, { ...baseProps, open: true }));
+    flushFrame();
+    const carousel = container.querySelector('[data-testid="swipe-board"]');
+
+    rerender(
+      createElement(DeferredBoard, {
+        ...baseProps,
+        open: true,
+        boardRenderData: { boardWidth: 1200, boardHeight: 1200 },
+      }),
+    );
+
+    expect(container.querySelector('[data-testid="swipe-board"]')).toBe(carousel);
+    expect(requestFrame).toHaveBeenCalledTimes(1);
+  });
+
+  it('still requires measured layout in screenshot mode', () => {
+    vi.stubEnv('EXPO_PUBLIC_SCREENSHOT_MODE', '1');
+    const { container, rerender } = render(
+      createElement(DeferredBoard, { ...baseProps, open: true, layoutReady: false }),
+    );
+    expect(container.querySelector('[data-testid="swipe-board"]')).toBeNull();
+
+    rerender(createElement(DeferredBoard, { ...baseProps, open: true }));
+    expect(container.querySelector('[data-testid="swipe-board"]')).toBeTruthy();
+    expect(requestFrame).not.toHaveBeenCalled();
   });
 
   it('does NOT re-defer when the climb changes while open (no swipe flash)', () => {

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
@@ -20,6 +20,7 @@ import { render, act } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import type { Climb } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { LayoutChangeEvent } from 'react-native';
 
 type Props = Record<string, unknown>;
 
@@ -34,6 +35,8 @@ const recorded = vi.hoisted(() => ({
   playback: [] as Props[],
   angleSheet: [] as Props[],
   lightbulb: [] as { canRelay?: boolean; onRelayToHolder?: () => void }[],
+  scroll: [] as Props[],
+  headerLayout: undefined as ((event: LayoutChangeEvent) => void) | undefined,
 }));
 const setCurrentClimb = vi.hoisted(() => vi.fn());
 const queueState = vi.hoisted(() => ({
@@ -54,7 +57,10 @@ const navigation = vi.hoisted(() => ({
 
 // --- Host platform -----------------------------------------------------------
 vi.mock('react-native', () => ({
-  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  View: ({ children, onLayout }: { children?: ReactNode; onLayout?: (event: LayoutChangeEvent) => void }) => {
+    if (onLayout) recorded.headerLayout = onLayout;
+    return createElement('div', null, children);
+  },
   Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
     createElement('button', { onClick: onPress }, children),
   StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1, absoluteFillObject: {} },
@@ -74,7 +80,10 @@ vi.mock('react-native-mmkv', () => {
   };
 });
 vi.mock('react-native-gesture-handler', () => ({
-  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({ children, ...props }: { children?: ReactNode } & Props) => {
+    recorded.scroll.push(props);
+    return createElement('div', null, children);
+  },
   GestureDetector: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
 }));
 vi.mock('react-native-reanimated', () => ({
@@ -273,6 +282,8 @@ beforeEach(() => {
   recorded.playback = [];
   recorded.angleSheet = [];
   recorded.lightbulb = [];
+  recorded.scroll = [];
+  recorded.headerLayout = undefined;
   queueState.queue = [];
   queueState.currentClimbQueueItem = null;
   navigation.state = { nextItem: null, prevItem: null, canNext: false, canPrevious: false };
@@ -300,6 +311,39 @@ describe('PlayDrawer relay board compatibility', () => {
     act(() => control?.onRelayToHolder?.());
     if (canRelay) expect(setCurrentClimb).toHaveBeenCalledWith(previewQueueItem, expect.anything());
     else expect(setCurrentClimb).not.toHaveBeenCalled();
+  });
+});
+
+describe('PlayDrawer opening layout', () => {
+  it.each(['viewport-first', 'headers-first'])('waits for every layout measurement (%s)', (order) => {
+    queueState.currentClimbQueueItem = queueItem(TWELVE_CLIMB, 'queue-twelve');
+    renderDrawer(vi.fn());
+    expect(lastBoardProps().layoutReady).toBe(false);
+    const viewportLayout = recorded.scroll.at(-1)?.onLayout as (event: LayoutChangeEvent) => void;
+    const headerLayout = recorded.headerLayout;
+    const logbookLayout = recorded.deferredSections.at(-1)?.onLogbookHeaderLayout as (height: number) => void;
+    if (!headerLayout) throw new Error('Title header is not measured');
+    const event = (height: number) =>
+      ({ nativeEvent: { layout: { x: 0, y: 0, width: 390, height } } }) as LayoutChangeEvent;
+    const firstMeasurement =
+      order === 'viewport-first' ? () => viewportLayout(event(844)) : () => headerLayout(event(70));
+    const secondMeasurement =
+      order === 'viewport-first' ? () => headerLayout(event(70)) : () => viewportLayout(event(844));
+
+    act(firstMeasurement);
+    expect(lastBoardProps().layoutReady).toBe(false);
+    act(() => logbookLayout(44));
+    expect(lastBoardProps().layoutReady).toBe(false);
+    act(secondMeasurement);
+    expect(lastBoardProps().layoutReady).toBe(true);
+
+    act(() => viewportLayout(event(600)));
+    expect(lastBoardProps().layoutReady).toBe(true);
+    expect(recorded.scroll.at(-1)).toMatchObject({
+      showsVerticalScrollIndicator: false,
+      showsHorizontalScrollIndicator: false,
+      nestedScrollEnabled: true,
+    });
   });
 });
 

--- a/packages/mobile/src/components/play-drawer/__tests__/swipe-board-carousel-layout.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/swipe-board-carousel-layout.test.tsx
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { LayoutChangeEvent } from 'react-native';
+
+type Box = { width: number; height: number };
+type ViewProps = {
+  children?: ReactNode;
+  onLayout?: (event: LayoutChangeEvent) => void;
+  testID?: string;
+  style?: unknown;
+};
+
+const recorded = vi.hoisted(() => ({
+  onLayout: undefined as ViewProps['onLayout'],
+  prefetch: vi.fn(),
+}));
+
+vi.mock('react-native', () => {
+  const flattenStyle = (style: unknown): Record<string, unknown> => {
+    if (Array.isArray(style)) return Object.assign({}, ...style.map(flattenStyle));
+    return style && typeof style === 'object' ? (style as Record<string, unknown>) : {};
+  };
+  return {
+    View: ({ children, onLayout, testID, style }: ViewProps) => {
+      if (testID === 'play-drawer-board-container') recorded.onLayout = onLayout;
+      const dimensions = flattenStyle(style);
+      return createElement(
+        'div',
+        {
+          'data-testid': testID,
+          'data-width': dimensions.width,
+          'data-height': dimensions.height,
+        },
+        children,
+      );
+    },
+    StyleSheet: { create: (styles: unknown) => styles },
+    useWindowDimensions: () => ({ width: 390, height: 844 }),
+    PixelRatio: { get: () => 3 },
+  };
+});
+vi.mock('react-native-reanimated', async () => {
+  const { View } = await import('react-native');
+  return {
+    default: { View },
+    useAnimatedStyle: (factory: () => unknown) => factory(),
+    useDerivedValue: (factory: () => unknown) => ({ value: factory() }),
+    useAnimatedReaction: () => undefined,
+    runOnJS: (callback: unknown) => callback,
+  };
+});
+vi.mock('react-native-gesture-handler', () => ({
+  Gesture: { Simultaneous: () => ({}) },
+  GestureDetector: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../use-carousel-gesture', () => ({
+  useCarouselGesture: () => ({ gesture: {}, translateX: { value: 0 } }),
+}));
+vi.mock('../use-zoom-pan-gesture', () => ({
+  useZoomPanGesture: () => ({
+    pinchGesture: {},
+    zoomPanGesture: {},
+    isZoomed: false,
+    isZoomedSV: { value: false },
+    resetZoom: () => {},
+    animatedZoomStyle: {},
+  }),
+}));
+vi.mock('../../BoardImageNative', () => ({
+  // Paint synchronously, like an image whose photo and overlay are already cached.
+  BoardImageNative: ({ frames, style, renderWidth }: { frames: string; style: Box; renderWidth: number }) =>
+    createElement('div', {
+      'data-testid': `board-${frames}`,
+      'data-width': style?.width,
+      'data-height': style?.height,
+      'data-render-width': renderWidth,
+    }),
+}));
+vi.mock('../UpcomingBoardPrefetch', () => ({
+  UpcomingBoardPrefetch: (props: unknown) => {
+    recorded.prefetch(props);
+    return null;
+  },
+}));
+vi.mock('../../board-controls/ResetZoomButton', () => ({ ResetZoomButton: () => null }));
+
+import { SwipeBoardCarousel } from '../SwipeBoardCarousel';
+
+const baseProps = {
+  boardName: 'kilter' as const,
+  boardRenderData: { boardWidth: 1000, boardHeight: 2000 },
+  layoutId: 1,
+  sizeId: 10,
+  setIds: '1,20',
+  currentFrames: 'current',
+  nextFrames: 'next',
+  prevFrames: null,
+  mirrored: false,
+  canSwipeNext: true,
+  canSwipePrevious: false,
+  onSwipeNext: vi.fn(),
+  onSwipePrevious: vi.fn(),
+};
+
+function measure(width: number, height: number) {
+  const onLayout = recorded.onLayout;
+  if (!onLayout) throw new Error('Carousel measurement container is missing');
+  act(() => onLayout({ nativeEvent: { layout: { x: 0, y: 0, width, height } } } as LayoutChangeEvent));
+}
+
+function expectDimensions(element: HTMLElement, width: number, height: number) {
+  expect(element.dataset.width).toBe(String(width));
+  expect(element.dataset.height).toBe(String(height));
+}
+
+beforeEach(() => {
+  recorded.onLayout = undefined;
+  recorded.prefetch.mockClear();
+  vi.stubEnv('EXPO_PUBLIC_SCREENSHOT_MODE', '0');
+});
+afterEach(() => vi.unstubAllEnvs());
+
+describe.each(['0', '1'])('SwipeBoardCarousel layout (screenshot mode %s)', (screenshotMode) => {
+  it('withholds cached images and prefetch until both dimensions are positive', () => {
+    vi.stubEnv('EXPO_PUBLIC_SCREENSHOT_MODE', screenshotMode);
+    const { queryAllByTestId, getByTestId } = render(createElement(SwipeBoardCarousel, baseProps));
+    expect(getByTestId('play-drawer-board-container')).toBeTruthy();
+    expect(queryAllByTestId(/^board-/)).toHaveLength(0);
+    expect(recorded.prefetch).not.toHaveBeenCalled();
+
+    measure(350, 0);
+    expect(queryAllByTestId(/^board-/)).toHaveLength(0);
+    expect(recorded.prefetch).not.toHaveBeenCalled();
+
+    measure(350, 500);
+    expectDimensions(getByTestId('board-current'), 250, 500);
+    expectDimensions(getByTestId('board-next'), 250, 500);
+    expect(getByTestId('board-current').dataset.renderWidth).toBe('750');
+    if (screenshotMode === '0') {
+      expect(recorded.prefetch).toHaveBeenLastCalledWith(expect.objectContaining({ renderWidth: 750 }));
+      const zoomWrapper = getByTestId('board-current').parentElement!;
+      expectDimensions(zoomWrapper, 250, 500);
+      expectDimensions(zoomWrapper.parentElement!, 250, 500);
+    } else {
+      expect(recorded.prefetch).not.toHaveBeenCalled();
+    }
+  });
+
+  it('resizes a mounted board for rotation or a narrower iPad pane without a placeholder', () => {
+    vi.stubEnv('EXPO_PUBLIC_SCREENSHOT_MODE', screenshotMode);
+    const { getByTestId } = render(createElement(SwipeBoardCarousel, baseProps));
+    measure(350, 500);
+    const currentImage = getByTestId('board-current');
+
+    measure(200, 600);
+    expect(getByTestId('board-current')).toBe(currentImage);
+    expectDimensions(currentImage, 200, 400);
+    expectDimensions(getByTestId('board-next'), 200, 400);
+    expect(currentImage.dataset.renderWidth).toBe('600');
+  });
+});
+
+it('contains a wide board and updates climbs without remounting the current image', () => {
+  const props = { ...baseProps, boardRenderData: { boardWidth: 2000, boardHeight: 1000 } };
+  const { getByTestId, rerender } = render(createElement(SwipeBoardCarousel, props));
+  measure(350, 500);
+  const currentImage = getByTestId('board-current');
+  expectDimensions(currentImage, 350, 175);
+
+  rerender(createElement(SwipeBoardCarousel, { ...props, currentFrames: 'another-climb' }));
+  expect(getByTestId('board-another-climb')).toBe(currentImage);
+  expectDimensions(currentImage, 350, 175);
+});

--- a/packages/mobile/src/components/play-drawer/play-drawer-layout.ts
+++ b/packages/mobile/src/components/play-drawer/play-drawer-layout.ts
@@ -12,7 +12,7 @@ export type BoardBox = { width: number; height: number };
  * Contain a board of the given aspect ratio within a box, preserving aspect
  * ratio and centering. Letterboxes horizontally on tall (portrait) boards and
  * vertically on wide ones. Returns null when the box or aspect ratio isn't
- * measurable yet (pre-layout), so callers fall back to a full-bleed default.
+ * measurable yet (pre-layout), so callers can wait before mounting board art.
  *
  * `aspectRatio` is width / height.
  */


### PR DESCRIPTION
## Summary

The play drawer could paint cached board art before its container was measured, then resize it during the native opening animation. It now waits for the viewport and header measurements, mounts images only at their contained size, and gives the zoom wrapper explicit dimensions. Scroll indicators are hidden while scrolling remains available.

Validation: CI tests, typechecking, lint, native mobile bundles, translation checks, and the PR test-plan gate passed on the rebased commit. The standard local pre-commit hooks also passed. Native iOS animation QA remains pending because the author environment is Linux.

Automated review is blocked by the reviewer account's weekly quota, which resets September 12 at 07:00 UTC. The PR remains draft and subscribed to feedback.

## Release Notes

Open climbs with a steady board image and no scrollbar.

## Test plan

1. Climbs → open a climb → board appears without growing.
2. Reopen the play drawer ten times → board size stays steady.
3. Scroll the play drawer → details move without a scrollbar.
4. Pinch and swipe the board → zoom and climb navigation work.
5. Rotate iPad → board fits the resized pane.

## Risk

Risk: 2/5 — isolated drawer layout changes with regression tests; iOS animation QA pending.
