### PR TITLE
fix(backend): guard every S3 body pipe so an aborted read can't kill the replica

### DIFF
--- a/packages/backend/src/__tests__/media-stream-pipe.test.ts
+++ b/packages/backend/src/__tests__/media-stream-pipe.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { once } from 'node:events';
+import { Readable } from 'node:stream';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const isS3ConfiguredMock = vi.hoisted(() => vi.fn(() => true));
+const getFromS3Mock = vi.hoisted(() => vi.fn());
+const validateTokenMock = vi.hoisted(() => vi.fn());
+const getDownloadableUserDataExportMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../storage/s3', async () => {
+  const actual = await vi.importActual<typeof import('../storage/s3')>('../storage/s3');
+  return { ...actual, isS3Configured: isS3ConfiguredMock, getFromS3: getFromS3Mock };
+});
+
+vi.mock('../middleware/auth', () => ({
+  validateToken: validateTokenMock,
+}));
+
+vi.mock('../services/user-data-export', () => ({
+  getDownloadableUserDataExport: getDownloadableUserDataExportMock,
+  getUserDataExportStatus: vi.fn(),
+  requestUserDataExport: vi.fn(),
+}));
+
+const { handleStaticBetaThumbnail } = await import('../handlers/static');
+const { handleUserDataExportDownload } = await import('../handlers/user-data-export');
+const { logger } = await import('../utils/logger');
+
+const THUMBNAIL_PATH = '/static/beta-link-thumbnails/instagram/ABC123.jpg';
+const EXPORT_PATH = '/api/user-data-export/download?boardType=kilter';
+
+// Declared Content-Length far larger than the bytes we actually push, so a
+// truncated response is unambiguous to the client's HTTP parser.
+const DECLARED_LENGTH = 4096;
+const FIRST_CHUNK = Buffer.alloc(16, 0x41);
+
+type RequestOutcome = {
+  response: Response;
+  serverResponse: ServerResponse;
+};
+
+/**
+ * A body that delivers one chunk and then dies the way an R2 read does when the
+ * backend→R2 TLS connection closes early: `destroy(new Error('aborted'))` on the
+ * source, which `readable.pipe(dest)` does not listen for.
+ */
+function abortingSource(): Readable {
+  let started = false;
+  const stream = new Readable({
+    read() {
+      if (started) return;
+      started = true;
+      this.push(FIRST_CHUNK);
+      setTimeout(() => this.destroy(new Error('aborted')), 25);
+    },
+  });
+  return stream;
+}
+
+/** A body that delivers one chunk and then stalls, so the client can abort first. */
+function stallingSource(): Readable {
+  let started = false;
+  return new Readable({
+    read() {
+      if (started) return;
+      started = true;
+      this.push(FIRST_CHUNK);
+    },
+  });
+}
+
+function s3Object(stream: Readable) {
+  return { stream, contentType: 'image/jpeg', contentLength: DECLARED_LENGTH };
+}
+
+async function startServer(handle: (req: IncomingMessage, res: ServerResponse) => Promise<void>) {
+  let lastResponse: ServerResponse | undefined;
+  const server = createServer((req, res) => {
+    lastResponse = res;
+    void handle(req, res);
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const { port } = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    server,
+    getLastResponse: () => lastResponse,
+  };
+}
+
+function closeServer(server: Server): Promise<void> {
+  // closeAllConnections first: an unguarded pipe leaves the response open
+  // forever, and `close()` alone would wait on it and hang the suite.
+  server.closeAllConnections();
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+/**
+ * Client-side deadline. Well past the ~25ms the fixed handler needs to tear a
+ * failed body down, and short enough that an unguarded pipe (which leaves the
+ * response hanging below its Content-Length) fails fast instead of stalling.
+ */
+const CLIENT_DEADLINE_MS = 2000;
+
+/**
+ * Run `body` with `process.on('uncaughtException')` swapped for a recorder, so a
+ * stream error thrown out of a `nextTick` is captured instead of taking down the
+ * worker. Node's own listeners are restored with `rawListeners`, which preserves
+ * `once` wrappers.
+ */
+async function recordUncaughtExceptions(body: () => Promise<void>): Promise<Error[]> {
+  const recorded: Error[] = [];
+  const original = process.rawListeners('uncaughtException') as NodeJS.UncaughtExceptionListener[];
+  process.removeAllListeners('uncaughtException');
+  process.on('uncaughtException', (error) => {
+    recorded.push(error);
+  });
+
+  try {
+    await body();
+    // Let a queued `emitErrorNT` land before we hand the process back.
+    await delay(100);
+  } finally {
+    process.removeAllListeners('uncaughtException');
+    for (const listener of original) process.on('uncaughtException', listener);
+  }
+
+  return recorded;
+}
+
+let infoSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  isS3ConfiguredMock.mockReturnValue(true);
+  infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+  warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe('media streaming: an S3 body that fails mid-response', () => {
+  it('does not reach process.on(uncaughtException) when the R2 read aborts', async () => {
+    getFromS3Mock.mockResolvedValue(s3Object(abortingSource()));
+
+    const { baseUrl, server, getLastResponse } = await startServer((req, res) =>
+      handleStaticBetaThumbnail(req, res, 'instagram', 'ABC123.jpg'),
+    );
+
+    let outcome: RequestOutcome | undefined;
+    try {
+      const recorded = await recordUncaughtExceptions(async () => {
+        const response = await fetch(`${baseUrl}${THUMBNAIL_PATH}`, {
+          signal: AbortSignal.timeout(CLIENT_DEADLINE_MS),
+        });
+        expect(response.status).toBe(200);
+        // The body is cut below its Content-Length, so the read fails.
+        await expect(response.arrayBuffer()).rejects.toThrow();
+        outcome = { response, serverResponse: getLastResponse() as ServerResponse };
+      });
+
+      expect(recorded.map((error) => error.message)).toEqual([]);
+    } finally {
+      await closeServer(server);
+    }
+
+    const serverResponse = outcome?.serverResponse;
+    expect(serverResponse).toBeDefined();
+    // Destroyed, never `end()`ed: a truncated body must not look complete.
+    expect(serverResponse?.destroyed).toBe(true);
+    expect(serverResponse?.writableEnded).toBe(false);
+  });
+
+  it('logs the failed read with its route and object key', async () => {
+    getFromS3Mock.mockResolvedValue(s3Object(abortingSource()));
+
+    const { baseUrl, server } = await startServer((req, res) =>
+      handleStaticBetaThumbnail(req, res, 'instagram', 'ABC123.jpg'),
+    );
+
+    try {
+      await recordUncaughtExceptions(async () => {
+        const response = await fetch(`${baseUrl}${THUMBNAIL_PATH}`, {
+          signal: AbortSignal.timeout(CLIENT_DEADLINE_MS),
+        });
+        await expect(response.arrayBuffer()).rejects.toThrow();
+      });
+    } finally {
+      await closeServer(server);
+    }
+
+    // `aborted` is whitelisted in isClientAbortError, so this classifies as an
+    // abort and logs at info — the point is that it is logged, with the key,
+    // instead of killing the replica.
+    const logged = [...infoSpy.mock.calls, ...warnSpy.mock.calls];
+    expect(logged.length).toBeGreaterThan(0);
+    const streamLog = logged.find((call) => String(call[0]).startsWith('Stream to client'));
+    expect(streamLog).toBeDefined();
+    expect(streamLog?.[1]).toMatchObject({
+      route: THUMBNAIL_PATH,
+      source: 'beta-link-thumbnails/instagram/ABC123.jpg',
+    });
+  });
+
+  it('guards the user-data-export download too', async () => {
+    validateTokenMock.mockResolvedValue({ userId: 'user-123' });
+    getDownloadableUserDataExportMock.mockResolvedValue({
+      key: 'user-data-exports/user-123/kilter.json',
+      filename: 'kilter-export.json',
+      stream: abortingSource(),
+      contentType: 'application/json',
+      contentLength: DECLARED_LENGTH,
+    });
+
+    const { baseUrl, server, getLastResponse } = await startServer((req, res) =>
+      handleUserDataExportDownload(req, res, new URL(EXPORT_PATH, 'http://127.0.0.1')),
+    );
+
+    try {
+      const recorded = await recordUncaughtExceptions(async () => {
+        const response = await fetch(`${baseUrl}${EXPORT_PATH}`, {
+          headers: { Authorization: 'Bearer export-token' },
+          signal: AbortSignal.timeout(CLIENT_DEADLINE_MS),
+        });
+        expect(response.status).toBe(200);
+        await expect(response.arrayBuffer()).rejects.toThrow();
+      });
+
+      expect(recorded.map((error) => error.message)).toEqual([]);
+      expect(getLastResponse()?.destroyed).toBe(true);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});
+
+describe('media streaming: a client that walks away mid-download', () => {
+  it('destroys the S3 source and logs at info, not warn', async () => {
+    const source = stallingSource();
+    getFromS3Mock.mockResolvedValue(s3Object(source));
+
+    const { baseUrl, server } = await startServer((req, res) =>
+      handleStaticBetaThumbnail(req, res, 'instagram', 'ABC123.jpg'),
+    );
+
+    try {
+      const abortController = new AbortController();
+      const response = await fetch(`${baseUrl}${THUMBNAIL_PATH}`, { signal: abortController.signal });
+      const reader = response.body?.getReader();
+      expect(reader).toBeDefined();
+      await reader?.read();
+      abortController.abort();
+      await reader?.cancel().catch(() => {});
+
+      // Give the server's end-of-stream detection a tick to fire.
+      for (let attempt = 0; attempt < 50 && !source.destroyed; attempt += 1) {
+        await delay(10);
+      }
+    } finally {
+      await closeServer(server);
+    }
+
+    // Without pipeline this upstream socket would keep draining into a dead
+    // response; with it, the client's disconnect tears the S3 read down.
+    expect(source.destroyed).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(
+      'Stream to client aborted',
+      expect.objectContaining({ route: THUMBNAIL_PATH }),
+    );
+  });
+});

--- a/packages/backend/src/handlers/http-utils.ts
+++ b/packages/backend/src/handlers/http-utils.ts
@@ -1,4 +1,8 @@
 import type { IncomingMessage, ServerResponse } from 'http';
+import type { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { isClientAbortError } from '../utils/http-errors';
+import { logger } from '../utils/logger';
 
 /**
  * Read a request body as a UTF-8 string, rejecting (and destroying the socket)
@@ -43,4 +47,64 @@ export function sendJson(
     ...extraHeaders,
   });
   res.end(JSON.stringify(body));
+}
+
+/** Where the bytes came from, so a failure is triageable from one log line. */
+export type StreamPipeContext = {
+  /** Request path being served, e.g. `/static/beta-link-thumbnails/instagram/abc.jpg`. */
+  route: string;
+  /** Object key or local file path the bytes were read from. */
+  source: string;
+};
+
+/**
+ * Stream a body (an S3 object, a local file) to the response with both ends
+ * guarded.
+ *
+ * `readable.pipe(res)` attaches an `'error'` listener to the *destination
+ * only*, so a source that fails mid-body emits an unhandled `'error'` — which
+ * Node throws from a `nextTick`, landing on `process.on('uncaughtException')`
+ * and killing the process along with every graphql-ws session on the replica
+ * (issue #5307). The request handler's `try/catch` can't help: its `await`
+ * resolved when the *headers* arrived, long before the body died.
+ *
+ * `pipeline` listens on both streams and destroys both on failure, which also
+ * closes the reverse leak — a client that disconnects mid-download no longer
+ * leaves the upstream S3 socket draining into a dead response.
+ *
+ * Never resolves before the body is fully flushed (or has failed), and never
+ * rejects: callers keep their existing control flow.
+ */
+export async function pipeStreamToResponse(
+  source: Readable,
+  res: ServerResponse,
+  context: StreamPipeContext,
+): Promise<void> {
+  try {
+    await pipeline(source, res);
+  } catch (error) {
+    const clientAborted = isClientAbortError(error, {
+      responseDestroyed: res.destroyed,
+      socketDestroyed: res.socket?.destroyed,
+    });
+
+    // A client walking away is routine; anything else is an upstream read we
+    // could not finish, and someone got a truncated file.
+    const details = { route: context.route, source: context.source, headersSent: res.headersSent };
+    if (clientAborted) {
+      logger.info('Stream to client aborted', details);
+    } else {
+      logger.warn('Stream to client failed', details, error);
+    }
+
+    // Past the headers there is no status left to send: `writeHead` would throw
+    // ERR_HTTP_HEADERS_SENT (a second crash) and `res.end()` would hand back a
+    // short body as if it were complete. Destroying truncates the response below
+    // its Content-Length, so the client's parser errors and no cache stores it.
+    if (!res.headersSent) {
+      sendJson(res, 502, { error: 'Upstream read failed' });
+    } else {
+      res.destroy();
+    }
+  }
 }

--- a/packages/backend/src/handlers/static.ts
+++ b/packages/backend/src/handlers/static.ts
@@ -3,6 +3,7 @@ import { createReadStream } from 'fs';
 import { stat } from 'fs/promises';
 import path, { extname } from 'path';
 import { applyCorsHeaders } from './cors';
+import { pipeStreamToResponse } from './http-utils';
 import { getAvatarsDir } from './avatars';
 import { getGymLogosDir } from './gym-logos';
 import { getGymPhotosDir } from './gym-photos';
@@ -34,17 +35,18 @@ async function serveResizedImageFromS3(
   res: ServerResponse,
   baseKey: string,
   size: AllowedImageSize,
-  options: { cacheVariant: boolean; cacheControl: string },
+  options: { cacheVariant: boolean; cacheControl: string; route: string },
 ): Promise<boolean> {
   if (options.cacheVariant) {
-    const cached = await getFromS3('media', resizedVariantKey(baseKey, size));
+    const variantKey = resizedVariantKey(baseKey, size);
+    const cached = await getFromS3('media', variantKey);
     if (cached) {
       res.writeHead(200, {
         'Content-Type': cached.contentType || 'image/jpeg',
         ...(cached.contentLength && { 'Content-Length': cached.contentLength }),
         'Cache-Control': options.cacheControl,
       });
-      cached.stream.pipe(res);
+      await pipeStreamToResponse(cached.stream, res, { route: options.route, source: variantKey });
       return true;
     }
   }
@@ -117,6 +119,7 @@ export async function handleStaticAvatar(
       const served = await serveResizedImageFromS3(res, s3Key, size, {
         cacheVariant: false,
         cacheControl: 'public, max-age=86400',
+        route: req.url ?? '/static/avatars',
       });
       if (!served) {
         res.writeHead(404, { 'Content-Type': 'application/json' });
@@ -142,8 +145,8 @@ export async function handleStaticAvatar(
       'Cache-Control': 'public, max-age=86400', // 1 day
     });
 
-    // Pipe the S3 stream to the response
-    s3Object.stream.pipe(res);
+    // Pipe the S3 stream to the response, guarding both ends.
+    await pipeStreamToResponse(s3Object.stream, res, { route: req.url ?? '/static/avatars', source: s3Key });
     return;
   }
 
@@ -186,7 +189,10 @@ export async function handleStaticAvatar(
       'Last-Modified': fileStat.mtime.toUTCString(),
     });
 
-    createReadStream(filePath).pipe(res);
+    await pipeStreamToResponse(createReadStream(filePath), res, {
+      route: req.url ?? filePath,
+      source: filePath,
+    });
   } catch {
     res.writeHead(404, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: 'Not found' }));
@@ -233,6 +239,7 @@ async function serveStaticGymImage(
       const served = await serveResizedImageFromS3(res, s3Key, size, {
         cacheVariant: false,
         cacheControl: 'public, max-age=86400',
+        route: req.url ?? `/static/${s3Prefix}`,
       });
       if (!served) {
         res.writeHead(404, { 'Content-Type': 'application/json' });
@@ -258,7 +265,7 @@ async function serveStaticGymImage(
       'Cache-Control': 'public, max-age=86400', // 1 day
     });
 
-    s3Object.stream.pipe(res);
+    await pipeStreamToResponse(s3Object.stream, res, { route: req.url ?? `/static/${s3Prefix}`, source: s3Key });
     return;
   }
 
@@ -297,7 +304,10 @@ async function serveStaticGymImage(
       'Last-Modified': fileStat.mtime.toUTCString(),
     });
 
-    createReadStream(filePath).pipe(res);
+    await pipeStreamToResponse(createReadStream(filePath), res, {
+      route: req.url ?? filePath,
+      source: filePath,
+    });
   } catch {
     res.writeHead(404, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: 'Not found' }));
@@ -373,6 +383,7 @@ export async function handleStaticBetaThumbnail(
     const served = await serveResizedImageFromS3(res, s3Key, size, {
       cacheVariant: true,
       cacheControl: 'public, max-age=31536000, immutable',
+      route: req.url ?? '/static/beta-link-thumbnails',
     });
     if (!served) {
       res.writeHead(404, { 'Content-Type': 'application/json' });
@@ -397,5 +408,8 @@ export async function handleStaticBetaThumbnail(
     'Cache-Control': 'public, max-age=31536000, immutable',
   });
 
-  s3Object.stream.pipe(res);
+  await pipeStreamToResponse(s3Object.stream, res, {
+    route: req.url ?? '/static/beta-link-thumbnails',
+    source: s3Key,
+  });
 }

--- a/packages/backend/src/handlers/user-data-export.ts
+++ b/packages/backend/src/handlers/user-data-export.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import { applyCorsHeaders } from './cors';
+import { pipeStreamToResponse } from './http-utils';
 import { validateToken } from '../middleware/auth';
 import { isAuroraBoardType } from '../services/user-data-export-format';
 import {
@@ -108,5 +109,8 @@ export async function handleUserDataExportDownload(req: IncomingMessage, res: Se
     ...(file.contentLength != null ? { 'Content-Length': String(file.contentLength) } : {}),
   });
 
-  file.stream.pipe(res);
+  await pipeStreamToResponse(file.stream, res, {
+    route: '/api/user-data-export/download',
+    source: file.key,
+  });
 }


