### PR TITLE
fix(mobile): keep the download handle alive until iOS is done with it

### DIFF
--- a/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
+++ b/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
@@ -24,6 +24,9 @@ const state = vi.hoisted(() => ({
     hasSignal: boolean;
   }>,
   taskReleases: 0,
+  // Every `release()` that landed while the fake's native URLSessionTask
+  // pointer was still live — the EXC_BAD_ACCESS window of issue #5297.
+  releasesDuringNativeTeardown: 0,
   taskResolvesNull: false,
   /** Overrides the finished file's on-disk size, for the exact decoded-size gate. */
   downloadedFileSize: null as number | null,
@@ -141,13 +144,41 @@ vi.mock('expo-file-system', () => {
           hasOnProgress: options?.onProgress !== undefined,
           hasSignal: options?.signal !== undefined,
         });
+        // Models the iOS SharedObject lifecycle that issue #5297 crashed on.
+        // `downloadAsync()` settles from `didFinishDownloadingTo`, but the
+        // native object only drops its URLSessionTask pointer later, from a
+        // SEPARATE delegate callback — `didCompleteWithError`'s
+        // `defer { finishTask() }`. Until then the pointer is live and
+        // Foundation is already tearing the task down.
+        let nativeTaskPointerLive = false;
+        const dropPointerOnALaterTurn = () => {
+          // A later turn, never the one that settled the promise: that gap is
+          // the whole bug.
+          setTimeout(() => {
+            nativeTaskPointerLive = false;
+          }, 0);
+        };
         return {
           downloadAsync: async () => {
-            const file = await runFakeTransfer(destination, options);
-            return state.taskResolvesNull ? null : file;
+            nativeTaskPointerLive = true;
+            try {
+              const file = await runFakeTransfer(destination, options);
+              return state.taskResolvesNull ? null : file;
+            } finally {
+              dropPointerOnALaterTurn();
+            }
           },
           release: () => {
             state.taskReleases += 1;
+            // `sharedObjectWillRelease()` cancels `downloadTask` with no
+            // completed-task guard. On a live pointer that is a use-after-free
+            // and the process dies; here it is a loud, catchable throw.
+            if (nativeTaskPointerLive) {
+              state.releasesDuringNativeTeardown += 1;
+              throw new Error(
+                'EXC_BAD_ACCESS: FileSystemDownloadTask.sharedObjectWillRelease cancelled a task Foundation is already tearing down',
+              );
+            }
           },
         };
       },
@@ -314,6 +345,7 @@ beforeEach(() => {
   state.files.clear();
   state.taskCalls = [];
   state.taskReleases = 0;
+  state.releasesDuringNativeTeardown = 0;
   state.taskResolvesNull = false;
   state.downloadedFileSize = null;
 });
@@ -665,17 +697,43 @@ describe('fixed download transport', () => {
     expect(signal.aborted).toBe(false);
   });
 
-  it('releases the native task handle on the success AND the throw path', async () => {
-    await mobileSnapshotSource.downloadArtifact(ENTRY);
-    expect(state.taskReleases).toBe(1);
+  // Issue #5297. The handle used to be released in a `finally` on the tick
+  // `downloadAsync()` settled, which runs iOS's `sharedObjectWillRelease()` →
+  // an unguarded `downloadTask?.cancel()` on a task Foundation is already
+  // tearing down. EXC_BAD_ACCESS, and the climber loses the whole ~100 MB
+  // transfer. The fake turns that window into a throw, so a regression here
+  // fails the transfer instead of passing quietly.
+  it('never touches the native task handle on the tick the transfer settles', async () => {
+    const result = await mobileSnapshotSource.downloadArtifact(ENTRY);
 
-    // A different build, so the sidecar the first download wrote cannot short
-    // -circuit this one into the reuse path.
+    expect(result).not.toBeNull();
+    expect(state.releasesDuringNativeTeardown).toBe(0);
+    expect(state.taskReleases).toBe(0);
+  });
+
+  it('leaves the handle alone on the throw path too, and still reports the failure', async () => {
     state.downloadError = new Error('boom');
-    await expect(
-      mobileSnapshotSource.downloadArtifact({ ...ENTRY, builtAt: '2026-06-02T00:00:00.000Z' }),
-    ).rejects.toThrow(/transfer failed/);
-    expect(state.taskReleases).toBe(2);
+
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow(/transfer failed/);
+
+    // The rejection must be the transport's, not a fault raised by our own
+    // teardown — a released-handle crash would replace it.
+    expect(state.releasesDuringNativeTeardown).toBe(0);
+    expect(state.taskReleases).toBe(0);
+  });
+
+  it('cancels through the abort signal only, and expo guards that call', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY, { signal: controller.signal })).rejects.toThrow();
+
+    // Not vacuous: the transfer really did reach the task transport.
+    expect(state.taskCalls).toHaveLength(1);
+    // Cancellation has exactly one owner: the signal expo wires to
+    // `DownloadTask.cancel()`. We never add a second, unguarded one.
+    expect(state.releasesDuringNativeTeardown).toBe(0);
+    expect(state.taskReleases).toBe(0);
   });
 
   it('treats a task that resolves null as a failed transfer, not a silent success', async () => {

--- a/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
+++ b/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
@@ -24,9 +24,20 @@ const state = vi.hoisted(() => ({
     hasSignal: boolean;
   }>,
   taskReleases: 0,
-  // Every `release()` that landed while the fake's native URLSessionTask
-  // pointer was still live — the EXC_BAD_ACCESS window of issue #5297.
+  // Every detach that landed while the fake's native URLSessionTask pointer was
+  // still live — the EXC_BAD_ACCESS window of issue #5297. An explicit
+  // `release()` is one way in; Hermes collecting an unreferenced handle is the
+  // other, and it runs the same `sharedObjectWillRelease()`.
   releasesDuringNativeTeardown: 0,
+  // Simulated Hermes collections that actually found a collectible handle. Not
+  // an error on its own — a collection AFTER the pointer drop is exactly what
+  // is supposed to happen — but it keeps the GC-window test from passing
+  // because nothing was ever collected.
+  garbageCollectedTasks: 0,
+  // One entry per handle the fake handed out: runs a Hermes collection against
+  // it if — and only if — the app no longer references it. Lets a test open the
+  // window again on a later turn, not just at the settling tick.
+  collectUnreachableTasks: [] as Array<() => void>,
   taskResolvesNull: false,
   /** Overrides the finished file's on-disk size, for the exact decoded-size gate. */
   downloadedFileSize: null as number | null,
@@ -48,6 +59,15 @@ const state = vi.hoisted(() => ({
   // turns on file existence, sidecar contents, sizes, and mtimes, so a fake
   // where `exists` is always true would prove nothing.
   files: new Map<string, { text: string | null; bytes: Uint8Array; size: number; lastModified: number }>(),
+}));
+
+// Reachability probe for the fake's garbage-collection model, filled in below
+// from the real retention registry. It throws until then so a broken wiring
+// fails loudly instead of silently modelling "everything is always retained".
+const reachability = vi.hoisted(() => ({
+  isRetainedByApp: (_task: object): boolean => {
+    throw new Error('snapshot-source test: retention probe was never wired to download-task-retention');
+  },
 }));
 
 vi.mock('expo-file-system', () => {
@@ -151,6 +171,7 @@ vi.mock('expo-file-system', () => {
         // `defer { finishTask() }`. Until then the pointer is live and
         // Foundation is already tearing the task down.
         let nativeTaskPointerLive = false;
+        let detached = false;
         const dropPointerOnALaterTurn = () => {
           // A later turn, never the one that settled the promise: that gap is
           // the whole bug.
@@ -158,13 +179,37 @@ vi.mock('expo-file-system', () => {
             nativeTaskPointerLive = false;
           }, 0);
         };
-        return {
+        // Both `release()` and Hermes collecting the handle land here. In
+        // expo-modules-core 57.0.14 the shared-object registry wires a releaser
+        // into the C++ native state's destructor
+        // (SharedObjectRegistry.swift:127-135, SharedObject.cpp:18-20), so
+        // `~NativeState()` calls the very `sharedObjectWillRelease()` that
+        // `release()` does. There is no third behaviour to model, only two
+        // doors into one.
+        const sharedObjectWillRelease = () => {
+          if (detached) return;
+          detached = true;
+          if (nativeTaskPointerLive) {
+            state.releasesDuringNativeTeardown += 1;
+            throw new Error(
+              'EXC_BAD_ACCESS: FileSystemDownloadTask.sharedObjectWillRelease cancelled a task Foundation is already tearing down',
+            );
+          }
+        };
+        const task = {
           downloadAsync: async () => {
             nativeTaskPointerLive = true;
             try {
               const file = await runFakeTransfer(destination, options);
               return state.taskResolvesNull ? null : file;
             } finally {
+              // Hermes may collect the handle on the tick the promise settles:
+              // its last JS use was the `await`, and the JS object's
+              // native-state slot is the only strong owner of the C++ state
+              // whose destructor fires the releaser. Model that collection
+              // BEFORE the pointer drops — the app has to be the thing keeping
+              // the handle reachable, not GC timing.
+              collectIfUnreachable();
               dropPointerOnALaterTurn();
             }
           },
@@ -173,14 +218,20 @@ vi.mock('expo-file-system', () => {
             // `sharedObjectWillRelease()` cancels `downloadTask` with no
             // completed-task guard. On a live pointer that is a use-after-free
             // and the process dies; here it is a loud, catchable throw.
-            if (nativeTaskPointerLive) {
-              state.releasesDuringNativeTeardown += 1;
-              throw new Error(
-                'EXC_BAD_ACCESS: FileSystemDownloadTask.sharedObjectWillRelease cancelled a task Foundation is already tearing down',
-              );
-            }
+            sharedObjectWillRelease();
           },
         };
+        // A collection can only reach an unreferenced handle. `isRetainedByApp`
+        // asks the app's own retention registry, so this stays a real test of
+        // the app's behaviour rather than a scripted crash.
+        function collectIfUnreachable() {
+          if (detached) return;
+          if (reachability.isRetainedByApp(task)) return;
+          state.garbageCollectedTasks += 1;
+          sharedObjectWillRelease();
+        }
+        state.collectUnreachableTasks.push(collectIfUnreachable);
+        return task;
       },
     );
 
@@ -289,6 +340,11 @@ vi.mock('../artifact-transfer-telemetry', () => ({
 
 import { mobileSnapshotSource, SNAPSHOT_MANIFEST_FETCH_TIMEOUT_MS } from '../snapshot-source';
 import {
+  clearRetainedDownloadTasks,
+  DOWNLOAD_TASK_RETENTION_MS,
+  isDownloadTaskRetained,
+} from '../download-task-retention';
+import {
   setBackgrounded,
   SnapshotArtifactTruncatedError,
   SnapshotBackgroundTransferInterruptedError,
@@ -328,9 +384,38 @@ function brokenJsonResponse(status = 200): Response {
   } as unknown as Response;
 }
 
+// The fake's garbage collector asks the app whether it still holds the handle.
+reachability.isRetainedByApp = isDownloadTaskRetained;
+
+/**
+ * Re-imports the source with a fresh module graph, for the cases that need
+ * module-init state (the platform-pinned download strategy) recomputed.
+ *
+ * `vi.resetModules()` also mints a fresh retention registry, so the probe is
+ * repointed at it for the duration — otherwise the fake's collector would ask
+ * the stale registry, be told the handle is unreferenced, and fail the test
+ * with a use-after-free the app never had.
+ */
+async function withFreshSnapshotSource<T>(run: (source: typeof mobileSnapshotSource) => Promise<T>): Promise<T> {
+  vi.resetModules();
+  const { mobileSnapshotSource: freshSource } = await import('../snapshot-source');
+  const freshRetention = await import('../download-task-retention');
+  const previousProbe = reachability.isRetainedByApp;
+  reachability.isRetainedByApp = freshRetention.isDownloadTaskRetained;
+  try {
+    return await run(freshSource);
+  } finally {
+    reachability.isRetainedByApp = previousProbe;
+    freshRetention.clearRetainedDownloadTasks();
+  }
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   setBackgrounded(false);
+  // Retained handles and their pending 30-second timers are module state; a
+  // leftover from the previous test would make the next one's GC a no-op.
+  clearRetainedDownloadTasks();
   platformState.OS = 'ios';
   state.availableDiskSpace = 10_000_000_000;
   state.createdDirectories = [];
@@ -346,6 +431,8 @@ beforeEach(() => {
   state.taskCalls = [];
   state.taskReleases = 0;
   state.releasesDuringNativeTeardown = 0;
+  state.garbageCollectedTasks = 0;
+  state.collectUnreachableTasks = [];
   state.taskResolvesNull = false;
   state.downloadedFileSize = null;
 });
@@ -571,10 +658,10 @@ describe('downloadArtifact', () => {
     const downloadError = new Error("The operation couldn't be completed. cannot decode raw data");
     state.downloadError = downloadError;
     platformState.OS = 'android';
-    vi.resetModules();
-    const { mobileSnapshotSource: foregroundSnapshotSource } = await import('../snapshot-source');
 
-    const rejection = await foregroundSnapshotSource.downloadArtifact(ENTRY).catch((error: unknown) => error);
+    const rejection = await withFreshSnapshotSource((foregroundSnapshotSource) =>
+      foregroundSnapshotSource.downloadArtifact(ENTRY).catch((error: unknown) => error),
+    );
 
     expect(rejection).toBeInstanceOf(Error);
     expect(rejection).not.toBeInstanceOf(SnapshotBackgroundTransferInterruptedError);
@@ -734,6 +821,55 @@ describe('fixed download transport', () => {
     // `DownloadTask.cancel()`. We never add a second, unguarded one.
     expect(state.releasesDuringNativeTeardown).toBe(0);
     expect(state.taskReleases).toBe(0);
+  });
+
+  // Issue #5297, second door. Not calling `release()` does not keep the handle
+  // alive: expo-modules-core 57.0.14 wires the registry's releaser into the C++
+  // native state's destructor (SharedObjectRegistry.swift:127-135 →
+  // SharedObject.cpp:18-20), and the JS object's native-state slot is that
+  // state's only strong owner — the Swift pairings are weak. So a Hermes
+  // collection runs the same unguarded `downloadTask?.cancel()`, and nothing
+  // orders it after `didCompleteWithError`. The fake collects any handle the app
+  // has stopped referencing, at the exact tick the promise settles.
+  it('survives a garbage collection on the settling tick, when the native pointer is still live', async () => {
+    const result = await mobileSnapshotSource.downloadArtifact(ENTRY);
+
+    expect(result).not.toBeNull();
+    // The window was open and the collector did run — it just found the handle
+    // still referenced.
+    expect(state.taskCalls).toHaveLength(1);
+    expect(state.garbageCollectedTasks).toBe(0);
+    expect(state.releasesDuringNativeTeardown).toBe(0);
+  });
+
+  it('keeps the handle reachable on the throw path, where the reject also beats finishTask', async () => {
+    state.downloadError = new Error('boom');
+
+    await expect(mobileSnapshotSource.downloadArtifact(ENTRY)).rejects.toThrow(/transfer failed/);
+
+    // The rejection is the transport's own, not a use-after-free raised by a
+    // collection landing inside Foundation's teardown.
+    expect(state.garbageCollectedTasks).toBe(0);
+    expect(state.releasesDuringNativeTeardown).toBe(0);
+  });
+
+  it('lets the handle go once the delegate has certainly finished with it', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      await mobileSnapshotSource.downloadArtifact(ENTRY);
+      // Past the drop of the native pointer AND past the retention window.
+      await vi.advanceTimersByTimeAsync(DOWNLOAD_TASK_RETENTION_MS + 1);
+
+      // Now a collection finds it — and finds nothing to cancel, because
+      // `didCompleteWithError` nilled the pointer long ago.
+      expect(state.collectUnreachableTasks).toHaveLength(1);
+      for (const collect of state.collectUnreachableTasks) collect();
+
+      expect(state.garbageCollectedTasks).toBe(1);
+      expect(state.releasesDuringNativeTeardown).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('treats a task that resolves null as a failed transfer, not a silent success', async () => {

--- a/packages/mobile/src/offline/download-task-retention.ts
+++ b/packages/mobile/src/offline/download-task-retention.ts
@@ -1,0 +1,127 @@
+// Keeps expo-file-system download handles reachable from JavaScript until the
+// iOS session delegate has finished with them (issue #5297).
+//
+// WHY THIS EXISTS
+//
+// `FileSystemDownloadTask.sharedObjectWillRelease()` calls
+// `downloadTask?.cancel()` with no completed-task guard (expo-file-system
+// 57.0.6, ios/FileSystemDownloadTask.swift:313-316). That pointer is nilled in
+// exactly one place for a transfer that ran to completion — `finishTask()`,
+// called from `didCompleteWithError`'s `defer` (:406-408 → :308-311/:318-324).
+// The promise `downloadAsync()` awaits, however, is resolved earlier, from
+// `didFinishDownloadingTo` (:363-404). Between those two delegate callbacks the
+// URLSessionTask pointer is live while Foundation is already tearing the task
+// down, and cancelling it there is the EXC_BAD_ACCESS of issue #5297.
+//
+// Dropping our own `task.release()` was necessary but NOT sufficient, because
+// `release()` is not the only way into `sharedObjectWillRelease()`. In
+// expo-modules-core 57.0.14 the registry wires a releaser into the C++ shared
+// object's native state (ios/Core/SharedObjects/SharedObjectRegistry.swift:127-135),
+// and `expo::SharedObject::NativeState::~NativeState()` calls it
+// (common/cpp/SharedObject.cpp:18-20). The JS object's native-state slot is the
+// only strong owner of that C++ state — the Swift side holds the pairing weakly
+// (`SharedObject.nativeState` is `weak`; `SharedObjectNativeState.pairedObjects`
+// stores `JavaScriptWeakObject`s) — so when Hermes collects the JS handle, the
+// destructor runs `SharedObjectRegistry.delete(id)`, which calls
+// `sharedObjectWillRelease()`. Same unguarded cancel, same window. Expo
+// documents `release()` as doing early what the GC does anyway: "detaches the
+// JS and native objects to let the native object deallocate before the JS
+// object gets deallocated by the JS garbage collector".
+//
+// Nothing orders that collection after `didCompleteWithError`. A handle whose
+// last JS use was the `await` becomes collectible on the very tick the promise
+// settles — the same tick the old eager `release()` fired on. So the fix is to
+// keep a strong JS reference until the delegate has certainly moved on.
+//
+// WHY A TIMER AND WHY THIS LONG
+//
+// JavaScript gets no signal for `didCompleteWithError`; expo exposes no
+// completion event, only `progress` (expo-file-system 57.0.6,
+// src/NetworkTasks.ts). What we need to outlast is one hop on the URLSession
+// delegate queue: `didCompleteWithError` is the next callback that queue runs
+// after `didFinishDownloadingTo` returns, with no work in between.
+// DOWNLOAD_TASK_RETENTION_MS is roughly four orders of magnitude more than that
+// hop, and holding a pointer-sized shell object for that long costs nothing —
+// the ~100 MB payload went straight to disk, never through this handle.
+//
+// The deterministic alternative is a native completed-task guard in
+// expo-file-system, which cannot be done in JavaScript: patching Swift moves
+// the fingerprint, so it would never reach the store builds the crashes are
+// coming from.
+
+/**
+ * How long a handle stays reachable after its transfer settles. See the header
+ * for why the delegate-queue hop this has to outlast is measured in
+ * microseconds.
+ */
+export const DOWNLOAD_TASK_RETENTION_MS = 30_000;
+
+/**
+ * The handles JavaScript still references, mapped to the timer that will drop
+ * them (`null` while the transfer is still running, so an in-flight handle is
+ * never evicted). Both the map key and the timer closure hold the handle
+ * strongly, which is the entire point: while it is in here, Hermes cannot
+ * collect it and `~NativeState()` cannot run.
+ *
+ * Keys are compared by identity, so a handle is only ever released by the
+ * transfer that retained it.
+ */
+const retainedDownloadTasks = new Map<object, ReturnType<typeof setTimeout> | null>();
+
+/**
+ * Pins `task` so the garbage collector cannot reach
+ * `sharedObjectWillRelease()`. Call it as soon as the handle exists — a
+ * collection mid-transfer would cancel a live download as well as risking the
+ * teardown window.
+ */
+export function retainDownloadTask(task: object): void {
+  if (retainedDownloadTasks.has(task)) return;
+  retainedDownloadTasks.set(task, null);
+}
+
+/**
+ * Starts the countdown that lets `task` become collectible again. Call it once
+ * the transfer has settled, whether it produced a file or threw: the error path
+ * settles from `didCompleteWithError` itself, whose `promise.reject(...)` runs
+ * BEFORE the `defer { finishTask() }` that clears the pointer, so it sits in
+ * the same window.
+ *
+ * By the time the timer fires, `didCompleteWithError` has long since nilled
+ * `downloadTask`, so the collection that eventually follows finds nothing to
+ * cancel.
+ */
+export function releaseDownloadTaskAfterNativeCompletion(task: object): void {
+  if (!retainedDownloadTasks.has(task)) return;
+  if (retainedDownloadTasks.get(task) !== null) return;
+  retainedDownloadTasks.set(
+    task,
+    setTimeout(() => {
+      retainedDownloadTasks.delete(task);
+    }, DOWNLOAD_TASK_RETENTION_MS),
+  );
+}
+
+/**
+ * Whether JavaScript still holds `task`, and so whether a Hermes collection
+ * could currently run `sharedObjectWillRelease()` on it.
+ *
+ * The app never needs to ask; the snapshot-source suite does, to model GC
+ * finalization of an unreferenced handle at the exact moment the window is
+ * open. Without a reachability query a test can only fake the collection, which
+ * proves nothing about whether the app prevented it.
+ */
+export function isDownloadTaskRetained(task: object): boolean {
+  return retainedDownloadTasks.has(task);
+}
+
+/**
+ * Drops every handle and cancels the pending releases, so one test's retained
+ * handles and 30-second timers cannot leak into the next. Production code has
+ * no reason to call this: a handle released early is exactly the crash.
+ */
+export function clearRetainedDownloadTasks(): void {
+  for (const timer of retainedDownloadTasks.values()) {
+    if (timer !== null) clearTimeout(timer);
+  }
+  retainedDownloadTasks.clear();
+}

--- a/packages/mobile/src/offline/snapshot-source.ts
+++ b/packages/mobile/src/offline/snapshot-source.ts
@@ -44,6 +44,7 @@ import { SNAPSHOT_BASE_URL } from '../lib/env';
 import { SNAPSHOT_DIR_NAME } from './snapshot-paths';
 import { reportHandledError } from '../lib/error-reporting';
 import { resolveSnapshotDownloadStrategy, type SnapshotDownloadStrategy } from './download-strategy';
+import { releaseDownloadTaskAfterNativeCompletion, retainDownloadTask } from './download-task-retention';
 import { reportArtifactTransfer, type ArtifactTransferOutcome } from './artifact-transfer-telemetry';
 
 // Fixed per platform for the lifetime of the bundle: iOS uses a background
@@ -357,18 +358,34 @@ async function runTransfer(args: {
   // disk. Expo documents `release()` as being for objects that "exclusively
   // retain some native memory", and only once "nothing else will use this
   // object later on". Something does: the session delegate still calls
-  // `finishTask()` on it. Dropping our last reference instead lets the GC
-  // release it seconds later, after that has run.
+  // `finishTask()` on it.
+  //
+  // Not calling `release()` is not enough on its own, though. Hermes collecting
+  // the handle runs the SAME `sharedObjectWillRelease()`, through the releaser
+  // the shared-object registry wires into the C++ native state's destructor,
+  // and nothing orders that collection after `didCompleteWithError`. So the
+  // handle is pinned for the whole transfer and released only well after it
+  // settles — see download-task-retention.ts for the ownership chain that makes
+  // GC reach the same unguarded cancel.
   //
   // Cancellation keeps exactly one owner: `args.signal`, which expo wires to
   // `DownloadTask.cancel()`. That one is state-guarded, so it is a no-op once
   // the transfer has completed, cancelled, or errored.
-  const file = await task.downloadAsync();
-  // `downloadAsync` resolves null ONLY when `pause()` was called, which we
-  // never do. Treat it as a failed transfer rather than a silent success that
-  // would hand the engine a handle to a file nobody wrote.
-  if (!file) throw new Error('snapshot download: transfer ended without a file');
-  return file;
+  retainDownloadTask(task);
+  try {
+    const file = await task.downloadAsync();
+    // `downloadAsync` resolves null ONLY when `pause()` was called, which we
+    // never do. Treat it as a failed transfer rather than a silent success that
+    // would hand the engine a handle to a file nobody wrote.
+    if (!file) throw new Error('snapshot download: transfer ended without a file');
+    return file;
+  } finally {
+    // Starts the countdown, never the release itself: the throw path settles
+    // from `didCompleteWithError`'s own `promise.reject(...)`, which runs
+    // before its `defer { finishTask() }`, so a failed transfer sits in the
+    // same window a successful one does.
+    releaseDownloadTaskAfterNativeCompletion(task);
+  }
 }
 
 /**

--- a/packages/mobile/src/offline/snapshot-source.ts
+++ b/packages/mobile/src/offline/snapshot-source.ts
@@ -338,18 +338,37 @@ async function runTransfer(args: {
     ...(args.signal ? { signal: args.signal } : {}),
     ...(args.onProgress ? { onProgress: args.onProgress } : {}),
   });
-  try {
-    const file = await task.downloadAsync();
-    // `downloadAsync` resolves null ONLY when `pause()` was called, which we
-    // never do. Treat it as a failed transfer rather than a silent success that
-    // would hand the engine a handle to a file nobody wrote.
-    if (!file) throw new Error('snapshot download: transfer ended without a file');
-    return file;
-  } finally {
-    // Only after the promise settles: `release()` frees the native shared
-    // object, and `sharedObjectDidRelease` cancels an in-flight call.
-    task.release();
-  }
+  // Nothing releases the handle here, and nothing may (issue #5297).
+  //
+  // `release()` runs iOS's `sharedObjectWillRelease()`, which calls
+  // `downloadTask?.cancel()` with no completed-task guard
+  // (expo-file-system 57.0.6, ios/FileSystemDownloadTask.swift:313-316). The
+  // promise below settles from `didFinishDownloadingTo` (:363-404), but that
+  // pointer is only nilled later, by `didCompleteWithError`'s
+  // `defer { finishTask() }` (:406-408 → :308-324). Releasing on the settling
+  // tick therefore cancels a task Foundation is already tearing down, and the
+  // process dies with EXC_BAD_ACCESS mid-transfer — 6 production crashes over
+  // 15 days, each one costing the climber the whole ~100 MB download.
+  //
+  // Eager release bought nothing to begin with: expo's own
+  // `_runDownloadOperation` finally has already removed the progress
+  // subscription and the abort listener by the time `downloadAsync()` settles,
+  // and the native object retains no bulk memory — the bytes went straight to
+  // disk. Expo documents `release()` as being for objects that "exclusively
+  // retain some native memory", and only once "nothing else will use this
+  // object later on". Something does: the session delegate still calls
+  // `finishTask()` on it. Dropping our last reference instead lets the GC
+  // release it seconds later, after that has run.
+  //
+  // Cancellation keeps exactly one owner: `args.signal`, which expo wires to
+  // `DownloadTask.cancel()`. That one is state-guarded, so it is a no-op once
+  // the transfer has completed, cancelled, or errored.
+  const file = await task.downloadAsync();
+  // `downloadAsync` resolves null ONLY when `pause()` was called, which we
+  // never do. Treat it as a failed transfer rather than a silent success that
+  // would hand the engine a handle to a file nobody wrote.
+  if (!file) throw new Error('snapshot download: transfer ended without a file');
+  return file;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #5297 — an iOS `EXC_BAD_ACCESS` in `FileSystemDownloadTask.sharedObjectWillRelease` that killed the app mid board-snapshot download. 6 crashes / 6 users / 6 devices over 15 days, `environment: production`, 4 of 6 in the foreground. Roughly 4% of iOS layout transfers; each one cost the climber the whole ~100 MB download, because the crash lands after the artifact is moved into place but before the completeness sidecar is written, so the next attempt deletes the file and starts over.

**Root cause is ours, not upstream's.** `runTransfer` released the native handle in a `finally`, on the same tick `await task.downloadAsync()` settled:

```ts
} finally {
  task.release();
}
```

On iOS that promise settles from `urlSession(_:downloadTask:didFinishDownloadingTo:)`, but the SharedObject only drops its `URLSessionDownloadTask` pointer later, from a **separate** delegate callback — `didCompleteWithError`'s `defer { sharedObject?.finishTask() }`. `release()` synchronously runs `sharedObjectWillRelease()`, which calls `downloadTask?.cancel()` with no completed-task guard. Between the two callbacks the pointer is live and Foundation is already tearing the task down, so the cancel is a use-after-free.

Verified verbatim against the installed expo-file-system 57.0.6 (and against expo `main` today, so upstream is not fixed):

```swift
override func sharedObjectWillRelease() {   // ios/FileSystemDownloadTask.swift:313
  downloadTask?.cancel()                    // no completed-task guard
  cleanup(unregisterDelegate: false)
}
```

**Dropping `release()` was necessary but not sufficient.** It closes one door into `sharedObjectWillRelease()`; the garbage collector is the other, and it is the same door. In expo-modules-core 57.0.14 the shared-object registry wires a releaser into the C++ native state (`ios/Core/SharedObjects/SharedObjectRegistry.swift:127-135`), and `expo::SharedObject::NativeState::~NativeState()` calls it (`common/cpp/SharedObject.cpp:18-20`) — reaching the very same `SharedObjectRegistry.delete(id)` → `native.sharedObjectWillRelease()` the JS `release()` reaches. The JS object's native-state slot is that C++ state's only strong owner: `SharedObject.nativeState` is declared `weak`, and `SharedObjectNativeState.pairedObjects` holds `JavaScriptWeakObject`s, so nothing native pins the JS handle. Expo documents `release()` as doing early exactly what the GC does anyway — "detaches the JS and native objects to let the native object deallocate before the JS object gets deallocated by the JS garbage collector".

Nothing orders that collection after `didCompleteWithError`, and the handle's last JS use was the `await` — so it became collectible on precisely the tick the eager `release()` used to fire on. Removing the release alone would have made the crash rarer, not impossible. Credit to the codex review for catching it.

**The fix is to keep the handle reachable until the delegate has certainly finished with it.** `runTransfer` pins it in a small module-level registry from the moment it exists, and starts a 30-second countdown in a `finally` once the transfer settles. The throw path is pinned too: `didCompleteWithError` calls `promise.reject(...)` before its own `defer { finishTask() }` clears the pointer, so a failed transfer sits in the same window a successful one does. What the retention has to outlast is one hop on the URLSession delegate queue — `didCompleteWithError` is the next callback that queue runs after `didFinishDownloadingTo` returns, with nothing in between — so 30 seconds is roughly four orders of magnitude of margin, on a pointer-sized shell object. The ~100 MB payload went straight to disk and never through this handle.

Cancellation still has exactly one owner: the `AbortSignal`, which expo wires to `DownloadTask.cancel()`. That one is state-guarded (`if (['completed', 'cancelled', 'error'].includes(this._state)) return;`), so it is idempotent and a no-op on a settled task. We add no second, unguarded canceller.

**Fingerprint impact: none, and that is what picked the fix.** The change is three TypeScript files under `packages/mobile/src/` — no `app.config.ts`, no plugins, no native modules, no dependency change. The runtime fingerprint is unchanged, so this rides OTA to the current store fleet.

The alternative was a completed-task guard in expo-file-system's Swift, which is more deterministic and is the right upstream fix. It is not reachable from here: patching Swift moves the fingerprint, and 7 of the 9 crashes are on `2.4.0+13` — the shipped build, which a new fingerprint cannot reach by OTA at all. The JS retain closes the window by construction (while the handle is reachable, Hermes cannot collect it and `~NativeState()` cannot run) and reaches exactly the fleet that is crashing. The missing native guard is still worth an upstream report — no expo issue filed yet, and no released version fixes it as of 57.0.6 — but our fix does not wait on one and stays correct if it lands.

**Testing.** The old fake modelled only explicit `release()`, which is why the suite went green on a scenario it could not see. It now models GC finalization: `release()` and a simulated collection both run one `sharedObjectWillRelease()`, and the fake collects every handle at the settling tick, while the native pointer is still live — if and only if the app no longer references it. Reachability is asked of the app's own retention registry, so the guard cannot pass by faking it. Three new cases (70 → 73 tests): survival of a collection on the settling tick, the same on the throw path, and — so the retain is not just permanent — that a later collection does happen and finds nothing to cancel.

Mutation-tested both halves. Removing the retain fails 51 of 73 tests in the file, the GC-window case among them, with `EXC_BAD_ACCESS: FileSystemDownloadTask.sharedObjectWillRelease cancelled a task Foundation is already tearing down` traced through `collectIfUnreachable` to `runTransfer`. Removing the release scheduling fails the "lets the handle go" case alone. Restored, 73/73 pass, and the full mobile suite is 9662/9662. `vp run typecheck:mobile`, `vp run check:mobile-bundle` and `vp check` (0 errors) are all clean; the macOS-only simulator and screenshot checks skip on Linux and were not run.

## Release Notes

Downloading a board for offline no longer crashes the app on iPhone or iPad. A transfer that used to die at the finish line — taking the whole 100 MB with it — now lands, and the board is ready to browse.

## Test plan

1. Open More, then Offline, and enable a Kilter board.
2. Watch the download bar climb all the way to done.
3. Lock the phone mid-download, unlock it a minute later.
4. Turn on airplane mode, browse and search that board.
5. Enable a second board; the app never dies mid-transfer.

## Risk

Risk: 3/5 — it is the offline board-download path, but no native, data or schema change: one helper keeps a reference a little longer, and cancellation still runs through the abort signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
