### PR TITLE
Fix acknowledgement refresh automation

### DIFF
--- a/.github/workflows/refresh-acknowledgements.yml
+++ b/.github/workflows/refresh-acknowledgements.yml
@@ -1,10 +1,9 @@
 name: Refresh Acknowledgements
 
 # Weekly: regenerate the mobile Acknowledgements data — GitHub contributors +
-# `boardsesh` org sponsors — and the bundled OSS license attribution. Both
-# generators degrade gracefully (keep the committed JSON on any failure), so a
-# missing token or API hiccup never produces an empty list. Idempotent: the
-# commit step only runs when the generated files actually change.
+# `boardsesh` org sponsors — and the bundled OSS license attribution. The
+# repository App commits the generated snapshot directly to protected main. A
+# partial refresh fails instead of silently preserving stale acknowledgements.
 on:
   schedule:
     - cron: '0 7 * * 1' # 07:00 UTC every Monday
@@ -15,15 +14,48 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   refresh:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Production permits only main. This keeps a manual dispatch from another
+    # branch from minting the App token that bypasses main's review rule.
+    environment: Production
+    outputs:
+      changed: ${{ steps.result.outputs.changed }}
+      commit_sha: ${{ steps.commit.outputs.commit_sha }}
+      contributors: ${{ steps.result.outputs.contributors }}
+      sponsors: ${{ steps.result.outputs.sponsors }}
+      private_sponsors: ${{ steps.result.outputs.private_sponsors }}
     steps:
-      - name: Checkout repository
+      - name: Require repository App credentials
+        env:
+          APP_ID: ${{ vars.OTA_PUSH_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.OTA_PUSH_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          [ -n "$APP_ID" ] || { echo '::error::Missing OTA_PUSH_APP_ID.'; exit 1; }
+          [ -n "$APP_PRIVATE_KEY" ] || { echo '::error::Missing OTA_PUSH_APP_PRIVATE_KEY.'; exit 1; }
+
+      # Mint before checkout: checkout persists this App identity for the
+      # protected-main push. Members:read permits the Sponsor GraphQL query.
+      - name: Mint repository App token
+        id: repository_app
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ vars.OTA_PUSH_APP_ID }}
+          private-key: ${{ secrets.OTA_PUSH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-members: read
+
+      - name: Checkout main
         uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.repository_app.outputs.token }}
 
       - uses: voidzero-dev/setup-vp@v1
         with:
@@ -35,29 +67,83 @@ jobs:
 
       - name: Regenerate acknowledgements + OSS licenses
         env:
-          # Contributors work with the default repo token. Reading the org's
-          # GitHub Sponsors needs a PAT with sponsors / read:org scope — set the
-          # ACKNOWLEDGEMENTS_GH_TOKEN secret to enable it; without it the sponsors
-          # list stays as-committed and the script still succeeds.
-          GH_TOKEN: ${{ secrets.ACKNOWLEDGEMENTS_GH_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.repository_app.outputs.token }}
         run: |
-          node --import tsx scripts/fetch-acknowledgements.ts
+          node --import tsx scripts/fetch-acknowledgements.ts --strict
           node --import tsx scripts/generate-oss-licenses.ts
 
-      # NOTE: changelog.generated.json is intentionally NOT refreshed here — the
-      # Mobile OTA Production workflow is its sole owner (it regenerates and pushes
-      # the file on every publish). Keep it out of this job to avoid two writers.
-      - name: Commit refreshed data
+      - name: Record refresh result
+        id: result
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if [[ -n "$(git status --porcelain packages/mobile/src/data)" ]]; then
-            git add packages/mobile/src/data/acknowledgements.generated.json packages/mobile/src/data/oss-licenses.generated.json
-            git commit -m "chore: refresh acknowledgements + OSS licenses [skip ci]"
-            # Explicit target: commit back to the branch this run was dispatched from
-            # (main on the schedule) — checkout leaves a detached HEAD, so a bare
-            # `git push` has no upstream and could otherwise be ambiguous.
-            git push origin "HEAD:${{ github.ref_name }}"
+          set -euo pipefail
+          ACKNOWLEDGEMENTS_FILE=packages/mobile/src/data/acknowledgements.generated.json
+          echo "contributors=$(jq '.contributors | length' "$ACKNOWLEDGEMENTS_FILE")" >> "$GITHUB_OUTPUT"
+          echo "sponsors=$(jq '.sponsors | length' "$ACKNOWLEDGEMENTS_FILE")" >> "$GITHUB_OUTPUT"
+          echo "private_sponsors=$(jq '.privateSponsorCount' "$ACKNOWLEDGEMENTS_FILE")" >> "$GITHUB_OUTPUT"
+          if git diff --quiet -- packages/mobile/src/data/acknowledgements.generated.json packages/mobile/src/data/oss-licenses.generated.json; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
           else
