### PR TITLE
fix(sync): stop dead-lettering a queued send on two transport failures

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -357,11 +357,12 @@ async function processMutation(mutation: PendingMutation) {
 The shipped classifier
 (`packages/shared/offline-sync/src/mutation-queue/error-classification.ts`) inverts that sketch's
 last default. The sketch dead-letters anything it does not recognise; the real one **retries anything
-it does not recognise**, and only `isPermanentRejection` — a resolved 400 / 403 / 405 / 409 / 410 /
-413 / 415 / 422 — blocks a replay. 404 is not in that set: this client posts GraphQL to one endpoint
-and a GraphQL server reports not-found as HTTP 200 with an `errors` array, so a 404 can only be an
-edge/proxy routing failure and joins 502/503/504 in `isServerUnavailableError`. See "Drainer safety"
-below.
+it does not recognise**, and only `isPermanentRejection` blocks a replay — a resolved
+400 / 403 / 405 / 409 / 410 / 413 / 415 / 422, or, on an HTTP 200, a `BAD_USER_INPUT` /
+`GRAPHQL_VALIDATION_FAILED` / `BAD_REQUEST` / `FORBIDDEN` extension code. 404 is in neither set: this
+client posts GraphQL to one endpoint and a GraphQL server reports not-found as HTTP 200 with an
+`errors` array, so a 404 can only be an edge/proxy routing failure and joins 502/503/504 in
+`isServerUnavailableError`. See "Drainer safety" below.
 
 ### Queue trigger points
 
@@ -515,8 +516,14 @@ rejects is itself "server down". The backend also answers connection-class DB fa
 503.
 
 **Default-retry (#5295).** `isRetryable` no longer dead-letters an error it cannot place. It returns
-`!isPermanentRejection(error)`, so only a resolved 400 / 403 / 405 / 409 / 410 / 413 / 415 / 422 —
-a server's permanent verdict on this exact request — stops a replay. The old
+`!isPermanentRejection(error)`, so only a server's permanent verdict on this exact request stops a
+replay. That verdict is read two ways, because GraphQL has no way to put one in the status line: a
+resolved 400 / 403 / 405 / 409 / 410 / 413 / 415 / 422, or — on an HTTP 200 — one of the
+`PERMANENT_GRAPHQL_ERROR_CODES` (`BAD_USER_INPUT`, `GRAPHQL_VALIDATION_FAILED`, `BAD_REQUEST`,
+`FORBIDDEN`) in the `errors` array. A code on a **non-2xx** response is ignored: that body is an edge
+error page, not a resolver's answer. `RATE_LIMITED` is deliberately absent — it is a "later", not a
+"never" (#4711) — and so is the masked `INTERNAL_SERVER_ERROR`, decided retryable before this check
+runs (#4862). An unrecognised code stays retryable; default-retry still governs the unknown. The old
 `status === null → dead-letter` default lost a queued write on attempt 0 of 10 four separate times
 (#4099 truncated 2xx body, #4027 bare NSURL prose, #4711 string `RATE_LIMITED`, #5295
 `TypeError: Network request timed out`), and each fix taught the classifier one more shape rather

--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -261,7 +261,8 @@ async function drainMutationQueue(db: SQLiteDatabase) {
           }
           break; // stop processing, retry later
         }
-        // Non-retryable (validation error, 404, 409): move to dead letter
+        // Non-retryable — a permanent server verdict on this request (400,
+        // 409, 422). NOT 404: see the classifier note below.
         await db.runAsync(`UPDATE pending_mutations SET status = 'dead_letter', last_error = ? WHERE id = ?`, [
           error.message,
           mutation.id,
@@ -352,6 +353,15 @@ async function processMutation(mutation: PendingMutation) {
   }
 }
 ```
+
+The shipped classifier
+(`packages/shared/offline-sync/src/mutation-queue/error-classification.ts`) inverts that sketch's
+last default. The sketch dead-letters anything it does not recognise; the real one **retries anything
+it does not recognise**, and only `isPermanentRejection` — a resolved 400 / 403 / 405 / 409 / 410 /
+413 / 415 / 422 — blocks a replay. 404 is not in that set: this client posts GraphQL to one endpoint
+and a GraphQL server reports not-found as HTTP 200 with an `errors` array, so a 404 can only be an
+edge/proxy routing failure and joins 502/503/504 in `isServerUnavailableError`. See "Drainer safety"
+below.
 
 ### Queue trigger points
 
@@ -499,9 +509,30 @@ dropped from error reporting (a local decision, not a failure); the store emits 
 `Backend Reachability Changed` event per real edge instead.
 
 **Drainer safety.** The shared classifier now treats the masked `INTERNAL_SERVER_ERROR` shape as
-retryable, 502/503/504 as a network stop (no `retry_count` strike), and a 500 asks the store's deduped
-probe (`DrainOptions.confirmServerAvailability`) before charging the mutation; a probe that rejects is
-itself "server down". The backend also answers connection-class DB failures with an honest 503.
+retryable, 404/502/503/504 as a network stop (no `retry_count` strike), and a 500 asks the store's
+deduped probe (`DrainOptions.confirmServerAvailability`) before charging the mutation; a probe that
+rejects is itself "server down". The backend also answers connection-class DB failures with an honest
+503.
+
+**Default-retry (#5295).** `isRetryable` no longer dead-letters an error it cannot place. It returns
+`!isPermanentRejection(error)`, so only a resolved 400 / 403 / 405 / 409 / 410 / 413 / 415 / 422 —
+a server's permanent verdict on this exact request — stops a replay. The old
+`status === null → dead-letter` default lost a queued write on attempt 0 of 10 four separate times
+(#4099 truncated 2xx body, #4027 bare NSURL prose, #4711 string `RATE_LIMITED`, #5295
+`TypeError: Network request timed out`), and each fix taught the classifier one more shape rather
+than changing the default. Being wrong the new way is bounded: `recordFailure` flips the row to
+`dead_letter` in the same atomic UPDATE that passes `max_retries`, so a genuine bad payload still
+surfaces — as `retries_exhausted` after ten attempts instead of `non_retryable` after one.
+
+Two precision layers sit in front of that backstop so the common shapes cost zero strikes rather than
+ten: `network request timed out` is a transport marker (whatwg-fetch's `xhr.ontimeout` sibling of
+`network request failed`), and an edge 404 is a server-unavailable verdict. Both reach the drainer's
+`networkStop`, which leaves the row pending and drains it on reconnect — the backstop alone would let
+a row burn all ten strikes inside one cycle's 30 s-capped backoff, in under a minute.
+
+Rows already at `status='dead_letter'` from those shapes are **not** revived by the classifier change.
+`retryDeadLetter` (`mutation-queue/queue.ts`) and the More → Sync issues → Retry button are the manual
+path.
 
 **What the climber sees.** One bottom banner (`components/connectivity/ConnectivityBanner.tsx`,
 folded into the bottom-chrome geometry so FABs, snackbars and toasts stack above it): "We're having

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -76,6 +76,8 @@ export {
   hasGraphqlErrorCode,
   isServerUnavailableError,
   isServerFailureSignal,
+  isPermanentRejection,
+  PERMANENT_REJECTION_STATUSES,
 } from './mutation-queue/error-classification';
 
 // --- Pull sync -----------------------------------------------------------------

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -78,6 +78,7 @@ export {
   isServerFailureSignal,
   isPermanentRejection,
   PERMANENT_REJECTION_STATUSES,
+  PERMANENT_GRAPHQL_ERROR_CODES,
 } from './mutation-queue/error-classification';
 
 // --- Pull sync -----------------------------------------------------------------

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer.test.ts
@@ -46,6 +46,21 @@ const mockIsServerUnavailableError = isServerUnavailableError as ReturnType<type
 const mockIsServerFailureSignal = isServerFailureSignal as ReturnType<typeof vi.fn>;
 const mockGetErrorStatus = getErrorStatus as ReturnType<typeof vi.fn>;
 
+// The suite mocks the classifier so each branch can be driven in isolation. The
+// #5295 cases below need the opposite: the REAL predicates, so the assertion is
+// that a genuine transport shape reaches the drainer's no-strike branch rather
+// than that a hand-set boolean does.
+const realClassification = await vi.importActual<typeof import('../error-classification')>('../error-classification');
+
+function useRealClassification(): void {
+  mockIsGraphQLEmptyResponseError.mockImplementation(realClassification.isGraphQLEmptyResponseError);
+  mockIsRetryable.mockImplementation(realClassification.isRetryable);
+  mockIsNetworkError.mockImplementation(realClassification.isNetworkError);
+  mockIsServerUnavailableError.mockImplementation(realClassification.isServerUnavailableError);
+  mockIsServerFailureSignal.mockImplementation(realClassification.isServerFailureSignal);
+  mockGetErrorStatus.mockImplementation(realClassification.getErrorStatus);
+}
+
 // Always online unless a test opts out — matches the onlineManager default and
 // keeps every existing drain-behaviour test running as before.
 const ONLINE = { isOnline: () => true } as const;
@@ -700,6 +715,83 @@ describe('drainMutationQueue', () => {
     expect(delays[0]).toBeLessThanOrEqual(100);
 
     randomSpy.mockRestore();
+  });
+
+  // Issue #5295: two transport shapes the classifier did not recognise reached
+  // the else-branch below `isRetryable` and were dead-lettered as
+  // `non_retryable` on attempt 0 of 10 — a logged send, gone. These run against
+  // the REAL classifier so the drainer branch, not a mock, is what is pinned.
+  describe('transport shapes that used to dead-letter a queued send (issue #5295)', () => {
+    it('leaves the row pending when fetch times out (TypeError: Network request timed out)', async () => {
+      useRealClassification();
+      const mutation = makeMutation({ id: 1 });
+      // No trailing empty peek: a network stop ends the cycle, so an unconsumed
+      // mockResolvedValueOnce would leak into the next test.
+      mockPeekPending.mockResolvedValueOnce([mutation]);
+      mockProcessMutation.mockRejectedValueOnce(new TypeError('Network request timed out'));
+      const onMutationDeadLettered = vi.fn();
+
+      await drainMutationQueue(mockDb, createMockQueryClient(), mockGraphqlFetch, {
+        ...ONLINE,
+        onMutationDeadLettered,
+      });
+
+      expect(mockRecordFailure).not.toHaveBeenCalled();
+      expect(mockMarkDeadLetter).not.toHaveBeenCalled();
+      expect(mockMarkCompleted).not.toHaveBeenCalled();
+      expect(onMutationDeadLettered).not.toHaveBeenCalled();
+      // One pass: the cycle ends to wait for reconnectivity.
+      expect(mockPeekPending).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves the row pending when an edge answers 404 instead of the GraphQL endpoint', async () => {
+      useRealClassification();
+      const mutation = makeMutation({ id: 1 });
+      mockPeekPending.mockResolvedValueOnce([mutation]);
+      mockProcessMutation.mockRejectedValueOnce(
+        Object.assign(new Error('Application not found: POST /graphql'), {
+          response: { status: 404, error: '{"code":404,"message":"Application not found"}' },
+        }),
+      );
+      const onMutationDeadLettered = vi.fn();
+      const confirmServerAvailability = vi.fn().mockResolvedValue(true);
+
+      await drainMutationQueue(mockDb, createMockQueryClient(), mockGraphqlFetch, {
+        ...ONLINE,
+        onMutationDeadLettered,
+        confirmServerAvailability,
+      });
+
+      // Same shape as the 503 case: the unavailable branch pre-empts both the
+      // health probe and the retry bookkeeping.
+      expect(confirmServerAvailability).not.toHaveBeenCalled();
+      expect(mockRecordFailure).not.toHaveBeenCalled();
+      expect(mockMarkDeadLetter).not.toHaveBeenCalled();
+      expect(mockMarkCompleted).not.toHaveBeenCalled();
+      expect(onMutationDeadLettered).not.toHaveBeenCalled();
+      expect(mockPeekPending).toHaveBeenCalledTimes(1);
+    });
+
+    it('still dead-letters a real 400 as non_retryable — default-retry did not become retry-everything', async () => {
+      useRealClassification();
+      const mutation = makeMutation({ id: 3, idempotency_key: 'invalid-tick', retry_count: 1 });
+      mockPeekPending.mockResolvedValueOnce([mutation]).mockResolvedValueOnce([]);
+      mockProcessMutation.mockRejectedValueOnce(
+        Object.assign(new Error('400 Bad Request'), { response: { status: 400 } }),
+      );
+      const onMutationDeadLettered = vi.fn();
+
+      await drainMutationQueue(mockDb, createMockQueryClient(), mockGraphqlFetch, {
+        ...ONLINE,
+        onMutationDeadLettered,
+      });
+
+      expect(mockMarkDeadLetter).toHaveBeenCalledWith(mockDb, 3, '400 Bad Request');
+      expect(mockRecordFailure).not.toHaveBeenCalled();
+      expect(onMutationDeadLettered).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: 'non_retryable', retryCount: 1, status: 400 }),
+      );
+    });
   });
 
   // Issue #4862: a backend that is up but whose database is down answers every

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
@@ -8,9 +8,11 @@ import {
   isRetryable,
   getErrorStatus,
   isNetworkError,
+  isPermanentRejection,
   isServerFailureSignal,
   isServerUnavailableError,
   isTransportNetworkError,
+  PERMANENT_REJECTION_STATUSES,
 } from '../error-classification';
 
 describe('isGraphQLEmptyResponseError', () => {
@@ -104,8 +106,14 @@ describe('isRetryable', () => {
     expect(isRetryable(new TypeError('Failed to fetch'))).toBe(true);
   });
 
-  it('non-network TypeError without status is NOT retryable (likely programmer bug, dead-letter)', () => {
-    expect(isRetryable(new TypeError('Cannot read property'))).toBe(false);
+  it('non-network TypeError without status IS retryable — a programmer bug costs ten attempts, a lost send costs a tick', () => {
+    // Default-retry (#5295). "No status resolved" was read as "this must be a
+    // programmer bug", and it was wrong four times: #4099 (truncated 2xx body),
+    // #4027 (bare NSURL prose), #4711 (string RATE_LIMITED), and the fetch
+    // timeout below. A genuine bug still dead-letters — it just arrives as
+    // `retries_exhausted` after max_retries instead of losing the write on
+    // attempt 0 of 10.
+    expect(isRetryable(new TypeError('Cannot read property'))).toBe(true);
   });
 
   it('an aborted request (AbortError by name) is retryable — it never completed against the server', () => {
@@ -142,20 +150,29 @@ describe('isRetryable', () => {
     expect(isRetryable({ status: 403 })).toBe(false);
   });
 
-  it('404 is not retryable', () => {
-    expect(isRetryable({ status: 404 })).toBe(false);
+  it('404 IS retryable: GraphQL answers not-found as 200 + errors, so a 404 can only be an edge verdict', () => {
+    // The drainer speaks GraphQL-over-POST to a single endpoint, and a GraphQL
+    // server reports "no such thing" as HTTP 200 with an `errors` array. A 404
+    // reaching this classifier is therefore an edge or proxy failing to route —
+    // not a verdict on this mutation. Railway's edge served exactly that for
+    // 6m30s on 2026-09-02 and three climbers lost a send (#5295).
+    expect(isRetryable({ status: 404 })).toBe(true);
   });
 
   it('409 is not retryable', () => {
     expect(isRetryable({ status: 409 })).toBe(false);
   });
 
-  it('unknown error without status is NOT retryable (dead-letter for visibility)', () => {
-    expect(isRetryable(new Error('something went wrong'))).toBe(false);
+  it('unknown error without status IS retryable — no status is no server verdict, and only a verdict may block a replay', () => {
+    // The policy flip at the heart of #5295: the classifier defaults to retry
+    // and only a positively identified permanent server verdict
+    // (isPermanentRejection) stops one. The cost is bounded — max_retries, then
+    // the row surfaces as `retries_exhausted`.
+    expect(isRetryable(new Error('something went wrong'))).toBe(true);
   });
 
-  it('plain string error without status is NOT retryable', () => {
-    expect(isRetryable('boom')).toBe(false);
+  it('plain string error without status IS retryable — a non-object throw carries no verdict either', () => {
+    expect(isRetryable('boom')).toBe(true);
   });
 
   it('network TypeError is retryable even though it has no status', () => {
@@ -447,7 +464,8 @@ describe('hasGraphqlErrorCode', () => {
 });
 
 describe('isServerUnavailableError', () => {
-  it('is true only for the edge/upstream verdicts 502, 503 and 504', () => {
+  it('is true only for the edge/proxy verdicts 404, 502, 503 and 504', () => {
+    expect(isServerUnavailableError({ status: 404 })).toBe(true);
     expect(isServerUnavailableError({ status: 502 })).toBe(true);
     expect(isServerUnavailableError({ status: 503 })).toBe(true);
     expect(isServerUnavailableError({ status: 504 })).toBe(true);
@@ -525,12 +543,160 @@ describe('the masked INTERNAL_SERVER_ERROR shape (issue #4862)', () => {
     expect(isServerUnavailableError(masked)).toBe(false);
   });
 
-  it('leaves an ordinary validation rejection dead-lettering as before', () => {
-    // Guard the blast radius: only the masked code changes verdict, so a real
-    // 4xx still fails fast instead of burning ten retries.
+  it('an ordinary validation rejection served over HTTP 200 now spends max_retries before it dead-letters', () => {
+    // Changed by the default-retry flip (#5295), and worth stating plainly: a
+    // BAD_USER_INPUT riding an HTTP 200 resolves status 200, which is not a
+    // permanent-rejection status, so it retries. That is the bounded cost of
+    // the flip — the row still ends up dead-lettered, as `retries_exhausted`
+    // rather than `non_retryable`. Reading the string code here instead would
+    // be the fifth bespoke branch the flip exists to stop adding. A validation
+    // rejection that carries a real 4xx status still fails fast (see
+    // isPermanentRejection below).
     const validationError = {
       response: { status: 200, errors: [{ message: 'title is required', extensions: { code: 'BAD_USER_INPUT' } }] },
     };
-    expect(isRetryable(validationError)).toBe(false);
+    expect(isRetryable(validationError)).toBe(true);
+  });
+});
+
+describe('a fetch timeout: TypeError "Network request timed out" (issue #5295)', () => {
+  // whatwg-fetch — the fetch React Native ships — rejects a dropped connection
+  // with "Network request failed" (fetch.umd.js:567) and a timed-out one with
+  // "Network request timed out" (:573): adjacent lines of the same
+  // xhr.onerror / xhr.ontimeout pair. Only the first was a marker, so the
+  // second resolved no status, matched nothing, and dead-lettered a queued send
+  // on attempt 0 of 10 — 24 events across 12 climbers (Sentry BOARDSESH-HT).
+  const timedOut = () => new TypeError('Network request timed out');
+
+  it('is a transport signal, a network error, and retryable', () => {
+    expect(isTransportNetworkError(timedOut())).toBe(true);
+    expect(isNetworkError(timedOut())).toBe(true);
+    expect(isRetryable(timedOut())).toBe(true);
+  });
+
+  it('resolves no status, so the drainer reads reachability rather than a server verdict', () => {
+    expect(getErrorStatus(timedOut())).toBeNull();
+  });
+
+  it('matches through a bounded cause chain, like the other transport markers', () => {
+    const wrapped = Object.assign(new Error('saveTick failed'), { cause: timedOut() });
+    expect(isTransportNetworkError(wrapped)).toBe(true);
+    expect(isNetworkError(wrapped)).toBe(true);
+  });
+
+  it('stays a FULL-phrase marker: a BLE timeout is still not transport', () => {
+    // The house rule from #3869, re-pinned here because the obvious shorthand
+    // ("timed out") would swallow every board-write timeout.
+    expect(isTransportNetworkError(new Error('BLE write timed out waiting for the board to accept data'))).toBe(false);
+    expect(isTransportNetworkError(new Error('Request timed out'))).toBe(false);
+  });
+});
+
+describe('an edge/proxy 404 (issue #5295)', () => {
+  // On 2026-09-02 Railway's edge answered five SaveTick mutations across three
+  // climbers with a 404 for 6m30s. The responses also carried
+  // `x-railway-fallback: true` — recorded here as evidence and deliberately NOT
+  // read by the classifier, which must not learn one host's header
+  // (docs/railway.md portability rule). The status alone is sufficient: this
+  // drainer speaks GraphQL-over-POST to one endpoint, and GraphQL answers
+  // not-found as HTTP 200 + `errors`, so a 404 here is always an edge verdict.
+  function railwayEdge404(body: string) {
+    return Object.assign(new Error('Application not found: POST /graphql'), {
+      response: { status: 404, error: body },
+    });
+  }
+
+  const JSON_EDGE_BODY = '{"code":404,"message":"Application not found"}';
+  const HTML_FALLBACK_BODY = '<!doctype html><html><body><h1>Application not found</h1></body></html>';
+
+  it('reads the JSON edge body as server-unavailable and keeps it retryable', () => {
+    const error = railwayEdge404(JSON_EDGE_BODY);
+    expect(getErrorStatus(error)).toBe(404);
+    expect(isServerUnavailableError(error)).toBe(true);
+    expect(isRetryable(error)).toBe(true);
+  });
+
+  it('reads an HTML fallback page the same way — the body is never parsed', () => {
+    const error = railwayEdge404(HTML_FALLBACK_BODY);
+    expect(getErrorStatus(error)).toBe(404);
+    expect(isServerUnavailableError(error)).toBe(true);
+    expect(isRetryable(error)).toBe(true);
+  });
+
+  it('is not a transport error — something answered, so the drainer takes the unavailable branch', () => {
+    // Both branches end the drain cycle with no retry_count strike; which one
+    // fires only changes the telemetry bucket.
+    expect(isNetworkError(railwayEdge404(JSON_EDGE_BODY))).toBe(false);
+  });
+});
+
+describe('a string RATE_LIMITED GraphQL rejection (issue #4711)', () => {
+  // The backend throws GraphQLError with the STRING extensions.code
+  // 'RATE_LIMITED' and no numeric status, so getErrorStatus resolves null. The
+  // old default dead-lettered it outright, losing a queued setter follow or a
+  // beta-link tick. Default-retry covers it with no bespoke branch: the
+  // drainer's backoff plus max_retries is the bound.
+  function rateLimited() {
+    return Object.assign(new Error('Too many requests'), {
+      response: {
+        errors: [{ message: 'Too many requests', extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 30 } }],
+      },
+    });
+  }
+
+  it('resolves no status at all', () => {
+    expect(getErrorStatus(rateLimited())).toBeNull();
+  });
+
+  it('is retryable, so a queued follow or beta-link tick drains instead of vanishing', () => {
+    expect(isRetryable(rateLimited())).toBe(true);
+  });
+});
+
+describe('isPermanentRejection — the only verdict that still blocks a retry (issue #5295)', () => {
+  // The classifier defaults to retrying now, so this set is the entire stop
+  // list. It must stay small and it must stay statuses a replay of the same
+  // bytes genuinely cannot change.
+  it('names exactly the statuses a replay cannot change', () => {
+    expect(Array.from(PERMANENT_REJECTION_STATUSES).sort((a, b) => a - b)).toEqual([
+      400, 403, 405, 409, 410, 413, 415, 422,
+    ]);
+  });
+
+  it('is true for each of them, and each still dead-letters on the first attempt', () => {
+    for (const status of PERMANENT_REJECTION_STATUSES) {
+      expect(isPermanentRejection({ status })).toBe(true);
+      expect(isRetryable({ status })).toBe(false);
+    }
+  });
+
+  it('does NOT include 404 — an edge verdict is not a rejection of this write', () => {
+    expect(PERMANENT_REJECTION_STATUSES.has(404)).toBe(false);
+    expect(isPermanentRejection({ status: 404 })).toBe(false);
+  });
+
+  it('does NOT include 401 or 429 — both are "later", not "never"', () => {
+    // 401 already survived authenticatedFetch's refresh-and-retry; 429 is a
+    // wait, which the drainer's backoff supplies.
+    expect(isPermanentRejection({ status: 401 })).toBe(false);
+    expect(isPermanentRejection({ status: 429 })).toBe(false);
+  });
+
+  it('is false whenever no status resolves at all', () => {
+    expect(isPermanentRejection(new Error('something went wrong'))).toBe(false);
+    expect(isPermanentRejection('boom')).toBe(false);
+    expect(isPermanentRejection(null)).toBe(false);
+    expect(isPermanentRejection(new TypeError('Network request timed out'))).toBe(false);
+  });
+
+  it('reads a nested graphql-request status the same way getErrorStatus does', () => {
+    const clientError = { response: { errors: [{ message: 'invalid', extensions: { code: 422 } }] } };
+    expect(isPermanentRejection(clientError)).toBe(true);
+    expect(isRetryable(clientError)).toBe(false);
+  });
+
+  it('keeps a 5xx retryable — the server failed, it did not reject the write', () => {
+    expect(isPermanentRejection({ status: 500 })).toBe(false);
+    expect(isPermanentRejection({ status: 503 })).toBe(false);
   });
 });

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
@@ -12,6 +12,7 @@ import {
   isServerFailureSignal,
   isServerUnavailableError,
   isTransportNetworkError,
+  PERMANENT_GRAPHQL_ERROR_CODES,
   PERMANENT_REJECTION_STATUSES,
 } from '../error-classification';
 
@@ -543,19 +544,18 @@ describe('the masked INTERNAL_SERVER_ERROR shape (issue #4862)', () => {
     expect(isServerUnavailableError(masked)).toBe(false);
   });
 
-  it('an ordinary validation rejection served over HTTP 200 now spends max_retries before it dead-letters', () => {
-    // Changed by the default-retry flip (#5295), and worth stating plainly: a
-    // BAD_USER_INPUT riding an HTTP 200 resolves status 200, which is not a
-    // permanent-rejection status, so it retries. That is the bounded cost of
-    // the flip — the row still ends up dead-lettered, as `retries_exhausted`
-    // rather than `non_retryable`. Reading the string code here instead would
-    // be the fifth bespoke branch the flip exists to stop adding. A validation
-    // rejection that carries a real 4xx status still fails fast (see
-    // isPermanentRejection below).
+  it('still fails an ordinary validation rejection fast — BAD_USER_INPUT over 200 is a verdict, not an unknown', () => {
+    // Guard the blast radius of the default-retry flip (#5295): GraphQL
+    // delivers "your input is invalid" over HTTP 200, so a status-only rule
+    // would read 200, find no permanent status, and retry a write the server
+    // will never accept — ten attempts, head-of-line-blocking the FIFO queue
+    // for minutes, before it lands as `retries_exhausted`. Reading the code is
+    // the SAME rule applied at the layer GraphQL answers on.
     const validationError = {
       response: { status: 200, errors: [{ message: 'title is required', extensions: { code: 'BAD_USER_INPUT' } }] },
     };
-    expect(isRetryable(validationError)).toBe(true);
+    expect(isPermanentRejection(validationError)).toBe(true);
+    expect(isRetryable(validationError)).toBe(false);
   });
 });
 
@@ -698,5 +698,81 @@ describe('isPermanentRejection — the only verdict that still blocks a retry (i
   it('keeps a 5xx retryable — the server failed, it did not reject the write', () => {
     expect(isPermanentRejection({ status: 500 })).toBe(false);
     expect(isPermanentRejection({ status: 503 })).toBe(false);
+  });
+});
+
+describe('permanent GraphQL verdicts served over HTTP 200 (issue #5295)', () => {
+  // GraphQL has no way to put "your input is invalid" in the status line — it
+  // answers 200 with an `errors` array — so a status-only permanent-rejection
+  // rule cannot see a verdict the server definitely reached. Recognising these
+  // codes is default-retry applied at the GraphQL layer, not an exception to
+  // it: anything NOT listed stays retryable.
+  function graphqlRejection(code: string, status: number | null = 200) {
+    const response: Record<string, unknown> = {
+      errors: [{ message: 'nope', extensions: { code } }],
+    };
+    if (status !== null) response.status = status;
+    return Object.assign(new Error('nope'), { response });
+  }
+
+  it('names exactly the codes a replay cannot change', () => {
+    expect(Array.from(PERMANENT_GRAPHQL_ERROR_CODES).sort()).toEqual([
+      'BAD_REQUEST',
+      'BAD_USER_INPUT',
+      'FORBIDDEN',
+      'GRAPHQL_VALIDATION_FAILED',
+    ]);
+  });
+
+  it('dead-letters each of them on the first attempt', () => {
+    for (const code of PERMANENT_GRAPHQL_ERROR_CODES) {
+      expect(isPermanentRejection(graphqlRejection(code))).toBe(true);
+      expect(isRetryable(graphqlRejection(code))).toBe(false);
+    }
+  });
+
+  it('reads a bare re-thrown GraphQLError that carries no response envelope', () => {
+    const bare = Object.assign(new Error('title is required'), { extensions: { code: 'BAD_USER_INPUT' } });
+    expect(getErrorStatus(bare)).toBeNull();
+    expect(isPermanentRejection(bare)).toBe(true);
+    expect(isRetryable(bare)).toBe(false);
+  });
+
+  it('keeps RATE_LIMITED retryable — a "later" is not a "never" (#4711)', () => {
+    // The one string code this PR must NOT turn permanent. Pinned next to the
+    // permanent codes so a future addition to that list has to walk past it.
+    const rateLimited = graphqlRejection('RATE_LIMITED');
+    expect(isPermanentRejection(rateLimited)).toBe(false);
+    expect(isRetryable(rateLimited)).toBe(true);
+  });
+
+  it('keeps an UNRECOGNISED code retryable — default-retry still governs the unknown', () => {
+    const unknown = graphqlRejection('SOMETHING_NOBODY_HAS_SEEN');
+    expect(isPermanentRejection(unknown)).toBe(false);
+    expect(isRetryable(unknown)).toBe(true);
+  });
+
+  it('ignores a permanent code riding a non-2xx status — that body is an edge page, not a resolver answer', () => {
+    // A 404/502/503/504 is an edge verdict about routing (see
+    // isServerUnavailableError). Whatever its body happens to contain, the
+    // request never got a resolver's answer, so it must stay replayable.
+    for (const status of [404, 502, 503, 504]) {
+      const edge = graphqlRejection('BAD_USER_INPUT', status);
+      expect(isPermanentRejection(edge)).toBe(false);
+      expect(isRetryable(edge)).toBe(true);
+    }
+  });
+
+  it('lets the masked INTERNAL_SERVER_ERROR keep winning over a permanent code', () => {
+    // A scrubbed server-side failure is retryable (#4862) and is decided before
+    // the permanent check, so a response carrying both is still a server
+    // failure — not a rejection of this write.
+    const both = Object.assign(new Error('boom'), {
+      response: {
+        status: 200,
+        errors: [{ extensions: { code: 'INTERNAL_SERVER_ERROR' } }, { extensions: { code: 'BAD_USER_INPUT' } }],
+      },
+    });
+    expect(isRetryable(both)).toBe(true);
   });
 });

--- a/packages/shared/offline-sync/src/mutation-queue/drainer.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/drainer.ts
@@ -311,7 +311,13 @@ export type MutationDeadLetterInfo = {
   operation: string;
   /** Raw entity uuid or a deterministic key; keep it out of analytics props. */
   idempotencyKey: string;
-  /** `retries_exhausted` burned the whole budget; `non_retryable` was a 4xx. */
+  /**
+   * `retries_exhausted` burned the whole budget; `non_retryable` is a server's
+   * permanent verdict on this request — `isPermanentRejection`: 400, 403, 405,
+   * 409, 410, 413, 415, 422. Since the default-retry flip (#5295) an error
+   * shape the classifier cannot place lands in the FIRST bucket, not the
+   * second: only an identified rejection dead-letters on attempt one.
+   */
   reason: 'retries_exhausted' | 'non_retryable';
   retryCount: number;
   maxRetries: number;

--- a/packages/shared/offline-sync/src/mutation-queue/drainer.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/drainer.ts
@@ -313,10 +313,11 @@ export type MutationDeadLetterInfo = {
   idempotencyKey: string;
   /**
    * `retries_exhausted` burned the whole budget; `non_retryable` is a server's
-   * permanent verdict on this request — `isPermanentRejection`: 400, 403, 405,
-   * 409, 410, 413, 415, 422. Since the default-retry flip (#5295) an error
-   * shape the classifier cannot place lands in the FIRST bucket, not the
-   * second: only an identified rejection dead-letters on attempt one.
+   * permanent verdict on this request — `isPermanentRejection`: a 400, 403,
+   * 405, 409, 410, 413, 415 or 422, or a BAD_USER_INPUT-class GraphQL code on
+   * an HTTP 200. Since the default-retry flip (#5295) an error shape the
+   * classifier cannot place lands in the FIRST bucket, not the second: only an
+   * identified rejection dead-letters on attempt one.
    */
   reason: 'retries_exhausted' | 'non_retryable';
   retryCount: number;

--- a/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
@@ -109,16 +109,24 @@ export function hasGraphqlErrorCode(error: unknown, code: string, depth = 0): bo
 
 // Locale-independent markers that identify a transport/offline failure regardless
 // of device language. These are stable IDENTIFIERS, not localized prose:
-//   - the fetch/polyfill wrapper strings ("Network request failed", "Failed to
-//     fetch", "fetch failed") are hardcoded English by the runtime, never localized
-//     (RN whatwg-fetch, browser/undici, and the WinterCG "fetch failed: <cause>"
-//     wrapper respectively);
+//   - the fetch/polyfill wrapper strings ("Network request failed", "Network
+//     request timed out", "Failed to fetch", "fetch failed") are hardcoded
+//     English by the runtime, never localized (RN whatwg-fetch, browser/undici,
+//     and the WinterCG "fetch failed: <cause>" wrapper respectively). The first
+//     two are siblings from the same whatwg-fetch XHR pair: `xhr.onerror`
+//     rejects with "Network request failed" (fetch.umd.js:567) and
+//     `xhr.ontimeout` with "Network request timed out" (:573). Only the first
+//     was listed here, so a timed-out send resolved no status, matched nothing,
+//     and was dead-lettered on attempt 0 of 10 (#5295);
 //   - Java networking exception class names surface verbatim in Android messages
 //     (e.g. `java.net.UnknownHostException`), independent of locale.
-// Kept narrow (never bare "network"/"fetch") so a programmer bug like
-// `TypeError: Cannot read property 'fetch' of undefined` is NOT swallowed.
+// Kept narrow (never bare "network"/"fetch"/"timed out") so a programmer bug like
+// `TypeError: Cannot read property 'fetch' of undefined` is NOT swallowed. The
+// timeout marker is the FULL phrase for the same reason: `BLE write timed out
+// waiting for the board to accept data` is a board failure, not a network one
+// (#3869).
 const TRANSPORT_NETWORK_MARKERS =
-  /network request failed|failed to fetch|fetch failed|unknownhostexception|sockettimeoutexception|socketexception|connectexception|sslexception|sslhandshakeexception|sslpeerunverifiedexception|unknownserviceexception/i;
+  /network request failed|network request timed out|failed to fetch|fetch failed|unknownhostexception|sockettimeoutexception|socketexception|connectexception|sslexception|sslhandshakeexception|sslpeerunverifiedexception|unknownserviceexception/i;
 
 // errno-style transport codes carried on the error or its `.cause` (undici / Node
 // networking). Locale-independent.
@@ -327,14 +335,29 @@ export function isNetworkError(error: unknown): boolean {
 const INTERNAL_SERVER_ERROR_CODE = 'INTERNAL_SERVER_ERROR';
 
 /**
- * A 502 / 503 / 504: an edge or upstream verdict — a gateway, a proxy, or a
- * backend that is not accepting work right now — rather than a verdict on the
- * request that happened to hit it. The drainer treats this like a dropped
- * connection: end the cycle, charge the mutation nothing.
+ * A 404 / 502 / 503 / 504: an edge/proxy verdict, not a verdict on this request
+ * — a gateway, a router, or a backend that is not accepting work right now. The
+ * drainer treats all four like a dropped connection: end the cycle, charge the
+ * mutation nothing.
+ *
+ * 404 belongs here rather than with the permanent rejections because of what
+ * this client is. The drainer speaks GraphQL-over-POST to ONE endpoint, and a
+ * GraphQL server answers "no such thing" as HTTP 200 with an `errors` array —
+ * it has no way to say not-found in the status line. So a 404 arriving here can
+ * only mean something in front of the server failed to route the request, and
+ * the write is as replayable as if the connection had dropped. Railway's edge
+ * served exactly that for 6m30s on 2026-09-02 and three climbers lost a logged
+ * send (#5295).
+ *
+ * The decision is on STATUS only. That outage also set an `x-railway-fallback`
+ * response header, which would identify the case precisely — and is exactly the
+ * kind of single-host detail this code must not learn (docs/railway.md: nothing
+ * Railway-specific in code, `pg_dump` and a `docker run` must be enough to move
+ * hosts). The header is recorded in the test comment as evidence instead.
  */
 export function isServerUnavailableError(error: unknown): boolean {
   const status = getErrorStatus(error);
-  return status === 502 || status === 503 || status === 504;
+  return status === 404 || status === 502 || status === 503 || status === 504;
 }
 
 /**
@@ -348,6 +371,31 @@ export function isServerFailureSignal(error: unknown): boolean {
   const status = getErrorStatus(error);
   if (status !== null && status >= 500) return true;
   return hasGraphqlErrorCode(error, INTERNAL_SERVER_ERROR_CODE);
+}
+
+/**
+ * The HTTP statuses that are a server's PERMANENT verdict on this exact request:
+ * replaying the identical bytes cannot change the answer. A malformed body
+ * (400), a forbidden action (403), the wrong method (405), a conflict the
+ * payload itself causes (409), a resource that is gone (410), a body too large
+ * (413), an unsupported media type (415), and a semantically invalid payload
+ * (422).
+ *
+ * 404 is deliberately NOT here — see `isServerUnavailableError` for why a 404
+ * reaching a single-endpoint GraphQL client is a routing failure rather than a
+ * rejection. 401 and 429 are absent for the reasons given in `isRetryable`.
+ */
+export const PERMANENT_REJECTION_STATUSES: ReadonlySet<number> = new Set([400, 403, 405, 409, 410, 413, 415, 422]);
+
+/**
+ * Did a server positively reject THIS request in a way a replay cannot fix?
+ * This is now the only thing that stops a queued write from being retried, so
+ * an error shape nobody has seen yet costs `max_retries` attempts instead of
+ * costing the climber the write (#5295).
+ */
+export function isPermanentRejection(error: unknown): boolean {
+  const status = getErrorStatus(error);
+  return status !== null && PERMANENT_REJECTION_STATUSES.has(status);
 }
 
 export function isRetryable(error: unknown): boolean {
@@ -377,22 +425,27 @@ export function isRetryable(error: unknown): boolean {
     return true;
   }
 
-  const status = getErrorStatus(error);
-
-  // No resolvable HTTP/GraphQL status and not a recognized network error: most
-  // likely a programmer / validation / parse bug. Dead-letter it (I5) so it's
-  // surfaced to the user instead of silently burning the retry budget.
-  if (status === null) {
-    return false;
-  }
-
-  // 401 is retryable because the drainer's fetch is authenticatedFetch
-  // (lib/auth-interceptor): it refreshes the token and retries once BEFORE the
-  // error reaches classification, and a failed refresh forces sign-out — which
-  // wipes the pending queue — so a retried 401 can't loop against a dead session.
-  if (status === 401) return true;
-  if (status === 429) return true;
-  if (status >= 500) return true;
-
-  return false;
+  // Everything else RETRIES: only a positively identified permanent server
+  // verdict blocks a replay. The old default was the opposite — "no resolvable
+  // status and not a recognized network error, so this is a programmer bug,
+  // dead-letter it" — and it was wrong four times running, each time losing a
+  // climber's logged send on attempt 0 of 10: a truncated 2xx body (#4099),
+  // bare NSURL prose (#4027), a string `RATE_LIMITED` code (#4711), and
+  // `TypeError: Network request timed out` (#5295). Each fix taught the
+  // classifier one more shape and left the default in place for the fifth.
+  //
+  // The cost of being wrong in this direction is bounded and already paid for
+  // elsewhere: `recordFailure` (queue.ts) flips the row to `dead_letter` in the
+  // same atomic UPDATE that bumps past `max_retries` (10), so a genuine
+  // programmer bug still surfaces to the user — as `retries_exhausted` after
+  // ten attempts rather than `non_retryable` after one. That is the same trade
+  // the INTERNAL_SERVER_ERROR branch above already makes.
+  //
+  // 401 and 429 stay out of PERMANENT_REJECTION_STATUSES on purpose. 401
+  // because the drainer's fetch is authenticatedFetch (lib/auth-interceptor):
+  // it refreshes the token and retries once BEFORE the error reaches
+  // classification, and a failed refresh forces sign-out — which wipes the
+  // pending queue — so a retried 401 can't loop against a dead session. 429 is
+  // a "later", not a "never", and the drainer's backoff is the wait.
+  return !isPermanentRejection(error);
 }

--- a/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
@@ -388,14 +388,58 @@ export function isServerFailureSignal(error: unknown): boolean {
 export const PERMANENT_REJECTION_STATUSES: ReadonlySet<number> = new Set([400, 403, 405, 409, 410, 413, 415, 422]);
 
 /**
+ * The STRING GraphQL `extensions.code` values that carry the same meaning as
+ * the statuses above: the server read this mutation and rejected it, and a
+ * replay of the same bytes cannot change that answer.
+ *
+ * They need their own list because GraphQL has no way to put a verdict in the
+ * status line — it answers "your input is invalid" with HTTP 200 and an
+ * `errors` array. A status-only rule reads 200, finds no permanent status, and
+ * retries a write the server will never accept: ten attempts, and because the
+ * outbox is FIFO with a break on the first retryable hit, every write queued
+ * behind it waits out those attempts too. Reading the code is the SAME rule as
+ * PERMANENT_REJECTION_STATUSES applied at the layer GraphQL actually answers
+ * on — not an exception to default-retry.
+ *
+ * Kept short on purpose. Anything NOT listed here stays retryable, and
+ * `RATE_LIMITED` is the one to keep looking at on the way past: it is a
+ * "later", not a "never", and turning it permanent is exactly the bug #4711
+ * reports. INTERNAL_SERVER_ERROR is absent too — it is a scrubbed server
+ * failure, decided as retryable before this check runs (#4862).
+ */
+export const PERMANENT_GRAPHQL_ERROR_CODES: ReadonlySet<string> = new Set([
+  'BAD_USER_INPUT',
+  'GRAPHQL_VALIDATION_FAILED',
+  'BAD_REQUEST',
+  'FORBIDDEN',
+]);
+
+/**
  * Did a server positively reject THIS request in a way a replay cannot fix?
  * This is now the only thing that stops a queued write from being retried, so
  * an error shape nobody has seen yet costs `max_retries` attempts instead of
  * costing the climber the write (#5295).
+ *
+ * Two readings of the same question: the HTTP status line, and — because
+ * GraphQL answers on HTTP 200 — the `extensions.code` a resolver attached.
  */
 export function isPermanentRejection(error: unknown): boolean {
   const status = getErrorStatus(error);
-  return status !== null && PERMANENT_REJECTION_STATUSES.has(status);
+  if (status !== null && PERMANENT_REJECTION_STATUSES.has(status)) return true;
+
+  // Only read a GraphQL verdict when the transport did not report one of its
+  // own. A 404 / 502 / 503 / 504 is an edge or proxy talking about routing (see
+  // isServerUnavailableError), and its body is an error page, not a resolver's
+  // answer — so whatever that body happens to contain, the write never reached
+  // a resolver and must stay replayable. `null` counts as "no transport
+  // verdict": that is a bare GraphQLError re-thrown without a response envelope.
+  const carriesAServerAnswer = status === null || (status >= 200 && status < 300);
+  if (!carriesAServerAnswer) return false;
+
+  for (const code of PERMANENT_GRAPHQL_ERROR_CODES) {
+    if (hasGraphqlErrorCode(error, code)) return true;
+  }
+  return false;
 }
 
 export function isRetryable(error: unknown): boolean {
@@ -426,7 +470,8 @@ export function isRetryable(error: unknown): boolean {
   }
 
   // Everything else RETRIES: only a positively identified permanent server
-  // verdict blocks a replay. The old default was the opposite — "no resolvable
+  // verdict — a rejection status, or the GraphQL code a resolver attached to an
+  // HTTP 200 — blocks a replay. The old default was the opposite — "no resolvable
   // status and not a recognized network error, so this is a programmer bug,
   // dead-letter it" — and it was wrong four times running, each time losing a
   // climber's logged send on attempt 0 of 10: a truncated 2xx body (#4099),


### PR DESCRIPTION
## Summary

A climber logs a send, the network hiccups, and the row is dead-lettered as `non_retryable` on
attempt 0 of 10. Nothing retries it. The only recovery is More → Sync issues → Retry, which the
climber has to find alone. 24 events across 12 climbers lifetime, spread evenly since 2026-07-09
(Sentry BOARDSESH-HT / BOARDSESH-A2), plus 5 lost SaveTick mutations across 3 climbers during one
6m30s Railway edge outage on 2026-09-02 (BOARDSESH-H8).

Two inputs, one drop path — the `status === null → return false` fallthrough in `isRetryable`
(`packages/shared/offline-sync/src/mutation-queue/error-classification.ts`):

- **`TypeError: Network request timed out`.** whatwg-fetch rejects a dropped connection with
  "Network request failed" (`fetch.umd.js:567`) and a timed-out one with "Network request timed out"
  (`:573`) — adjacent lines of the same `xhr.onerror` / `xhr.ontimeout` pair. Only the first was a
  transport marker. The second has no `.code` and no `.response`, so no status resolves, nothing
  matches, and `drainer.ts` takes its else-branch to `markDeadLetter`.
- **An edge 404.** graphql-request wraps the non-2xx, so the status resolves to 404.
  `isServerUnavailableError` covered 502/503/504 only, and the retryable allow-list was
  401 / 429 / ≥500. Same else-branch, same dead letter.

### The fix: default-retry, plus two precision layers

`isRetryable` now ends in `return !isPermanentRejection(error)`. Only a positively identified
permanent server verdict blocks a replay. This is the fourth input to reach that fallthrough (#4099
truncated 2xx body, #4027 bare NSURL prose, #4711 string `RATE_LIMITED`, and now these two); each
earlier fix taught the classifier one more shape and left the default in place for the next one.

**A verdict is read two ways**, because GraphQL has no way to put one in the status line:

- a resolved **400, 403, 405, 409, 410, 413, 415, 422**; or
- on an HTTP 200, a **`BAD_USER_INPUT` / `GRAPHQL_VALIDATION_FAILED` / `BAD_REQUEST` / `FORBIDDEN`**
  `extensions.code` in the `errors` array.

The second list is the same rule as the first, applied at the layer GraphQL actually answers on — not
an exception to default-retry. Without it a mutation the server will *never* accept burns ten
attempts, and since the outbox is FIFO with a break on the first retryable hit, every write queued
behind it waits those attempts out before the bad row lands as `retries_exhausted`.

Three deliberate exclusions, each pinned by a test: **`RATE_LIMITED` stays retryable** (a "later", not
a "never" — that is #4711, which this PR subsumes); the masked **`INTERNAL_SERVER_ERROR` stays
retryable** (#4862, decided before this check); and an **unrecognised code stays retryable** —
default-retry still governs the unknown. A permanent code riding a **non-2xx** response is also
ignored: a 404/502/503/504 body is an edge error page, not a resolver's answer, so the write never
reached a resolver and must stay replayable.

**Both layers are needed.** The default flip alone gives a timeout a *strike*. With `max_retries` 10,
`maxCycleAttempts` 6 and a 30 s backoff cap, a row burns all ten strikes in roughly two cycles — under
a minute — so it would still lose the write in a 6m30s outage. So the timeout also became a transport
marker and the 404 a server-unavailable verdict: both now reach the drainer's `networkStop`, which
charges zero strikes, leaves the row pending, and drains it on reconnect. The precision layer is the
correct treatment; the default flip is the bounded backstop for the shape nobody has seen yet.

**404 is a status-only decision.** The drainer speaks GraphQL-over-POST to one endpoint, and a GraphQL
server answers not-found as HTTP 200 with an `errors` array — it has no way to say not-found in the
status line. So a 404 arriving at this classifier can only be an edge or proxy failing to route. The
outage responses also carried `x-railway-fallback: true`, which would identify the case exactly and is
precisely the single-host detail this code must not learn (`docs/railway.md`). That header appears in
a test comment as evidence, never in a branch.

**Bounding is unchanged.** `recordFailure` (`queue.ts`) flips the row to `dead_letter` in the same
atomic UPDATE that passes `max_retries`, so a poison row costs at most 10 attempts and then surfaces
as `retries_exhausted` instead of `non_retryable`. FIFO head-of-line blocking is bounded the same way
and is pre-existing.

### Closes #4711 as a test-only change

Default-retry subsumes the string `RATE_LIMITED` case — it resolves no status, so it is not a
permanent rejection — with no bespoke branch. Covered by a new test rather than new code.

### Existing dead-lettered rows are NOT recovered

Roughly 17 climbers already have rows at `status='dead_letter'` from these two shapes. Reviving them
mutates user data, so it is a separate human decision being asked in parallel and deliberately not in
this PR. Today's manual path is unchanged: `retryDeadLetter` (`mutation-queue/queue.ts`) behind the
More → Sync issues → Retry button.

### One behaviour change worth calling out

The mobile adapter's `classifyCycleErrorKind` buckets a cycle that failed on a 404 as
`server_unavailable` rather than `server`. That is the intended reading — an edge 404 during an
outage is an outage, not a sync defect.

Everything else that dead-lettered on attempt one before still does. `isRetryable({status: 400})`,
`{status: 422}`, the graphql-request 400 ClientError and `BAD_USER_INPUT`-over-200 are all pinned
`false`; the drainer still reports them as `reason: 'non_retryable'`. The one verdict that genuinely
changed sides is the 404, which is the point.

Fixes #5295
Closes #4711

## Release Notes

The send you log in the gym stops vanishing when the network wobbles. A tick queued while your phone
is on a flaky connection now waits for signal and syncs when it comes back, instead of being written
off on its first failed attempt and buried in Sync issues for you to find.

## Test plan

1. Log a send with Airplane mode on. It shows as queued.
2. Turn Airplane mode off. The send lands in your logbook.
3. Open More → Sync issues. No new failed rows appear.
4. Log three sends offline, then reconnect. All three land.

## Risk

Risk: 4/5 — changes the retry and dead-letter verdict on the offline write path every queued tick takes.

No schema change, no migration, no new network call, and the blast radius is that one verdict. Every
permanent rejection still fails fast on attempt one, pinned by tests on both the status list and the
GraphQL code list. The residual risk is an unrecognised *permanent* shape now costing ten attempts
and briefly head-of-line-blocking the FIFO outbox instead of dead-lettering immediately — bounded by
`max_retries`, and the trade this PR is deliberately making against losing the write outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
