### PR TITLE
fix(sync): requeue the sends #5295 dead-lettered, and tell the climber

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -381,6 +381,25 @@ Each mutation gets a client-generated UUID as an idempotency key. The backend's 
 
 Mutations that exceed `MAX_RETRY_COUNT` or fail with non-retryable errors are moved to `status = 'dead_letter'`. The app shows a badge/indicator when dead-letter mutations exist. Users can view failed mutations and choose to retry or discard them. This prevents silent data loss — the user always knows if a tick didn't sync.
 
+#### The one-time recovery of the #5295 dead letters (#5335)
+
+Before the classifier fix above, two transport failures resolved as non-retryable and dead-lettered a queued send on attempt 0 of 10: whatwg-fetch's `Network request timed out`, and a Railway edge 404 whose body carried no GraphQL `errors` array. Roughly 17 climbers were left with a row holding a send they logged and believe is recorded. The fix stops new losses; it does not give those rows back, so recovery is its own decision — taken 2026-09-08 in favour of a one-time automatic requeue that the climber is told about.
+
+It is schema migration **6**, and every property it needs falls out of being one:
+
+- **Once per install** — the version stamp. No separate marker to keep, and no way to run it twice.
+- **Interruption-safe** — its data step shares the migration's exclusive transaction, so a killed app rolls the rows and the stamp back together. A row is always `pending` or `dead_letter`, never a third thing.
+- **Narrow** — `isRecoverableTransportDeadLetter` matches the RECORDED ERROR and nothing else. Not age, not table, not `retry_count`. The timeout is an equality match and the 404 an anchored `GraphQL Error (Code: 404)` prefix, because a graphql-request `ClientError` message embeds the whole request: a substring search would let a tick comment talk a 400 rejection into a replay. A row a server permanently rejected comes out untouched, which is what keeps this from being "revive everything".
+- **Reuses the row transition** — `retryDeadLetter`, the same statement More → Sync issues → Retry has always used, so the automatic recovery cannot drift from the manual one.
+
+It must land **with or after** the classifier fix. Revived rows meeting the old classifier would dead-letter again on the first hiccup.
+
+**Telling the climber.** The migration leaves a `sync_meta` note (`dead-letter-recovery-notice`) holding how many sends it put back, and only when that is at least one — a fresh install owes nobody a notice. `SendRecoveryGate`, a launch gate mounted after `OnboardingGate` and `QaTesterGate`, delivers it once as a dismissable modal route, clearing the note before it navigates, and emits `Offline Send Recovery Shown { recoveredCount }`. That event is the only way the recovery is measurable in the field: the rows it moves stop being dead letters, so nothing else can count them afterwards.
+
+The copy says the sends are **on their way**, not that they were recovered. At the moment the notice shows, the requeued rows may still be in flight, and a climber told "3 sends recovered" who then finds one still pending has been lied to. "On their way" is true when it is shown and cannot be falsified by a later failure — and with default-retry a failure now leaves the row pending rather than dead-lettering it, so the promise holds.
+
+The accepted cost: a climber who already re-logged a lost send by hand can end up with two ticks. The server-side `idempotency_key` limits duplicates but cannot eliminate this one, because a hand re-log is a genuinely different mutation. The notice is what makes that duplicate explicable rather than baffling.
+
 ## Sync pull — incremental updates
 
 A pull client that fetches changes since the last sync checkpoint using a composite cursor to avoid timestamp collision bugs.

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -98,6 +98,7 @@ import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
 import { AccessoryOnboardingTip } from '../src/components/onboarding/AccessoryOnboardingTip';
 import { ConnectivityBanner } from '../src/components/connectivity/ConnectivityBanner';
 import { QaTesterGate } from '../src/components/qa/QaTesterGate';
+import { SendRecoveryGate } from '../src/components/offline/SendRecoveryGate';
 import { FreezeDebugOverlay } from '../src/components/FreezeDebugOverlay';
 import { BottomChromeDebugOverlay } from '../src/components/BottomChromeDebugOverlay';
 import { WindowInsetPublisher } from '../src/hooks/use-window-bottom-inset';
@@ -805,6 +806,17 @@ function RootLayout() {
                                                                           headerShown: false,
                                                                         }}
                                                                       />
