### PR TITLE
fix(mobile): stop the SQLite teardown freeing a connection queries are still on (#5300)

### DIFF
--- a/packages/mobile/src/db/connection-retention.ts
+++ b/packages/mobile/src/db/connection-retention.ts
@@ -38,6 +38,12 @@
 // `OnDestroy` closes every cached connection when the module goes away. In dev the
 // provider's teardown also unregisters the database from the devtools plugin even
 // though our handle survives; the next mount re-registers it.
+//
+// It also costs nothing at the WAL switch, which is the obvious place to worry.
+// `configureMainConnection` flips `journal_mode` on the first launch after install,
+// and SQLite refuses that flip while ANOTHER connection holds the file. This is a
+// refcount bump on the same `NativeDatabase` — the same `sqlite3*` — not a second
+// connection, so there is nothing new to contend with.
 
 import { openDatabaseAsync, type SQLiteDatabase } from 'expo-sqlite';
 import { reportError } from '../lib/error-reporting';

--- a/packages/mobile/src/db/connection-retention.ts
+++ b/packages/mobile/src/db/connection-retention.ts
@@ -75,8 +75,10 @@ export function retainDatabaseConnection(): Promise<SQLiteDatabase | null> {
 
 /**
  * Test-only. Drops the retain so a suite can drive the first-launch path more than
- * once. Reachable from application code only through the ./testing barrel, which the
- * seam guard in `connection-test-seam.test.ts` keeps out of `src/` and `app/`.
+ * once. Deliberately NOT re-exported from ./testing — that barrel is imported by
+ * node-env suites, and this module's `expo-sqlite` import reaches react-native's Flow
+ * source, which Rolldown cannot parse during collection. Callers mock `expo-sqlite`
+ * and import this directly.
  */
 export function resetConnectionRetentionForTests(): void {
   retention = null;

--- a/packages/mobile/src/db/connection-retention.ts
+++ b/packages/mobile/src/db/connection-retention.ts
@@ -1,0 +1,83 @@
+// One process-lifetime reference to the app database, so `SQLiteProvider`'s effect
+// teardown can never be the last one out.
+//
+// WHY (#5300). expo-sqlite runs every `*Async` entry point on a CONCURRENT dispatch
+// queue (`moduleQueue`, iOS `SQLiteModule.swift`), so a close and a query are on the
+// wire at the same instant whenever the provider tears down while work is in flight.
+// `closeDatabase` frees the connection with `exsqlite3_close` and — because
+// `finalizeUnusedStatementsBeforeClosing` defaults to true (`SQLiteOptions.swift`) —
+// first walks `exsqlite3_next_stmt` and finalizes EVERY statement on it without
+// clearing the per-statement `isFinalized` flag JS checks. Whatever was mid-flight is
+// then touching memory that is already gone: `sqlite3_column_type` on a freed Vdbe
+// (EXC_BAD_ACCESS), a `prepare_v2` against a freed `sqlite3*`, or the `finalizeAsync`
+// that expo-sqlite's own `finally` runs next double-freeing an already-finalized
+// statement ("pointer being freed was not allocated"). SQLite is built serialized and
+// its connection mutex is healthy in every one of those crash reports — a mutex
+// cannot protect memory that has already been freed.
+//
+// WHY THE #5292 FIX IS NOT ENOUGH. #5336 retracts the published handle before the
+// close lands, so no reader can PICK UP a connection the provider already closed.
+// That is the branch where the check wins. This is the branch where the free wins: a
+// reader that took the handle a moment earlier is already inside an `await` chain,
+// holds its own reference to the `SQLiteDatabase`, and keeps issuing queries. No
+// amount of JS-side handle bookkeeping reaches it, because the object it is holding
+// never went through `getDatabaseHandle()` again.
+//
+// THE LEVER. expo-sqlite's native connection cache is refcounted, identically on both
+// platforms (iOS `SQLiteModule.swift`, Android `SQLiteModule.kt`): opening the same
+// path with the same options returns the CACHED `NativeDatabase` and `addRef()`s it,
+// and `closeAsync` reaches `exsqlite3_close` only when `removeCachedDatabase` sees the
+// refcount fall to zero. Holding one extra handle and never closing it pins the count
+// at >= 1, so every `SQLiteProvider` teardown still runs and still decrements but can
+// no longer free anything under an in-flight query. The connection stays valid
+// (`isClosed` is only set inside the branch that actually closes), so the provider's
+// next mount gets the same live connection back instead of reopening the file.
+//
+// WHAT IT COSTS. Nothing that would otherwise have been reclaimed: the app has exactly
+// one database and needs it for the whole process, and the SQLite module's own
+// `OnDestroy` closes every cached connection when the module goes away. In dev the
+// provider's teardown also unregisters the database from the devtools plugin even
+// though our handle survives; the next mount re-registers it.
+
+import { openDatabaseAsync, type SQLiteDatabase } from 'expo-sqlite';
+import { reportError } from '../lib/error-reporting';
+import { DATABASE_NAME } from './connection';
+
+/**
+ * The single retain, kept as its promise so concurrent callers share one open and a
+ * remount after the first launch adds no further references.
+ */
+let retention: Promise<SQLiteDatabase | null> | null = null;
+
+/**
+ * Takes the process-lifetime reference described above, once. Safe to call on every
+ * `onInit`, including the ones a remount produces.
+ *
+ * Never rejects. A failed open leaves the provider's teardown able to free the
+ * connection again, which is the crash — so the promise is dropped on failure and the
+ * next `onInit` retries rather than caching the failure for the session.
+ *
+ * The returned connection is deliberately not published anywhere. It exists to hold a
+ * reference, not to be queried: readers keep using the connection `SQLiteProvider`
+ * hands them, which — once this has landed — is the same native connection.
+ */
+export function retainDatabaseConnection(): Promise<SQLiteDatabase | null> {
+  retention ??= openDatabaseAsync(DATABASE_NAME).then(
+    (connection) => connection,
+    (error: unknown) => {
+      retention = null;
+      reportError(error, { tags: { source: 'offline-sync', kind: 'sqlite-retain' } });
+      return null;
+    },
+  );
+  return retention;
+}
+
+/**
+ * Test-only. Drops the retain so a suite can drive the first-launch path more than
+ * once. Reachable from application code only through the ./testing barrel, which the
+ * seam guard in `connection-test-seam.test.ts` keeps out of `src/` and `app/`.
+ */
+export function resetConnectionRetentionForTests(): void {
+  retention = null;
+}

--- a/packages/mobile/src/db/testing.ts
+++ b/packages/mobile/src/db/testing.ts
@@ -5,3 +5,4 @@
 // state lives; this barrel exists so the sanctioned import path for it is visibly a
 // test path, and so the production barrel (./index.ts) can stay free of it.
 export { resetDatabaseInitializationForTests } from './connection';
+export { resetConnectionRetentionForTests } from './connection-retention';

--- a/packages/mobile/src/db/testing.ts
+++ b/packages/mobile/src/db/testing.ts
@@ -5,4 +5,9 @@
 // state lives; this barrel exists so the sanctioned import path for it is visibly a
 // test path, and so the production barrel (./index.ts) can stay free of it.
 export { resetDatabaseInitializationForTests } from './connection';
-export { resetConnectionRetentionForTests } from './connection-retention';
+// `resetConnectionRetentionForTests` deliberately does NOT come through here.
+// ./connection-retention imports expo-sqlite for real, whose entry reaches
+// react-native's Flow source — unparseable by Rolldown's collection-time scan — so
+// re-exporting it would break every node-env suite that only wanted the init reset
+// (db/__tests__/connection.test.ts among them). Suites that need it import it from
+// './connection-retention' directly, having mocked expo-sqlite.

--- a/packages/mobile/src/providers/__tests__/database-provider-retention.test.tsx
+++ b/packages/mobile/src/providers/__tests__/database-provider-retention.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+// #5300: `SQLiteProvider`'s effect teardown closes its connection, and expo-sqlite's
+// close frees the `sqlite3*` and finalizes every statement on it while other queries
+// are still running on the module's concurrent dispatch queue — a native
+// use-after-free, not a JS error anyone can catch. #5336 stopped new readers picking
+// up a closed connection; it cannot reach a reader already mid-`await`.
+//
+// The fix is to hold one process-lifetime reference, so the provider's close is never
+// the last one out. This suite models the piece of expo-sqlite that makes that work:
+// its native connection cache is REFCOUNTED — opening the same path with the same
+// options returns the cached `NativeDatabase` and `addRef()`s it, and `closeAsync`
+// reaches `exsqlite3_close` only when the count falls to zero (iOS
+// `SQLiteModule.swift` / Android `SQLiteModule.kt`, identical on both). The assertion
+// is therefore about the native free, which is the thing that crashes: after the
+// provider tears down, nothing may have been freed.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, waitFor } from '@testing-library/react';
+
+vi.mock('../../lib/error-reporting', () => ({ reportError: vi.fn() }));
+vi.mock('../../lib/profiling/startup-profile', () => ({ markStartup: vi.fn() }));
+vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
+
+// The real engine runs SQL, and its node:sqlite test adapter cannot be bundled into
+// this file's jsdom environment. The DDL is covered against the REAL schema in
+// db/__tests__/connection.test.ts; all this suite needs from the setup sequence is
+// that it succeeds, so the provider gets far enough to publish and then tear down.
+vi.mock('@boardsesh/offline-sync', () => ({
+  configureMainConnection: vi.fn(async () => {}),
+  ensureMutationQueueTable: vi.fn(async () => {}),
+  runMigrations: vi.fn(async () => {}),
+  classifySqliteLockError: () => ({ locked: false, code: null }),
+  applyBusyTimeout: vi.fn(async () => {}),
+  beginImmediateWrite: vi.fn(async () => {}),
+  deleteUserCheckpoints: vi.fn(async () => {}),
+  deleteAllSyncMeta: vi.fn(async () => {}),
+  vacuumDatabase: vi.fn(async () => true),
+  getUnfinishedDownloadScopeKeys: vi.fn(async () => []),
+  claimAbandonedDownloadTerminal: vi.fn(() => true),
+  purgeNamespaceForScopeKey: vi.fn(async () => {}),
+  OFFLINE_DB_BUSY_TIMEOUT_MS: 5_000,
+  BOARD_DATA_TABLES: [],
+}));
+
+// expo-sqlite's native side, reduced to the two things that decide whether a teardown
+// crashes: the refcounted connection cache, and a provider that opens through it.
+// vi.hoisted because the mock factory below is hoisted above this file's imports.
+const sqlite = vi.hoisted(() => {
+  type NativeConnection = { id: number; path: string; refCount: number; freed: boolean };
+
+  const cache = new Map<string, NativeConnection>();
+  const freedConnectionIds: number[] = [];
+  const openedConnectionIds: number[] = [];
+  let nextConnectionId = 0;
+
+  // `NativeDatabase`'s constructor: a cached connection for the same path is reused
+  // and its refcount bumped; only a cache miss opens a new `sqlite3*`.
+  function openNative(path: string): NativeConnection {
+    const cached = cache.get(path);
+    if (cached !== undefined) {
+      cached.refCount += 1;
+      openedConnectionIds.push(cached.id);
+      return cached;
+    }
+    nextConnectionId += 1;
+    const connection: NativeConnection = { id: nextConnectionId, path, refCount: 1, freed: false };
+    cache.set(path, connection);
+    openedConnectionIds.push(connection.id);
+    return connection;
+  }
+
+  // `closeAsync` -> `removeCachedDatabase`: decrement, and free only at zero.
+  function closeNative(connection: NativeConnection): void {
+    connection.refCount -= 1;
+    if (connection.refCount > 0) return;
+    connection.freed = true;
+    cache.delete(connection.path);
+    freedConnectionIds.push(connection.id);
+  }
+
+  return {
+    liveConnections(): { id: number; refCount: number }[] {
+      return [...cache.values()].map(({ id, refCount }) => ({ id, refCount }));
+    },
+    freedConnectionIds,
+    openedConnectionIds,
+    openNative,
+    closeNative,
+    reset(): void {
+      cache.clear();
+      freedConnectionIds.length = 0;
+      openedConnectionIds.length = 0;
+      nextConnectionId = 0;
+    },
+  };
+});
+
+vi.mock('expo-sqlite', async () => {
+  const { createContext, createElement, useContext, useEffect, useRef, useState } = await import('react');
+  const SQLiteContext = createContext<unknown>(null);
+
+  // The JS wrapper `openDatabaseAsync` returns: a fresh object per call, all of them
+  // bound to one refcounted native connection.
+  async function openDatabaseAsync(databaseName: string): Promise<unknown> {
+    const native = sqlite.openNative(databaseName);
+    return {
+      native,
+      closeAsync: async (): Promise<void> => {
+        sqlite.closeNative(native);
+      },
+    };
+  }
+
+  // expo-sqlite's own provider (`build/hooks.js`): the effect opens a connection
+  // through the same cache, awaits `onInit`, publishes it, and closes it on teardown.
+  function SQLiteProvider({
+    children,
+    databaseName,
+    onInit,
+  }: {
+    children?: unknown;
+    databaseName: string;
+    onInit: (db: never) => Promise<void>;
+  }) {
+    const databaseRef = useRef<{ closeAsync: () => Promise<void> } | null>(null);
+    const [, setOpened] = useState(false);
+
+    useEffect(() => {
+      async function setup(): Promise<void> {
+        const database = (await openDatabaseAsync(databaseName)) as { closeAsync: () => Promise<void> };
+        await onInit(database as never);
+        databaseRef.current = database;
+        setOpened(true);
+      }
+      void setup();
+      return () => {
+        const database = databaseRef.current;
+        databaseRef.current = null;
+        setOpened(false);
+        void database?.closeAsync();
+      };
+    }, [databaseName, onInit]);
+
+    if (databaseRef.current === null) return null;
+    return createElement(SQLiteContext.Provider, { value: databaseRef.current }, children as never);
+  }
+
+  return { SQLiteProvider, openDatabaseAsync, useSQLiteContext: () => useContext(SQLiteContext) };
+});
+
+import { DatabaseProvider } from '../database-provider';
+import { getDatabaseHandle, setDatabaseHandle } from '../../db/connection';
+import { resetDatabaseInitializationForTests, resetConnectionRetentionForTests } from '../../db/testing';
+
+beforeEach(() => {
+  resetDatabaseInitializationForTests();
+  resetConnectionRetentionForTests();
+  setDatabaseHandle(null);
+  sqlite.reset();
+});
+
+/**
+ * Drain every pending microtask. The retain is started from `onInit` and deliberately
+ * not awaited, and the provider's close is `void db.closeAsync()` — both settle a few
+ * microtasks after the render/unmount that triggered them.
+ */
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function mountUntilPublished(): Promise<{ unmount: () => void }> {
+  const view = render(
+    <DatabaseProvider>
+      <div data-testid="child" />
+    </DatabaseProvider>,
+  );
+  await waitFor(() => {
+    expect(getDatabaseHandle()).not.toBeNull();
+  });
+  await settle();
+  return view;
+}
+
+describe('DatabaseProvider connection retention', () => {
+  it('leaves the native connection alive when the provider tears down', async () => {
+    const view = await mountUntilPublished();
+
+    view.unmount();
+    await settle();
+
+    // Nothing was freed, so no other thread's in-flight `sqlite3_step` /
+    // `sqlite3_column_type` / `sqlite3_finalize` can be reading freed memory. Without
+    // the retain the provider holds the only reference and this teardown frees it.
+    expect(sqlite.freedConnectionIds).toEqual([]);
+    expect(sqlite.liveConnections()).toEqual([{ id: 1, refCount: 1 }]);
+  });
+
+  it('hands the same live connection back to the next mount', async () => {
+    const first = await mountUntilPublished();
+    first.unmount();
+    await settle();
+
+    const second = await mountUntilPublished();
+
+    // One connection for the whole process: the remount reused connection 1 rather
+    // than reopening the file, which is only possible because it was never freed.
+    expect(new Set(sqlite.openedConnectionIds)).toEqual(new Set([1]));
+    expect(sqlite.freedConnectionIds).toEqual([]);
+
+    second.unmount();
+    await settle();
+    expect(sqlite.freedConnectionIds).toEqual([]);
+  });
+});

--- a/packages/mobile/src/providers/__tests__/database-provider-retention.test.tsx
+++ b/packages/mobile/src/providers/__tests__/database-provider-retention.test.tsx
@@ -149,7 +149,11 @@ vi.mock('expo-sqlite', async () => {
 
 import { DatabaseProvider } from '../database-provider';
 import { getDatabaseHandle, setDatabaseHandle } from '../../db/connection';
-import { resetDatabaseInitializationForTests, resetConnectionRetentionForTests } from '../../db/testing';
+import { resetDatabaseInitializationForTests } from '../../db/testing';
+// Direct, not through ./testing: that barrel must stay clear of expo-sqlite so the
+// node-env suites can use it (see the note there). Safe here because this file mocks
+// expo-sqlite above.
+import { resetConnectionRetentionForTests } from '../../db/connection-retention';
 
 beforeEach(() => {
   resetDatabaseInitializationForTests();

--- a/packages/mobile/src/providers/__tests__/database-provider-retention.test.tsx
+++ b/packages/mobile/src/providers/__tests__/database-provider-retention.test.tsx
@@ -52,6 +52,19 @@ const sqlite = vi.hoisted(() => {
   const openedConnectionIds: number[] = [];
   let nextConnectionId = 0;
 
+  // `openDatabaseAsync` awaits `ensureDatabasePathExistsAsync` BEFORE it reaches the
+  // constructor that bumps the refcount, so the reference does not exist the moment
+  // the call is made. This models that gap: opens past `ungatedOpens` wait until the
+  // test releases them.
+  let ungatedOpens = Number.POSITIVE_INFINITY;
+  let gate: Promise<void> | null = null;
+  let openCalls = 0;
+
+  async function awaitOpenGate(): Promise<void> {
+    openCalls += 1;
+    if (openCalls > ungatedOpens && gate !== null) await gate;
+  }
+
   // `NativeDatabase`'s constructor: a cached connection for the same path is reused
   // and its refcount bumped; only a cache miss opens a new `sqlite3*`.
   function openNative(path: string): NativeConnection {
@@ -85,11 +98,26 @@ const sqlite = vi.hoisted(() => {
     openedConnectionIds,
     openNative,
     closeNative,
+    awaitOpenGate,
+    /** Stall every open past the first `count`; returns the release. */
+    stallOpensAfter(count: number): () => void {
+      ungatedOpens = count;
+      let release = (): void => {};
+      gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return () => {
+        release();
+      };
+    },
     reset(): void {
       cache.clear();
       freedConnectionIds.length = 0;
       openedConnectionIds.length = 0;
       nextConnectionId = 0;
+      ungatedOpens = Number.POSITIVE_INFINITY;
+      gate = null;
+      openCalls = 0;
     },
   };
 });
@@ -101,6 +129,7 @@ vi.mock('expo-sqlite', async () => {
   // The JS wrapper `openDatabaseAsync` returns: a fresh object per call, all of them
   // bound to one refcounted native connection.
   async function openDatabaseAsync(databaseName: string): Promise<unknown> {
+    await sqlite.awaitOpenGate();
     const native = sqlite.openNative(databaseName);
     return {
       native,
@@ -163,9 +192,8 @@ beforeEach(() => {
 });
 
 /**
- * Drain every pending microtask. The retain is started from `onInit` and deliberately
- * not awaited, and the provider's close is `void db.closeAsync()` — both settle a few
- * microtasks after the render/unmount that triggered them.
+ * Drain the pending task queue. The provider's close is `void db.closeAsync()`, which
+ * settles a few microtasks after the unmount that started it.
  */
 async function settle(): Promise<void> {
   await act(async () => {
@@ -173,14 +201,24 @@ async function settle(): Promise<void> {
   });
 }
 
-async function mountUntilPublished(): Promise<{ unmount: () => void }> {
-  const view = render(
+function renderProvider(): { unmount: () => void; queryByTestId: (id: string) => unknown } {
+  return render(
     <DatabaseProvider>
       <div data-testid="child" />
     </DatabaseProvider>,
   );
+}
+
+/**
+ * Mount and wait until the provider has PUBLISHED — children rendered, meaning
+ * `onInit` resolved and its teardown now has a connection to close. Waiting on the
+ * module handle instead would be too early: `initializeDatabase` publishes that while
+ * `onInit` is still settling.
+ */
+async function mountUntilPublished(): Promise<{ unmount: () => void }> {
+  const view = renderProvider();
   await waitFor(() => {
-    expect(getDatabaseHandle()).not.toBeNull();
+    expect(view.queryByTestId('child')).not.toBeNull();
   });
   await settle();
   return view;
@@ -213,6 +251,34 @@ describe('DatabaseProvider connection retention', () => {
     expect(sqlite.freedConnectionIds).toEqual([]);
 
     second.unmount();
+    await settle();
+    expect(sqlite.freedConnectionIds).toEqual([]);
+  });
+
+  it('does not publish the provider while the reference is still being taken', async () => {
+    // The retain's open is stalled where the real one waits on
+    // `ensureDatabasePathExistsAsync` — after the call is made, before the constructor
+    // that bumps the refcount. The provider's own open (the first) runs normally.
+    const releaseRetainOpen = sqlite.stallOpensAfter(1);
+    const view = renderProvider();
+
+    // The setup sequence has finished and published the module handle, so `onInit` is
+    // waiting on nothing but the retain.
+    await waitFor(() => {
+      expect(getDatabaseHandle()).not.toBeNull();
+    });
+    await settle();
+
+    view.unmount();
+    await settle();
+
+    // `onInit` had not resolved, so the provider never stored a connection and its
+    // teardown had nothing to close. Start the retain and forget it, and this unmount
+    // frees the only reference while that open is still in flight — the crash, moved
+    // to the first seconds of launch instead of avoided.
+    expect(sqlite.freedConnectionIds).toEqual([]);
+
+    releaseRetainOpen();
     await settle();
     expect(sqlite.freedConnectionIds).toEqual([]);
   });

--- a/packages/mobile/src/providers/__tests__/database-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/database-provider.test.tsx
@@ -86,7 +86,16 @@ vi.mock('expo-sqlite', async () => {
     return createElement(SQLiteContext.Provider, { value: databaseRef.current }, children as never);
   }
 
-  return { SQLiteProvider, useSQLiteContext: () => useContext(SQLiteContext) };
+  // The provider's `onInit` also takes the process-lifetime reference that keeps a
+  // teardown from freeing the connection (#5300). Its refcounting is what
+  // database-provider-retention.test.tsx models; here it only has to exist, and
+  // deliberately does NOT feed `sqlite.closes` — this suite is about the handle
+  // retraction, whose assertion is the provider's own close.
+  async function openDatabaseAsync(): Promise<unknown> {
+    return { retained: true, closeAsync: async (): Promise<void> => {} };
+  }
+
+  return { SQLiteProvider, openDatabaseAsync, useSQLiteContext: () => useContext(SQLiteContext) };
 });
 
 import { DatabaseProvider } from '../database-provider';

--- a/packages/mobile/src/providers/database-provider.tsx
+++ b/packages/mobile/src/providers/database-provider.tsx
@@ -1,6 +1,7 @@
 import { useEffect, type ReactNode } from 'react';
-import { SQLiteProvider, useSQLiteContext } from 'expo-sqlite';
+import { SQLiteProvider, useSQLiteContext, type SQLiteDatabase } from 'expo-sqlite';
 import { DATABASE_NAME, initializeDatabase, releaseDatabaseHandle } from '../db';
+import { retainDatabaseConnection } from '../db/connection-retention';
 
 function handleDatabaseError(error: Error): void {
   if (__DEV__) {
@@ -30,9 +31,35 @@ function DatabaseHandleLifecycle() {
   return null;
 }
 
+/**
+ * The provider's `onInit`: take the process-lifetime reference on the connection
+ * first, then run the usual setup sequence.
+ *
+ * Ordering matters. `SQLiteProvider` opens the connection, awaits `onInit`, and only
+ * then stores it in the ref its teardown closes — so `onInit` is the earliest point at
+ * which the connection exists in expo-sqlite's native cache, and it is strictly before
+ * any teardown that could free it. Taking the reference here means the provider's
+ * close is never the last one out (#5300): it decrements, the connection survives, and
+ * whatever query was mid-flight on another module-queue thread keeps reading live
+ * memory instead of a freed `sqlite3*`.
+ *
+ * Started, never awaited: the provider renders nothing until `onInit` resolves, so
+ * launch must not wait on a second open, and nothing in the setup sequence depends on
+ * it. `retainDatabaseConnection` never rejects.
+ *
+ * Declared at module scope rather than as a `useCallback`, because `onInit` sits in
+ * `SQLiteProviderNonSuspense`'s effect deps AND in its `memo` comparator — a fresh
+ * identity per render would close and reopen the database on every parent re-render,
+ * which is the exact churn this file exists to survive.
+ */
+function initializeAndRetainDatabase(db: SQLiteDatabase): Promise<void> {
+  void retainDatabaseConnection();
+  return initializeDatabase(db);
+}
+
 export function DatabaseProvider({ children }: { children: ReactNode }) {
   return (
-    <SQLiteProvider databaseName={DATABASE_NAME} onInit={initializeDatabase} onError={handleDatabaseError}>
+    <SQLiteProvider databaseName={DATABASE_NAME} onInit={initializeAndRetainDatabase} onError={handleDatabaseError}>
       <DatabaseHandleLifecycle />
       {children}
     </SQLiteProvider>

--- a/packages/mobile/src/providers/database-provider.tsx
+++ b/packages/mobile/src/providers/database-provider.tsx
@@ -32,8 +32,8 @@ function DatabaseHandleLifecycle() {
 }
 
 /**
- * The provider's `onInit`: take the process-lifetime reference on the connection
- * first, then run the usual setup sequence.
+ * The provider's `onInit`: run the usual setup sequence and, alongside it, take the
+ * process-lifetime reference on the connection.
  *
  * Ordering matters. `SQLiteProvider` opens the connection, awaits `onInit`, and only
  * then stores it in the ref its teardown closes — so `onInit` is the earliest point at
@@ -43,9 +43,23 @@ function DatabaseHandleLifecycle() {
  * whatever query was mid-flight on another module-queue thread keeps reading live
  * memory instead of a freed `sqlite3*`.
  *
- * Started, never awaited: the provider renders nothing until `onInit` resolves, so
- * launch must not wait on a second open, and nothing in the setup sequence depends on
- * it. `retainDatabaseConnection` never rejects.
+ * Both are STARTED synchronously and awaited together, which is load-bearing at both
+ * ends:
+ *
+ * - `initializeDatabase` first and un-awaited, so its synchronous retraction of a
+ *   stale handle still lands the instant `onInit` runs for a new connection (#5336).
+ *   Putting an await in front of it would push that retraction a microtask later.
+ * - `onInit` does not resolve until the reference exists. `openDatabaseAsync` awaits
+ *   `ensureDatabasePathExistsAsync` before it reaches the constructor that bumps the
+ *   refcount, so a fire-and-forget retain leaves a window where the provider has
+ *   already published — and can therefore already tear down and close the only
+ *   reference — while the retain is still in flight. Resolving late costs nothing
+ *   next to the migrations running alongside it, and on every later mount the retain
+ *   is an already-settled promise.
+ *
+ * Neither promise rejects (`initializeDatabase` swallows setup failures so the app is
+ * never stuck rendering null; `retainDatabaseConnection` reports and resolves null),
+ * so neither does this.
  *
  * Declared at module scope rather than as a `useCallback`, because `onInit` sits in
  * `SQLiteProviderNonSuspense`'s effect deps AND in its `memo` comparator — a fresh
@@ -53,8 +67,8 @@ function DatabaseHandleLifecycle() {
  * which is the exact churn this file exists to survive.
  */
 function initializeAndRetainDatabase(db: SQLiteDatabase): Promise<void> {
-  void retainDatabaseConnection();
-  return initializeDatabase(db);
+  const initialization = initializeDatabase(db);
+  return Promise.all([initialization, retainDatabaseConnection()]).then(() => undefined);
 }
 
 export function DatabaseProvider({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary

Fixes #5300

The app dies 3-11 seconds after a cold launch on iOS, foreground, no warning — `EXC_BAD_ACCESS` (BOARDSESH-E9) or `SIGABRT: pointer being freed was not allocated` (BOARDSESH-H4). 13 events / 13 users, 1:1, all on the current store build `2.4.0+13`, still landing today.

**Root cause.** `SQLiteProvider`'s effect teardown calls `db.closeAsync()`, and expo-sqlite runs every `*Async` entry point on a **concurrent** dispatch queue — so that close lands while other queries are still on the wire. `closeDatabase` frees the connection with `exsqlite3_close`, and because `finalizeUnusedStatementsBeforeClosing` defaults to `true` it first walks `exsqlite3_next_stmt` finalizing **every** statement on the connection, without setting the per-statement `isFinalized` flag JS checks. Whatever was mid-flight then dereferences memory that is already gone. The two crashing frames are the first pointer touch after those Bool guards pass:

- **E9** — `SQLiteModule.run` (`SQLiteModule.swift:399`) = `exsqlite3_reset(statement.pointer)`, one line after `maybeThrowForFinalizedStatement` said the statement was fine. Faults in `exsqlite3_mutex_enter` reading `pStmt->db->mutex` at `0xfd71`.
- **H4** — `prepareStatement` (`SQLiteModule.swift:381`) = `exsqlite3_prepare_v2(database.pointer, …)` against a freed `sqlite3*`; the error path then double-frees a db-owned string (`sqlite3ErrorWithMsg` → `sqlite3DbFree` → `exsqlite3_free`).

SQLite is built serialized and its connection mutex is healthy in every report — a mutex cannot protect memory that has already been freed. `closeDatabase` also frees **before** it sets `db.isClosed = true`, so the guard cannot help.

**Why #5336 did not already close this.** #5336 (issue #5292) retracts the published handle before the close lands, so no reader can *pick up* a connection the provider already closed. That is the branch where the check wins. This is the branch where the free wins: a reader that took the handle a moment earlier is already inside an `await` chain, holds its own `SQLiteDatabase` reference and keeps querying — nothing that bookkeeps `getDatabaseHandle()` can reach it. E9's newest event is **2026-09-08 22:29:51Z, 47 minutes after #5336 merged**, on the embedded `2.4.0+13` bundle.

**The fix.** expo-sqlite's native connection cache is refcounted, identically on iOS (`SQLiteModule.swift`) and Android (`SQLiteModule.kt`): opening the same path with the same options returns the cached `NativeDatabase` and `addRef()`s it, and `closeAsync` reaches `exsqlite3_close` only when `removeCachedDatabase` sees the count fall to zero. So `onInit` now takes one extra reference and never releases it. Every provider teardown still runs and still decrements — it just can no longer be the last one out, and can no longer free a connection under an in-flight query. The app has exactly one database and needs it for the whole process; the SQLite module's own `OnDestroy` closes it at teardown.

**Fingerprint impact: none.** Five TypeScript files under `packages/mobile/src`, no native inputs touched (`app.config.ts`, `plugins/**`, `modules/**`, `patches/**`, `package.json`, `ios/`, `android/` all untouched), so the runtimeVersion fingerprint is unchanged and this rides an OTA to the `2.4.0+13` store fleet that is crashing today. A native fix could not have reached them without a store release.

The new suite models expo-sqlite's refcounted cache and asserts the native free never happens. Mutation-run against the fix reverted: `expected [ 1 ] to deeply equal []` — the teardown frees connection 1.

## Release Notes

Fixed a crash that killed the app a few seconds after opening, straight back to your home screen, before you'd even picked a board. Your on-device climb data now stays open for the whole session instead of being closed out from under whatever the app was reading.

## Test plan

1. Open the app cold, then wait thirty seconds.
2. App stays open — no sudden drop to the home screen.
3. Force-quit and reopen five times; every launch survives.
4. Download a board, then browse its climbs offline.
5. Log a tick, then find it in your logbook.

## Risk

Risk: 3/5 — changes the app database's lifecycle on every launch, but JS-only with no native change and no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