### PR DESCRIPTION
## Summary

Fixes #5307.

A media read from R2 that died mid-body took the whole realtime backend replica
with it, and every graphql-ws session on it — party mode, kiosk presence,
notifications. Sentry logged ~8 such exits over three weeks (BOARDSESH-BX,
`Error: aborted` on `/static/beta-link-thumbnails/instagram/*.jpg`).

`readable.pipe(res)` attaches an `'error'` listener to the **destination only**.
When the backend→R2 connection closed before the body was complete, the S3 body
emitted an unhandled `'error'`, Node threw it from a `nextTick`, and it landed on
`process.on('uncaughtException')`. The handler's own `try/catch` never saw it:
`getFromS3` resolves when the *headers* arrive, so the `await` was long done by
the time the body failed.

New `pipeStreamToResponse(source, res, context)` in `handlers/http-utils.ts` runs
`await pipeline(source, res)` (`node:stream/promises`), which listens on both
streams and destroys both on failure. Every S3 and local-file pipe now goes
through it: the four `/static/*` proxy bodies, the two local-dev
`createReadStream` bodies, and `GET /api/user-data-export/download` — the one
route that was never covered by the `MEDIA_PUBLIC_BASE_URL` 302 mitigation
(af449ccd5) and so is still live today.

Failures are classified with the existing `isClientAbortError`: a client walking
away logs at `info`, anything else at `warn`, both with the route and the object
key so a log line is enough to triage. Past the headers it destroys the response
rather than writing a status — `writeHead` would throw `ERR_HTTP_HEADERS_SENT`
(a second crash) and `res.end()` would present a truncated body as complete.
Destroying truncates below `Content-Length`, so the client's parser errors and
no cache stores a partial object.