+                                                                      {/* One-time "sends we lost are on their way" notice
+                                                      (#5335). A plain modal, like the QA screens: it paints
+                                                      its own body and a swipe-dismiss is a perfectly good
+                                                      way to close it. */}
+                                                                      <Stack.Screen
+                                                                        name="send-recovery"
+                                                                        options={{
+                                                                          presentation: 'modal',
+                                                                          headerShown: false,
+                                                                        }}
+                                                                      />
                                                                       <Stack.Screen
                                                                         name="user-drawer"
                                                                         options={{
@@ -851,6 +863,13 @@ function RootLayout() {
                                                             else. Mounted after OnboardingGate so the first-run
                                                             walkthrough always wins a cold start. */}
                                                                   <QaTesterGate ready={authReady && fontsReady} />
+                                                                  {/* Tells a climber the one-time #5335 recovery found sends
+                                                            of theirs that never reached the server. Silent for
+                                                            everyone else, which is almost everyone. Mounted last
+                                                            of the launch gates: a first run and a PR brief both
+                                                            outrank it, and its note is durable, so a launch it
+                                                            sits out costs nothing. */}
+                                                                  <SendRecoveryGate ready={authReady && fontsReady} />
                                                                   {/* Tester-only diagnostic for the Android-16 edge-to-edge
                                                             touch-dead bug; a root sibling (stays tappable while the
                                                             <Stack> hit-region is frozen). No-op unless built with

--- a/packages/mobile/app/send-recovery.tsx
+++ b/packages/mobile/app/send-recovery.tsx
@@ -1,0 +1,5 @@
+import { SendRecoveryScreen } from '../src/components/offline/SendRecoveryScreen';
+
+export default function SendRecoveryRoute() {
+  return <SendRecoveryScreen />;
+}

--- a/packages/mobile/src/components/offline/SendRecoveryGate.tsx
+++ b/packages/mobile/src/components/offline/SendRecoveryGate.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useRef } from 'react';
+import { InteractionManager } from 'react-native';
+import { router, useSegments } from 'expo-router';
+import * as Linking from 'expo-linking';
+import { clearDeadLetterRecoveryNotice, readDeadLetterRecoveryNotice } from '@boardsesh/offline-sync';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { getDatabaseHandle } from '../../db/connection';
+import { useOfflineSchemaReady } from '../../db/use-offline-schema-ready';
+import { hasSeenOnboarding } from '../../lib/onboarding/onboarding-storage';
+import { track } from '../../lib/analytics';
+import { reportHandledError } from '../../lib/error-reporting';
+import { decideSendRecovery, type SendRecoveryInput } from '../../lib/offline-recovery/send-recovery-decision';
+
+type SendRecoveryGateProps = {
+  /** True once auth + fonts are resolved and the splash has hidden. */
+  ready: boolean;
+};
+
+// Once per JS session, not once per mount — a re-render must never push a second
+// copy of the notice.
+let announcedThisSession = false;
+
+/** Test seam: put the session guard back so each case starts from a cold start. */
+export function resetSendRecoverySessionForTests(): void {
+  announcedThisSession = false;
+}
+
+/**
+ * Tells a climber that the one-time #5335 recovery found sends of theirs that
+ * never reached the server. Renders nothing.
+ *
+ * The recovery itself already happened, before React mounted: it is the data step
+ * of schema migration 6, which requeues the rows two transport failures had
+ * dead-lettered and leaves a `sync_meta` note saying how many. This component
+ * only delivers that note, once, and then removes it.
+ *
+ * The note is cleared BEFORE the route is pushed, so the notice is shown at most
+ * once ever. Losing it to a crash in that instant costs a message, not data —
+ * the sends are already back on the queue and will land either way, which is the
+ * cheaper failure than telling somebody twice.
+ *
+ * The decision lives in `decideSendRecovery`, a pure function, so the policy is
+ * unit-tested without a renderer. Everyone with nothing to recover — which is
+ * almost everyone, and every fresh install — reads one `sync_meta` row and stops.
+ */
+export function SendRecoveryGate({ ready }: SendRecoveryGateProps) {
+  const segments = useSegments();
+  // Latest top-level segment for the async re-check, without re-running the
+  // effect on every navigation — the gate decides once per launch.
+  const topSegmentRef = useRef<string | undefined>(segments[0]);
+  topSegmentRef.current = segments[0];
+
+  const schemaReady = useOfflineSchemaReady();
+
+  useEffect(() => {
+    if (announcedThisSession) return;
+
+    const sharedInput = {
+      ready,
+      schemaReady,
+      screenshotMode: process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1',
+      topSegment: topSegmentRef.current,
+    } satisfies Omit<SendRecoveryInput, 'launchedByDeepLink' | 'onboardingSeen' | 'recoveredCount'>;
+
+    // First pass with optimistic stand-ins for the values only readable
+    // asynchronously. `wait` leaves the guard unset so the effect runs again
+    // when its deps change.
+    const preflight = decideSendRecovery({
+      ...sharedInput,
+      launchedByDeepLink: false,
+      onboardingSeen: true,
+      recoveredCount: 1,
+    });
+    if (preflight === 'wait') return;
+    announcedThisSession = true;
+    if (preflight === 'none') return;
+
+    let cancelled = false;
+    const interaction = InteractionManager.runAfterInteractions(() => {
+      void (async () => {
+        const db = getDatabaseHandle();
+        // No handle means the schema-ready flag and the connection disagree, which
+        // resolves itself on a later launch. The note is durable; nothing is lost.
+        if (db === null) return;
+
+        let recoveredCount: number | null = null;
+        try {
+          recoveredCount = await readDeadLetterRecoveryNotice(db);
+        } catch (error) {
+          reportHandledError(error, { tags: { source: 'offline-sync', op: 'read-recovery-notice' } });
+          return;
+        }
+        if (cancelled || recoveredCount === null) return;
+
+        // A custom-scheme deep link that resolves INTO a tab lands with
+        // segments[0] === '(tabs)', so the segment guard alone misses it. The
+        // cold-start launch URL is the reliable signal that the climber has
+        // intent elsewhere; a plain launch returns null.
+        let launchUrl: string | null = null;
+        try {
+          launchUrl = await Linking.getInitialURL();
+        } catch {
+          launchUrl = null;
+        }
+        if (cancelled) return;
+
+        const onboardingSeen = await hasSeenOnboarding();
+        if (cancelled) return;
+
+        // Re-decide against the CURRENT route: a deep link may have arrived
+        // while the reads were in flight.
+        const decision = decideSendRecovery({
+          ...sharedInput,
+          topSegment: topSegmentRef.current,
+          launchedByDeepLink: launchUrl !== null,
+          onboardingSeen,
+          recoveredCount,
+        });
+        if (decision !== 'show') return;
+
+        // Cleared before navigating, for the same reason the QA brief marks
+        // itself seen before it pushes: a climber who dismisses the notice and
+        // relaunches has already been told.
+        try {
+          await clearDeadLetterRecoveryNotice(db);
+        } catch (error) {
+          // Telling them twice is worse than not telling them at all here — the
+          // sends are on the queue regardless — so a failed clear stops the push.
+          reportHandledError(error, { tags: { source: 'offline-sync', op: 'clear-recovery-notice' } });
+          return;
+        }
+        if (cancelled) return;
+
+        track(SHARED_EVENTS.OfflineSendRecoveryShown, { recoveredCount });
+        router.push({ pathname: '/send-recovery', params: { count: String(recoveredCount) } });
+      })();
+    });
+
+    return () => {
+      cancelled = true;
+      interaction.cancel();
+    };
+  }, [ready, schemaReady]);
+
+  return null;
+}

--- a/packages/mobile/src/components/offline/SendRecoveryScreen.tsx
+++ b/packages/mobile/src/components/offline/SendRecoveryScreen.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useMemo } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { router, useLocalSearchParams } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../Button';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing } from '../../theme/tokens';
+
+/**
+ * "We found sends of yours that never reached the server" (issue #5335).
+ *
+ * The count arrives as a route param rather than being re-read here, because
+ * `SendRecoveryGate` clears the note in the database before it pushes this
+ * screen — the number is already spent by the time this mounts.
+ *
+ * The copy deliberately promises delivery rather than claiming it: the sends are
+ * back on the queue and will land, but at this moment some of them may still be
+ * in flight, and a climber told "3 sends recovered" who then sees one still
+ * pending has been lied to. "On their way" is true when it is shown and stays
+ * true afterwards.
+ */
+export function SendRecoveryScreen() {
+  const insets = useSafeAreaInsets();
+  const { t } = useTranslation('common');
+  const { systemColors } = useTheme();
+  const params = useLocalSearchParams<{ count?: string }>();
+
+  const recoveredCount = useMemo(() => {
+    const parsed = Number(params.count);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+  }, [params.count]);
+
+  // Nothing to announce means nothing to show. Reachable only if the route is
+  // opened without its param (a stale deep link, a dev reload), and closing is
+  // honester than rendering a sentence about zero sends.
+  useEffect(() => {
+    if (recoveredCount === null) router.back();
+  }, [recoveredCount]);
+
+  if (recoveredCount === null) return null;
+
+  return (
+    <View style={[styles.root, { backgroundColor: systemColors.groupedBackground, paddingTop: insets.top }]}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text variant="title3" style={styles.title}>
+          {t('mobile.sendRecovery.title', { count: recoveredCount })}
+        </Text>
+        <Text variant="body" color={systemColors.secondaryLabel}>
+          {t('mobile.sendRecovery.body', { count: recoveredCount })}
+        </Text>
+        <View style={styles.actions}>
+          <Button
+            title={t('mobile.sendRecovery.dismiss')}
+            onPress={() => router.back()}
+            variant="filled"
+            size="large"
+          />
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  content: {
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[4],
+    gap: spacing[3],
+  },
+  title: {
+    fontWeight: '700',
+  },
+  actions: {
+    gap: spacing[2],
+    marginTop: spacing[2],
+  },
+});

--- a/packages/mobile/src/components/offline/__tests__/send-recovery-gate.test.tsx
+++ b/packages/mobile/src/components/offline/__tests__/send-recovery-gate.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+
+const pushMock = vi.hoisted(() => vi.fn());
+const segmentsCtrl = vi.hoisted(() => ({ segments: ['(tabs)', 'climbs'] as string[] }));
+const hasSeenOnboardingMock = vi.hoisted(() => vi.fn());
+const getInitialURLMock = vi.hoisted(() => vi.fn());
+const readNoticeMock = vi.hoisted(() => vi.fn());
+const clearNoticeMock = vi.hoisted(() => vi.fn());
+const trackMock = vi.hoisted(() => vi.fn());
+const reportHandledErrorMock = vi.hoisted(() => vi.fn());
+const dbCtrl = vi.hoisted(() => ({ handle: { name: 'db' } as object | null, schemaReady: true }));
+
+vi.mock('expo-router', () => ({
+  router: { push: pushMock },
+  useSegments: () => segmentsCtrl.segments,
+}));
+vi.mock('expo-linking', () => ({ getInitialURL: getInitialURLMock }));
+// Run the deferred work inline so each case is one awaited tick rather than a
+// timer dance; the real InteractionManager only postpones it past the frame.
+vi.mock('react-native', () => ({
+  InteractionManager: {
+    runAfterInteractions: (task: () => void) => {
+      task();
+      return { cancel: vi.fn() };
+    },
+  },
+}));
+vi.mock('@boardsesh/offline-sync', () => ({
+  readDeadLetterRecoveryNotice: readNoticeMock,
+  clearDeadLetterRecoveryNotice: clearNoticeMock,
+}));
+vi.mock('../../../db/connection', () => ({ getDatabaseHandle: () => dbCtrl.handle }));
+vi.mock('../../../db/use-offline-schema-ready', () => ({ useOfflineSchemaReady: () => dbCtrl.schemaReady }));
+vi.mock('../../../lib/onboarding/onboarding-storage', () => ({ hasSeenOnboarding: hasSeenOnboardingMock }));
+vi.mock('../../../lib/analytics', () => ({ track: trackMock }));
+vi.mock('../../../lib/error-reporting', () => ({ reportHandledError: reportHandledErrorMock }));
+
+import { SendRecoveryGate, resetSendRecoverySessionForTests } from '../SendRecoveryGate';
+
+beforeEach(() => {
+  resetSendRecoverySessionForTests();
+  pushMock.mockClear();
+  trackMock.mockClear();
+  reportHandledErrorMock.mockClear();
+  hasSeenOnboardingMock.mockReset().mockResolvedValue(true);
+  getInitialURLMock.mockReset().mockResolvedValue(null);
+  readNoticeMock.mockReset().mockResolvedValue(3);
+  clearNoticeMock.mockReset().mockResolvedValue(undefined);
+  segmentsCtrl.segments = ['(tabs)', 'climbs'];
+  dbCtrl.handle = { name: 'db' };
+  dbCtrl.schemaReady = true;
+  delete process.env.EXPO_PUBLIC_SCREENSHOT_MODE;
+});
+
+describe('SendRecoveryGate', () => {
+  it('tells the climber how many sends came back, and reports it once', async () => {
+    render(<SendRecoveryGate ready />);
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith({ pathname: '/send-recovery', params: { count: '3' } }));
+    expect(trackMock).toHaveBeenCalledWith('Offline Send Recovery Shown', { recoveredCount: 3 });
+    expect(pushMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('says nothing when the recovery found nothing', async () => {
+    readNoticeMock.mockResolvedValue(null);
+
+    render(<SendRecoveryGate ready />);
+
+    await waitFor(() => expect(readNoticeMock).toHaveBeenCalled());
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(trackMock).not.toHaveBeenCalled();
+    expect(clearNoticeMock).not.toHaveBeenCalled();
+  });
+
+  it('clears the note before navigating, so a later launch stays quiet', async () => {
+    render(<SendRecoveryGate ready />);
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalled());
+    expect(clearNoticeMock).toHaveBeenCalledTimes(1);
+
+    // The next cold start reads what the first one left: nothing.
+    resetSendRecoverySessionForTests();
+    readNoticeMock.mockResolvedValue(null);
+    pushMock.mockClear();
+    trackMock.mockClear();
+
+    render(<SendRecoveryGate ready />);
+
+    await waitFor(() => expect(readNoticeMock).toHaveBeenCalledTimes(2));
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+
+  it('does not push twice within one session', async () => {
+    const first = render(<SendRecoveryGate ready />);
+    await waitFor(() => expect(pushMock).toHaveBeenCalledTimes(1));
+    first.unmount();
+
+    render(<SendRecoveryGate ready />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for the schema, because the migration is what does the recovering', async () => {
+    dbCtrl.schemaReady = false;
+
+    render(<SendRecoveryGate ready />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(readNoticeMock).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('yields to the first-run walkthrough and tries again next launch', async () => {
+    hasSeenOnboardingMock.mockResolvedValue(false);
+
+    render(<SendRecoveryGate ready />);
+    await waitFor(() => expect(hasSeenOnboardingMock).toHaveBeenCalled());
+
+    expect(pushMock).not.toHaveBeenCalled();
+    // The note is still there for the next launch — nothing was consumed.
+    expect(clearNoticeMock).not.toHaveBeenCalled();
+  });
+
+  it('yields to a cold start that came in through a deep link', async () => {
+    getInitialURLMock.mockResolvedValue('com.boardsesh.app://join/abc');
+
+    render(<SendRecoveryGate ready />);
+    await waitFor(() => expect(getInitialURLMock).toHaveBeenCalled());
+
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(clearNoticeMock).not.toHaveBeenCalled();
+  });
+
+  it('never announces a notice it could not consume', async () => {
+    clearNoticeMock.mockRejectedValue(new Error('database is locked'));
+
+    render(<SendRecoveryGate ready />);
+    await waitFor(() => expect(reportHandledErrorMock).toHaveBeenCalled());
+
+    // Telling somebody twice is worse than telling them next launch: the sends
+    // are already back on the queue either way.
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+
+  it('stays out of App Store screenshots', async () => {
+    process.env.EXPO_PUBLIC_SCREENSHOT_MODE = '1';
+
+    render(<SendRecoveryGate ready />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(readNoticeMock).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/offline-recovery/__tests__/send-recovery-decision.test.ts
+++ b/packages/mobile/src/lib/offline-recovery/__tests__/send-recovery-decision.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { decideSendRecovery, type SendRecoveryInput } from '../send-recovery-decision';
+
+// Everything known, something to say, nothing in the way.
+const READY: SendRecoveryInput = {
+  ready: true,
+  schemaReady: true,
+  recoveredCount: 3,
+  screenshotMode: false,
+  launchedByDeepLink: false,
+  topSegment: '(tabs)',
+  onboardingSeen: true,
+};
+
+describe('decideSendRecovery', () => {
+  it('shows the notice when sends were recovered and the app has settled', () => {
+    expect(decideSendRecovery(READY)).toBe('show');
+  });
+
+  it('waits rather than guessing while anything is still unknown', () => {
+    expect(decideSendRecovery({ ...READY, ready: false })).toBe('wait');
+    // The recovery IS the migration, so before the schema lands there is no
+    // answer — and reading "no note yet" as "nothing to say" would drop the
+    // notice on a contended launch.
+    expect(decideSendRecovery({ ...READY, schemaReady: false })).toBe('wait');
+    expect(decideSendRecovery({ ...READY, recoveredCount: undefined })).toBe('wait');
+    expect(decideSendRecovery({ ...READY, onboardingSeen: undefined })).toBe('wait');
+  });
+
+  it('says nothing at all when nothing was recovered', () => {
+    // The requirement in its sharpest form: zero recovered sends is not a
+    // quieter notice, it is silence. Almost every install lands here.
+    expect(decideSendRecovery({ ...READY, recoveredCount: null })).toBe('none');
+    expect(decideSendRecovery({ ...READY, recoveredCount: 0 })).toBe('none');
+    expect(decideSendRecovery({ ...READY, recoveredCount: -1 })).toBe('none');
+  });
+
+  it('shows for a single recovered send', () => {
+    expect(decideSendRecovery({ ...READY, recoveredCount: 1 })).toBe('show');
+  });
+
+  it('never fires on top of the first-run walkthrough', () => {
+    expect(decideSendRecovery({ ...READY, onboardingSeen: false })).toBe('none');
+    expect(decideSendRecovery({ ...READY, topSegment: 'onboarding' })).toBe('none');
+  });
+
+  it('yields to a deep link, by route and by launch URL', () => {
+    expect(decideSendRecovery({ ...READY, topSegment: 'join' })).toBe('none');
+    expect(decideSendRecovery({ ...READY, topSegment: 'session' })).toBe('none');
+    expect(decideSendRecovery({ ...READY, topSegment: 'auth' })).toBe('none');
+    // A custom-scheme link resolves INTO a tab, so the segment says '(tabs)'
+    // and only the launch URL gives it away.
+    expect(decideSendRecovery({ ...READY, launchedByDeepLink: true })).toBe('none');
+  });
+
+  it('does not push a second copy over itself', () => {
+    expect(decideSendRecovery({ ...READY, topSegment: 'send-recovery' })).toBe('none');
+  });
+
+  it('stays out of App Store screenshots', () => {
+    expect(decideSendRecovery({ ...READY, screenshotMode: true })).toBe('none');
+  });
+});

--- a/packages/mobile/src/lib/offline-recovery/send-recovery-decision.ts
+++ b/packages/mobile/src/lib/offline-recovery/send-recovery-decision.ts
@@ -1,0 +1,74 @@
+import { DEEP_LINK_SEGMENTS } from '../deep-link-segments';
+
+/**
+ * Top-level route groups the recovery notice must not cover. The onboarding /
+ * deep-link set, plus `send-recovery` itself so a re-render while the notice is
+ * already up can never push a second copy of it.
+ */
+export const SEND_RECOVERY_BLOCKED_TOP_SEGMENTS: ReadonlySet<string> = new Set([
+  ...DEEP_LINK_SEGMENTS,
+  'onboarding',
+  'send-recovery',
+]);
+
+export type SendRecoveryInput = {
+  /** Auth + fonts resolved and the splash hidden. */
+  ready: boolean;
+  /**
+   * The migration that recovers the sends has run. Until it has, "no notice" and
+   * "not asked yet" are the same value, and treating that as "nothing to say"
+   * would silently drop the notice on a contended launch.
+   */
+  schemaReady: boolean;
+  /**
+   * How many sends the one-time recovery put back, or `null` for "none owed".
+   * `undefined` while the read is still in flight — never treat that as none.
+   */
+  recoveredCount: number | null | undefined;
+  screenshotMode: boolean;
+  /** The cold start came in through a deep link, so the climber has intent elsewhere. */
+  launchedByDeepLink: boolean;
+  topSegment: string | undefined;
+  /** `undefined` while the persisted flag is still being read. */
+  onboardingSeen: boolean | undefined;
+};
+
+/**
+ * `wait` — not enough is known yet; ask again when the inputs change.
+ * `none` — say nothing this launch.
+ * `show` — tell the climber what came back.
+ */
+export type SendRecoveryDecision = 'wait' | 'none' | 'show';
+
+/**
+ * The whole launch-time policy for the #5335 recovery notice, as one pure
+ * function so every branch is unit-testable without a renderer.
+ *
+ * Same two-pass shape as `decideQaGate`: the gate calls this once with
+ * optimistic stand-ins for the values only readable asynchronously, and again
+ * with the real ones. A non-`wait` first answer means "none of the cheap
+ * synchronous reasons to stop apply — go pay for the reads".
+ *
+ * The count is the only reason this ever fires. Zero recovered sends is not a
+ * quieter notice, it is no notice: nothing happened to that climber.
+ */
+export function decideSendRecovery(input: SendRecoveryInput): SendRecoveryDecision {
+  if (!input.ready) return 'wait';
+  // The recovery runs inside the schema migration, so before that lands there is
+  // nothing to read and no answer to give.
+  if (!input.schemaReady) return 'wait';
+  if (input.recoveredCount === undefined) return 'wait';
+  if (input.onboardingSeen === undefined) return 'wait';
+
+  if (input.screenshotMode) return 'none';
+  if (input.recoveredCount === null || input.recoveredCount < 1) return 'none';
+  if (input.launchedByDeepLink) return 'none';
+  // The first-run walkthrough always wins a cold start. `none`, not `wait`: the
+  // notice is durable in the database, so skipping this launch costs nothing and
+  // the climber gets told on the next one — whereas waiting would hold a session
+  // guard open behind a flag that only flips after a whole tour.
+  if (!input.onboardingSeen) return 'none';
+  if (input.topSegment !== undefined && SEND_RECOVERY_BLOCKED_TOP_SEGMENTS.has(input.topSegment)) return 'none';
+
+  return 'show';
+}

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -639,6 +639,14 @@ export const SHARED_EVENTS = {
   // error }. The idempotency key is deliberately NOT a prop — it is a raw uuid
   // or a per-climb key, i.e. unbounded cardinality; it rides the Sentry event.
   OfflineMutationDeadLettered: 'Offline Mutation Dead Lettered',
+  // Offline sync — the one-time #5335 recovery put dead-lettered sends back on
+  // the queue and the climber was told. Fires when the notice is shown, once per
+  // device ever, and only for a device that actually had something to recover —
+  // so the total across the fleet IS how many climbers the recovery reached, and
+  // summing `recoveredCount` is how many sends it pulled out of the bin. Without
+  // it the recovery is unmeasurable: the rows it moves stop being dead letters,
+  // so no other event can ever count them. Props: { recoveredCount }.
+  OfflineSendRecoveryShown: 'Offline Send Recovery Shown',
   // Offline sync — how much unsynced work was already sitting in the outbox at
   // launch. Per-mutation events only count from ship day, so without this every
   // backlog that accumulated earlier is invisible. Fires at most once per app

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -390,6 +390,13 @@
         "testPlanSubtitle": "Was du in der laufenden Vorschau ausprobieren sollst"
       }
     },
+    "sendRecovery": {
+      "title_one": "1 Begehung ist unterwegs",
+      "title_other": "{{count}} Begehungen sind unterwegs",
+      "body_one": "Du hast sie eingetragen, aber bei uns ist sie nie angekommen. Wir haben sie gefunden und zurück in die Warteschlange gelegt. Sobald du online bist, wird sie übertragen, du musst sie also nicht noch einmal eintragen.",
+      "body_other": "Du hast sie eingetragen, aber bei uns sind sie nie angekommen. Wir haben sie gefunden und zurück in die Warteschlange gelegt. Sobald du online bist, werden sie übertragen, du musst sie also nicht noch einmal eintragen.",
+      "dismiss": "Alles klar"
+    },
     "about": {
       "title": "Über",
       "heroTitle": "Boardsesh",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -390,6 +390,13 @@
         "testPlanSubtitle": "What to try on the preview you're running"
       }
     },
+    "sendRecovery": {
+      "title_one": "1 send is on its way",
+      "title_other": "{{count}} sends are on their way",
+      "body_one": "You logged it, but it never reached us. We found it and put it back in the queue. It goes up as soon as you're online, so there's no need to log it again.",
+      "body_other": "You logged them, but they never reached us. We found them and put them back in the queue. They go up as soon as you're online, so there's no need to log them again.",
+      "dismiss": "Got it"
+    },
     "about": {
       "title": "About",
       "heroTitle": "Boardsesh",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -655,6 +655,13 @@
         "testPlanSubtitle": "Qué probar en la vista previa que tienes abierta"
       }
     },
+    "sendRecovery": {
+      "title_one": "1 encadene va de camino",
+      "title_other": "{{count}} encadenes van de camino",
+      "body_one": "Lo registraste, pero nunca llegó hasta nosotros. Lo hemos encontrado y lo hemos puesto de nuevo en la cola. Se subirá en cuanto tengas conexión, así que no hace falta que lo vuelvas a registrar.",
+      "body_other": "Los registraste, pero nunca llegaron hasta nosotros. Los hemos encontrado y los hemos puesto de nuevo en la cola. Se subirán en cuanto tengas conexión, así que no hace falta que los vuelvas a registrar.",
+      "dismiss": "Entendido"
+    },
     "about": {
       "title": "Sobre Boardsesh",
       "heroTitle": "Boardsesh",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -390,6 +390,13 @@
         "testPlanSubtitle": "Ce qu'il faut essayer sur l'aperçu en cours"
       }
     },
+    "sendRecovery": {
+      "title_one": "1 croix est en route",
+      "title_other": "{{count}} croix sont en route",
+      "body_one": "Tu l'as enregistrée, mais elle ne nous est jamais parvenue. On l'a retrouvée et remise dans la file. Elle partira dès que tu seras en ligne, pas besoin de l'enregistrer à nouveau.",
+      "body_other": "Tu les as enregistrées, mais elles ne nous sont jamais parvenues. On les a retrouvées et remises dans la file. Elles partiront dès que tu seras en ligne, pas besoin de les enregistrer à nouveau.",
+      "dismiss": "C'est noté"
+    },
     "about": {
       "title": "À propos de Boardsesh",
       "heroTitle": "Boardsesh",

--- a/packages/shared/offline-sync/src/db/migrations.ts
+++ b/packages/shared/offline-sync/src/db/migrations.ts
@@ -13,11 +13,21 @@
 
 import { SCHEMA_STATEMENTS } from './schema';
 import { applyBusyTimeout } from './pragmas';
+import { requeueTransportDeadLetters, setDeadLetterRecoveryNotice } from '../mutation-queue/dead-letter-recovery';
 import type { OfflineDatabase, SqlExecutor } from '../database';
 
 export type Migration = {
   version: number;
   statements: string[];
+  /**
+   * An optional DATA step, run after `statements` and inside the SAME exclusive
+   * transaction as the version stamp. Exists for the one thing a DDL string
+   * cannot do: reuse the queue's own row transitions instead of restating them
+   * as bulk SQL that can drift from them (issue #5335). Sharing the transaction
+   * is what makes such a step interruption-safe — a killed app rolls the rows
+   * and the stamp back together, and the migration re-runs cleanly next launch.
+   */
+  run?: (txn: SqlExecutor) => Promise<void>;
 };
 
 // Migration 1 stands up the full v1 schema. Future schema changes append
@@ -78,6 +88,33 @@ export const MIGRATIONS: Migration[] = [
     version: 5,
     statements: ['ALTER TABLE board_climbs ADD COLUMN is_hidden INTEGER;'],
   },
+  {
+    // One-time recovery of the sends #5295 threw away (issue #5335). Two
+    // transport failures the old classifier did not recognise dead-lettered a
+    // queued send on attempt 0 of 10; roughly 17 climbers have a row holding a
+    // send they logged and believe is recorded. This puts exactly those rows
+    // back on the queue — matched on the recorded error and nothing else, so a
+    // row a server permanently rejected stays where it is.
+    //
+    // A data step rather than a statement list because the row transition must
+    // BE `retryDeadLetter`, the same one the manual Sync-issues retry uses. It
+    // is version-stamped like any other migration, which is what makes it
+    // once-per-install, and it shares the migration's transaction, which is
+    // what makes an interrupted launch leave every row either `pending` or
+    // `dead_letter` and never a third thing.
+    //
+    // MUST ship with or after the #5295 classifier fix: revived rows meeting the
+    // old classifier would dead-letter again on the first hiccup.
+    version: 6,
+    statements: [],
+    run: async (txn) => {
+      const requeued = await requeueTransportDeadLetters(txn);
+      // Only a real recovery leaves a trace. Every fresh install runs this
+      // migration against an empty queue, and none of them should owe anybody a
+      // notice.
+      if (requeued > 0) await setDeadLetterRecoveryNotice(txn, requeued);
+    },
+  },
 ];
 
 const SCHEMA_VERSION_TABLE = `
@@ -100,9 +137,10 @@ async function stampVersion(db: SqlExecutor, version: number): Promise<void> {
 
 /**
  * Brings the database up to LATEST_SCHEMA_VERSION. Applies each pending migration
- * (version > current) in ascending order; every migration's statements plus its
- * version stamp run inside one exclusive transaction, so a crash mid-migration
- * leaves the stored version untouched and the migration re-runs cleanly next launch.
+ * (version > current) in ascending order; every migration's statements, its
+ * optional data step, and its version stamp run inside one exclusive transaction,
+ * so a crash mid-migration leaves the stored version untouched, rolls back
+ * whatever the migration had done, and re-runs cleanly next launch.
  */
 export async function runMigrations(db: OfflineDatabase): Promise<void> {
   await db.execAsync(SCHEMA_VERSION_TABLE);
@@ -120,6 +158,7 @@ export async function runMigrations(db: OfflineDatabase): Promise<void> {
       for (const statement of migration.statements) {
         await txn.execAsync(statement);
       }
+      await migration.run?.(txn);
       await stampVersion(txn, migration.version);
     });
   }

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -64,6 +64,17 @@ export type {
   MutationDeadLetterReporter,
 } from './mutation-queue/drainer';
 export { ensureMutationQueueTable, MUTATION_QUEUE_SCHEMA } from './mutation-queue/schema';
+// --- One-time recovery of the sends #5295 threw away (issue #5335) ------------
+// `requeueTransportDeadLetters` is the migration's own data step and is NOT
+// exported: nothing outside the versioned migration may replay dead letters in
+// bulk. The app reads only the notice the migration left behind — how many sends
+// it put back, and whether the climber has been told yet.
+export {
+  readDeadLetterRecoveryNotice,
+  clearDeadLetterRecoveryNotice,
+  isRecoverableTransportDeadLetter,
+  DEAD_LETTER_RECOVERY_NOTICE_KEY,
+} from './mutation-queue/dead-letter-recovery';
 export { processMutation } from './mutation-queue/handlers';
 export type { GraphQLFetch } from './mutation-queue/handlers';
 export {

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/dead-letter-recovery.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/dead-letter-recovery.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { runMigrations, MIGRATIONS } from '../../db/migrations';
+import {
+  clearDeadLetterRecoveryNotice,
+  isRecoverableTransportDeadLetter,
+  readDeadLetterRecoveryNotice,
+  requeueTransportDeadLetters,
+  setDeadLetterRecoveryNotice,
+  DEAD_LETTER_RECOVERY_NOTICE_KEY,
+  EDGE_404_LAST_ERROR_PREFIX,
+  FETCH_TIMEOUT_LAST_ERROR,
+} from '../dead-letter-recovery';
+import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
+import type { SqlRunResult, SqlValue } from '../../database';
+
+// The two `last_error` values off the production rows, copied verbatim from the
+// Sentry events named in issue #5335. The drainer stores `error.message`, so
+// these ARE what sits in the column — not a paraphrase of it.
+//
+// BOARDSESH-HT: `extra.errorMessage = "Network request timed out"`.
+const TIMEOUT_LAST_ERROR = 'Network request timed out';
+// BOARDSESH-H8: graphql-request's ClientError message for the Railway edge 404
+// (`x-railway-fallback: true`), truncated after the parts that matter — note
+// that the real string continues with the whole request, variables included,
+// which is why the matcher anchors at the start rather than searching.
+const EDGE_404_LAST_ERROR =
+  'GraphQL Error (Code: 404): {"response":{"status":404,"headers":{"map":{"server":"cloudflare",' +
+  '"x-railway-fallback":"true"}},"body":"{\\"status\\":\\"error\\",\\"code\\":404,\\"message\\":' +
+  '\\"Application not found\\"}"},"request":{"query":"mutation SaveTick($input: SaveTickInput!) ' +
+  '{ saveTick(input: $input) { uuid } }","variables":{"input":{"uuid":"3a4205a3"}}}}';
+// A server's permanent verdict on the payload, served with a real 4xx and no
+// GraphQL `errors` array, so graphql-request falls back to the status wording.
+// This row is the whole reason the matcher is narrow: reviving it would make the
+// migration "replay everything in the bin". Note how little separates it from
+// EDGE_404_LAST_ERROR above — one digit — which is the point of putting the
+// status inside the anchored prefix.
+const VALIDATION_400_LAST_ERROR =
+  'GraphQL Error (Code: 400): {"response":{"status":400,"body":"Bad Request"},' +
+  '"request":{"query":"mutation SaveTick"}}';
+// The OTHER permanent verdict, and the one the field will mostly produce from
+// now on: GraphQL answers "your input is invalid" with HTTP 200 and an `errors`
+// array, so `ClientError.extractMessage` returns errors[0].message and the
+// recorded string carries NO "GraphQL Error (Code: …)" prefix at all. The
+// classifier this recovery ships behind reads `extensions.code` for exactly this
+// shape, which is what puts these rows in the dead-letter bin — so the matcher
+// has to reject a shape that looks nothing like either of the two it accepts.
+const VALIDATION_200_BAD_USER_INPUT_LAST_ERROR =
+  'climbedAt is required: {"response":{"status":200,"errors":[{"message":"climbedAt is required",' +
+  '"extensions":{"code":"BAD_USER_INPUT"}}]},"request":{"query":"mutation SaveTick"}}';
+
+const RECOVERY_MIGRATION_VERSION = 6;
+
+let db: TestSqliteDb;
+
+beforeEach(async () => {
+  db = createTestDatabase();
+});
+
+afterEach(() => {
+  db.close();
+});
+
+type SeedRow = {
+  key: string;
+  status: 'pending' | 'dead_letter';
+  lastError: string | null;
+  retryCount?: number;
+};
+
+/** Seeds the outbox directly, so a row can be planted in any state the field produced. */
+async function seed(rows: SeedRow[]): Promise<void> {
+  for (const row of rows) {
+    await db.runAsync(
+      `INSERT INTO pending_mutations (table_name, operation, payload, idempotency_key, retry_count, last_error, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        'boardsesh_ticks',
+        'create',
+        JSON.stringify({ climbUuid: row.key }),
+        row.key,
+        row.retryCount ?? 10,
+        row.lastError,
+        row.status,
+      ],
+    );
+  }
+}
+
+async function rowByKey(key: string): Promise<{ status: string; retry_count: number; last_error: string | null }> {
+  const row = await db.getFirstAsync<{ status: string; retry_count: number; last_error: string | null }>(
+    'SELECT status, retry_count, last_error FROM pending_mutations WHERE idempotency_key = ?',
+    [key],
+  );
+  if (row === null) throw new Error(`no row for ${key}`);
+  return row;
+}
+
+/** Brings the schema up to the version just before the recovery migration. */
+async function migrateToBeforeRecovery(): Promise<void> {
+  const upTo = MIGRATIONS.filter((migration) => migration.version < RECOVERY_MIGRATION_VERSION);
+  await db.execAsync(
+    'CREATE TABLE IF NOT EXISTS schema_version (id INTEGER PRIMARY KEY CHECK (id = 1), version INTEGER NOT NULL)',
+  );
+  for (const migration of upTo) {
+    for (const statement of migration.statements) {
+      await db.execAsync(statement);
+    }
+  }
+  await db.runAsync('INSERT OR REPLACE INTO schema_version (id, version) VALUES (1, ?)', [
+    RECOVERY_MIGRATION_VERSION - 1,
+  ]);
+}
+
+// The array-form overload of SqlExecutor.runAsync — the only one the engine
+// calls, so the interruption case can swap it for one that throws partway.
+type PatchedRunAsync = (source: string, params: SqlValue[]) => Promise<SqlRunResult>;
+
+function patchRunAsync(target: TestSqliteDb, replacement: PatchedRunAsync): void {
+  (target as unknown as { runAsync: PatchedRunAsync }).runAsync = replacement;
+}
+
+async function storedSchemaVersion(): Promise<number | null> {
+  const row = await db.getFirstAsync<{ version: number }>('SELECT version FROM schema_version WHERE id = 1');
+  return row?.version ?? null;
+}
+
+describe('isRecoverableTransportDeadLetter', () => {
+  it('matches the fetch timeout by whole-string equality', () => {
+    expect(isRecoverableTransportDeadLetter(TIMEOUT_LAST_ERROR)).toBe(true);
+    expect(isRecoverableTransportDeadLetter(`  ${TIMEOUT_LAST_ERROR}  `)).toBe(true);
+  });
+
+  it('matches the Railway edge 404 by its ClientError prefix', () => {
+    expect(isRecoverableTransportDeadLetter(EDGE_404_LAST_ERROR)).toBe(true);
+  });
+
+  it('does NOT match a 400 the server decided on the payload', () => {
+    expect(isRecoverableTransportDeadLetter(VALIDATION_400_LAST_ERROR)).toBe(false);
+  });
+
+  it('does NOT match a BAD_USER_INPUT the server answered over HTTP 200', () => {
+    // The shape the revised classifier sends to the dead letter from now on. It
+    // shares no prefix with either accepted shape, and must stay in the bin.
+    expect(isRecoverableTransportDeadLetter(VALIDATION_200_BAD_USER_INPUT_LAST_ERROR)).toBe(false);
+  });
+
+  it('cannot be spelled into a match by request content echoed inside a ClientError', () => {
+    // The 404 message embeds the whole request. A climber whose tick comment
+    // says "Network request timed out" must not be able to talk a 400 rejection
+    // into a replay — which is why the timeout is an equality match and the 404
+    // an anchored prefix, never a substring search.
+    const spoofed =
+      'GraphQL Error (Code: 400): {"response":{"status":400},"request":{"variables":' +
+      '{"comment":"Network request timed out","body":"Application not found"}}}';
+    expect(isRecoverableTransportDeadLetter(spoofed)).toBe(false);
+  });
+
+  it('leaves every other recorded error alone, including none at all', () => {
+    expect(isRecoverableTransportDeadLetter(null)).toBe(false);
+    expect(isRecoverableTransportDeadLetter(undefined)).toBe(false);
+    expect(isRecoverableTransportDeadLetter('')).toBe(false);
+    expect(isRecoverableTransportDeadLetter('Network request failed')).toBe(false);
+    expect(isRecoverableTransportDeadLetter('BLE write timed out waiting for the board')).toBe(false);
+    expect(isRecoverableTransportDeadLetter('GraphQL Error (Code: 422): {}')).toBe(false);
+  });
+
+  it('keeps the two literals it matches on in sync with the exported constants', () => {
+    expect(TIMEOUT_LAST_ERROR).toBe(FETCH_TIMEOUT_LAST_ERROR);
+    expect(EDGE_404_LAST_ERROR.startsWith(EDGE_404_LAST_ERROR_PREFIX)).toBe(true);
+  });
+});
+
+describe('requeueTransportDeadLetters', () => {
+  beforeEach(async () => {
+    await runMigrations(db);
+  });
+
+  it('requeues a fetch-timeout dead letter as pending with a fresh retry budget', async () => {
+    await seed([{ key: 'timeout', status: 'dead_letter', lastError: TIMEOUT_LAST_ERROR }]);
+
+    expect(await requeueTransportDeadLetters(db)).toBe(1);
+
+    expect(await rowByKey('timeout')).toEqual({ status: 'pending', retry_count: 0, last_error: null });
+  });
+
+  it('requeues an edge-404 dead letter as pending with a fresh retry budget', async () => {
+    await seed([{ key: 'edge404', status: 'dead_letter', lastError: EDGE_404_LAST_ERROR }]);
+
+    expect(await requeueTransportDeadLetters(db)).toBe(1);
+
+    expect(await rowByKey('edge404')).toEqual({ status: 'pending', retry_count: 0, last_error: null });
+  });
+
+  it('leaves a dead letter the server permanently rejected exactly where it is', async () => {
+    await seed([
+      { key: 'validation400', status: 'dead_letter', lastError: VALIDATION_400_LAST_ERROR },
+      { key: 'validation200', status: 'dead_letter', lastError: VALIDATION_200_BAD_USER_INPUT_LAST_ERROR },
+    ]);
+
+    expect(await requeueTransportDeadLetters(db)).toBe(0);
+
+    expect(await rowByKey('validation400')).toEqual({
+      status: 'dead_letter',
+      retry_count: 10,
+      last_error: VALIDATION_400_LAST_ERROR,
+    });
+    expect(await rowByKey('validation200')).toEqual({
+      status: 'dead_letter',
+      retry_count: 10,
+      last_error: VALIDATION_200_BAD_USER_INPUT_LAST_ERROR,
+    });
+  });
+
+  it('does not touch a row that is already pending', async () => {
+    await seed([{ key: 'inflight', status: 'pending', lastError: TIMEOUT_LAST_ERROR, retryCount: 3 }]);
+
+    expect(await requeueTransportDeadLetters(db)).toBe(0);
+
+    expect(await rowByKey('inflight')).toEqual({
+      status: 'pending',
+      retry_count: 3,
+      last_error: TIMEOUT_LAST_ERROR,
+    });
+  });
+
+  it('requeues only the matching rows out of a mixed outbox', async () => {
+    await seed([
+      { key: 'timeout', status: 'dead_letter', lastError: TIMEOUT_LAST_ERROR },
+      { key: 'edge404', status: 'dead_letter', lastError: EDGE_404_LAST_ERROR },
+      { key: 'validation400', status: 'dead_letter', lastError: VALIDATION_400_LAST_ERROR },
+      { key: 'validation200', status: 'dead_letter', lastError: VALIDATION_200_BAD_USER_INPUT_LAST_ERROR },
+      { key: 'noError', status: 'dead_letter', lastError: null },
+      { key: 'inflight', status: 'pending', lastError: null, retryCount: 0 },
+    ]);
+
+    expect(await requeueTransportDeadLetters(db)).toBe(2);
+
+    const remaining = await db.getAllAsync<{ idempotency_key: string }>(
+      "SELECT idempotency_key FROM pending_mutations WHERE status = 'dead_letter' ORDER BY idempotency_key",
+    );
+    expect(remaining.map((row) => row.idempotency_key)).toEqual(['noError', 'validation200', 'validation400']);
+  });
+
+  it('requeues nothing on a second run', async () => {
+    await seed([{ key: 'timeout', status: 'dead_letter', lastError: TIMEOUT_LAST_ERROR }]);
+
+    expect(await requeueTransportDeadLetters(db)).toBe(1);
+    expect(await requeueTransportDeadLetters(db)).toBe(0);
+  });
+});
+
+describe('the recovery migration (version 6)', () => {
+  it('requeues both shapes, leaves the 400 alone, and records the count once', async () => {
+    await migrateToBeforeRecovery();
+    await seed([
+      { key: 'timeout', status: 'dead_letter', lastError: TIMEOUT_LAST_ERROR },
+      { key: 'edge404', status: 'dead_letter', lastError: EDGE_404_LAST_ERROR },
+      { key: 'validation', status: 'dead_letter', lastError: VALIDATION_400_LAST_ERROR },
+    ]);
+
+    await runMigrations(db);
+
+    expect(await rowByKey('timeout')).toEqual({ status: 'pending', retry_count: 0, last_error: null });
+    expect(await rowByKey('edge404')).toEqual({ status: 'pending', retry_count: 0, last_error: null });
+    expect((await rowByKey('validation')).status).toBe('dead_letter');
+    expect(await readDeadLetterRecoveryNotice(db)).toBe(2);
+  });
+
+  it('records nothing when it requeues nothing — a fresh install owes no notice', async () => {
+    await migrateToBeforeRecovery();
+    await seed([{ key: 'validation', status: 'dead_letter', lastError: VALIDATION_400_LAST_ERROR }]);
+
+    await runMigrations(db);
+
+    expect(await readDeadLetterRecoveryNotice(db)).toBeNull();
+    // Not merely unreadable — absent. Every install on earth runs this migration,
+    // and none of them should be left holding a row that says "recovered 0".
+    const noticeRows = await db.getAllAsync<{ key: string }>('SELECT key FROM sync_meta WHERE key = ?', [
+      DEAD_LETTER_RECOVERY_NOTICE_KEY,
+    ]);
+    expect(noticeRows).toEqual([]);
+  });
+
+  it('is idempotent: a second launch requeues nothing and writes no second notice', async () => {
+    await migrateToBeforeRecovery();
+    await seed([{ key: 'timeout', status: 'dead_letter', lastError: TIMEOUT_LAST_ERROR }]);
+
+    await runMigrations(db);
+    expect(await readDeadLetterRecoveryNotice(db)).toBe(1);
+    // The climber has been told; the notice is consumed.
+    await clearDeadLetterRecoveryNotice(db);
+
+    // A row dead-lettered AFTER the recovery — by the same shape — must not be
+    // swept up by a re-run, because there is no re-run: the version is stamped.
+    await seed([{ key: 'later', status: 'dead_letter', lastError: TIMEOUT_LAST_ERROR }]);
+    await runMigrations(db);
+
+    expect((await rowByKey('later')).status).toBe('dead_letter');
+    expect(await readDeadLetterRecoveryNotice(db)).toBeNull();
+  });
+
+  it('interrupted mid-run, every row is still pending or dead_letter and the migration re-runs', async () => {
+    await migrateToBeforeRecovery();
+    await seed([
+      { key: 'timeout', status: 'dead_letter', lastError: TIMEOUT_LAST_ERROR },
+      { key: 'edge404', status: 'dead_letter', lastError: EDGE_404_LAST_ERROR },
+    ]);
+
+    // Stands in for the app being killed after the first row moved: the write
+    // that would have followed it throws instead, so the transaction unwinds
+    // exactly where a process death would have left it.
+    const originalRunAsync = db.runAsync.bind(db) as unknown as PatchedRunAsync;
+    let requeueWrites = 0;
+    const killAfterFirstRequeue: PatchedRunAsync = async (source, params) => {
+      if (source.includes("SET status = 'pending'")) {
+        requeueWrites += 1;
+        if (requeueWrites > 1) throw new Error('app killed mid-migration');
+      }
+      return originalRunAsync(source, params);
+    };
+    patchRunAsync(db, killAfterFirstRequeue);
+
+    await expect(runMigrations(db)).rejects.toThrow('app killed mid-migration');
+
+    patchRunAsync(db, originalRunAsync);
+
+    // No third state anywhere, and no half-recovery: the rollback took the one
+    // moved row back with it.
+    const statuses = await db.getAllAsync<{ idempotency_key: string; status: string }>(
+      'SELECT idempotency_key, status FROM pending_mutations ORDER BY idempotency_key',
+    );
+    for (const row of statuses) {
+      expect(['pending', 'dead_letter']).toContain(row.status);
+    }
+    expect(statuses).toEqual([
+      { idempotency_key: 'edge404', status: 'dead_letter' },
+      { idempotency_key: 'timeout', status: 'dead_letter' },
+    ]);
+    // The stamp rolled back with the rows, so the next launch tries again.
+    expect(await storedSchemaVersion()).toBe(RECOVERY_MIGRATION_VERSION - 1);
+    expect(await readDeadLetterRecoveryNotice(db)).toBeNull();
+
+    await runMigrations(db);
+
+    expect(await rowByKey('timeout')).toEqual({ status: 'pending', retry_count: 0, last_error: null });
+    expect(await rowByKey('edge404')).toEqual({ status: 'pending', retry_count: 0, last_error: null });
+    expect(await readDeadLetterRecoveryNotice(db)).toBe(2);
+  });
+});
+
+describe('the recovery notice', () => {
+  beforeEach(async () => {
+    await runMigrations(db);
+  });
+
+  it('reads back null once cleared, so it is shown once and never again', async () => {
+    await setDeadLetterRecoveryNotice(db, 3);
+
+    expect(await readDeadLetterRecoveryNotice(db)).toBe(3);
+    await clearDeadLetterRecoveryNotice(db);
+    expect(await readDeadLetterRecoveryNotice(db)).toBeNull();
+  });
+
+  it('reads a corrupt or non-positive value as no notice rather than crashing a launch', async () => {
+    for (const stored of ['0', '-3', 'lots', '']) {
+      await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+        DEAD_LETTER_RECOVERY_NOTICE_KEY,
+        stored,
+      ]);
+      expect(await readDeadLetterRecoveryNotice(db)).toBeNull();
+    }
+  });
+});

--- a/packages/shared/offline-sync/src/mutation-queue/dead-letter-recovery.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/dead-letter-recovery.ts
@@ -1,0 +1,121 @@
+// One-time recovery of the sends #5295 threw away (issue #5335).
+//
+// Before the classifier fix, two transport failures resolved as "non-retryable"
+// and dead-lettered a queued send on attempt 0 of 10. Roughly 17 climbers have a
+// `pending_mutations` row at `status = 'dead_letter'` holding a send they logged
+// and believe is recorded. The classifier fix stops new losses; it does not give
+// those rows back.
+//
+// The predicate below is the whole safety argument, so it matches on the RECORDED
+// ERROR and nothing else — not age, not table, not retry_count. A row a server
+// permanently rejected (a 400) must come out of this untouched, or the recovery
+// stops being "give back the two shapes we misjudged" and becomes "replay
+// everything in the bin", which is a different, unapproved decision.
+//
+// Both literals below are the exact `last_error` values off the production rows
+// (Sentry BOARDSESH-HT and BOARDSESH-H8): the drainer stores `error.message`
+// verbatim, so what is compared here is what was written.
+
+import type { SqlExecutor } from '../database';
+import { getDeadLetters, retryDeadLetter } from './queue';
+
+/**
+ * whatwg-fetch's `xhr.ontimeout` rejection (`fetch.umd.js:573`) — the sibling of
+ * "Network request failed" at :567, and a `TypeError` whose message is this
+ * string and nothing else. Matched by EQUALITY rather than containment on
+ * purpose: a graphql-request `ClientError` message embeds the whole request,
+ * variables included, so a climber who typed this phrase into a tick comment
+ * would otherwise be able to spell a 400 rejection into a requeue.
+ */
+export const FETCH_TIMEOUT_LAST_ERROR = 'Network request timed out';
+
+/**
+ * graphql-request's `ClientError.extractMessage` fallback for a 404 whose body
+ * carries no GraphQL `errors` array — the shape Railway's edge served for 6m30s
+ * on 2026-09-02 (`{"code":404,"message":"Application not found"}` with
+ * `x-railway-fallback: true`). Anchored to the START of the message, again so a
+ * request payload echoed further along the string can never fabricate a match.
+ *
+ * The status is in the prefix, so a `GraphQL Error (Code: 400)` — a real server
+ * verdict on the payload — does not match, which is precisely the row this
+ * migration must leave where it is.
+ */
+export const EDGE_404_LAST_ERROR_PREFIX = 'GraphQL Error (Code: 404)';
+
+/**
+ * Was this dead letter caused by one of the two transport failures #5295
+ * misclassified? Any other recorded error — including a null one, which proves
+ * nothing about why the row is here — is left alone.
+ */
+export function isRecoverableTransportDeadLetter(lastError: string | null | undefined): boolean {
+  if (typeof lastError !== 'string') return false;
+  const recorded = lastError.trim();
+  if (recorded === FETCH_TIMEOUT_LAST_ERROR) return true;
+  return recorded.startsWith(EDGE_404_LAST_ERROR_PREFIX);
+}
+
+/**
+ * Moves every dead letter matching `isRecoverableTransportDeadLetter` back to
+ * `pending` with a fresh retry budget, and answers how many moved.
+ *
+ * The per-row transition is `retryDeadLetter` — the same statement More → Sync
+ * issues → Retry has always used — rather than a bespoke bulk UPDATE, so this
+ * recovery cannot drift from the manual one.
+ *
+ * The caller runs this inside a transaction (the schema-migration runner does),
+ * which is what keeps a killed app from leaving a row in a third state: either
+ * every matched row is `pending` and the migration is stamped, or nothing moved
+ * and it runs again next launch. Running it a second time finds nothing —
+ * `retryDeadLetter` clears `last_error` and the rows are no longer dead letters.
+ */
+export async function requeueTransportDeadLetters(db: SqlExecutor): Promise<number> {
+  const deadLetters = await getDeadLetters(db);
+  let requeued = 0;
+  for (const deadLetter of deadLetters) {
+    if (!isRecoverableTransportDeadLetter(deadLetter.last_error)) continue;
+    await retryDeadLetter(db, deadLetter.id);
+    requeued += 1;
+  }
+  return requeued;
+}
+
+/**
+ * The `sync_meta` key holding "this device requeued N sends and has not told the
+ * climber yet". Written by the migration only when N >= 1, so its absence is the
+ * ordinary case and no launch has to reason about a zero.
+ *
+ * It lives in `sync_meta` rather than in memory because the migration and the
+ * modal are separated by a whole app startup: the requeue happens before React
+ * mounts, and a launch that dies in between must still owe the climber a notice.
+ * The sign-out wipe (`deleteAllSyncMeta`) clears it, which is correct — that
+ * wipe removes the queued rows the notice would be describing.
+ */
+export const DEAD_LETTER_RECOVERY_NOTICE_KEY = 'dead-letter-recovery-notice';
+
+/** Records that `requeued` sends are owed a notice. Overwrites, never accumulates. */
+export async function setDeadLetterRecoveryNotice(db: SqlExecutor, requeued: number): Promise<void> {
+  await db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [
+    DEAD_LETTER_RECOVERY_NOTICE_KEY,
+    String(requeued),
+  ]);
+}
+
+/**
+ * How many recovered sends this device still owes the climber a notice about, or
+ * `null` when it owes none. A stored value that isn't a positive integer is read
+ * as "none" rather than crashing a launch on a corrupt row.
+ */
+export async function readDeadLetterRecoveryNotice(db: SqlExecutor): Promise<number | null> {
+  const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [
+    DEAD_LETTER_RECOVERY_NOTICE_KEY,
+  ]);
+  if (!row) return null;
+  const requeued = Number(row.value);
+  if (!Number.isInteger(requeued) || requeued < 1) return null;
+  return requeued;
+}
+
+/** Clears the notice, so it is shown once and never again on a later launch. */
+export async function clearDeadLetterRecoveryNotice(db: SqlExecutor): Promise<void> {
+  await db.runAsync('DELETE FROM sync_meta WHERE key = ?', [DEAD_LETTER_RECOVERY_NOTICE_KEY]);
+}


### PR DESCRIPTION
## Summary

Fixes #5335.

**Ordering, which is load-bearing: #5344 must land first, and it has** (`df6a4f05`, merged 2026-09-09). This PR opened stacked on that branch; now that it is on `main` this is rebased onto `main` and carries only its own 17 files. Reviving these rows into the *old* classifier would have re-dead-lettered them on the first hiccup, which is exactly how they got here — so this could never have merged first.

Two transport failures the old classifier did not recognise dead-lettered a queued send on attempt 0 of 10. Roughly 17 climbers have a `pending_mutations` row at `status = 'dead_letter'` holding a send they logged and believe is recorded. #5344 stopped new losses; it did not give those rows back.

**The requeue** is schema migration **6**, and every property the issue asks for falls out of being one:

- **Once per install** — the version stamp. No second marker to keep in sync, no way to run it twice.
- **Interruption-safe** — the data step shares the migration's exclusive transaction, so a killed app rolls the rows and the stamp back together. Every row is `pending` or `dead_letter`, never a third state, and the next launch retries cleanly.
- **Narrow** — `isRecoverableTransportDeadLetter` matches the recorded error and nothing else: not age, not table, not `retry_count`. The two literals are copied off the production rows (`extra.errorMessage` in Sentry BOARDSESH-HT and BOARDSESH-H8), because the drainer stores `error.message` verbatim.
- **Reuses the transition** — `retryDeadLetter`, the same statement More → Sync issues → Retry has always used, so the automatic recovery cannot drift from the manual one.

The matcher is an **equality** check on `Network request timed out` and an **anchored prefix** on `GraphQL Error (Code: 404)`, not a substring search. A graphql-request `ClientError` message embeds the entire request, variables included, so a loose search would let a climber's tick comment talk a 400 rejection into a replay. That assertion is what stops this being "revive everything", and it is mutation-tested.

Two permanent-rejection shapes are pinned as *not* matching, because they are the two the bin will actually hold:

- `GraphQL Error (Code: 400): …` — one digit away from the 404 it must not be confused with, which is why the status lives inside the anchored prefix rather than being checked separately.
- `climbedAt is required: {…"extensions":{"code":"BAD_USER_INPUT"}…}` — a verdict GraphQL served over HTTP 200, so `ClientError.extractMessage` returns the resolver's message and there is no `GraphQL Error (Code: …)` prefix at all. This is the shape #5344's `PERMANENT_GRAPHQL_ERROR_CODES` makes permanent again, so it is the shape the bin will mostly hold from here on.

**Telling the climber.** The migration leaves a `sync_meta` note holding how many sends it put back, and only when that is at least one, so a fresh install owes nobody a notice. `SendRecoveryGate` is a launch gate mounted after `OnboardingGate` and `QaTesterGate`; it delivers the note once as a dismissable modal route, clears it before navigating, and emits `Offline Send Recovery Shown { recoveredCount }`. That event is the only way this is measurable in the field — the rows it moves stop being dead letters, so nothing else can count them afterwards.

### One deliberate deviation: "on their way", not "recovered"

The issue asked to prefer firing after the drain settles so the reported count is what actually landed. I report the **requeued** count instead, and the copy promises delivery rather than claiming it. Three reasons:

1. Waiting for a drain to settle risks never firing at all, and the population that got here is exactly the population with a flaky uplink.
2. With the default-retry now on `main`, a row that fails again stays `pending` and lands later. A "landed" snapshot at modal time would understate the recovery and need a second modal to correct itself.
3. "We found N sends that never reached us, they're on their way" is true when it is shown and cannot be falsified by a later failure — which is the guarantee "never claim a send was recovered that then failed again" is actually asking for.

### Known cost, accepted

This re-sends writes some climbers may have already re-logged by hand. The server-side `idempotency_key` limits duplicates but does not eliminate them, because a hand re-log is a genuinely different mutation — so a climber can end up with two ticks on the same climb. That cost was accepted deliberately against silently keeping ~17 people's sends in the bin, and the modal is what makes a duplicate explicable rather than baffling.

### Verification

- `vp test run --project offline-sync` — 19 new tests, including each error shape, the two untouched permanent rejections, the untouched pending row, idempotence and the interrupted migration.
- `vp test run --project mobile` — 17 new tests across the pure gate policy and the gate component.
- Every guard was mutation-tested: the line reverted, the test confirmed red, the rest confirmed green, the line restored. Eleven in total.
- Rebased onto `main` at `df6a4f05` (#5344's squash). Nothing here reads a classifier verdict — the tests seed `pending_mutations` rows directly and never run the drainer, and the production chain (`migrations.ts → dead-letter-recovery.ts → queue.ts`) never imports `error-classification.ts` — so the base's new `PERMANENT_GRAPHQL_ERROR_CODES` set changes no assertion in this PR. It does change which rows the bin holds, which is what the new HTTP-200 guard above covers.

## Release Notes

Sends that never made it off your phone are being sent again. A network blip could quietly bin a send you'd logged, and it stayed binned. If that happened to you, the app now finds those sends, puts them back in the queue, and tells you how many are on their way — so you don't have to log them a second time.

## Test plan

1. Open the app fresh. You land on Climbs as usual.
2. Log a send on any climb. It saves.
3. Force-quit and reopen. No stray popup appears.
4. Open More. Sync issues behaves as before.

## Risk

Risk: 4/5 — a data migration rewrites rows in the on-device outbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
