### PR TITLE
fix(mobile): keep offline storage alive when a launch loses the write lock

### DIFF
--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -768,6 +768,87 @@ describe('initializeDatabase lock contention (#4104)', () => {
     expect(trackMock.mock.calls[0][1]).toMatchObject({ phase: 'queue-table', sqliteCode: 5 });
   });
 
+  // The cost of the longer ladder, paid back. A remount inside a slow gap only moved
+  // `latestDatabase` and got the already-resolved launch gate, while the chain stayed
+  // parked in `delay()` — so the replacement provider rendered with a null handle and
+  // `schemaReady` false for up to a MINUTE over a connection that was usable
+  // immediately. At the old 17.5s ceiling that stranding cost seconds.
+  it('wakes the backoff when a replacement connection arrives, instead of sleeping out the gap', async () => {
+    vi.useFakeTimers();
+    const contended = createContendedDatabase();
+
+    await initializeDatabase(contended.db);
+    // Spend the fast ladder, which parks the chain in the first slow gap.
+    await vi.advanceTimersByTimeAsync(FAST_LADDER_MS);
+    expect(getDatabaseHandle()).toBeNull();
+
+    // SQLiteProvider remounts. Its connection is fine — whatever held the file is gone
+    // with the connection that waited on it.
+    const replacement = createContendedDatabase();
+    replacement.unlock();
+    await initializeDatabase(replacement.db);
+
+    // ONE tick of the fake clock, nowhere near the remaining gap. Reading the wake off
+    // the fake timer rather than a wall-clock wait keeps the assertion off the box's
+    // load: without the wake, the chain is still asleep here.
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(getDatabaseHandle()).toBe(replacement.db);
+    expect(isSchemaReady()).toBe(true);
+    // Retargeted, not retried: the stale connection is not touched again after the
+    // attempt that predates the remount.
+    expect(contended.failures()).toBe(INIT_RETRY_DELAYS_MS.length + 1);
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  // The wake ends a SLEEP; it must not hand the loop a second go at an attempt that is
+  // still running. `wakeFromBackoff` is null outside the sleep, so a remount landing
+  // mid-attempt falls through to the retarget path the chain already had.
+  it('does not double-run an attempt when the remount lands while one is in flight', async () => {
+    vi.useFakeTimers();
+    const healthy = createContendedDatabase();
+    healthy.unlock();
+    const contended = createContendedDatabase({
+      onFailure: (failureCount) => {
+        if (failureCount === 1) void initializeDatabase(healthy.db);
+      },
+    });
+
+    await initializeDatabase(contended.db);
+    await vi.advanceTimersByTimeAsync(FIRST_RETRY_DELAY_MS);
+
+    expect(contended.failures()).toBe(1);
+    expect(getDatabaseHandle()).toBe(healthy.db);
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  // A remount storm must not turn the ladder into a perpetual motion machine: a wake
+  // shortens a wait, it does not refund budget. The chain still ends inside
+  // MAX_INIT_ATTEMPTS and still reports exactly once.
+  it('spends the same budget however many remounts wake it', async () => {
+    vi.useFakeTimers();
+    // One connection per attempt the ladder allows: the first starts the chain, and
+    // every other one wakes it out of the gap it had just entered. If a wake refunded
+    // budget this would never run out.
+    const connections = Array.from({ length: TOTAL_ATTEMPTS }, () => createContendedDatabase());
+
+    await initializeDatabase(connections[0].db);
+    for (const connection of connections.slice(1)) {
+      await initializeDatabase(connection.db);
+      await vi.advanceTimersByTimeAsync(1);
+    }
+
+    const totalFailures = connections.reduce((total, connection) => total + connection.failures(), 0);
+    expect(totalFailures).toBe(TOTAL_ATTEMPTS);
+    expect(getDatabaseHandle()).toBeNull();
+    expect(reportErrorMock).toHaveBeenCalledTimes(1);
+    // And the chain is over rather than still parked, so nothing is left to fire into
+    // the next launch: no sleep survives the whole remaining ladder.
+    await vi.advanceTimersByTimeAsync(WHOLE_LADDER_MS);
+    expect(totalFailures).toBe(TOTAL_ATTEMPTS);
+    expect(reportErrorMock).toHaveBeenCalledTimes(1);
+  });
+
   it('does not retry a failure that is not lock contention', async () => {
     // A full disk or a corrupt file fails identically forever; burning the window on
     // it would just delay the report.

--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -37,6 +37,7 @@ import {
   getDatabaseHandle,
   initializeDatabase,
   INIT_RETRY_DELAYS_MS,
+  INIT_LOCK_RETRY_DELAYS_MS,
   setDatabaseHandle,
   releaseDatabaseHandle,
 } from '../connection';
@@ -413,6 +414,16 @@ describe('initializeDatabase lock contention (#4104)', () => {
   // and nothing else, and it keeps tracking if the backoff is ever retuned.
   const FIRST_RETRY_DELAY_MS = INIT_RETRY_DELAYS_MS[0];
 
+  // The fast ladder's gaps, plus a second to clear the attempt that follows the last
+  // of them. Advancing by exactly this leaves the chain where every phase-tagged
+  // sqlite-init report on 2.4.0 sits: the whole #4104 window spent on a real lock.
+  const FAST_LADDER_MS = INIT_RETRY_DELAYS_MS.reduce((total, gap) => total + gap, 0) + 1_000;
+  // Every gap in both ladders, so a test can drive the chain to its true end without
+  // mirroring the numbers.
+  const WHOLE_LADDER_MS =
+    [...INIT_RETRY_DELAYS_MS, ...INIT_LOCK_RETRY_DELAYS_MS].reduce((total, gap) => total + gap, 0) + 1_000;
+  const TOTAL_ATTEMPTS = INIT_RETRY_DELAYS_MS.length + INIT_LOCK_RETRY_DELAYS_MS.length + 1;
+
   // The failure report awaits a best-effort `PRAGMA journal_mode` read-back, so it
   // lands a microtask or two after the launch gate the test awaited. Wait for the
   // report itself rather than guessing a tick count.
@@ -492,9 +503,6 @@ describe('initializeDatabase lock contention (#4104)', () => {
   });
 
   it('does not block app launch on the retry, leaving the handle unpublished for now', async () => {
-    // This test deliberately walks away mid-chain, so the retry it leaves pending must
-    // sit on the fake clock: afterEach's useRealTimers() discards it, instead of a real
-    // timer firing into a later test and publishing a handle or reporting an error there.
     vi.useFakeTimers();
     const contended = createContendedDatabase();
 
@@ -509,6 +517,15 @@ describe('initializeDatabase lock contention (#4104)', () => {
     expect(getDatabaseHandle()).toBeNull();
     // A launch that is still retrying is not yet newsworthy.
     expect(reportErrorMock).not.toHaveBeenCalled();
+
+    // Let the chain END rather than walking away from it. `afterEach`'s
+    // `useRealTimers()` does NOT discard the retry this test leaves pending — it hands
+    // it to the real clock, where it goes on driving the module-level handle and the
+    // mocks into whichever test is running by then. That was survivable while the
+    // ladder ran out in 17.5s; it is not now that a lock keeps the chain alive for
+    // minutes (#4314). The unlock is the writer finishing, exactly as everywhere else.
+    contended.unlock();
+    await vi.advanceTimersByTimeAsync(FIRST_RETRY_DELAY_MS);
   });
 
   it('publishes the handle once a retry wins, instead of staying dead for the session', async () => {
@@ -664,11 +681,11 @@ describe('initializeDatabase lock contention (#4104)', () => {
     const contended = createContendedDatabase();
 
     await initializeDatabase(contended.db);
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(WHOLE_LADDER_MS);
 
     const [, context] = reportErrorMock.mock.calls[0];
     expect(context.tags).toMatchObject({ sqlite_code: 5, journal_mode: 'wal' });
-    expect(context.extra).toMatchObject({ attempts: 5, retryable: true });
+    expect(context.extra).toMatchObject({ attempts: TOTAL_ATTEMPTS, retryable: true });
     expect(typeof context.extra.elapsedMs).toBe('number');
   });
 
@@ -707,15 +724,48 @@ describe('initializeDatabase lock contention (#4104)', () => {
     const contended = createContendedDatabase();
 
     await initializeDatabase(contended.db);
-    // Drive the whole backoff chain (500 + 2000 + 5000 + 10000 = 17.5s, inside the 30s ceiling).
-    await vi.advanceTimersByTimeAsync(30_000);
+    // Drive both ladders to their end — the fast #4104 gaps and the slow #4314 ones.
+    await vi.advanceTimersByTimeAsync(WHOLE_LADDER_MS);
 
-    expect(contended.failures()).toBe(5);
+    expect(contended.failures()).toBe(TOTAL_ATTEMPTS);
     expect(getDatabaseHandle()).toBeNull();
     expect(reportErrorMock).toHaveBeenCalledTimes(1);
     const [, context] = reportErrorMock.mock.calls[0];
     expect(context.tags).toMatchObject({ source: 'offline-sync', kind: 'sqlite-init', phase: 'queue-table' });
-    expect(context.extra).toMatchObject({ attempts: 5, retryable: true });
+    expect(context.extra).toMatchObject({ attempts: TOTAL_ATTEMPTS, retryable: true });
+  });
+
+  // #4314: the fast ladder is sized for a writer that is merely in the way, but the one
+  // that actually loses this window is a board-data snapshot import (`importMs` reaches
+  // 253,939ms). Every phase-tagged sqlite-init report on 2.4.0 reads `retryable: true`,
+  // `attempts: 4`, `elapsedMs: 29,875` — the whole window spent waiting out a real lock.
+  // The chain then RETURNED, and `SQLiteProvider` calls `onInit` once per connection, so
+  // nothing was left to try again: offline storage stayed off for the rest of the
+  // session over a database that became writable a minute later.
+  it('keeps retrying a lock that outlives the fast window, instead of dying for the session', async () => {
+    vi.useFakeTimers();
+    const contended = createContendedDatabase();
+
+    await initializeDatabase(contended.db);
+    await vi.advanceTimersByTimeAsync(FAST_LADDER_MS);
+
+    // The old ceiling. The lock is real and still held, so this is not the moment to
+    // declare the database unusable and file it in the sqlite-init aggregate.
+    expect(getDatabaseHandle()).toBeNull();
+    expect(reportErrorMock).not.toHaveBeenCalled();
+
+    // The import commits a minute in.
+    contended.unlock();
+    await vi.advanceTimersByTimeAsync(INIT_LOCK_RETRY_DELAYS_MS[0]);
+
+    expect(getDatabaseHandle()).toBe(contended.db);
+    expect(isSchemaReady()).toBe(true);
+    expect(reportErrorMock).not.toHaveBeenCalled();
+    // A launch that contended and came back is a recovery, not a failure — and it is
+    // the only signal that separates "fixed" from "still contending, just retrying its
+    // way out" once the fleet is on this build.
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock.mock.calls[0][1]).toMatchObject({ phase: 'queue-table', sqliteCode: 5 });
   });
 
   it('does not retry a failure that is not lock contention', async () => {

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -81,19 +81,55 @@ export function releaseDatabaseHandle(db: SQLiteDatabase): void {
 }
 
 /**
- * How many times the whole setup sequence is attempted before giving up, and the
- * hard wall-clock ceiling across all of them.
+ * The gaps BETWEEN attempts, in two phases. Exported so the retry tests advance their
+ * fake clock by the real gap rather than mirroring these numbers in a literal that
+ * silently drifts from them.
  *
- * Sized against the longest writer that can legitimately hold the file while the app
- * starts: `vacuumDatabase` documents an exclusive lock of 5-20s on a 200-400MB
- * database, and a snapshot import is the same order. 30s therefore outlasts a genuine
- * one, while anything still locked past it is wedged rather than busy — further
- * retries would only burn battery on a launch that has already fallen back to
- * network-only. The delays are the gaps BETWEEN attempts; the deadline is checked
- * before each sleep so a slow attempt cannot overrun the window.
+ * FAST (#4104) — sized for a writer that is merely in the way: a tick commit, a
+ * checkpoint stamp, one `SNAPSHOT_IMPORT_BATCH_ROWS` import batch. Almost every
+ * contended launch is won here, and the whole ladder fits in 17.5s.
  */
-const MAX_INIT_ATTEMPTS = 5;
-const MAX_INIT_WINDOW_MS = 30_000;
+export const INIT_RETRY_DELAYS_MS = [500, 2_000, 5_000, 10_000];
+
+/**
+ * SLOW (#4314) — the gaps that follow, reached ONLY by lock contention.
+ *
+ * The fast ladder stops at 17.5s of gaps, so the chain used to give up around 30s.
+ * That was sized against `vacuumDatabase`'s documented 5-20s exclusive lock, but the
+ * writer that actually loses this window in the field is a board-data snapshot
+ * import: `Offline Board Download Completed.importMs` runs to 253,939ms at the top of
+ * the 30-day distribution, an order of magnitude past the old ceiling. Every
+ * phase-tagged `kind: 'sqlite-init'` report on 2.4.0 has the same shape —
+ * `retryable: true`, `attempts: 4`, `elapsedMs: 29,875` — i.e. the chain spent its
+ * entire window waiting out a real lock and then walked away.
+ *
+ * Walking away was permanent. `SQLiteProvider` calls `onInit` exactly once per
+ * connection, so once the chain returned there was nothing left to try again: the
+ * handle stayed null and offline storage was off for the REST OF THE SESSION, over a
+ * database that became writable a minute or two later. These four gaps carry the
+ * chain to ~227.5s of waiting (~272s with every attempt blocking its full
+ * `busy_timeout`), which covers that 253,939ms tail.
+ *
+ * It costs a healthy launch nothing. Only a failure `classifySqliteLockError` calls
+ * contention gets here — a full disk or a corrupt file still ends the chain on
+ * attempt 1 — and a blocked attempt is an idle await, not a spin.
+ */
+export const INIT_LOCK_RETRY_DELAYS_MS = [30_000, 60_000, 60_000, 60_000];
+
+const INIT_ALL_RETRY_DELAYS_MS = [...INIT_RETRY_DELAYS_MS, ...INIT_LOCK_RETRY_DELAYS_MS];
+
+/**
+ * How many times the whole setup sequence is attempted before giving up, and the hard
+ * wall-clock ceiling across all of them.
+ *
+ * The attempt count is derived from the ladder so the two can never disagree. The
+ * ceiling is the backstop for an attempt that is itself slow — every gap plus a full
+ * `busy_timeout` on all nine attempts still lands inside it — so the ladder, not the
+ * clock, is what normally ends the chain. It is checked before each sleep, so a slow
+ * attempt cannot overrun the window.
+ */
+const MAX_INIT_ATTEMPTS = INIT_ALL_RETRY_DELAYS_MS.length + 1;
+const MAX_INIT_WINDOW_MS = 360_000;
 /**
  * How many times a superseded attempt may be refunded (see the restart branch in
  * `beginInitialization`). Each refund needs its own remount — the retry immediately
@@ -101,9 +137,6 @@ const MAX_INIT_WINDOW_MS = 30_000;
  * pathological remount loop from keeping one chain alive forever.
  */
 const MAX_SUPERSEDED_RESTARTS = 3;
-// Exported so the retry tests advance their fake clock by the real gap rather than
-// mirroring these numbers in a literal that silently drifts from them.
-export const INIT_RETRY_DELAYS_MS = [500, 2_000, 5_000, 10_000];
 
 /**
  * Single-flight guard spanning the ENTIRE init lifecycle, background retries
@@ -353,7 +386,7 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
       }
 
       budgetSpent += 1;
-      const retryDelayMs = INIT_RETRY_DELAYS_MS[budgetSpent - 1];
+      const retryDelayMs = INIT_ALL_RETRY_DELAYS_MS[budgetSpent - 1];
       const outOfRoad =
         (!outcome.retryable && !superseded) ||
         budgetSpent === MAX_INIT_ATTEMPTS ||

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -190,8 +190,52 @@ type InitOutcome =
 // shapes differ per platform and are only knowable from telemetry, so they need a
 // test pinning the literal strings Sentry carries.
 
-function delay(durationMs: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, durationMs));
+/**
+ * Ends the backoff the chain is currently parked in. Non-null ONLY while a sleep is in
+ * flight — `sleepUntilRetry` sets it as it parks and clears it on the way out, so a
+ * wake that arrives during an attempt finds nothing to do and cannot make the loop
+ * run that attempt twice. At most one sleeper exists: `activeInitialization`
+ * single-flights the chain, and every path that clears it has already returned.
+ */
+let wakeFromBackoff: (() => void) | null = null;
+
+/**
+ * The gap between two attempts, endable early.
+ *
+ * The slow #4314 gaps run to a minute, and a `SQLiteProvider` remount arriving inside
+ * one used to be invisible to the chain: `initializeDatabase` moves `latestDatabase`
+ * and hands the remount the already-resolved launch gate, so the replacement provider
+ * renders with a null handle and `schemaReady` false until the sleep runs out — over a
+ * fresh connection that would work right now. The wake exists so that lands on the
+ * NEXT loop iteration instead, which reads `latestDatabase` and retargets through the
+ * path that already exists rather than a second one.
+ *
+ * It shortens a wait; it does not buy an attempt. The budget slot was already spent
+ * before the sleep and `supersededRestarts` is untouched, so a remount loop cannot
+ * keep one chain alive past `MAX_INIT_ATTEMPTS`.
+ */
+function sleepUntilRetry(durationMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    // Both exits null the slot, so "set" and "parked" are the same state. That is what
+    // makes the no-double-run property above STRUCTURAL rather than accidental: there
+    // is no window where a wake could reach a chain that is mid-attempt.
+    //
+    // A left-behind resolver would in fact be inert — it closes over its own timer and
+    // its own promise, both already settled by the time it could be called again, and
+    // the next sleep overwrites the slot regardless. Mutation-tested: dropping either
+    // assignment changes no observable behaviour. They are kept because the invariant,
+    // not the assignment, is the thing this function's callers rely on.
+    const timer = setTimeout(() => {
+      wakeFromBackoff = null;
+      resolve();
+    }, durationMs);
+
+    wakeFromBackoff = () => {
+      clearTimeout(timer);
+      wakeFromBackoff = null;
+      resolve();
+    };
+  });
 }
 
 /**
@@ -237,6 +281,7 @@ async function readJournalMode(db: SQLiteDatabase): Promise<string> {
  * layout, size) scope.
  */
 export function initializeDatabase(db: SQLiteDatabase): Promise<void> {
+  const replacesTheOneInFlight = latestDatabase !== null && latestDatabase !== db;
   // Recorded on EVERY call, including the remount that only gets the shared promise
   // back, so the in-flight chain can retarget onto the live connection.
   latestDatabase = db;
@@ -247,6 +292,11 @@ export function initializeDatabase(db: SQLiteDatabase): Promise<void> {
   // old one (#5292). The chain below republishes once the new connection's migrations
   // are in place.
   if (databaseHandle !== null && databaseHandle !== db) setDatabaseHandle(null);
+  // Whatever lock the chain is sitting out belongs to a connection that no longer
+  // exists, so the rest of the gap buys nothing — and at the slow #4314 gaps it costs
+  // this mount up to a minute of null handle. End the sleep and let the loop retarget.
+  // A no-op unless the chain is actually parked (see `wakeFromBackoff`).
+  if (replacesTheOneInFlight) wakeFromBackoff?.();
   activeInitialization ??= beginInitialization(db);
   return activeInitialization;
 }
@@ -427,7 +477,7 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
       }
 
       markStartup('sqlite.recovery.start');
-      await delay(retryDelayMs);
+      await sleepUntilRetry(retryDelayMs);
     }
   })();
 
@@ -469,6 +519,9 @@ export function resetDatabaseInitializationForTests(): void {
   activeInitialization = null;
   latestDatabase = null;
   hasReportedRecovery = false;
+  // A chain a test walked away from must not be reachable from the next one's first
+  // `initializeDatabase` call.
+  wakeFromBackoff = null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #4314.

A launch whose SQLite setup collides with a board-data snapshot import lost offline storage for the **rest of the session**. The init retry chain gave up around 30 s, and `SQLiteProvider` calls `onInit` exactly once per connection — so once the chain returned, nothing was left to try again. The handle stayed null, offline search and local ticks fell back to the network until the app was killed, over a database that became writable a minute or two later.

**The bug still reproduces — #5336 did not fix it, and could not have.** #5336 (issue #5292) reworked the handle *lifecycle* and addresses the `Access to closed resource` family. What is still arriving is `database is locked` with `retryable: true` — a different failure entirely, on a code path #5336 does not touch. Latest events: `2026-09-08T22:41:51Z` (iOS `2.4.0+13`) and `2026-09-08T22:36:56Z`.

### What the field data actually says

`kind:sqlite-init`, 30 d, grouped by `tags[phase]` + `release` — 39 phase-tagged events on the current 2.4.0 fleet (a phase tag is only emitted by post-#4121 JS, so unlike the phase-empty tail earlier triage measured, these are genuine post-fix failures):

| release | phase | journal_mode | events |
| --- | --- | --- | --- |
| 2.4.0+2001018 | migrations | wal | 21 |
| 2.4.0+13 | migrations | wal | 9 |
| 2.4.0+2001004 | migrations | wal | 5 |
| 2.4.0+2001016 / +2001017 | migrations | wal | 3 |
| 2.4.0+2001018 / +13 | wal / queue-table | unavailable | 2 |

One event's own telemetry settles the mechanism (`2c3fe961183f45f88b6096fc37dbb21c`):

```
phase: migrations   journal_mode: wal   retryable: true
attempts: 4         elapsedMs: 29875
error: NativeDatabase.execAsync rejected → Caused by: database is locked
```

29,875 ms of a 30,000 ms window. Subtract the 7.5 s of backoff sleeps and each attempt blocked ~5.6 s — i.e. `busy_timeout` was set, consulted, and waited its full 5 s every time. The wait works; the **window** is too short. It was sized against `vacuumDatabase`'s documented 5–20 s exclusive lock, but the writer that actually holds the file is a board-data snapshot import, whose `importMs` reaches 253,939 ms.

### The thread I pulled and had to drop

`PRAGMA busy_timeout` is connection-local, so a connection that skips `configureMainConnection` would fail instantly rather than wait. I probed every statement the init path issues against real SQLite, with a second connection holding an `IMMEDIATE` write transaction on a WAL file:

```
CREATE TABLE IF NOT EXISTS pending_mutations (exists)  -> OK in 0ms    (takes no lock)
CREATE TABLE IF NOT EXISTS schema_version   (exists)   -> OK in 1ms    (takes no lock)
SELECT version FROM schema_version                     -> OK in 0ms    (WAL reader)
BEGIN + PRAGMA busy_timeout=300 + ALTER TABLE          -> THREW in 302ms: database is locked
CREATE TABLE IF NOT EXISTS brand_new (does not exist)  -> THREW in 302ms: database is locked
```

Every init-path statement either takes no lock at all or honours the timeout `applyBusyTimeout` sets — the migration DDL waited its full 302 ms before failing. So a missing `busy_timeout` is **not** the residual cause, and the only statement that can contend is a genuinely pending migration's DDL. That matches `phase: migrations` and matches the timing: migration v5 landed in `b941bbdd8` on 2026-09-07, so the whole 2.4.0 fleet runs a pending `ALTER TABLE` on its first launches after the update.

### The change

**Commit 1 — a longer ladder.** Four more gaps (30 s, then 60 s × 3), carrying the chain to ~227 s of waiting. Reached **only** by a failure `classifySqliteLockError` calls contention: a full disk or a corrupt file still ends the chain on attempt 1, a healthy launch never sees them, and a blocked attempt is an idle await, not a spin. The launch gate still opens after attempt 1, so nothing about app startup changes.

A launch that comes back now fires `Offline SQLite Init Recovered` instead of a Sentry report. That is deliberate: it turns the `kind:sqlite-init` aggregate into "genuinely wedged past four minutes" and leaves the recovery event as the signal separating *fixed* from *still contending, just retrying its way out* — the close criterion this issue asked for.

**Commit 2 — the backoff is interruptible** (review feedback). A remount inside one of the new 60 s gaps used to be invisible to the chain: `initializeDatabase` moved `latestDatabase` and handed the remount the already-resolved launch gate, while the detached loop stayed parked in `delay()`. The replacement provider therefore rendered with a null handle and `schemaReady` false for up to a minute over a connection that was usable immediately. At the old 17.5 s ceiling that stranding cost seconds; the longer ladder is what sharpens it into a minute, so it belongs in this PR.

`initializeDatabase` now ends the sleep when the connection it is handed differs from the one in flight, and the loop falls into the **retarget path it already had** — one code path, not two. Three properties, each with a guard:

- a wake **retargets** rather than retrying the stale connection;
- a wake **cannot double-run an in-flight attempt** — `wakeFromBackoff` is non-null only while the chain is parked, so this is structural rather than accidental;
- a wake **buys no budget**. The slot was spent before the sleep and `supersededRestarts` is untouched, so a remount storm cannot keep one chain alive past `MAX_INIT_ATTEMPTS`.

One thing I could not guard, stated plainly: nulling the resolver on each exit is invariant hygiene, not observable behaviour. A left-behind resolver closes over its own already-fired timer and already-settled promise, and the next sleep overwrites the slot regardless — mutation-tested, and dropping either assignment changes nothing a test can see. The assignments stay because the *invariant* is what the no-double-run property rests on; the code comment says so rather than implying a bug that does not exist.

### Relationship to #5366, #5302 and #5300

- **#5366** (P1, from the post-merge review of #5336) — `attemptInitialization` publishes `setDatabaseHandle(target)` unconditionally on success even when `latestDatabase` has already superseded and closed it, and neither the retarget `continue` nor the give-up path retracts. **That fix should land before or with this PR**, and the two compose: #5366 makes the handle `null` in exactly the window this PR's wake exists to shorten. I have deliberately kept out of the publish/retract semantics — this PR touches the sleep and the entry point only, not the retarget branch #5366 rewrites. Checked before editing: no `fix/5366-` branch or PR exists yet.
- **#5302** — the *holder's* side: a sync cycle aborting on the lock, mostly in the `board_data` pull, in `packages/shared/offline-sync/src/sync/`. Untouched. A shorter hold there makes this ladder fire less often; neither fix needs the other.
- **#5300** — the expo-sqlite teardown use-after-free. Merged as #5358; this branch is rebased on it.

### Verification

**New behaviour, mutation-tested.** With the slow ladder unwired:

```
× tags the failure report with the SQLite result code and the journal mode
    expected { attempts: 5, retryable: true, …(1) } to match object { attempts: 9, retryable: true }
× gives up after the bounded attempt window and reports once, tagged with the phase
    expected 5 to be 9
× keeps retrying a lock that outlives the fast window, instead of dying for the session
    expected "vi.fn()" to not be called at all, but actually been called 1 times
      [Error: Calling the 'execAsync' function has failed → Error code 5: database is locked]
× wakes the backoff when a replacement connection arrives, instead of sleeping out the gap
× spends the same budget however many remounts wake it
Tests  5 failed | 35 passed (40)
```

With the wake suppressed (`if (replacesTheOneInFlight && false)`):

```
× wakes the backoff when a replacement connection arrives, instead of sleeping out the gap
    AssertionError: expected null to be { …(4) }
× spends the same budget however many remounts wake it
    AssertionError: expected 1 to be 9
Tests  2 failed | 38 passed (40)
```

The wake assertion advances the **fake** clock by 1 ms, not the wall clock, so it cannot race the box.

**#5336's five shipped guards were re-run against this change and all five still go red:**

| guard | mutation | red |
| --- | --- | --- |
| `retracts the closed connection when the remount starts…` | drop the synchronous retraction in `initializeDatabase` | `expected { …(4) } to be null` |
| `re-publishes the connection a remount opened` | keep `activeInitialization` on the success path | `expected null to be { …(4) }` |
| `retargets when the remount lands during the attempt that wins` | disable the retarget `continue` | `expected { …(4) } to be { …(4) }` |
| `ignores a teardown for a connection a newer mount has already replaced` | drop `releaseDatabaseHandle`'s identity check | `expected null to be { …(4) }` |
| `retracts the handle before the connection is closed` | remove `<DatabaseHandleLifecycle />` | `expected { connection: 1 } to be null` |

- `vp run typecheck:mobile` — clean
- `vp test run --project mobile src/db/__tests__/connection.test.ts src/providers/__tests__/database-provider.test.tsx` — `Tests 41 passed (41)`
- `vp run check:mobile-bundle` — `android bundle: OK`
- `vp check` on the two changed files — `correctly formatted`, `no warnings, lint errors, or type errors`

The full mobile and offline-sync suites were **not** run locally: the box is under heavy multi-agent load and those suites produce shifting hook/test timeouts there (verified the same failures on a stashed clean tree). CI is authoritative. No file under `packages/shared/offline-sync` is touched.

## Release Notes

Start the app while a board is still downloading and offline mode used to switch itself off until you force-quit — your ticks went straight to the network and offline search came up empty. Now the app waits the download out and offline storage comes back on its own.

## Test plan

1. Start a board download, force-quit mid-download.
2. Reopen the app, go to My Boards.
3. Wait for the download to finish, stay in the app.
4. Turn on airplane mode, open Search.
5. Your downloaded climbs still list, and ticks save.

## Risk

Risk: 3/5 — one retry ladder in the mobile SQLite startup path. It only lengthens what a lock-classified failure does; non-lock failures, the launch gate, and the handle lifecycle are unchanged. Worst case is a wedged database retrying idly for four minutes instead of thirty seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