-            echo "No changes to acknowledgements data."
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Commit refreshed data
+        id: commit
+        if: steps.result.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name 'boardsesh-repo-bot[bot]'
+          git config user.email 'boardsesh-repo-bot[bot]@users.noreply.github.com'
+          git add packages/mobile/src/data/acknowledgements.generated.json packages/mobile/src/data/oss-licenses.generated.json
+          git commit -m 'chore: refresh acknowledgements + OSS licenses [skip ci]'
+
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ "$attempt" = 3 ]; then
+              echo '::error::Could not push the refresh after three attempts.'
+              exit 1
+            fi
+            git fetch origin main
+            git rebase origin/main
+          done
+
+  notify:
+    needs: refresh
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: Production
+    steps:
+      - name: Notify deployments channel
+        env:
+          DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
+          REFRESH_RESULT: ${{ needs.refresh.result }}
+          CHANGED: ${{ needs.refresh.outputs.changed }}
+          COMMIT_SHA: ${{ needs.refresh.outputs.commit_sha }}
+          CONTRIBUTORS: ${{ needs.refresh.outputs.contributors }}
+          SPONSORS: ${{ needs.refresh.outputs.sponsors }}
+          PRIVATE_SPONSORS: ${{ needs.refresh.outputs.private_sponsors }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$DISCORD_DEPLOY_WEBHOOK" ]; then
+            echo 'DISCORD_DEPLOY_WEBHOOK not set — skipping notification'
+            exit 0
+          fi
+
+          if [ "$REFRESH_RESULT" = success ]; then
+            if [ "$CHANGED" = true ]; then
+              UPDATE_LINE="committed ${COMMIT_SHA:0:7}"
+            else
+              UPDATE_LINE='no generated-data changes'
+            fi
+            CONTENT=$(printf '✅ **Acknowledgements refreshed** — %s\n• contributors: %s\n• public sponsors: %s\n• private sponsors: %s\n<%s>' \
+              "$UPDATE_LINE" "$CONTRIBUTORS" "$SPONSORS" "$PRIVATE_SPONSORS" "$RUN_URL")
+          else
+            CONTENT=$(printf '🚨 **Acknowledgements refresh %s**\n<%s>' "$REFRESH_RESULT" "$RUN_URL")
+          fi
+
+          jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
+            | curl -sS --fail-with-body -X POST -H 'Content-Type: application/json' -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
+              echo '::warning::Failed to post Discord notification (see status above)'

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -101,6 +101,22 @@ scheduler's `timeoutMs` becomes the only bound.
 `packages/web/vercel.json` itself stays until the Phase 4 scrub; it is not
 deleted now that the last cron has left it.
 
+### GitHub Actions acknowledgement refresh
+
+`refresh-acknowledgements.yml` remains a GitHub Actions job because it reads
+GitHub contributors and Sponsors, then commits the bundled mobile snapshot.
+It runs each Monday at 07:00 UTC and uses the Boardsesh Repo Bot installation
+token for both the GraphQL requests and its protected-`main` commit. The App
+needs repository Contents: write plus Organization Members: read; the latter
+authorizes `sponsorshipsAsMaintainer`, including the private-sponsor total.
+
+The job runs the acknowledgement generator in strict mode. A missing GitHub
+source, malformed GraphQL response, or unavailable private-sponsor count fails
+the run before the committed snapshot changes. Successful and failed runs post
+their outcome to the deployments Discord channel through the Production-scoped
+`DISCORD_DEPLOY_WEBHOOK` secret. The legacy `ACKNOWLEDGEMENTS_GH_TOKEN` remains
+unused and may be retained until its normal secret-rotation review.
+
 ### Not in scope
 
 - The GitHub-Actions-scheduled jobs (`refresh-recommendations`,

--- a/packages/mobile/app/__tests__/about.test.tsx
+++ b/packages/mobile/app/__tests__/about.test.tsx
@@ -31,6 +31,7 @@ vi.mock('react-i18next', () => ({
       ({
         'mobile.about.joinDiscord': 'Join Discord',
         'mobile.about.acknowledgementsLink': 'Acknowledgements',
+        'mobile.about.changelogLink': "What's New",
         'mobile.about.viewOnGithub': 'View on GitHub',
       })[key] ?? key,
   }),
@@ -118,6 +119,14 @@ describe('AboutScreen partnerships + acknowledgements', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Acknowledgements' }));
 
+    expect(routerMock.push).toHaveBeenCalledWith('/acknowledgements');
+  });
+
+  it("does not duplicate the root-menu What's New link", () => {
+    render(<AboutScreen />);
+
+    expect(screen.queryByRole('button', { name: "What's New" })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Acknowledgements' }));
     expect(routerMock.push).toHaveBeenCalledWith('/acknowledgements');
   });
 

--- a/packages/mobile/app/about.tsx
+++ b/packages/mobile/app/about.tsx
@@ -45,9 +45,6 @@ export default function AboutScreen() {
   const handleOpenAcknowledgements = useCallback(() => {
     router.push('/acknowledgements');
   }, [router]);
-  const handleOpenChangelog = useCallback(() => {
-    router.push('/changelog');
-  }, [router]);
   const handleOpenGithub = useCallback(() => {
     void openExternalUrl(GITHUB_REPO_URL, 'about-github');
   }, []);
@@ -152,28 +149,6 @@ export default function AboutScreen() {
             style={styles.partnerButton}
           />
         </View>
-
-        <PressableSurface
-          onPress={handleOpenChangelog}
-          feedback="opacity"
-          opacityTo={0.7}
-          accessibilityRole="button"
-          accessibilityLabel={t('mobile.about.changelogLink')}
-          style={[styles.linkRow, { backgroundColor: systemColors.secondaryBackground }]}
-        >
-          <View style={[styles.cardIcon, { backgroundColor: systemColors.fill }]}>
-            <Icon name="flash" size={22} color={systemColors.accent} />
-          </View>
-          <View style={styles.cardText}>
-            <Text variant="headline" style={styles.cardTitle}>
-              {t('mobile.about.changelogLink')}
-            </Text>
-            <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.cardBody}>
-              {t('mobile.about.changelogLinkBody')}
-            </Text>
-          </View>
-          <Icon name="chevron.right" size={16} color={systemColors.secondaryLabel} />
-        </PressableSurface>
 
         <PressableSurface
           onPress={handleOpenAcknowledgements}

--- a/packages/mobile/src/data/acknowledgements.generated.json
+++ b/packages/mobile/src/data/acknowledgements.generated.json
@@ -1,23 +1,50 @@
 {
-  "generatedAt": "2026-06-15T03:43:45.371Z",
+  "generatedAt": "2026-09-08T23:31:58.738Z",
   "contributors": [
     {
       "login": "marcodejongh",
       "name": "Marco de Jongh",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1107647?u=63993f18e3d652404c7a04ae91a5f7a505fdef5c&v=4",
       "htmlUrl": "https://github.com/marcodejongh",
-      "pullRequests": 2187,
-      "issues": 393,
-      "contributions": 2580
+      "pullRequests": 3679,
+      "issues": 1143,
+      "contributions": 4822
     },
     {
       "login": "ES-Alexander",
       "name": null,
       "avatarUrl": "https://avatars.githubusercontent.com/u/25898329?u=02154126eda9e5537b1cf9f1b139096031f8e57b&v=4",
       "htmlUrl": "https://github.com/ES-Alexander",
-      "pullRequests": 0,
-      "issues": 52,
-      "contributions": 52
+      "pullRequests": 2,
+      "issues": 106,
+      "contributions": 108
+    },
+    {
+      "login": "azuttre",
+      "name": "Helter Skilter",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3766782?u=9f484b4611ad060ec18326e2a53fd044b1ee9b1a&v=4",
+      "htmlUrl": "https://github.com/azuttre",
+      "pullRequests": 27,
+      "issues": 2,
+      "contributions": 29
+    },
+    {
+      "login": "fallaciousreasoning",
+      "name": "Jay Harris",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7678024?v=4",
+      "htmlUrl": "https://github.com/fallaciousreasoning",
+      "pullRequests": 24,
+      "issues": 1,
+      "contributions": 25
+    },
+    {
+      "login": "alejandrosanchezcabana",
+      "name": "Alex Sánchez",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10997544?u=41ac204494f58d9a5f32b3652af16a75c20869df&v=4",
+      "htmlUrl": "https://github.com/alejandrosanchezcabana",
+      "pullRequests": 20,
+      "issues": 2,
+      "contributions": 22
     },
     {
       "login": "gardaholm",
@@ -29,15 +56,6 @@
       "contributions": 22
     },
     {
-      "login": "alejandrosanchezcabana",
-      "name": "Alex Sánchez",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/10997544?u=41ac204494f58d9a5f32b3652af16a75c20869df&v=4",
-      "htmlUrl": "https://github.com/alejandrosanchezcabana",
-      "pullRequests": 9,
-      "issues": 2,
-      "contributions": 11
-    },
-    {
       "login": "shelldandy",
       "name": "Miguel P",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7088511?u=badde0a126221b6e46a32e89ae21770fee7d0f5c&v=4",
@@ -45,6 +63,15 @@
       "pullRequests": 6,
       "issues": 1,
       "contributions": 7
+    },
+    {
+      "login": "alexpooley",
+      "name": "Alex Pooley",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12389?v=4",
+      "htmlUrl": "https://github.com/alexpooley",
+      "pullRequests": 5,
+      "issues": 1,
+      "contributions": 6
     },
     {
       "login": "lilylilylily123",
@@ -65,12 +92,12 @@
       "contributions": 5
     },
     {
-      "login": "azuttre",
-      "name": "WinnebagoMaaan",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/3766782?u=9f484b4611ad060ec18326e2a53fd044b1ee9b1a&v=4",
-      "htmlUrl": "https://github.com/azuttre",
-      "pullRequests": 3,
-      "issues": 1,
+      "login": "d-e-s-o",
+      "name": "Daniel Müller",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6610056?u=b419d4ead00c0a5654687fa7f78d961d6ee5b508&v=4",
+      "htmlUrl": "https://github.com/d-e-s-o",
+      "pullRequests": 0,
+      "issues": 4,
       "contributions": 4
     },
     {
@@ -92,6 +119,24 @@
       "contributions": 4
     },
     {
+      "login": "mohitkyadav",
+      "name": "Mohit Kumar Yadav",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/25580776?u=be6f0c0e5a50095fdece1e6a1a9b205d59f1e212&v=4",
+      "htmlUrl": "https://github.com/mohitkyadav",
+      "pullRequests": 0,
+      "issues": 4,
+      "contributions": 4
+    },
+    {
+      "login": "alecgdouglas",
+      "name": "Alec Douglas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3189085?u=216caa536c024c8dda5a246d0e329c9f25482f98&v=4",
+      "htmlUrl": "https://github.com/alecgdouglas",
+      "pullRequests": 0,
+      "issues": 2,
+      "contributions": 2
+    },
+    {
       "login": "cpud",
       "name": null,
       "avatarUrl": "https://avatars.githubusercontent.com/u/43917749?v=4",
@@ -108,6 +153,24 @@
       "pullRequests": 1,
       "issues": 1,
       "contributions": 2
+    },
+    {
+      "login": "aliebling",
+      "name": null,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1900068?u=cf20aea456c6d86c5ee1b046494023b26ec1b216&v=4",
+      "htmlUrl": "https://github.com/aliebling",
+      "pullRequests": 0,
+      "issues": 1,
+      "contributions": 1
+    },
+    {
+      "login": "axelperschmann",
+      "name": "Axel Perschmann",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/9463154?u=d51187700609351334a1494b38c4c295ea05a2ad&v=4",
+      "htmlUrl": "https://github.com/axelperschmann",
+      "pullRequests": 1,
+      "issues": 0,
+      "contributions": 1
     },
     {
       "login": "crcklt",
@@ -173,10 +236,28 @@
       "contributions": 1
     },
     {
+      "login": "kay-jay95",
+      "name": null,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/261702971?v=4",
+      "htmlUrl": "https://github.com/kay-jay95",
+      "pullRequests": 0,
+      "issues": 1,
+      "contributions": 1
+    },
+    {
       "login": "lukalelovic",
       "name": "Luka Lelovic",
       "avatarUrl": "https://avatars.githubusercontent.com/u/58709344?u=db4195ace34107bb99d0b3b6d2beee6bea2396b9&v=4",
       "htmlUrl": "https://github.com/lukalelovic",
+      "pullRequests": 1,
+      "issues": 0,
+      "contributions": 1
+    },
+    {
+      "login": "mayank-dev-15",
+      "name": "Mayank Basena",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/289773841?v=4",
+      "htmlUrl": "https://github.com/mayank-dev-15",
       "pullRequests": 1,
       "issues": 0,
       "contributions": 1
@@ -191,6 +272,15 @@
       "contributions": 1
     },
     {
+      "login": "p4t7m4n",
+      "name": "Schlomo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45936392?u=3a91d94a41afec4631cd1cf7c60eaab22fdd2cc6&v=4",
+      "htmlUrl": "https://github.com/p4t7m4n",
+      "pullRequests": 0,
+      "issues": 1,
+      "contributions": 1
+    },
+    {
       "login": "PascalHoenisch",
       "name": null,
       "avatarUrl": "https://avatars.githubusercontent.com/u/65446468?v=4",
@@ -200,10 +290,46 @@
       "contributions": 1
     },
     {
+      "login": "peter-popescu",
+      "name": "Peter Popescu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/59096961?u=220c148f6b1acc65d84a0d153a5be2e41593b8b3&v=4",
+      "htmlUrl": "https://github.com/peter-popescu",
+      "pullRequests": 1,
+      "issues": 0,
+      "contributions": 1
+    },
+    {
+      "login": "pxcuthbert",
+      "name": null,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/21166436?v=4",
+      "htmlUrl": "https://github.com/pxcuthbert",
+      "pullRequests": 0,
+      "issues": 1,
+      "contributions": 1
+    },
+    {
       "login": "SaidPar",
       "name": "Said Pazirandeh",
       "avatarUrl": "https://avatars.githubusercontent.com/u/16970708?u=78e05fd203ba985c06b4e0938a20657e4b7f5e4e&v=4",
       "htmlUrl": "https://github.com/SaidPar",
+      "pullRequests": 0,
+      "issues": 1,
+      "contributions": 1
+    },
+    {
+      "login": "SamRoehrich",
+      "name": "Sam Roehrich",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/26787961?u=3a62179e459a45ca215efc7eb2cfac496e205420&v=4",
+      "htmlUrl": "https://github.com/SamRoehrich",
+      "pullRequests": 1,
+      "issues": 0,
+      "contributions": 1
+    },
+    {
+      "login": "T1llK",
+      "name": null,
+      "avatarUrl": "https://avatars.githubusercontent.com/u/75973120?v=4",
+      "htmlUrl": "https://github.com/T1llK",
       "pullRequests": 0,
       "issues": 1,
       "contributions": 1
@@ -233,7 +359,25 @@
       "name": "Shuying Zhang",
       "avatarUrl": "https://avatars.githubusercontent.com/u/26174891?v=4",
       "url": "https://github.com/bluejayio"
+    },
+    {
+      "login": "axelmarciano",
+      "name": "Axel Marciano",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12605993?u=414a078bf0072e97d9cbb2252a957755081b8fb4&v=4",
+      "url": "https://github.com/axelmarciano"
+    },
+    {
+      "login": "belav",
+      "name": "Bela VanderVoort",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3606529?u=7245d9e44badb218c288d96f5b4a392df7daa94f&v=4",
+      "url": "https://github.com/belav"
+    },
+    {
+      "login": "alecgdouglas",
+      "name": "Alec Douglas",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3189085?u=216caa536c024c8dda5a246d0e329c9f25482f98&v=4",
+      "url": "https://github.com/alecgdouglas"
     }
   ],
-  "privateSponsorCount": 1
+  "privateSponsorCount": 2
 }

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -407,9 +407,7 @@
       "partnerTitle": "Offiziell mit uns zusammenarbeiten",
       "partnerBody": "Boardsesh arbeitet von außen mit Kilter, Tension und MoonBoard. Wenn du Boards baust und etwas Offizielles zusammen machen willst, reden wir gern.",
       "acknowledgementsLink": "Danksagungen",
-      "acknowledgementsLinkBody": "Die Menschen hinter Boardsesh",
-      "changelogLink": "Neuigkeiten",
-      "changelogLinkBody": "Aktuelle Updates und Fixes"
+      "acknowledgementsLinkBody": "Die Menschen hinter Boardsesh"
     },
     "acknowledgements": {
       "title": "Danksagungen",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -407,9 +407,7 @@
       "partnerTitle": "Partner with us officially",
       "partnerBody": "Boardsesh works with Kilter, Tension, and MoonBoard from the outside. If you build boards and want to make something official together, we're keen to talk.",
       "acknowledgementsLink": "Acknowledgements",
-      "acknowledgementsLinkBody": "The people behind Boardsesh",
-      "changelogLink": "What's New",
-      "changelogLinkBody": "Recent updates and fixes"
+      "acknowledgementsLinkBody": "The people behind Boardsesh"
     },
     "acknowledgements": {
       "title": "Acknowledgements",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -672,9 +672,7 @@
       "partnerTitle": "Colabora oficialmente con nosotros",
       "partnerBody": "Boardsesh funciona con Kilter, Tension y MoonBoard desde fuera. Si fabricas plafones y quieres crear algo oficial juntos, nos encantaría hablar.",
       "acknowledgementsLink": "Agradecimientos",
-      "acknowledgementsLinkBody": "Las personas detrás de Boardsesh",
-      "changelogLink": "Novedades",
-      "changelogLinkBody": "Últimas mejoras y correcciones"
+      "acknowledgementsLinkBody": "Las personas detrás de Boardsesh"
     },
     "acknowledgements": {
       "title": "Agradecimientos",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -407,9 +407,7 @@
       "partnerTitle": "Devenez partenaire officiel",
       "partnerBody": "Boardsesh fonctionne avec Kilter, Tension et MoonBoard depuis l'extérieur. Si vous fabriquez des boards et voulez construire quelque chose d'officiel ensemble, on serait ravis d'en parler.",
       "acknowledgementsLink": "Remerciements",
-      "acknowledgementsLinkBody": "Les personnes derrière Boardsesh",
-      "changelogLink": "Nouveautés",
-      "changelogLinkBody": "Dernières améliorations et corrections"
+      "acknowledgementsLinkBody": "Les personnes derrière Boardsesh"
     },
     "acknowledgements": {
       "title": "Remerciements",

--- a/scripts/__tests__/acknowledgements-transform.test.ts
+++ b/scripts/__tests__/acknowledgements-transform.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
   isBotLogin,
   aggregateContributors,
+  resolveAcknowledgements,
   transformSponsors,
+  type AcknowledgementsData,
   type AuthorRef,
   type RawSponsorNode,
 } from '../lib/acknowledgements-transform';
@@ -79,5 +81,52 @@ describe('transformSponsors', () => {
   it('backfills a profile URL when the entity omits one', () => {
     const [first] = transformSponsors([{ sponsorEntity: { login: 'patron' } }]);
     expect(first.url).toBe('https://github.com/patron');
+  });
+});
+
+describe('resolveAcknowledgements', () => {
+  const existingAcknowledgements: AcknowledgementsData = {
+    generatedAt: '2026-06-15T03:43:45.371Z',
+    contributors: [
+      {
+        login: 'existing-contributor',
+        name: null,
+        avatarUrl: '',
+        htmlUrl: 'https://github.com/existing-contributor',
+        pullRequests: 1,
+        issues: 0,
+        contributions: 1,
+      },
+    ],
+    sponsors: [{ login: 'existing-sponsor', name: null, avatarUrl: '', url: 'https://github.com/existing-sponsor' }],
+    privateSponsorCount: 2,
+  };
+
+  it('keeps unavailable sections for best-effort local refreshes', () => {
+    const acknowledgements = resolveAcknowledgements(
+      existingAcknowledgements,
+      {
+        contributors: [],
+        sponsors: [
+          { login: 'fresh-sponsor', name: 'Fresh Sponsor', avatarUrl: '', url: 'https://github.com/fresh-sponsor' },
+        ],
+        privateSponsorCount: null,
+      },
+      'best-effort',
+    );
+
+    expect(acknowledgements.contributors).toEqual([]);
+    expect(acknowledgements.sponsors.map((sponsor) => sponsor.login)).toEqual(['fresh-sponsor']);
+    expect(acknowledgements.privateSponsorCount).toBe(2);
+  });
+
+  it('rejects a partial refresh in strict scheduled mode', () => {
+    expect(() =>
+      resolveAcknowledgements(
+        existingAcknowledgements,
+        { contributors: null, sponsors: [], privateSponsorCount: null },
+        'strict',
+      ),
+    ).toThrow('Unable to refresh acknowledgements: contributors, private sponsor count.');
   });
 });

--- a/scripts/__tests__/acknowledgements-workflow.test.ts
+++ b/scripts/__tests__/acknowledgements-workflow.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(
+  resolve(import.meta.dirname, '../../.github/workflows/refresh-acknowledgements.yml'),
+  'utf8',
+);
+
+function stepBlock(stepName: string): string {
+  const start = workflow.indexOf(`      - name: ${stepName}\n`);
+  const nextStep = workflow.indexOf('\n      - name: ', start + 1);
+  expect(start).toBeGreaterThanOrEqual(0);
+  return workflow.slice(start, nextStep >= 0 ? nextStep : workflow.length);
+}
+
+describe('refresh acknowledgements workflow', () => {
+  it('mints the scoped Repository App token before checkout and refreshes strictly', () => {
+    const credentialCheck = stepBlock('Require repository App credentials');
+    const mintToken = stepBlock('Mint repository App token');
+    const checkout = stepBlock('Checkout main');
+    const regenerate = stepBlock('Regenerate acknowledgements + OSS licenses');
+    const refreshStart = workflow.indexOf('\n  refresh:\n');
+    const notifyStart = workflow.indexOf('\n  notify:\n');
+    const refresh = workflow.slice(refreshStart, notifyStart);
+
+    expect(refreshStart).toBeGreaterThanOrEqual(0);
+    expect(notifyStart).toBeGreaterThan(refreshStart);
+    expect(refresh).toContain('environment: Production');
+    expect(credentialCheck).toContain('OTA_PUSH_APP_ID');
+    expect(credentialCheck).toContain('OTA_PUSH_APP_PRIVATE_KEY');
+    expect(workflow.indexOf(mintToken)).toBeLessThan(workflow.indexOf(checkout));
+    expect(mintToken).toContain('actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547');
+    expect(mintToken).toContain('permission-contents: write');
+    expect(mintToken).toContain('permission-members: read');
+    expect(checkout).toContain('token: ${{ steps.repository_app.outputs.token }}');
+    expect(regenerate).toContain('GH_TOKEN: ${{ steps.repository_app.outputs.token }}');
+    expect(regenerate).toContain('scripts/fetch-acknowledgements.ts --strict');
+    expect(workflow).not.toContain('ACKNOWLEDGEMENTS_GH_TOKEN');
+  });
+
+  it('retries the App-backed protected-main commit rather than leaving a stale snapshot', () => {
+    const commit = stepBlock('Commit refreshed data');
+
+    expect(commit).toContain("git config user.name 'boardsesh-repo-bot[bot]'");
+    expect(commit).toContain('for attempt in 1 2 3; do');
+    expect(commit).toContain('git push origin HEAD:main');
+    expect(commit).toContain('git rebase origin/main');
+  });
+
+  it('notifies the deployments channel after both successful and failed runs', () => {
+    const notifyStart = workflow.indexOf('\n  notify:\n');
+    const notify = workflow.slice(notifyStart);
+
+    expect(notifyStart).toBeGreaterThanOrEqual(0);
+    expect(notify).toContain('if: always()');
+    expect(notify).toContain('environment: Production');
+    expect(notify).toContain('DISCORD_DEPLOY_WEBHOOK');
+    expect(notify).toContain('REFRESH_RESULT: ${{ needs.refresh.result }}');
+    expect(notify).toContain('Acknowledgements refreshed');
+    expect(notify).toContain('Acknowledgements refresh %s');
+    expect(notify).toContain('allowed_mentions: {parse: []}');
+  });
+});

--- a/scripts/fetch-acknowledgements.ts
+++ b/scripts/fetch-acknowledgements.ts
@@ -5,18 +5,17 @@
  * contributor + sponsor lists shown on the mobile Acknowledgements screen.
  *
  * Contributors come from paginated GraphQL over the repo's pull requests + issues
- * (public data, no special scope). Sponsors come from the GitHub GraphQL API for
- * the `boardsesh` org, which needs an authenticated token with sponsors /
- * `read:org` scope — locally that's your `gh` keyring; in CI it's the
- * ACKNOWLEDGEMENTS_GH_TOKEN secret. The default Actions `GITHUB_TOKEN` can read
- * contributors but NOT org sponsors.
+ * and sponsors come from the GitHub GraphQL API for the `boardsesh` org. Locally
+ * this uses your `gh` keyring. In CI it uses the Boardsesh Repo Bot installation
+ * token, whose read-only Organization Members permission permits the sponsors
+ * query and whose repository permission permits the contributor query.
  *
- * Degrades gracefully: if a fetch fails (offline, `gh` missing, no sponsor
- * scope) the existing committed JSON for that section is kept and the script
- * still exits 0, so it never breaks a build or CI run. `generatedAt` only moves
- * when the data actually changes, keeping the committed file churn-free.
+ * Local runs degrade gracefully: if a fetch fails, the existing committed JSON
+ * for that section is kept. CI passes --strict, which fails before writing if
+ * any source cannot refresh. `generatedAt` only moves when the data actually
+ * changes, keeping the committed file churn-free.
  *
- * Usage: vp run generate:acknowledgements
+ * Usage: vp run generate:acknowledgements [--strict]
  */
 
 import { execFileSync } from 'node:child_process';
@@ -25,8 +24,10 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   aggregateContributors,
+  resolveAcknowledgements,
   transformSponsors,
   type AcknowledgementsData,
+  type AcknowledgementsRefreshMode,
   type AuthorRef,
   type Contributor,
   type Sponsor,
@@ -39,6 +40,7 @@ const SPONSOR_ORG = 'boardsesh';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const OUTPUT_PATH = resolve(here, '../packages/mobile/src/data/acknowledgements.generated.json');
+const refreshMode: AcknowledgementsRefreshMode = process.argv.includes('--strict') ? 'strict' : 'best-effort';
 
 function gh(args: string[]): string {
   return execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
@@ -79,6 +81,14 @@ type AuthorConnection = {
   nodes?: { author?: AuthorNode | null }[];
 };
 
+type GraphQlResponse = { errors?: { message?: string }[] };
+
+function throwOnGraphQlErrors(response: GraphQlResponse): void {
+  if (!response.errors?.length) return;
+  const messages = response.errors.map((error) => error.message ?? 'unknown GraphQL error').join('; ');
+  throw new Error(`GitHub GraphQL query failed: ${messages}`);
+}
+
 function fetchAuthors(query: string, connectionKey: 'pullRequests' | 'issues'): AuthorRef[] {
   const authors: AuthorRef[] = [];
   let cursor: string | null = null;
@@ -86,9 +96,15 @@ function fetchAuthors(query: string, connectionKey: 'pullRequests' | 'issues'): 
   for (let page = 0; page < 200; page += 1) {
     const args = ['api', 'graphql', '-f', `query=${query}`, '-f', `owner=${REPO_OWNER}`, '-f', `name=${REPO_NAME}`];
     if (cursor) args.push('-f', `cursor=${cursor}`);
-    const response = JSON.parse(gh(args)) as { data?: { repository?: Record<string, AuthorConnection> } };
+    const response = JSON.parse(gh(args)) as GraphQlResponse & {
+      data?: { repository?: Record<string, AuthorConnection> };
+    };
+    throwOnGraphQlErrors(response);
     const connection = response.data?.repository?.[connectionKey];
-    for (const node of connection?.nodes ?? []) {
+    if (!connection?.pageInfo || !Array.isArray(connection.nodes)) {
+      throw new Error(`GitHub did not return a valid ${connectionKey} connection.`);
+    }
+    for (const node of connection.nodes) {
       const author = node.author;
       if (author?.login) {
         authors.push({
@@ -100,10 +116,13 @@ function fetchAuthors(query: string, connectionKey: 'pullRequests' | 'issues'): 
         });
       }
     }
-    if (!connection?.pageInfo?.hasNextPage || !connection.pageInfo.endCursor) break;
+    if (!connection.pageInfo.hasNextPage) return authors;
+    if (!connection.pageInfo.endCursor) {
+      throw new Error(`GitHub reported another ${connectionKey} page without a cursor.`);
+    }
     cursor = connection.pageInfo.endCursor;
   }
-  return authors;
+  throw new Error(`GitHub ${connectionKey} pagination exceeded the 200-page safety limit.`);
 }
 
 function fetchContributors(): Contributor[] | null {
@@ -137,8 +156,8 @@ const PUBLIC_SPONSORS_QUERY = `query($login: String!, $cursor: String) {
   }
 }`;
 
-// includePrivate:true returns the FULL count (public + private) but only when the
-// token belongs to the org maintainer (the refresh secret does). private = all − public.
+// includePrivate:true returns the FULL count (public + private) to the Repo Bot,
+// whose Organization Members permission grants it sponsor visibility. private = all − public.
 const ALL_SPONSOR_COUNT_QUERY = `query($login: String!) {
   organization(login: $login) {
     sponsorshipsAsMaintainer(first: 1, activeOnly: false, includePrivate: true) {
@@ -147,7 +166,7 @@ const ALL_SPONSOR_COUNT_QUERY = `query($login: String!) {
   }
 }`;
 
-function fetchSponsorData(): { sponsors: Sponsor[]; privateCount: number } | null {
+function fetchSponsorData(): { sponsors: Sponsor[] | null; privateCount: number | null } {
   type PublicConnection = {
     totalCount?: number;
     pageInfo?: { hasNextPage?: boolean; endCursor?: string };
@@ -161,35 +180,48 @@ function fetchSponsorData(): { sponsors: Sponsor[]; privateCount: number } | nul
     for (let page = 0; page < 200; page += 1) {
       const args = ['api', 'graphql', '-f', `query=${PUBLIC_SPONSORS_QUERY}`, '-f', `login=${SPONSOR_ORG}`];
       if (cursor) args.push('-f', `cursor=${cursor}`);
-      const response = JSON.parse(gh(args)) as {
+      const response = JSON.parse(gh(args)) as GraphQlResponse & {
         data?: { organization?: { sponsorshipsAsMaintainer?: PublicConnection } };
       };
+      throwOnGraphQlErrors(response);
       const connection = response.data?.organization?.sponsorshipsAsMaintainer;
-      if (!connection) break;
+      if (!connection?.pageInfo || !Array.isArray(connection.nodes)) {
+        throw new Error('GitHub did not return a valid public sponsors connection.');
+      }
       publicCount = connection.totalCount ?? publicCount;
-      for (const node of connection.nodes ?? []) rawNodes.push(node);
-      if (!connection.pageInfo?.hasNextPage || !connection.pageInfo.endCursor) break;
+      for (const node of connection.nodes) rawNodes.push(node);
+      if (!connection.pageInfo.hasNextPage) break;
+      if (!connection.pageInfo.endCursor) {
+        throw new Error('GitHub reported another public sponsors page without a cursor.');
+      }
       cursor = connection.pageInfo.endCursor;
+      if (page === 199) {
+        throw new Error('GitHub public sponsor pagination exceeded the 200-page safety limit.');
+      }
     }
   } catch (error) {
     console.warn(`[acknowledgements] sponsors fetch failed, keeping existing list: ${String(error)}`);
-    return null;
+    return { sponsors: null, privateCount: null };
   }
 
   const sponsors = transformSponsors(rawNodes);
   publicCount = publicCount || sponsors.length;
 
-  // Private count is best-effort: it needs the org-maintainer token, so any
-  // failure just means we don't show the anonymous count rather than failing.
-  let privateCount = 0;
+  // Local runs retain the existing anonymous count when it is unavailable.
+  // Scheduled strict runs reject that partial refresh in resolveAcknowledgements.
+  let privateCount: number | null = null;
   try {
     const response = JSON.parse(
       gh(['api', 'graphql', '-f', `query=${ALL_SPONSOR_COUNT_QUERY}`, '-f', `login=${SPONSOR_ORG}`]),
-    ) as { data?: { organization?: { sponsorshipsAsMaintainer?: { totalCount?: number } } } };
-    const allCount = response.data?.organization?.sponsorshipsAsMaintainer?.totalCount ?? publicCount;
+    ) as GraphQlResponse & { data?: { organization?: { sponsorshipsAsMaintainer?: { totalCount?: number } } } };
+    throwOnGraphQlErrors(response);
+    const allCount = response.data?.organization?.sponsorshipsAsMaintainer?.totalCount;
+    if (typeof allCount !== 'number') {
+      throw new Error('GitHub did not return a total sponsorship count.');
+    }
     privateCount = Math.max(0, allCount - publicCount);
   } catch (error) {
-    console.warn(`[acknowledgements] private sponsor count unavailable (needs org-maintainer token): ${String(error)}`);
+    console.warn(`[acknowledgements] private sponsor count unavailable, keeping the existing count: ${String(error)}`);
   }
 
   return { sponsors, privateCount };
@@ -197,10 +229,18 @@ function fetchSponsorData(): { sponsors: Sponsor[]; privateCount: number } | nul
 
 function main(): void {
   const existing = readExisting();
-  const contributors = fetchContributors() ?? existing.contributors;
-  const sponsorData = fetchSponsorData();
-  const sponsors = sponsorData?.sponsors ?? existing.sponsors;
-  const privateSponsorCount = sponsorData?.privateCount ?? existing.privateSponsorCount ?? 0;
+  const refreshedContributors = fetchContributors();
+  const refreshedSponsors = fetchSponsorData();
+  const acknowledgements = resolveAcknowledgements(
+    existing,
+    {
+      contributors: refreshedContributors,
+      sponsors: refreshedSponsors.sponsors,
+      privateSponsorCount: refreshedSponsors.privateCount,
+    },
+    refreshMode,
+  );
+  const { contributors, sponsors, privateSponsorCount } = acknowledgements;
 
   // Keep generatedAt stable when nothing changed so the committed file (and the
   // refresh workflow's "commit only if changed") stays quiet on no-op runs.
@@ -213,9 +253,9 @@ function main(): void {
     });
   const generatedAt = dataChanged || !existing.generatedAt ? new Date().toISOString() : existing.generatedAt;
 
-  const data: AcknowledgementsData = { generatedAt, contributors, sponsors, privateSponsorCount };
+  const generatedAcknowledgements: AcknowledgementsData = { generatedAt, contributors, sponsors, privateSponsorCount };
   mkdirSync(dirname(OUTPUT_PATH), { recursive: true });
-  writeFileSync(OUTPUT_PATH, `${JSON.stringify(data, null, 2)}\n`);
+  writeFileSync(OUTPUT_PATH, `${JSON.stringify(generatedAcknowledgements, null, 2)}\n`);
   console.log(
     `[acknowledgements] wrote ${contributors.length} contributors, ${sponsors.length} public sponsors, ${privateSponsorCount} private`,
   );

--- a/scripts/lib/acknowledgements-transform.ts
+++ b/scripts/lib/acknowledgements-transform.ts
@@ -32,6 +32,14 @@ export type AcknowledgementsData = {
   privateSponsorCount: number;
 };
 
+export type AcknowledgementsRefresh = {
+  contributors: Contributor[] | null;
+  sponsors: Sponsor[] | null;
+  privateSponsorCount: number | null;
+};
+
+export type AcknowledgementsRefreshMode = 'best-effort' | 'strict';
+
 /** A GraphQL pull-request / issue `author` (an Actor: User, Organization, Bot, …). */
 export type AuthorRef = {
   login?: string;
@@ -151,4 +159,33 @@ export function transformSponsors(nodes: RawSponsorNode[]): Sponsor[] {
       avatarUrl: entity.avatarUrl ?? '',
       url: entity.url ?? `https://github.com/${entity.login}`,
     }));
+}
+
+/**
+ * Combines fresh GitHub results with the committed snapshot. Local runs may be
+ * best-effort so a developer without every permission can still refresh what
+ * they can see. Scheduled publishing is strict: a partial result would make a
+ * public thank-you list look current while silently retaining stale sections.
+ */
+export function resolveAcknowledgements(
+  existingAcknowledgements: AcknowledgementsData,
+  refreshedAcknowledgements: AcknowledgementsRefresh,
+  refreshMode: AcknowledgementsRefreshMode,
+): AcknowledgementsData {
+  const unavailableSections = [
+    refreshedAcknowledgements.contributors === null ? 'contributors' : null,
+    refreshedAcknowledgements.sponsors === null ? 'public sponsors' : null,
+    refreshedAcknowledgements.privateSponsorCount === null ? 'private sponsor count' : null,
+  ].filter((section): section is string => section !== null);
+
+  if (refreshMode === 'strict' && unavailableSections.length > 0) {
+    throw new Error(`Unable to refresh acknowledgements: ${unavailableSections.join(', ')}.`);
+  }
+
+  return {
+    generatedAt: existingAcknowledgements.generatedAt,
+    contributors: refreshedAcknowledgements.contributors ?? existingAcknowledgements.contributors,
+    sponsors: refreshedAcknowledgements.sponsors ?? existingAcknowledgements.sponsors,
+    privateSponsorCount: refreshedAcknowledgements.privateSponsorCount ?? existingAcknowledgements.privateSponsorCount,
+  };
 }


### PR DESCRIPTION
## Summary

Refresh acknowledgements with the Boardsesh Repo Bot’s installation token, including Organization Members read access for the sponsors query. The scheduled job now fails on partial GitHub data, retries its protected-main commit, and posts success or failure to the deployments Discord channel.

Updated the bundled snapshot to 39 contributors, four public sponsors, and two private sponsors. Removed the duplicate What's New link from mobile About.

Validated with focused acknowledgement/About tests, `vp run typecheck`, `vp run typecheck:mobile`, `vp run test:mobile`, and `vp run check:mobile-bundle`.

## Release Notes

- New sponsors and contributors now show up automatically in Acknowledgements.
- About is cleaner, with What's New in one place.

## Test plan

1. Open More → About; What's New is absent.
2. Tap Acknowledgements; current sponsors and contributors appear.

## Risk

Risk: 4/5 — scheduled data refresh pushes directly to protected main.
