### PR TITLE
fix(mobile): stop the wall-state pill crashing the app on web (#5301)

### DIFF
--- a/packages/mobile/src/components/play-drawer/WallStateCallout.tsx
+++ b/packages/mobile/src/components/play-drawer/WallStateCallout.tsx
@@ -18,7 +18,7 @@
 // host — any state change or navigation.
 
 import { memo, useEffect, useMemo, useRef } from 'react';
-import { AccessibilityInfo, BackHandler, findNodeHandle, Pressable, StyleSheet, View } from 'react-native';
+import { BackHandler, Pressable, StyleSheet, View } from 'react-native';
 import Animated, { FadeIn, FadeInUp, useReducedMotion } from 'react-native-reanimated';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -30,6 +30,7 @@ import { selectByVariant } from '../../theme/variants/select-by-variant';
 import { glassSize } from '../../theme/layout';
 import { Text } from '../Text';
 import { BoardDriverAvatar } from '../board-presence/BoardDriverAvatar';
+import { useAnnounceBodyFocus } from './use-announce-body-focus';
 import { useWallDriver } from './use-wall-driver';
 import type { WallStatePillState } from './WallStatePill';
 
@@ -102,12 +103,8 @@ function WallStateCalloutImpl({
   // than wherever the focus happened to be when the card claimed the modal. The
   // notice asked for nothing, so it never yanks focus off whatever the climber
   // was reading — it announces politely and gets out of the way.
-  useEffect(() => {
-    if (isNotice) return;
-    const nodeHandle = findNodeHandle(bodyRef.current);
-    if (nodeHandle == null) return;
-    AccessibilityInfo.setAccessibilityFocus(nodeHandle);
-  }, [isNotice]);
+  // Forked per platform — see use-announce-body-focus.web.ts (#5301).
+  useAnnounceBodyFocus(bodyRef, !isNotice);
 
   // Android hardware back closes the explainer instead of dismissing the whole
   // player — the same "innermost transient surface first" order a sheet gets.

--- a/packages/mobile/src/components/play-drawer/__tests__/use-announce-body-focus.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-announce-body-focus.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { RefObject } from 'react';
+import type { View } from 'react-native';
+
+const findNodeHandle = vi.fn((_component: unknown): number | null => 7);
+const setAccessibilityFocus = vi.fn();
+
+vi.mock('react-native', () => ({
+  AccessibilityInfo: { setAccessibilityFocus: (...args: unknown[]) => setAccessibilityFocus(...args) },
+  findNodeHandle: (component: unknown) => findNodeHandle(component),
+}));
+
+import { useAnnounceBodyFocus } from '../use-announce-body-focus';
+
+describe('useAnnounceBodyFocus (native)', () => {
+  beforeEach(() => {
+    findNodeHandle.mockClear();
+    findNodeHandle.mockReturnValue(7);
+    setAccessibilityFocus.mockClear();
+  });
+
+  it('lands accessibility focus on the resolved node handle', () => {
+    const bodyRef: RefObject<View | null> = { current: {} as View };
+    renderHook(() => useAnnounceBodyFocus(bodyRef, true));
+
+    expect(findNodeHandle).toHaveBeenCalledWith(bodyRef.current);
+    expect(setAccessibilityFocus).toHaveBeenCalledWith(7);
+  });
+
+  it('does nothing when the ref has not mounted', () => {
+    findNodeHandle.mockReturnValue(null);
+    const bodyRef: RefObject<View | null> = { current: null };
+    renderHook(() => useAnnounceBodyFocus(bodyRef, true));
+
+    expect(setAccessibilityFocus).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/use-announce-body-focus.web.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-announce-body-focus.web.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { RefObject } from 'react';
+import type { View } from 'react-native';
+import { useAnnounceBodyFocus } from '../use-announce-body-focus.web';
+
+describe('useAnnounceBodyFocus (web)', () => {
+  it('focuses the body element directly — no findNodeHandle, no AccessibilityInfo', () => {
+    const node = document.createElement('div');
+    document.body.appendChild(node);
+    const bodyRef = { current: node as unknown as View } as RefObject<View | null>;
+
+    renderHook(() => useAnnounceBodyFocus(bodyRef, true));
+
+    expect(document.activeElement).toBe(node);
+    expect(node.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('does not overwrite an existing tabindex', () => {
+    const node = document.createElement('div');
+    node.setAttribute('tabindex', '0');
+    document.body.appendChild(node);
+    const bodyRef = { current: node as unknown as View } as RefObject<View | null>;
+
+    renderHook(() => useAnnounceBodyFocus(bodyRef, true));
+
+    expect(node.getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(node);
+  });
+
+  it('does not throw when the ref has not mounted', () => {
+    const bodyRef = { current: null } as RefObject<View | null>;
+    expect(() => renderHook(() => useAnnounceBodyFocus(bodyRef, true))).not.toThrow();
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/wall-state-callout.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/wall-state-callout.test.tsx
@@ -4,7 +4,7 @@
 // about which actions it offers in which state, and that it can always be closed.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render } from '@testing-library/react';
-import { createElement, type ReactNode } from 'react';
+import { createElement, forwardRef, type ReactNode } from 'react';
 
 const routerPush = vi.hoisted(() => vi.fn());
 const backHandler = vi.hoisted(() => ({
@@ -12,6 +12,10 @@ const backHandler = vi.hoisted(() => ({
   remove: vi.fn(),
 }));
 const setAccessibilityFocus = vi.hoisted(() => vi.fn());
+// Flips the react-native mock (and the accessibility-focus hook) into the
+// react-native-web shape for the "#5301 on web" describe block below, without
+// needing a separate copy of every other mock in this file.
+const wallStateCalloutPlatform = vi.hoisted(() => ({ web: false }));
 
 type ViewMockProps = { children?: ReactNode; style?: unknown; accessibilityViewIsModal?: boolean };
 type PressMockProps = {
@@ -22,8 +26,11 @@ type PressMockProps = {
 };
 
 vi.mock('react-native', () => ({
-  View: ({ children, accessibilityViewIsModal }: ViewMockProps) =>
-    createElement('div', { 'data-modal': accessibilityViewIsModal ? 'true' : '' }, children),
+  // Forwards the ref like the real View does, so bodyRef.current in the
+  // component under test is the actual DOM node the focus hook operates on.
+  View: forwardRef<HTMLDivElement, ViewMockProps>(({ children, accessibilityViewIsModal }, ref) =>
+    createElement('div', { ref, 'data-modal': accessibilityViewIsModal ? 'true' : '' }, children),
+  ),
   Pressable: ({ children, onPress, disabled, accessibilityLabel }: PressMockProps) =>
     createElement('button', { onClick: onPress, disabled, 'data-label': accessibilityLabel ?? '' }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1, absoluteFill: {} },
@@ -34,9 +41,33 @@ vi.mock('react-native', () => ({
     },
   },
   AccessibilityInfo: { setAccessibilityFocus },
-  // A real node handle, so the focus call isn't skipped by the null guard.
-  findNodeHandle: () => 7,
+  // react-native-web 0.21.2's findNodeHandle is a bare, unconditional throw —
+  // see the "#5301 on web" describe block. Otherwise a real node handle, so
+  // the focus call isn't skipped by the null guard.
+  findNodeHandle: () => {
+    if (wallStateCalloutPlatform.web) {
+      throw new Error('findNodeHandle is not supported on web. Use the ref property on the component instead.');
+    }
+    return 7;
+  },
 }));
+
+// Routes the accessibility-focus effect to the same fork Metro would pick for
+// the current platform, so the "#5301 on web" tests below exercise the real
+// use-announce-body-focus.web.ts implementation instead of the native one.
+vi.mock('../use-announce-body-focus', async () => {
+  const native = await vi.importActual<typeof import('../use-announce-body-focus')>('../use-announce-body-focus');
+  const web = await vi.importActual<typeof import('../use-announce-body-focus.web')>('../use-announce-body-focus.web');
+  return {
+    useAnnounceBodyFocus: (
+      bodyRef: Parameters<typeof native.useAnnounceBodyFocus>[0],
+      enabled: Parameters<typeof native.useAnnounceBodyFocus>[1],
+    ) =>
+      wallStateCalloutPlatform.web
+        ? web.useAnnounceBodyFocus(bodyRef, enabled)
+        : native.useAnnounceBodyFocus(bodyRef, enabled),
+  };
+});
 
 vi.mock('react-native-reanimated', () => {
   const settleBuilder: Record<string, unknown> = {};
@@ -302,6 +333,42 @@ describe('WallStateCallout — the one-shot joined-a-crew notice', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// #5301: on app.boardsesh.com, tapping the wall-state pill mounted this card,
+// its mount effect called findNodeHandle, react-native-web's findNodeHandle is
+// an unconditional throw, and the root error boundary replaced the whole app
+// with the crash screen. 100% failure rate — it never once worked in a
+// browser. These tests run the SAME component tree through the mocked web
+// runtime (see wallStateCalloutPlatform above) to prove that no longer happens.
+describe('WallStateCallout on web (#5301)', () => {
+  beforeEach(() => {
+    wallStateCalloutPlatform.web = true;
+  });
+
+  afterEach(() => {
+    wallStateCalloutPlatform.web = false;
+  });
+
+  it('does not throw when the accessibility-focus effect runs', () => {
+    expect(() => renderCallout({ state: 'browsing' })).not.toThrow();
+  });
+
+  it('still renders the explainer sentence and actions', () => {
+    const { container } = renderCallout({ state: 'live', onBrowseFromHere: vi.fn() });
+    expect(container.textContent).toContain('playView.wallState.liveHint');
+    expect(container.textContent).toContain('playView.wallState.browseFromHere');
+  });
+
+  it('lands DOM focus on the body sentence instead of using AccessibilityInfo', () => {
+    const { container } = renderCallout({ state: 'browsing' });
+    // modalRegion div > card div (Animated.View) > body div (the ref target).
+    const body = container.querySelector('div[data-modal="true"] > div:nth-child(2) > div:first-child');
+    expect(body).not.toBeNull();
+    expect(document.activeElement).toBe(body);
+    // The native-only API is never reached on the web fork.
+    expect(setAccessibilityFocus).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/mobile/src/components/play-drawer/use-announce-body-focus.ts
+++ b/packages/mobile/src/components/play-drawer/use-announce-body-focus.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import type { RefObject } from 'react';
+import { AccessibilityInfo, findNodeHandle, type View } from 'react-native';
+
+/**
+ * Lands the screen reader on the sentence the climber just asked for, rather
+ * than wherever the focus happened to be when the card claimed the modal.
+ *
+ * Native-only: `findNodeHandle` and `AccessibilityInfo.setAccessibilityFocus`
+ * both require a real host-view "tag", which only exists on iOS/Android. See
+ * `use-announce-body-focus.web.ts` for the browser equivalent — react-native-web
+ * doesn't have a node-handle concept (a ref already IS the DOM node), and its
+ * `findNodeHandle` throws unconditionally (#5301).
+ *
+ * `enabled` is false for the notice variant, which asked for nothing and so
+ * never yanks focus off whatever the climber was already reading.
+ */
+export function useAnnounceBodyFocus(bodyRef: RefObject<View | null>, enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled) return;
+    const nodeHandle = findNodeHandle(bodyRef.current);
+    if (nodeHandle == null) return;
+    AccessibilityInfo.setAccessibilityFocus(nodeHandle);
+  }, [bodyRef, enabled]);
+}

--- a/packages/mobile/src/components/play-drawer/use-announce-body-focus.web.ts
+++ b/packages/mobile/src/components/play-drawer/use-announce-body-focus.web.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import type { RefObject } from 'react';
+import type { View } from 'react-native';
+
+/**
+ * react-native-web has no node-handle concept — a `ref` on a `View` already
+ * IS the underlying DOM element — so `findNodeHandle` is an unconditional
+ * throw (`findNodeHandle is not supported on web. Use the ref property on the
+ * component instead.`) and `AccessibilityInfo.setAccessibilityFocus` is a
+ * silent no-op even when a handle exists. Calling either from this effect is
+ * exactly issue #5301: the wall-state pill's callout crashed the whole app on
+ * app.boardsesh.com every single time it opened in a browser.
+ *
+ * The DOM equivalent of "accessibility focus" is a real `.focus()` call. The
+ * body sentence isn't natively focusable (it's a `<div>`, not a control), so
+ * this gives it `tabindex="-1"` first — focusable programmatically, but never
+ * part of Tab order — then focuses it, which is what actually lands a screen
+ * reader on the sentence in a browser.
+ *
+ * `enabled` is false for the notice variant, which asked for nothing and so
+ * never yanks focus off whatever the climber was already reading.
+ */
+export function useAnnounceBodyFocus(bodyRef: RefObject<View | null>, enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled) return;
+    const node = bodyRef.current as unknown as HTMLElement | null;
+    if (node == null || typeof node.focus !== 'function') return;
+    if (!node.hasAttribute('tabindex')) {
+      node.setAttribute('tabindex', '-1');
+    }
+    node.focus({ preventScroll: true });
+  }, [bodyRef, enabled]);
+}


### PR DESCRIPTION
## Summary

Fixes #5301. On app.boardsesh.com, tapping the wall-state pill in the play drawer opened `WallStateCallout`, whose mount effect called `findNodeHandle(bodyRef.current)` to move screen-reader focus onto the explainer sentence. react-native-web 0.21.2's `findNodeHandle` is a bare, unconditional throw (`findNodeHandle is not supported on web. Use the ref property on the component instead.`), so this crashed 100% of the time in a browser — the root error boundary replaced the whole app with the crash screen. It had never once worked on web.

`AccessibilityInfo.setAccessibilityFocus` is also a silent no-op on react-native-web, so even guarding the throw away would have left the accessibility behavior doing nothing.

Fix: extracted the accessibility-focus effect into `useAnnounceBodyFocus`, forked per platform per CLAUDE.md's Expo web rules (`.web.ts` fork, no `patch-package`):
- `packages/mobile/src/components/play-drawer/use-announce-body-focus.ts` (native, unchanged behavior — `findNodeHandle` + `AccessibilityInfo.setAccessibilityFocus`).
- `packages/mobile/src/components/play-drawer/use-announce-body-focus.web.ts` (web) — react-native-web already hands a `View` ref straight to its host DOM node, so no node-handle indirection is needed. The web fork gives the body element `tabindex="-1"` (programmatically focusable, never in Tab order) and calls `.focus()` on it directly, which is the real way to land a screen reader on new content in a browser.

`WallStateCallout.tsx` now calls `useAnnounceBodyFocus(bodyRef)` instead of the inline native-only effect, and no longer imports `findNodeHandle`/`AccessibilityInfo` at all.

**Does the pill actually work on web now, or just stop crashing?** It works. The crash was the *only* thing broken here — the card's open/dismiss/outside-tap/8s-auto-dismiss/action-button logic is all platform-generic `View`/`Pressable`/Reanimated code that already ran fine on web elsewhere in the app; it just never got the chance to render because the very first effect on mount threw and took the whole tree down with it. With the throw gone, all of that renders and behaves normally in a browser. The accessibility-focus behavior itself is also a real equivalent, not a stub: the web fork calls a genuine DOM `.focus()` on the explainer's element (after giving it `tabindex="-1"` so it's programmatically focusable without joining Tab order), which is the actual way a screen reader gets pointed at new content in a browser — as opposed to `AccessibilityInfo.setAccessibilityFocus`, which react-native-web already silently no-ops even when given a valid handle. So both "the pill opens a working card" and "the explainer sentence gets read" are true on web now, not just "no crash."

**Native fingerprint: confirmed unchanged.** This only adds two new TypeScript files under `packages/mobile/src/**` (no `app.config.ts`, plugin, or native-module change) and edits one existing `.tsx` file's internals — Metro's native (iOS/Android) bundle resolves the exact same `findNodeHandle`/`AccessibilityInfo` calls it always did, just moved into `use-announce-body-focus.ts`. Verified directly rather than asserted: ran `TAILSCALE_HOSTS= vp exec expo-updates runtimeversion:resolve --platform ios|android` on this branch, then again with the fix's files stashed back to the `main` baseline:

| platform | baseline (main) | this branch | match |
|---|---|---|---|
| iOS | `2bba2c60ae36f3d914afe10e996460d0aefa6c91` | `2bba2c60ae36f3d914afe10e996460d0aefa6c91` | identical |
| Android | `81840ab57de6b637ab38d00e4e5c4799dedc1c4b` | `81840ab57de6b637ab38d00e4e5c4799dedc1c4b` | identical |

Also ran `vp run check:mobile-bundle` (native Metro bundle) and `vp run check:mobile-web-bundle` (browser export + shell/WASM assets) — both pass.

**Validation note**: `vp run test:mobile` (the full 872-file suite) was not run locally — the box was at load average 135+ from many concurrent agents, which produces spurious hook/test timeouts unrelated to any change (proven separately: another agent saw the same files fail, worse, with its changes stashed on a clean tree). Instead ran only the changed/added test files directly (`vp test run --project mobile --reporter=agent wall-state-callout use-announce-body-focus`, no `--` before the pattern — that flag position runs the whole project): 18/18 pass. CI's full run is authoritative.

## Release Notes

- [x] No release note needed (internal / technical change)

The wall-state pill's tap explainer no longer crashes the app in a browser — screen-reader focus now lands on the explainer sentence there too. This ships fixing a crash-only path (browser had a 100% failure rate on tap), so there's no meaningful behavior change to describe to native app users.

## Test plan

1. Open app.boardsesh.com in your phone's browser and sign in.
2. Start a session → tap the wall-state pill above the board.
3. See the explainer card open — no crash, no blank screen.
4. Tap outside the card → it closes normally.

## Risk

Risk: 2/5 — isolated hook extraction + platform fork behind existing UI, covered by tests, no native/BLE/migration surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
