### PR TITLE
fix(sync): retry a contended sqlite write instead of aborting the pull cycle

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -903,7 +903,7 @@ whether offline storage comes up at all.
 | --------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | Startup DDL (`ensureMutationQueueTable`, `runMigrations`) | the app's main connection                                   | milliseconds on a warm install; the full migration set on an upgrade                                                                           |
 | Snapshot import (`bootstrapScopeFromSnapshot`)            | its own native connection (`withExclusiveTransactionAsync`) | one `BEGIN EXCLUSIVE` covering `reconcileScope` + `importScope` ONLY — the artifact is already downloaded to disk before the transaction opens |
-| Paged crawl (`pull-client`)                               | its own native connection                                   | one short exclusive transaction per page, with a 5s `busy_timeout`, so a contender can win in the gaps                                         |
+| Paged crawl (`pull-client`)                               | its own native connection                                   | one short exclusive transaction per page, opened `BEGIN IMMEDIATE` with a 5s `busy_timeout`, so a contender can win in the gaps               |
 | `VACUUM` / teardown deletes                               | the main connection                                         | 5-20s on a 200-400MB file                                                                                                                      |
 
 `OfflineBoardDownloadCompleted.durationMs` is **not** a lock-hold measurement. It is
@@ -912,6 +912,28 @@ artifact download as well as the import — mostly network. Sizing a retry windo
 it overstates the real contention by an order of magnitude. The measurement that
 does describe the lock is `Offline SQLite Init Recovered`'s `elapsedMs`: how long a
 launch that lost the lock took to win it back.
