### PR TITLE
ci: make Claude review advisory

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
+        # Claude's provider-side allowance can be exhausted; this advisory review must not block a PR.
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1.0.142
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/scripts/__tests__/ci-capacity-workflows.test.ts
+++ b/scripts/__tests__/ci-capacity-workflows.test.ts
@@ -37,6 +37,15 @@ describe('PR workflow capacity controls', () => {
     expect(source).toContain(cancellation);
   });
 
+  it('keeps Claude Code review advisory when the action cannot complete', () => {
+    const source = workflow('claude-code-review.yml');
+    const reviewStepStart = source.indexOf('      - name: Run Claude Code Review');
+    const reviewStepEnd = source.indexOf('\n      - name:', reviewStepStart + 1);
+    const reviewStep = source.slice(reviewStepStart, reviewStepEnd < 0 ? undefined : reviewStepEnd);
+
+    expect(reviewStep).toContain('continue-on-error: true');
+  });
+
   it('caps every PR test matrix without serializing main', () => {
     const source = workflow('ci.yml');
     const defaultTests = mappingEntry(source, 'test-default', 2);


### PR DESCRIPTION
## Summary

- Makes the automatic Claude Code review advisory when its external action cannot complete, including exhausted provider allowance.
- Adds a regression test that keeps the tolerant setting scoped to the Claude review step.
- Verified: `vp test run --reporter=agent scripts/__tests__/ci-capacity-workflows.test.ts`; staged-file pre-commit checks passed. Full `vp check` remains blocked by pre-existing repository lint issues outside this change.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — CI-only workflow status handling.