`pipeline` also closes the reverse leak: a client that disconnects mid-download
no longer leaves the upstream R2 socket draining into a dead response.

The `/static/*` proxy bodies stay in place — they are the documented rollback
path for unsetting `MEDIA_PUBLIC_BASE_URL`. `/og/climb` buffers and the four
`req.pipe(busboy)` uploads already have `busboy.on('error')`, so neither is
touched. No schema, env or route changes.

**Verification.** New `media-stream-pipe.test.ts` serves a real loopback request
whose mocked S3 body pushes one chunk then `destroy(new Error('aborted'))`, with
`process.on('uncaughtException')` swapped for a recorder. Confirmed red on this
branch with the handler change stashed — all four tests failed and the recorder
captured `Error: aborted` on both the thumbnail route and the export route — and
green with the change applied. It also asserts the response is destroyed and
never `end()`ed, and that a client aborting mid-body tears the S3 source down and
logs at `info`. `vp run typecheck:backend` passes; `vp check` reports the same
2 errors / 367 warnings as the base commit, none of them in this diff.

## Release Notes

Party sessions no longer drop out from under you. A hiccup fetching a beta
thumbnail or an avatar used to take down the server everyone in the session was
connected to — mid-climb, mid-queue. Now a bad image read is just a bad image
read: your session, the kiosk board and your notifications keep running.

## Test plan

1. Open a climb with beta videos. Thumbnails load.
2. Start a party session with a friend. Both see the queue.
3. Scroll the feed for a minute. Session stays connected.
4. Tap a profile photo anywhere. Avatar loads.

## Risk

Risk: 3/5 — touches every media-serving handler on the backend, including the
live data-export download. No schema or route changes, and the `/static/*` proxy
bodies stay unchanged behind the existing CDN redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