+
+**What happens when the pull loses it anyway** (issue #5302)
+
+Every write transaction in `pull-client` — the page upsert, the deletions page, the
+refresh tail — goes through `runPullWrite`, which does two things the raw
+`withExclusiveTransactionAsync` call did not:
+
+- Opens the transaction with `beginImmediateWrite`, not a bare `applyBusyTimeout`.
+  Expo's wrapper opens a DEFERRED `BEGIN`, which picks its lock from whichever
+  statement runs first, and the refresh tail's first statement is a `getCheckpoint`
+  SELECT. That made it a READ transaction whose later write had to upgrade, and
+  SQLite does not run the busy handler on an upgrade (#4332 measured it failing in
+  ~1ms against a 5,000ms `busy_timeout`). `BEGIN IMMEDIATE` makes the wait real.
+- Wraps it in `runLocalWriteWithRetry` at background sizing
+  (`OFFLINE_BACKGROUND_WRITE_*`: 3 attempts, 250ms gap, 20s budget, the full 5s
+  `busy_timeout` on every attempt). Before this, a single lost lock threw out of
+  `upsertDocuments` → `syncTable` → `pullSync` and ended the CYCLE — every later
+  table skipped, no checkpoint advanced, no `scope-complete:` marker — so the board
+  stayed stale until the next 30s wake met the same contention.
+
+A recovered lock reports nothing. One the ladder cannot win still surfaces as a
+failed cycle through `warnCycleError`, so a genuinely wedged database stays visible.
 
 **Why the launch gate opens before the schema is ready**
 

--- a/packages/shared/offline-sync/src/db/write-retry.ts
+++ b/packages/shared/offline-sync/src/db/write-retry.ts
@@ -58,6 +58,35 @@ import { isDatabaseLockedError } from './lock-errors';
  */
 export const OFFLINE_LOCAL_WRITE_BUDGET_MS = 9000;
 
+/**
+ * The same ladder, sized for a write NOBODY IS WAITING ON: a sync pull's page
+ * upsert, its deletions page, its refresh tail (issue #5302).
+ *
+ * Three numbers, and why they differ from the foreground ones above:
+ *  - ATTEMPTS (3, not 2). The foreground ladder is short because a second failed
+ *    attempt has to give the log-ascent sheet its thread back. A pull page has no
+ *    sheet behind it; the only cost of another attempt is that this cycle finishes
+ *    a few seconds later, against the alternative of the WHOLE cycle aborting and
+ *    the climber's downloaded board staying stale for at least 30 seconds.
+ *  - BUSY TIMEOUT (the full OFFLINE_DB_BUSY_TIMEOUT_MS on every attempt, applied by
+ *    the caller). The foreground ladder shortens attempt 2 to 1.5s as a "did the
+ *    lock clear in the gap" probe. Shortening it here would only make the pull give
+ *    up sooner on a holder it can afford to outwait.
+ *  - DELAY (250ms, not 150ms). The holders a pull meets are not the ~340ms tick
+ *    writes the foreground ladder was measured against — `removeBoardScopeData`
+ *    holds an exclusive transaction for seconds (pull-client.ts says so where it
+ *    guards the scope-complete write), and a snapshot import batch is the other
+ *    documented long holder. A slightly longer gap costs a background writer
+ *    nothing and gives a real holder room to commit.
+ *
+ * Worst case 5000 + 250 + 5000 + 250 + 5000 = 15.5s, inside the budget below and
+ * comfortably inside the scheduler's 30s cycle-error retry, so a ladder that
+ * exhausts still lands before the wake that would have re-run the cycle anyway.
+ */
+export const OFFLINE_BACKGROUND_WRITE_MAX_ATTEMPTS = 3;
+export const OFFLINE_BACKGROUND_WRITE_RETRY_DELAY_MS = 250;
+export const OFFLINE_BACKGROUND_WRITE_BUDGET_MS = 20_000;
+
 /** What the ladder did, reported once per write whose first attempt threw. */
 export type LocalWriteRetryOutcome = {
   /** How many attempts ran, 1-based. `1` means the error was not retryable. */

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client-lock-retry.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client-lock-retry.test.ts
@@ -1,0 +1,215 @@
+// #5302: a board_data page write that loses the SQLite write lock used to throw
+// straight out of `upsertDocuments` → `syncTable` → `pullSync`, aborting the WHOLE
+// cycle. Nothing downstream of the losing page ran: no checkpoint advanced, no
+// `scope-complete:` marker was written, and the climber's downloaded board stayed
+// where the previous cycle left it until the scheduler's next 30s wake — which met
+// the same contention and aborted again ("Waiting to download").
+//
+// The error shape below is the real one, copied from Sentry BOARDSESH-CW: expo's
+// `runAsync` finalizes its statement in a `finally`, and `sqlite3_finalize` re-reports
+// the step's SQLITE_BUSY, so the throw that escapes names `finalizeAsync` and carries
+// `database is locked` only on its `cause`. Using the real shape is load-bearing —
+// the ladder's `shouldRetry` is `isDatabaseLockedError`, which has to walk that cause.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { OfflineDatabase, QueryInvalidator } from '../../database';
+
+vi.mock('../checkpoints', async () => ({
+  ...(await vi.importActual<typeof import('../checkpoints')>('../checkpoints')),
+  getCheckpoint: vi.fn().mockResolvedValue(null),
+  setCheckpoint: vi.fn().mockResolvedValue(undefined),
+  markScopeDownloadComplete: vi.fn().mockResolvedValue(undefined),
+  isScopeDownloadComplete: vi.fn().mockResolvedValue(false),
+  markScopeDownloadStarted: vi.fn().mockResolvedValue(undefined),
+  isScopeDownloadStarted: vi.fn().mockResolvedValue(false),
+  ensureScopeDownloadStartedAt: vi.fn(async (_db: unknown, _scopeKey: string, nowMs: number) => nowMs),
+  rewindDeletionsCheckpoint: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { pullSync } from '../pull-client';
+import { markScopeDownloadComplete } from '../checkpoints';
+import { setSigningOut, setBackgrounded } from '../../mutation-queue/drainer';
+import { TABLE_CONFIGS } from '../table-config';
+
+/**
+ * The exact two-level error expo-sqlite raises on iOS when a statement's step
+ * returned SQLITE_BUSY (Sentry BOARDSESH-CW, 717 events / 264 users in 30 days on
+ * `phase:board_data`). The outer message says nothing about locking; only the cause
+ * does.
+ */
+function busyError(): Error {
+  return new Error(
+    "FunctionCallException: Calling the 'finalizeAsync' function has failed (at ExpoModulesCore/AsyncFunctionDefinition.swift:123)",
+    {
+      cause: new Error('SQLiteErrorException: Error code 5: database is locked (at ExpoSQLite/SQLiteModule.swift:471)'),
+    },
+  );
+}
+
+type Write = { sql: string; params: unknown[] };
+
+/**
+ * A database whose exclusive transactions lose the write lock the first
+ * `lockedAttempts` times a statement touches `lockedTable`, then behave normally.
+ *
+ * Faithful to expo on the two points the fix depends on: the throw comes from the
+ * statement (not from the wrapper), and the wrapper discards everything the failed
+ * task staged — `withExclusiveTransactionAsync` rolls the transaction back, so a
+ * retry must be able to re-run every statement in it.
+ */
+function createContendedDatabase(options: { lockedTable: string; lockedAttempts: number }) {
+  const committedWrites: Write[] = [];
+  // Every statement each transaction issued, in order, so a test can assert WHEN
+  // the write lock was taken relative to the task's own first statement.
+  const transactionStatements: string[][] = [];
+  let remainingLocks = options.lockedAttempts;
+  let transactions = 0;
+
+  const db = {
+    runAsync: vi.fn(async (sql: string, params: unknown[]) => {
+      committedWrites.push({ sql, params });
+      return { changes: 0, lastInsertRowId: 0 };
+    }),
+    execAsync: vi.fn(async () => {}),
+    getAllAsync: vi.fn().mockResolvedValue([]),
+    getFirstAsync: vi.fn().mockResolvedValue(null),
+    withExclusiveTransactionAsync: vi.fn(async (task: (txn: unknown) => Promise<void>) => {
+      transactions += 1;
+      const staged: Write[] = [];
+      const statements: string[] = [];
+      transactionStatements.push(statements);
+      const txn = {
+        execAsync: vi.fn(async (sql: string) => {
+          statements.push(sql);
+        }),
+        runAsync: vi.fn(async (sql: string, params: unknown[]) => {
+          statements.push(sql);
+          if (remainingLocks > 0 && sql.includes(options.lockedTable)) {
+            remainingLocks -= 1;
+            throw busyError();
+          }
+          staged.push({ sql, params });
+          return { changes: 0, lastInsertRowId: 0 };
+        }),
+        getAllAsync: vi.fn(async (sql: string) => {
+          statements.push(sql);
+          return [];
+        }),
+        getFirstAsync: vi.fn(async (sql: string) => {
+          statements.push(sql);
+          return null;
+        }),
+      };
+      await task(txn);
+      committedWrites.push(...staged);
+    }),
+  } as unknown as OfflineDatabase;
+
+  return {
+    db,
+    committedWrites,
+    transactionStatements,
+    lockReleased: () => remainingLocks === 0,
+    transactionCount: () => transactions,
+  };
+}
+
+function createQueryClient(): QueryInvalidator {
+  return { invalidateQueries: vi.fn().mockResolvedValue(undefined) } as unknown as QueryInvalidator;
+}
+
+const SCOPE_KEY = 'kilter:8:25';
+const STATS_PAGE = [
+  { climb_uuid: 'climb-1', angle: 40, ascensionist_count: 12 },
+  { climb_uuid: 'climb-2', angle: 40, ascensionist_count: 3 },
+];
+
+/** Every table serves one page except board_climb_stats, which serves STATS_PAGE. */
+function createGraphqlFetch() {
+  return vi.fn(async (query: string) => {
+    if (query.includes('syncDeletions')) {
+      return {
+        syncDeletions: { deletions: [], cursor: { updatedAt: '2026-09-08T00:00:00Z', syncSeq: '1' }, hasMore: false },
+      };
+    }
+    const statsQuery = TABLE_CONFIGS.board_climb_stats.queryName;
+    if (query.includes(statsQuery)) {
+      return {
+        [statsQuery]: {
+          documents: STATS_PAGE,
+          cursor: { updatedAt: '2026-09-08T00:00:00Z', syncSeq: '9' },
+          hasMore: false,
+        },
+      };
+    }
+    for (const config of Object.values(TABLE_CONFIGS)) {
+      if (query.includes(config.queryName)) {
+        return {
+          [config.queryName]: {
+            documents: [],
+            cursor: { updatedAt: '2026-09-08T00:00:00Z', syncSeq: '1' },
+            hasMore: false,
+          },
+        };
+      }
+    }
+    throw new Error(`Unexpected query: ${query}`);
+  }) as unknown as <T>(query: string, variables?: Record<string, unknown>) => Promise<T>;
+}
+
+describe('board_data pull under write-lock contention (#5302)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setSigningOut(false);
+    setBackgrounded(false);
+  });
+
+  it('finishes the cycle when a board_climb_stats page loses the lock once', async () => {
+    const contended = createContendedDatabase({ lockedTable: 'board_climb_stats', lockedAttempts: 1 });
+    const graphqlFetch = createGraphqlFetch();
+
+    await pullSync(contended.db, createQueryClient(), graphqlFetch, { enabledBoards: [SCOPE_KEY] });
+
+    // The contention really happened — otherwise this test proves nothing.
+    expect(contended.lockReleased()).toBe(true);
+    // ...and the page it hit still landed, on the retry.
+    const statsWrites = contended.committedWrites.filter((write) => write.sql.includes('board_climb_stats'));
+    expect(statsWrites).toHaveLength(1);
+    expect(statsWrites[0].params).toEqual(expect.arrayContaining(['climb-1', 'climb-2']));
+    // The user-visible consequence: the scope reached its tail, so local-first
+    // search may serve this board instead of showing it as still downloading.
+    expect(markScopeDownloadComplete).toHaveBeenCalledWith(contended.db, SCOPE_KEY);
+  });
+
+  it('takes the write lock before the transaction runs anything of its own', async () => {
+    // Why this ordering is the fix and not decoration (#4332, measured against real
+    // SQLite): expo opens the wrapper with a DEFERRED `BEGIN`, which picks its lock
+    // from whichever statement runs first. The pull's refresh tail starts with a
+    // `getCheckpoint` SELECT, so that transaction became a READ transaction and its
+    // later write had to UPGRADE — and SQLite does not run the busy handler on an
+    // upgrade, so `busy_timeout` was set and then never consulted. `BEGIN IMMEDIATE`
+    // as the transaction's first lock-taking statement is what makes the wait real
+    // for every one of these tasks, whatever they start with.
+    const contended = createContendedDatabase({ lockedTable: 'never-matches', lockedAttempts: 0 });
+
+    await pullSync(contended.db, createQueryClient(), createGraphqlFetch(), { enabledBoards: [SCOPE_KEY] });
+
+    expect(contended.transactionCount()).toBeGreaterThan(0);
+    for (const statements of contended.transactionStatements) {
+      expect(statements.slice(0, 3)).toEqual(['PRAGMA busy_timeout = 5000', 'COMMIT', 'BEGIN IMMEDIATE']);
+    }
+  });
+
+  it('gives up and aborts the cycle when the lock never clears', async () => {
+    // The ladder is bounded, not infinite: a genuinely wedged database still
+    // surfaces as a failed cycle, so `warnCycleError` keeps reporting the case
+    // that needs a human. Only the recovered ones go quiet.
+    const contended = createContendedDatabase({ lockedTable: 'board_climb_stats', lockedAttempts: 99 });
+    const graphqlFetch = createGraphqlFetch();
+
+    await expect(
+      pullSync(contended.db, createQueryClient(), graphqlFetch, { enabledBoards: [SCOPE_KEY] }),
+    ).rejects.toThrow(/finalizeAsync/);
+
+    expect(markScopeDownloadComplete).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -86,8 +86,14 @@ import {
   setDeletionsCoverageAt,
   resetUserDataForLostCoverage,
 } from './deletions-coverage';
-import { applyBusyTimeout } from '../db/pragmas';
+import { beginImmediateWrite, OFFLINE_DB_BUSY_TIMEOUT_MS } from '../db/pragmas';
 import { classifySqliteLockError } from '../db/lock-errors';
+import {
+  runLocalWriteWithRetry,
+  OFFLINE_BACKGROUND_WRITE_BUDGET_MS,
+  OFFLINE_BACKGROUND_WRITE_MAX_ATTEMPTS,
+  OFFLINE_BACKGROUND_WRITE_RETRY_DELAY_MS,
+} from '../db/write-retry';
 import { getPendingCount } from '../mutation-queue/queue';
 import { isNetworkError } from '../mutation-queue/error-classification';
 import {
@@ -702,6 +708,64 @@ function buildMultiRowInsertSql(
           >= (${timestampKey(`${tableName}.${cursorColumn}`)}, ${tableName}.sync_seq)`;
 }
 
+/**
+ * Run one of the pull's write transactions, retrying a lost SQLite write lock
+ * instead of letting it abort the whole cycle (issue #5302).
+ *
+ * WHAT USED TO HAPPEN. Each of these transactions opened expo's deferred `BEGIN`,
+ * set `busy_timeout`, and wrote. A `SQLITE_BUSY` anywhere inside threw out of
+ * `upsertDocuments` → `syncTable` → `pullSync`, so ONE contended page ended the
+ * cycle: every table after it in BOARD_DATA_TABLES was skipped, no checkpoint
+ * advanced, and no `scope-complete:` marker was written. The scheduler's next wake
+ * is 30s later and met the same contention, which is what "Waiting to download"
+ * looks like from the outside. 1,431 events across 365 users in 30 days landed on
+ * `phase:board_data` alone (Sentry BOARDSESH-CW / BOARDSESH-CF).
+ *
+ * TWO THINGS ARE WRONG WITH THE OLD SHAPE, and this fixes both:
+ *
+ *  1. `applyBusyTimeout` alone is not enough for a task that READS before it
+ *     writes. `markSchemaRefreshComplete` in `'refresh'` mode opens with a
+ *     `getCheckpoint` SELECT, so the deferred `BEGIN` becomes a READ transaction
+ *     and the write that follows has to UPGRADE — the case #4332 measured against
+ *     real SQLite, where the busy handler is never consulted and the write fails in
+ *     about a millisecond against a 5,000ms setting. `beginImmediateWrite` takes
+ *     the write lock up front so the wait is real for every one of these
+ *     transactions, whichever statement they happen to start with.
+ *  2. Even a write-first transaction can genuinely lose a 5s race — the code below
+ *     notes that `removeBoardScopeData` holds an exclusive transaction for seconds,
+ *     and a snapshot import batch is the other documented long holder. The engine
+ *     has had a bounded ladder for exactly this since #4332; every user-facing
+ *     write goes through it and the pull did not. Now it does, at background
+ *     sizing (see OFFLINE_BACKGROUND_WRITE_* — nobody is waiting on a tap here).
+ *
+ * SAFE TO RE-RUN, which the ladder requires: expo rolls the whole transaction back
+ * on a throw, and every statement in these three tasks is idempotent anyway —
+ * `INSERT OR REPLACE` / `ON CONFLICT DO UPDATE` upserts, `DELETE`s, and checkpoint
+ * writes that either replace a row or only move a cursor forward. The one throw
+ * that must NOT be retried, `DeletionPageAbortedError`, is not a lock error, and
+ * the ladder's default `shouldRetry` is `isDatabaseLockedError`, so it rethrows
+ * immediately.
+ *
+ * A recovered lock reports NOTHING: `runLocalWriteWithRetry` is silent unless
+ * attempt 1 threw, and no `onSettled` is passed, so the only lock that still
+ * reaches telemetry is one the ladder could not win — which surfaces exactly where
+ * it did before, as a failed cycle.
+ */
+async function runPullWrite(db: OfflineDatabase, task: (transaction: SqlExecutor) => Promise<void>): Promise<void> {
+  await runLocalWriteWithRetry(
+    () =>
+      db.withExclusiveTransactionAsync(async (transaction) => {
+        await beginImmediateWrite(transaction, OFFLINE_DB_BUSY_TIMEOUT_MS);
+        await task(transaction);
+      }),
+    {
+      maxAttempts: OFFLINE_BACKGROUND_WRITE_MAX_ATTEMPTS,
+      retryDelayMs: OFFLINE_BACKGROUND_WRITE_RETRY_DELAY_MS,
+      budgetMs: OFFLINE_BACKGROUND_WRITE_BUDGET_MS,
+    },
+  );
+}
+
 async function upsertDocuments(
   db: OfflineDatabase,
   tableName: string,
@@ -763,10 +827,11 @@ async function upsertDocuments(
   // commit overhead by 10 while giving the drainer no meaningful extra window —
   // it can interleave between pages either way.
   let committed = false;
-  await db.withExclusiveTransactionAsync(async (transaction) => {
-    // This page's insert runs on its own connection (busy_timeout defaults to 0);
-    // wait for a held lock instead of losing the whole page to an instant SQLITE_BUSY.
-    await applyBusyTimeout(transaction);
+  await runPullWrite(db, async (transaction) => {
+    // A retried attempt re-runs this whole body, and the rollback of the failed one
+    // means none of its rows are there — so reset rather than carry the last
+    // attempt's verdict into this one.
+    committed = false;
     if (page && !page.canWrite()) return;
     for (let chunkStart = 0; chunkStart < documents.length; chunkStart += chunkSize) {
       const chunk = documents.slice(chunkStart, chunkStart + chunkSize);
@@ -939,8 +1004,13 @@ async function syncTable(
 
     if (revision && boardScope && (refresh || fullDownload) && !completedAtTail) {
       let completed = false;
-      await db.withExclusiveTransactionAsync(async (transaction) => {
-        await applyBusyTimeout(transaction);
+      // The read-then-upgrade case runPullWrite's docblock names: in `'refresh'`
+      // mode `markSchemaRefreshComplete` opens with a `getCheckpoint` SELECT, so
+      // before #5302 this transaction's later write had to upgrade a READ
+      // transaction and lost instantly under any contention, `busy_timeout`
+      // notwithstanding.
+      await runPullWrite(db, async (transaction) => {
+        completed = false;
         if (!canWrite()) return;
         await markSchemaRefreshComplete(
           transaction,
@@ -1014,14 +1084,14 @@ async function processDeletions(
     // failed tombstone rolls the entire page back for a clean retry.
     const pageInvalidatedKeys = new Set<string>();
     try {
-      await db.withExclusiveTransactionAsync(async (transaction) => {
-        await applyBusyTimeout(transaction);
-
+      await runPullWrite(db, async (transaction) => {
         // Expo opens this wrapper with deferred BEGIN: entering the callback is
-        // NOT writer-lock ownership. Re-writing the page's current cursor (or
-        // creating the epoch cursor on page one) is the first real main-DB write,
-        // so it waits behind a purge and then acquires SQLite's RESERVED writer
-        // lock. If the purge won, the guard immediately rolls this write back.
+        // NOT writer-lock ownership — `beginImmediateWrite` inside runPullWrite is
+        // what takes it, before the first statement below rather than because of
+        // it. Re-writing the page's current cursor (or creating the epoch cursor on
+        // page one) then runs with the writer lock already held, so it still
+        // waits behind a purge and the guard after it still rolls this write back
+        // if the purge won.
         // If we won, a purge cannot finish until this transaction commits or
         // rolls back. This closes the queue gap where a stale page could otherwise
         // commit after a wipe that landed between callback entry and first DELETE.


### PR DESCRIPTION
## Summary

A single SQLite `SQLITE_BUSY` inside the offline sync pull used to kill the whole cycle. `upsertDocuments` threw, the throw escaped `syncTable` and `pullSync`, and every table after the losing page was skipped — no checkpoint advanced, no `scope-complete:` marker was written. The scheduler's next wake is 30 s later and, if the contention is still there, aborts the same way. 1,839 events / 449 users in 30 days on `source:offline-sync kind:cycle`, of which 1,431 / 365 land on `phase:board_data` (Sentry BOARDSESH-CW on iOS, BOARDSESH-CF on Android).

### What I proved about the cause

The brief named three candidates. Only the third holds, plus a fourth that the code makes plain:

1. **Not an unconfigured connection.** The pull's page writes never run on the app's main connection. `withExclusiveTransactionAsync` opens a *fresh* native connection (`useNewConnection: true`, verified in `expo-sqlite/build/SQLiteDatabase.js` — `Transaction.createAsync`), which starts at `busy_timeout = 0`, and `pull-client.ts` armed it with `applyBusyTimeout` as the task's first statement. So the pull already had a 5 s wait.
2. **Not a hold that is too long.** The pull's own transaction is one page (≤ `PAGE_LIMIT` rows) per commit. It is the *dominant holder* during a board download, which is what starves the drainer — that is #5305's side of the same cluster, not this one.
3. **Genuine contention, with no retry.** Whatever wins the race — `removeBoardScopeData`, which this file's own comment says "holds an exclusive transaction for seconds"; a snapshot import batch; a foreground tick — the pull had *no* retry. `db/write-retry.ts` has shipped a bounded lock ladder since #4332, every user-facing write goes through it, and the pull did not.
4. **One transaction could never wait at all.** `markSchemaRefreshComplete` in `'refresh'` mode opens with a `getCheckpoint` SELECT, so that deferred `BEGIN` became a READ transaction and its later write had to *upgrade*. #4332 measured that case against real SQLite: the busy handler is not run on an upgrade, and the write failed in ~1 ms against a 5,000 ms `busy_timeout`. `applyBusyTimeout` alone was never enough there.

The Sentry title names the wrong function, which is worth knowing when reading the cluster: expo's `runAsync` finalizes its statement in a `finally`, and `sqlite3_finalize` re-reports the step's `SQLITE_BUSY`, so the throw that escapes is always `finalizeAsync` no matter which statement actually lost the lock.

### What #5336 already removed, and why it did not fix this

#5336 (issue #5292) closed the "republished connection with no `busy_timeout`" path: before it, a `SQLiteProvider` remount opened a new connection, `initializeDatabase` handed back the already-resolved single-flight promise, and `configureMainConnection` never ran on that connection — so every `useSQLiteContext()` consumer got a main connection at `busy_timeout = 0`. Real, and really removed. But the pull's page writes take their timeout from their *own* transaction connection, not from the main one, so that path was never the source of these `board_data` aborts. #5336 is a prerequisite here, not a duplicate.

### The fix

One helper, `runPullWrite`, now wraps all three of the pull's write transactions (page upsert, refresh tail, deletions page):

- `beginImmediateWrite` instead of a bare `applyBusyTimeout`, so the write lock is taken up front and the busy handler is engaged whatever statement the task starts with — closing (4).
- `runLocalWriteWithRetry` at background sizing (3 attempts, 250 ms gap, 20 s budget, full 5 s `busy_timeout` on every attempt), so a lost lock is retried instead of ending the cycle — closing (3). Nobody is waiting on a tap behind a pull, which is why the sizing differs from the foreground ladder; the reasoning is in the new constants' docblock.

Every statement in those three tasks is already idempotent (`INSERT OR REPLACE` / `ON CONFLICT DO UPDATE`, `DELETE`s, checkpoint writes), which is what the ladder requires. `DeletionPageAbortedError` is not a lock error, so `shouldRetry` rethrows it immediately and the purge/sign-out guards keep working.

A recovered lock now reports **nothing** — no `onSettled` is passed, and the ladder is silent unless attempt 1 threw. A lock the ladder cannot win still surfaces exactly where it did before, as a failed cycle, so a genuinely wedged database stays visible.

### How this relates to the sibling issues

- **#4314** (`kind:sqlite-init`) is the same lock family at app launch, before the schema exists. Different path, different owner, no overlap with this diff.
- **#5305** is the drain side: the mutation drainer dead-letters a mutation after the server accepted it. It asks for the same remedy on that path. This PR touches only `pull-client.ts` and adds constants to `write-retry.ts`, so the two land independently.
- **#5292 / #5336** is the connection-lifecycle fix described above.

### Tests

`pull-client-lock-retry.test.ts` drives `pullSync` with a database that loses the lock on a `board_climb_stats` page, throwing the exact two-level error from BOARDSESH-CW (the outer message says nothing about locking; only the `.cause` does, which is what `isDatabaseLockedError` has to walk). Three cases: the cycle finishes and the page lands on the retry; every pull transaction opens `BEGIN IMMEDIATE` before its own first statement; a lock that never clears still aborts the cycle.

Both mutations confirmed red: `maxAttempts: 1` makes the recovery test fail with the real error at `pull-client.ts:844`, and swapping `beginImmediateWrite` back for a bare `PRAGMA busy_timeout` makes the ordering test fail with the SELECT/INSERT running where `BEGIN IMMEDIATE` should be.

Full `offline-sync` and `mobile` suites were **not** run locally — the box was at load average ~135 with 78 concurrent vitest processes, which produces a shifting set of spurious hook/test timeouts. CI is authoritative for those.

## Release Notes

Your downloaded boards stop going stale. A busy moment in the local database used to kill the whole sync in one go, so climbs, stats and grades you had already asked for sat half-downloaded until the next attempt hit the same wall — with nothing on screen to tell you. Sync now waits out the busy moment and carries on.

## Test plan

1. Download a board, then log a tick mid-download.
2. Download finishes; My Boards shows it complete.
3. Search that board offline; climbs and grades appear.
4. Remove a downloaded board while another downloads.
5. The other board still finishes downloading.

## Risk

Risk: 3/5 — touches every write in the sync pull's hot path (page upsert, deletions, refresh tail). Behaviour under contention changes; the statements themselves do not. Idempotency of each retried transaction is the load-bearing assumption, and the purge/sign-out abort is deliberately excluded from the retry.

Fixes #5302

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
