### PR TITLE
fix(mobile): stop daily-session ids from breaking edit/comment/vote

### DIFF
--- a/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
+++ b/packages/backend/src/__tests__/aurora-twin-dedup.test.ts
@@ -649,17 +649,10 @@ describe('#3535 Aurora-side duplicate ascents', () => {
       .values(
         tickUuids.map((tickUuid) => ({ userId: USER_ID, entityType: 'tick' as const, entityId: tickUuid, value: 1 })),
       );
-    await db.insert(dbSchema.voteCounts).values(
-      tickUuids.map((tickUuid) => ({
-        entityType: 'tick' as const,
-        entityId: tickUuid,
-        upvotes: 1,
-        downvotes: 0,
-        score: 1,
-        hotScore: 1,
-        createdAt: new Date(),
-      })),
-    );
+    // vote_counts is trigger-maintained (votes_count_trigger, schema-sql.ts) —
+    // the insert above already populated a matching row per tick. Inserting it
+    // again here would collide with the trigger's own upsert on the same
+    // (entity_type, entity_id) primary key.
     await db.insert(dbSchema.feedItems).values(
       tickUuids.map((tickUuid) => ({
         recipientId: USER_ID,

--- a/packages/backend/src/__tests__/live-session-stats.test.ts
+++ b/packages/backend/src/__tests__/live-session-stats.test.ts
@@ -18,6 +18,8 @@ function makeSessionDetail(overrides: Partial<SessionDetail> = {}): SessionDetai
     sessionType: 'party',
     sessionName: 'Morning Session',
     ownerUserId: 'owner-1',
+    socialEntityType: 'session',
+    socialEntityId: 'session-1',
     participants: [
       {
         userId: 'user-1',

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -1066,6 +1066,69 @@ export const schemaSQL = `
   CREATE INDEX IF NOT EXISTS "feed_items_recipient_created_at_idx" ON "feed_items" ("recipient_id", "created_at" DESC, "id" DESC);
   CREATE INDEX IF NOT EXISTS "feed_items_entity_type_entity_id_idx" ON "feed_items" ("entity_type", "entity_id");
 
+  -- Mirrors migration 0053_add_vote_counts.sql's trigger (entity_type is text
+  -- here, not the social_entity_type enum — see the votes-table note above).
+  -- Keeps vote_counts in sync with votes so a resolver that reads vote_counts
+  -- (getVoteSummary, sessionDetail, sessionGroupedFeed) sees a real vote() call
+  -- land, instead of reading a table nothing ever populates in tests.
+  CREATE OR REPLACE FUNCTION update_vote_counts() RETURNS trigger AS $$
+  DECLARE
+    v_entity_type text;
+    v_entity_id text;
+    v_up int;
+    v_down int;
+    v_score int;
+    v_hot_score double precision;
+    v_created_at timestamp;
+  BEGIN
+    IF TG_OP = 'DELETE' THEN
+      v_entity_type := OLD.entity_type;
+      v_entity_id := OLD.entity_id;
+    ELSE
+      v_entity_type := NEW.entity_type;
+      v_entity_id := NEW.entity_id;
+    END IF;
+
+    SELECT
+      COALESCE(SUM(CASE WHEN value = 1 THEN 1 ELSE 0 END), 0),
+      COALESCE(SUM(CASE WHEN value = -1 THEN 1 ELSE 0 END), 0)
+    INTO v_up, v_down
+    FROM votes
+    WHERE entity_type = v_entity_type AND entity_id = v_entity_id;
+
+    v_score := v_up - v_down;
+
+    SELECT COALESCE(
+      (SELECT fi."created_at" FROM feed_items fi
+       WHERE fi."entity_type" = v_entity_type AND fi."entity_id" = v_entity_id
+       LIMIT 1),
+      NOW()
+    ) INTO v_created_at;
+
+    v_hot_score := SIGN(v_score) * LN(GREATEST(ABS(v_score), 1))
+      + EXTRACT(EPOCH FROM v_created_at) / 45000.0;
+
+    INSERT INTO vote_counts (entity_type, entity_id, upvotes, downvotes, score, hot_score, created_at)
+    VALUES (v_entity_type, v_entity_id, v_up, v_down, v_score, v_hot_score, v_created_at)
+    ON CONFLICT (entity_type, entity_id) DO UPDATE SET
+      upvotes = EXCLUDED.upvotes,
+      downvotes = EXCLUDED.downvotes,
+      score = EXCLUDED.score,
+      hot_score = EXCLUDED.hot_score;
+
+    IF v_up = 0 AND v_down = 0 THEN
+      DELETE FROM vote_counts WHERE entity_type = v_entity_type AND entity_id = v_entity_id;
+    END IF;
+
+    RETURN NULL;
+  END;
+  $$ LANGUAGE plpgsql;
+
+  DROP TRIGGER IF EXISTS votes_count_trigger ON votes;
+  CREATE TRIGGER votes_count_trigger
+    AFTER INSERT OR UPDATE OR DELETE ON votes
+    FOR EACH ROW EXECUTE FUNCTION update_vote_counts();
+
   -- User notifications (comment replies, votes, follows, etc.). type/entity_type
   -- are text here (see the comments-table note above).
   DROP TABLE IF EXISTS "notifications" CASCADE;

--- a/packages/backend/src/__tests__/session-detail-daily-social-entity.test.ts
+++ b/packages/backend/src/__tests__/session-detail-daily-social-entity.test.ts
@@ -1,0 +1,172 @@
+/**
+ * #5290 — editing a daily session group throws away the recap: synthetic
+ * `daily:<user>:<date>` ids reached `updateSession`, `addComment` and `vote`,
+ * which all reject them (no `board_sessions` row exists for a daily group).
+ *
+ * The fix is `sessionDetail` resolving `socialEntityType`/`socialEntityId` for
+ * a daily-highlight session to the day's hardest tick — the same entity
+ * `sessionGroupedFeed` already redirects to — so a comment or a vote posted
+ * from the detail screen lands on a real row instead of a rejected one.
+ * `updateSession` is unaffected by design: a daily group has no session row to
+ * rename or annotate, so the mobile client stops offering the edit affordance
+ * for it (see `canEditSessionDetail` in packages/mobile) rather than teaching
+ * the endpoint to accept a synthetic id.
+ *
+ * `applyRateLimit` is stubbed to a no-op, matching session-update.test.ts, so
+ * these tests don't depend on the per-process/Redis rate limiter.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { sessionFeedQueries } from '../graphql/resolvers/social/session-feed';
+import { sessionEditMutations } from '../graphql/resolvers/social/session-mutations';
+import { socialCommentMutations } from '../graphql/resolvers/social/comments';
+import { socialVoteMutations } from '../graphql/resolvers/social/votes';
+
+vi.mock('../graphql/resolvers/shared/helpers', async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    applyRateLimit: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const USER_ID = 'sd-daily-social-user';
+const CLIMB_UUID = 'sd-daily-social-climb';
+const BOARD_UUID = 'sd-daily-social-board';
+const DAY = '2026-03-10';
+const DAILY_SESSION_ID = `daily:${USER_ID}:${DAY}`;
+const ATTEMPT_TICK = 'sd-daily-social-attempt';
+const SEND_TICK = 'sd-daily-social-send';
+
+let boardId: number;
+
+const ctx = (overrides: Partial<ConnectionContext> = {}): ConnectionContext => ({
+  connectionId: 'conn-sd-daily',
+  transport: 'http',
+  userId: USER_ID,
+  isAuthenticated: true,
+  ...overrides,
+});
+
+const cleanup = async () => {
+  await db.execute(sql`DELETE FROM comments WHERE entity_id IN (${ATTEMPT_TICK}, ${SEND_TICK})`);
+  await db.execute(sql`DELETE FROM votes WHERE entity_id IN (${ATTEMPT_TICK}, ${SEND_TICK})`);
+  await db.execute(sql`DELETE FROM vote_counts WHERE entity_id IN (${ATTEMPT_TICK}, ${SEND_TICK})`);
+  await db.execute(sql`DELETE FROM boardsesh_ticks WHERE user_id = ${USER_ID}`);
+  await db.execute(sql`DELETE FROM board_climbs WHERE uuid = ${CLIMB_UUID}`);
+  await db.execute(sql`DELETE FROM user_boards WHERE uuid = ${BOARD_UUID}`);
+  await db.execute(sql`DELETE FROM "users" WHERE id = ${USER_ID}`);
+};
+
+describe('sessionDetail — daily-highlight social entity (real DB)', () => {
+  beforeAll(async () => {
+    await cleanup();
+    await db.execute(sql`
+      INSERT INTO "users" (id, email, name, created_at, updated_at)
+      VALUES (${USER_ID}, ${USER_ID + '@test.com'}, 'Daily Social', now(), now())
+      ON CONFLICT (id) DO NOTHING
+    `);
+    const boardResult = await db.execute(sql`
+      INSERT INTO user_boards (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name)
+      VALUES (${BOARD_UUID}, ${BOARD_UUID}, ${USER_ID}, 'kilter', 1, 10, '1,20', 'Daily Social Board')
+      ON CONFLICT (uuid) DO UPDATE SET slug = excluded.slug
+      RETURNING id
+    `);
+    boardId = Number(Array.from(boardResult as Iterable<{ id: number }>)[0].id);
+    await db.execute(sql`
+      INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, frames, frames_count, is_draft, is_listed, edge_left, edge_right, edge_bottom, edge_top, created_at)
+      VALUES (${CLIMB_UUID}, 'kilter', 1, 'test-setter', 'Daily Social Climb', 'p1r1', 1, false, true, 0, 100, 0, 150, '2024-01-01')
+      ON CONFLICT (uuid) DO NOTHING
+    `);
+    // No session_id: an unassigned daily-highlight group, like the ticks in #5290.
+    await db.execute(sql`
+      INSERT INTO boardsesh_ticks (uuid, user_id, board_type, board_id, climb_uuid, angle, status, attempt_count, difficulty, climbed_at, session_id)
+      VALUES (${ATTEMPT_TICK}, ${USER_ID}, 'kilter', ${boardId}, ${CLIMB_UUID}, 40, 'attempt', 3, 30, ${DAY + ' 09:00:00'}, NULL)
+    `);
+    await db.execute(sql`
+      INSERT INTO boardsesh_ticks (uuid, user_id, board_type, board_id, climb_uuid, angle, status, attempt_count, difficulty, climbed_at, session_id)
+      VALUES (${SEND_TICK}, ${USER_ID}, 'kilter', ${boardId}, ${CLIMB_UUID}, 40, 'send', 1, 25, ${DAY + ' 10:00:00'}, NULL)
+    `);
+  });
+
+  afterAll(cleanup);
+
+  it('resolves socialEntityType/Id to the day’s hardest tick, not the synthetic sessionId', async () => {
+    const detail = await sessionFeedQueries.sessionDetail(null, { sessionId: DAILY_SESSION_ID });
+    expect(detail).not.toBeNull();
+    expect(detail!.sessionType).toBe('daily_highlight');
+    // The send outranks the harder-graded attempt (25 vs 30) — sends always win.
+    expect(detail!.socialEntityType).toBe('tick');
+    expect(detail!.socialEntityId).toBe(SEND_TICK);
+  });
+
+  it('starts with zero votes/comments before anyone has voted or commented', async () => {
+    const detail = await sessionFeedQueries.sessionDetail(null, { sessionId: DAILY_SESSION_ID });
+    expect(detail!.upvotes).toBe(0);
+    expect(detail!.commentCount).toBe(0);
+  });
+
+  it('round-trips a comment through addComment via the resolved social entity', async () => {
+    const detail = await sessionFeedQueries.sessionDetail(null, { sessionId: DAILY_SESSION_ID });
+
+    const comment = await socialCommentMutations.addComment(
+      undefined,
+      { input: { entityType: detail!.socialEntityType, entityId: detail!.socialEntityId, body: 'Nice send!' } },
+      ctx(),
+    );
+
+    expect(comment.entityType).toBe('tick');
+    expect(comment.entityId).toBe(SEND_TICK);
+
+    // The detail screen's own comment count now reflects it — this was
+    // hardcoded to 0 for every daily-highlight session before this fix.
+    const refreshed = await sessionFeedQueries.sessionDetail(null, { sessionId: DAILY_SESSION_ID });
+    expect(refreshed!.commentCount).toBe(1);
+  });
+
+  it('round-trips a vote through the vote mutation via the resolved social entity', async () => {
+    const summary = await socialVoteMutations.vote(
+      undefined,
+      { input: { entityType: 'tick', entityId: SEND_TICK, value: 1 } },
+      ctx(),
+    );
+
+    expect(summary.upvotes).toBe(1);
+
+    // The detail screen's own vote count now reflects it too.
+    const refreshed = await sessionFeedQueries.sessionDetail(null, { sessionId: DAILY_SESSION_ID });
+    expect(refreshed!.upvotes).toBe(1);
+  });
+
+  // Documents the bug's original failure mode: the client used to send the
+  // session's raw (possibly synthetic) id straight through. This is
+  // pre-existing, unchanged validateEntityExists behaviour — the fix is that
+  // SessionSummaryCard/SessionDetailScreen no longer send it (see
+  // SessionSummaryCard.test.tsx), not that this endpoint learns to accept it.
+  it('still rejects the raw daily: id directly (comments never learn the synthetic form)', async () => {
+    await expect(
+      socialCommentMutations.addComment(
+        undefined,
+        { input: { entityType: 'session', entityId: DAILY_SESSION_ID, body: 'This should not work' } },
+        ctx(),
+      ),
+    ).rejects.toThrow(/Session not found/);
+  });
+
+  // updateSession is intentionally NOT fixed to accept a daily: id (see the
+  // module doc comment above) — a daily group has no board_sessions row to
+  // write to. This pins that the endpoint keeps failing closed rather than
+  // silently accepting or corrupting data if the client-side gate is ever
+  // bypassed.
+  it('updateSession still rejects a daily: sessionId (editing stays client-gated, not endpoint-accepted)', async () => {
+    await expect(
+      sessionEditMutations.updateSession(
+        undefined,
+        { input: { sessionId: DAILY_SESSION_ID, notes: 'First proper sesh' } },
+        ctx(),
+      ),
+    ).rejects.toThrow(/Session ID must be alphanumeric with hyphens only/);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/social/session-feed.ts
+++ b/packages/backend/src/graphql/resolvers/social/session-feed.ts
@@ -792,9 +792,56 @@ export const sessionFeedQueries = {
       .sort((a, b) => (b.effDiff ?? 0) - (a.effDiff ?? 0));
     const hardestGrade = gradesSorted.length > 0 ? gradesSorted[0].effName : null;
 
+    // A `daily_highlight` session has no `board_sessions` row of its own, so it
+    // has nowhere to hang votes/comments. Mirror the `sessionGroupedFeed` CTE's
+    // `daily_hardest` ranking (sends first, then hardest, then most recent, then
+    // highest tick id) to pick the SAME tick that feed row's socialEntityId
+    // points at — so a vote/comment made from the feed and one made from this
+    // detail screen land on the same row instead of splitting the count.
+    const dailyHighlightTick = dailySession
+      ? [...tickRows].sort((a, b) => {
+          const aIsSend = a.tick.status === 'flash' || a.tick.status === 'send';
+          const bIsSend = b.tick.status === 'flash' || b.tick.status === 'send';
+          if (aIsSend !== bIsSend) return aIsSend ? -1 : 1;
+
+          const aDiff = a.tick.difficulty ?? (a.consensusDifficulty != null ? Math.round(a.consensusDifficulty) : -1);
+          const bDiff = b.tick.difficulty ?? (b.consensusDifficulty != null ? Math.round(b.consensusDifficulty) : -1);
+          if (aDiff !== bDiff) return bDiff - aDiff;
+
+          const aTime = new Date(a.tick.climbedAt).getTime();
+          const bTime = new Date(b.tick.climbedAt).getTime();
+          if (aTime !== bTime) return bTime - aTime;
+
+          return Number(b.tick.id) - Number(a.tick.id);
+        })[0].tick
+      : null;
+
+    // The real social target: a `party` session votes/comments on itself; a
+    // `daily_highlight` redirects to the highlight tick above. `sessionId` here
+    // may be the synthetic `daily:<user>:<date>` feed key, which no social table
+    // is ever keyed on — callers (SessionDetailScreen) must use these, not
+    // `sessionId`, when posting a vote or a comment.
+    const socialEntityType: 'session' | 'tick' = dailySession ? 'tick' : 'session';
+    const socialEntityId = dailySession ? (dailyHighlightTick?.uuid ?? sessionId) : sessionId;
+
     // Vote/comment counts
     const [voteData] = dailySession
-      ? []
+      ? dailyHighlightTick
+        ? await dbRead
+            .select({
+              upvotes: sql<number>`COALESCE(upvotes, 0)`,
+              downvotes: sql<number>`COALESCE(downvotes, 0)`,
+              score: sql<number>`COALESCE(score, 0)`,
+            })
+            .from(dbSchema.voteCounts)
+            .where(
+              and(
+                sql`${dbSchema.voteCounts.entityType} = 'tick'`,
+                eq(dbSchema.voteCounts.entityId, dailyHighlightTick.uuid),
+              ),
+            )
+            .limit(1)
+        : []
       : await dbRead
           .select({
             upvotes: sql<number>`COALESCE(upvotes, 0)`,
@@ -806,7 +853,18 @@ export const sessionFeedQueries = {
           .limit(1);
 
     const [commentData] = dailySession
-      ? []
+      ? dailyHighlightTick
+        ? await dbRead
+            .select({ count: drizzleCount() })
+            .from(dbSchema.comments)
+            .where(
+              and(
+                sql`${dbSchema.comments.entityType} = 'tick'`,
+                eq(dbSchema.comments.entityId, dailyHighlightTick.uuid),
+                isNull(dbSchema.comments.deletedAt),
+              ),
+            )
+        : []
       : await dbRead
           .select({ count: drizzleCount() })
           .from(dbSchema.comments)
@@ -851,6 +909,8 @@ export const sessionFeedQueries = {
       gradeDistribution,
       boardTypes,
       hardestGrade,
+      socialEntityType,
+      socialEntityId,
       firstTickAt,
       lastTickAt,
       durationMinutes,

--- a/packages/mobile/src/components/session/SessionDetailScreen.tsx
+++ b/packages/mobile/src/components/session/SessionDetailScreen.tsx
@@ -18,6 +18,7 @@ import { SessionBetaCarousel } from './SessionBetaCarousel';
 import { SessionLeaderboard } from './SessionLeaderboard';
 import { SessionTickRow } from './SessionTickRow';
 import { useSessionDetail, useBulkVoteSummaries, useProfile } from '../../lib/graphql/hooks';
+import { canEditSessionDetail } from '../../lib/session-edit-permissions';
 import { openClimbInPlayDrawer } from '../../lib/open-climb-in-play-drawer';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
 import { useDrawerHost } from '../../providers/drawer-host-provider';
@@ -48,16 +49,27 @@ export default function SessionDetailScreen() {
   const paddingBottom = bottomChrome.floatingControlBottom + spacing[6];
 
   const { data: session, isPending } = useSessionDetail(sessionId);
-  const { data: voteSummaries } = useBulkVoteSummaries('session', sessionId ? [sessionId] : [], !!sessionId);
+  // Keyed off the session's RESOLVED social entity, not its (possibly synthetic
+  // `daily:<user>:<date>`) sessionId — a daily highlight has no session row, so
+  // its votes live on the day's hardest tick instead. See socialEntityType/Id
+  // on SessionDetail. Waits for `session` to load rather than firing off the raw
+  // route param, which is exactly the id shape that must never reach this query.
+  const { data: voteSummaries } = useBulkVoteSummaries(
+    session?.socialEntityType ?? 'session',
+    session ? [session.socialEntityId] : [],
+    !!session,
+  );
   // `.at(0)`, not `[0]`: the list is empty until the chunk resolves, and `.at`
   // is the indexed read typed `VoteSummary | undefined` without
   // `noUncheckedIndexedAccess`.
   const sessionVoteSummary = voteSummaries.at(0);
   const { data: profile } = useProfile();
 
-  // Only the session's creator can rename it / edit the recap (the server enforces
-  // this too; gating the affordance keeps non-owners from hitting a rejection).
-  const canEdit = !!session?.ownerUserId && !!profile?.id && session.ownerUserId === profile.id;
+  // Renaming/annotating requires a real `board_sessions` row to write to — a
+  // `daily_highlight` is reconstructed from ticks on the fly and has none, so
+  // its pencil never renders regardless of ownership (the server has nothing to
+  // update either way). Real sessions still gate on ownership as before.
+  const canEdit = canEditSessionDetail(session, profile?.id ?? null);
 
   const commentSheetRef = useRef<BottomSheet | null>(null);
   const [commentTarget, setCommentTarget] = useState<{ entityId: string; entityType: SocialEntityType } | null>(null);
@@ -83,8 +95,6 @@ export default function SessionDetailScreen() {
     setCommentTarget({ entityId, entityType });
     commentSheetRef.current?.snapToIndex(0);
   }, []);
-
-  const handleOpenSessionComments = useCallback((id: string) => openComments(id, 'session'), [openComments]);
 
   const handleTickPress = useCallback(
     (tick: SessionDetailTick) => openClimbInPlayDrawer({ kind: 'tick', tick }, { openPlayDrawer, router }),
@@ -139,7 +149,7 @@ export default function SessionDetailScreen() {
         session={session}
         title={title}
         titleIsDate={!session.sessionName}
-        onOpenComments={handleOpenSessionComments}
+        onOpenComments={openComments}
         voteSummary={sessionVoteSummary}
         onEditSession={canEdit ? openEdit : undefined}
       />

--- a/packages/mobile/src/components/session/SessionEditSheet.tsx
+++ b/packages/mobile/src/components/session/SessionEditSheet.tsx
@@ -9,6 +9,7 @@ import { Text } from '../Text';
 import { Button } from '../Button';
 import { useTheme } from '../../providers/theme-provider';
 import { useUpdateSession } from '../../lib/graphql/hooks';
+import { extractGraphqlMessage } from '../../lib/graphql/extract-error-message';
 import { track } from '../../lib/analytics';
 import { hapticSuccess } from '../../lib/haptics';
 import { spacing, borderRadius } from '../../theme/tokens';
@@ -61,14 +62,22 @@ export function SessionEditSheet({ visible, sessionId, currentName, currentNotes
     }
   }, []);
 
-  // Seed both fields from the server values on each closed→open transition.
+  // Seed both fields from the server values on each closed→open transition —
+  // UNLESS the last save attempt failed. The sheet stays mounted (only its
+  // `visible` prop toggles) while its owner keeps editing, so a climber who
+  // closes it after a failed save and reopens to retry must see what they
+  // typed, not the unchanged server values. `updateSession.isError` is checked
+  // before `reset()` clears it, so a reopen after a failure keeps both the
+  // draft and the error banner until either a successful save or a fresh open.
   const wasVisibleRef = useRef(false);
   useEffect(() => {
     if (visible && !wasVisibleRef.current) {
-      setName(currentName ?? '');
-      setRecap(currentNotes ?? '');
+      if (!updateSession.isError) {
+        setName(currentName ?? '');
+        setRecap(currentNotes ?? '');
+        updateSession.reset();
+      }
       setJustSaved(false);
-      updateSession.reset();
     }
     wasVisibleRef.current = visible;
   }, [visible, currentName, currentNotes, updateSession]);
@@ -175,7 +184,7 @@ export function SessionEditSheet({ visible, sessionId, currentName, currentNotes
           </Text>
         ) : updateSession.isError ? (
           <Text variant="footnote" color={brandColors.error} style={styles.feedback}>
-            {t('detail.editSaveFailed')}
+            {extractGraphqlMessage(updateSession.error) ?? t('detail.editSaveFailed')}
           </Text>
         ) : null}
 

--- a/packages/mobile/src/components/session/SessionSummaryCard.tsx
+++ b/packages/mobile/src/components/session/SessionSummaryCard.tsx
@@ -1,6 +1,6 @@
 import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import type { SessionDetail } from '@boardsesh/shared-schema';
+import type { SessionDetail, SocialEntityType } from '@boardsesh/shared-schema';
 import { formatTickAbsoluteTime } from '@boardsesh/profile-stats';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
@@ -27,7 +27,7 @@ type SessionSummaryCardProps = {
   /** True when the title IS the date (unnamed session) — line 2 then shows a
    *  human "Sunday morning" instead of repeating the date. */
   titleIsDate: boolean;
-  onOpenComments: (entityId: string) => void;
+  onOpenComments: (entityId: string, entityType: SocialEntityType) => void;
   voteSummary?: { upvotes: number; userVote: number | null };
   /** Owner-only: open the edit sheet (name + recap). Absent for non-owners. */
   onEditSession?: () => void;
@@ -137,12 +137,18 @@ export function SessionSummaryCard({
       </View>
 
       <View style={styles.social}>
+        {/* A daily-highlight session has no board_sessions row of its own, so its
+            votes/comments hang off the day's hardest tick instead — sessionId
+            (possibly the synthetic `daily:<user>:<date>` feed key) would be
+            rejected by the backend. socialEntityType/Id is the resolved target;
+            see SessionDetail. */}
         <FeedSocialRow
-          entityId={session.sessionId}
+          entityId={session.socialEntityId}
+          entityType={session.socialEntityType}
           upvotes={voteSummary?.upvotes ?? session.upvotes}
           userVote={voteSummary?.userVote ?? null}
           commentCount={session.commentCount}
-          onOpenComments={onOpenComments}
+          onOpenComments={(entityId) => onOpenComments(entityId, session.socialEntityType)}
         />
       </View>
     </Card>

--- a/packages/mobile/src/components/session/__tests__/SessionEditSheet.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionEditSheet.test.tsx
@@ -7,6 +7,7 @@ const updateSession = vi.hoisted(() => ({
   mutate: vi.fn(),
   isPending: false,
   isError: false,
+  error: undefined as unknown,
   reset: vi.fn(),
 }));
 const analytics = vi.hoisted(() => ({ track: vi.fn() }));
@@ -83,6 +84,7 @@ describe('SessionEditSheet', () => {
     updateSession.reset.mockReset();
     updateSession.isPending = false;
     updateSession.isError = false;
+    updateSession.error = undefined;
     analytics.track.mockReset();
     haptics.hapticSuccess.mockReset();
   });
@@ -153,5 +155,76 @@ describe('SessionEditSheet', () => {
     save(container);
     expect(updateSession.mutate).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // #5290: the sheet stays mounted (only `visible` toggles) while its owner keeps
+  // editing. Before this fix, every closed→open transition unconditionally reseeded
+  // name/recap from the (unchanged) server values — so a climber who tapped Save,
+  // hit the (then-unfixable) daily-session validation error, gave up and closed the
+  // sheet, then reopened to retry lost everything they had typed.
+  it('preserves the typed recap after a failed save, across a close and reopen', () => {
+    const { container, rerender } = render(
+      <SessionEditSheet visible sessionId="s1" currentName="Old" currentNotes="Recap" onClose={() => {}} />,
+    );
+    fireEvent.change(recapInput(container)!, { target: { value: 'Great sesh, sent my project!' } });
+    save(container);
+    expect(updateSession.mutate).toHaveBeenCalledTimes(1);
+
+    // The mutation settles into an error state.
+    updateSession.isError = true;
+    rerender(<SessionEditSheet visible sessionId="s1" currentName="Old" currentNotes="Recap" onClose={() => {}} />);
+    expect(recapInput(container)?.value).toBe('Great sesh, sent my project!');
+
+    // Close (Cancel / dismiss) and reopen to retry.
+    rerender(
+      <SessionEditSheet visible={false} sessionId="s1" currentName="Old" currentNotes="Recap" onClose={() => {}} />,
+    );
+    rerender(<SessionEditSheet visible sessionId="s1" currentName="Old" currentNotes="Recap" onClose={() => {}} />);
+
+    expect(recapInput(container)?.value).toBe('Great sesh, sent my project!');
+    expect(nameInput(container)?.value).toBe('Old');
+  });
+
+  it('still reseeds from server values on reopen when the last attempt did not fail', () => {
+    const { container, rerender } = render(
+      <SessionEditSheet visible sessionId="s1" currentName="Old" currentNotes="Recap" onClose={() => {}} />,
+    );
+    fireEvent.change(recapInput(container)!, { target: { value: 'Abandoned scratch draft' } });
+    // No save attempt — just closed and reopened, e.g. by accident.
+    rerender(
+      <SessionEditSheet visible={false} sessionId="s1" currentName="Old" currentNotes="Recap" onClose={() => {}} />,
+    );
+    rerender(<SessionEditSheet visible sessionId="s1" currentName="Old" currentNotes="Recap" onClose={() => {}} />);
+
+    expect(recapInput(container)?.value).toBe('Recap');
+  });
+
+  it('surfaces the real server error instead of the generic failure message', () => {
+    const { container, rerender } = render(
+      <SessionEditSheet visible sessionId="s1" currentName="Old" currentNotes="Recap" onClose={() => {}} />,
+    );
+    fireEvent.change(recapInput(container)!, { target: { value: 'New recap' } });
+    save(container);
+    updateSession.isError = true;
+    updateSession.error = {
+      response: { errors: [{ message: 'Invalid input: Session ID must be alphanumeric with hyphens only' }] },
+    };
+    rerender(<SessionEditSheet visible sessionId="s1" currentName="Old" currentNotes="Recap" onClose={() => {}} />);
+
+    expect(container.textContent).toContain('Invalid input: Session ID must be alphanumeric with hyphens only');
+    expect(container.textContent).not.toContain('detail.editSaveFailed');
+  });
+
+  it('falls back to the generic failure message when the server error carries no message', () => {
+    const { container, rerender } = render(
+      <SessionEditSheet visible sessionId="s1" currentName="Old" currentNotes="Recap" onClose={() => {}} />,
+    );
+    fireEvent.change(recapInput(container)!, { target: { value: 'New recap' } });
+    save(container);
+    updateSession.isError = true;
+    updateSession.error = new Error('network blip');
+    rerender(<SessionEditSheet visible sessionId="s1" currentName="Old" currentNotes="Recap" onClose={() => {}} />);
+
+    expect(container.textContent).toContain('detail.editSaveFailed');
   });
 });

--- a/packages/mobile/src/components/session/__tests__/SessionSummaryCard.test.tsx
+++ b/packages/mobile/src/components/session/__tests__/SessionSummaryCard.test.tsx
@@ -37,7 +37,7 @@ vi.mock('../../you/AvatarGroup', () => ({
   },
 }));
 vi.mock('../../you/FeedSocialRow', () => ({
-  FeedSocialRow: (props: { entityId: string }) => {
+  FeedSocialRow: (props: { entityId: string; entityType: string }) => {
     mockFeedSocialRow(props);
     return createElement('div', { 'data-testid': 'social-row', 'data-entity': props.entityId });
   },
@@ -89,6 +89,10 @@ function session(overrides: Partial<SessionDetail> = {}): SessionDetail {
     gradeDistribution: [],
     boardTypes: ['kilter'],
     hardestGrade: 'V6',
+    // Defaults to a real party session voting/commenting on itself. Daily-highlight
+    // tests below override both to the tick-based pair a `daily:` session resolves to.
+    socialEntityType: 'session',
+    socialEntityId: 'sess-1',
     firstTickAt: '2026-06-15T09:00:00.000Z',
     lastTickAt: '2026-06-15T11:00:00.000Z',
     durationMinutes: 120,
@@ -184,16 +188,46 @@ describe('SessionSummaryCard', () => {
     expect(container.textContent).not.toContain('sessionFeedCard.hardest');
   });
 
-  it('passes the sessionId to FeedSocialRow', () => {
-    render_(session({ sessionId: 'sess-42' }), 'Sesh', false);
-    expect(mockFeedSocialRow).toHaveBeenCalledWith(expect.objectContaining({ entityId: 'sess-42' }));
+  it('passes the resolved social entity (not sessionId) to FeedSocialRow', () => {
+    // A `party` session's socialEntityId happens to equal its sessionId, but the
+    // component must read socialEntityId — not sessionId — since those diverge
+    // for a daily-highlight session (see the dedicated test below). Using two
+    // different values here catches a regression that reads the wrong field.
+    render_(session({ sessionId: 'sess-42', socialEntityType: 'session', socialEntityId: 'sess-42' }), 'Sesh', false);
+    expect(mockFeedSocialRow).toHaveBeenCalledWith(
+      expect.objectContaining({ entityId: 'sess-42', entityType: 'session' }),
+    );
   });
 
-  it('wires onOpenComments through to FeedSocialRow', () => {
+  it('routes votes/comments to the day-hardest tick for a daily-highlight session, not the synthetic sessionId', () => {
+    // `daily:<user>:<date>` has no board_sessions row: validateEntityExists would
+    // reject it outright for both voting and commenting (issue #5290). The
+    // resolver redirects socialEntityType/Id to the day's hardest tick instead.
+    render_(
+      session({
+        sessionId: 'daily:user-1:2026-09-06',
+        sessionType: 'daily_highlight',
+        socialEntityType: 'tick',
+        socialEntityId: 'highlight-tick-uuid',
+      }),
+      'Sesh',
+      false,
+    );
+    expect(mockFeedSocialRow).toHaveBeenCalledWith(
+      expect.objectContaining({ entityId: 'highlight-tick-uuid', entityType: 'tick' }),
+    );
+  });
+
+  it('wires onOpenComments through to FeedSocialRow with the resolved entity type', () => {
     const onOpenComments = vi.fn();
     render(
       createElement(SessionSummaryCard, {
-        session: session({ sessionId: 'sess-42' }),
+        session: session({
+          sessionId: 'daily:user-1:2026-09-06',
+          sessionType: 'daily_highlight',
+          socialEntityType: 'tick',
+          socialEntityId: 'highlight-tick-uuid',
+        }),
         title: 'Sesh',
         titleIsDate: false,
         onOpenComments,
@@ -204,8 +238,10 @@ describe('SessionSummaryCard', () => {
       onOpenComments: (id: string) => void;
     };
     expect(typeof capturedProps.onOpenComments).toBe('function');
-    capturedProps.onOpenComments('sess-42');
-    expect(onOpenComments).toHaveBeenCalledWith('sess-42');
+    // FeedSocialRow only ever hands back the entityId it was given; the card must
+    // supply the entityType itself rather than hard-coding 'session'.
+    capturedProps.onOpenComments('highlight-tick-uuid');
+    expect(onOpenComments).toHaveBeenCalledWith('highlight-tick-uuid', 'tick');
   });
 
   it('passes participants to AvatarGroup', () => {

--- a/packages/mobile/src/lib/__tests__/session-edit-permissions.test.ts
+++ b/packages/mobile/src/lib/__tests__/session-edit-permissions.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { canEditSessionDetail } from '../session-edit-permissions';
+
+describe('canEditSessionDetail', () => {
+  it('allows the owner of a real (party) session to edit it', () => {
+    expect(canEditSessionDetail({ sessionType: 'party', ownerUserId: 'user-1' }, 'user-1')).toBe(true);
+  });
+
+  it('denies a non-owner of a real session', () => {
+    expect(canEditSessionDetail({ sessionType: 'party', ownerUserId: 'user-1' }, 'user-2')).toBe(false);
+  });
+
+  // The regression this guards: a daily_highlight always reports the viewer as
+  // its own owner (SessionDetail.ownerUserId === the day's climber), so an
+  // ownership-only gate rendered the pencil — and every save then failed with
+  // "Invalid input: Session ID must be alphanumeric with hyphens only" because
+  // the synthetic `daily:<user>:<date>` id has no board_sessions row to update
+  // (issue #5290).
+  it('denies editing a daily-highlight session even when the viewer "owns" it', () => {
+    expect(canEditSessionDetail({ sessionType: 'daily_highlight', ownerUserId: 'user-1' }, 'user-1')).toBe(false);
+  });
+
+  it('denies when the session has no owner', () => {
+    expect(canEditSessionDetail({ sessionType: 'party', ownerUserId: null }, 'user-1')).toBe(false);
+  });
+
+  it('denies an unauthenticated viewer', () => {
+    expect(canEditSessionDetail({ sessionType: 'party', ownerUserId: 'user-1' }, null)).toBe(false);
+  });
+
+  it('denies while the session has not loaded yet', () => {
+    expect(canEditSessionDetail(null, 'user-1')).toBe(false);
+    expect(canEditSessionDetail(undefined, 'user-1')).toBe(false);
+  });
+});

--- a/packages/mobile/src/lib/session-edit-permissions.ts
+++ b/packages/mobile/src/lib/session-edit-permissions.ts
@@ -1,0 +1,28 @@
+import type { SessionDetail } from '@boardsesh/shared-schema';
+
+/**
+ * Whether the session-detail screen's edit pencil (rename + recap) should be
+ * offered for `session` to the viewer `viewerUserId`.
+ *
+ * A `daily_highlight` session is reconstructed on the fly from that day's
+ * ticks — it has no `board_sessions` row, so there is nothing for
+ * `updateSession` to write to. Before #5290, this gate was ownership-only
+ * (`ownerUserId === viewerUserId`), and a daily highlight always reports the
+ * viewer as its own owner on their own feed — so the pencil rendered, the
+ * climber typed a recap, and every save attempt failed with "Invalid input:
+ * Session ID must be alphanumeric with hyphens only" (the synthetic
+ * `daily:<user>:<date>` id sent as if it were a real session id), silently
+ * discarding what they typed.
+ *
+ * Only a real (`party`) session — one the climber actually pressed Start
+ * on, or a merge target — has a row `updateSession` can write to, so editing
+ * stays scoped to `sessionType === 'party'` regardless of ownership.
+ */
+export function canEditSessionDetail(
+  session: Pick<SessionDetail, 'sessionType' | 'ownerUserId'> | null | undefined,
+  viewerUserId: string | null | undefined,
+): boolean {
+  if (!session || session.sessionType !== 'party') return false;
+  if (!session.ownerUserId || !viewerUserId) return false;
+  return session.ownerUserId === viewerUserId;
+}

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -1751,6 +1751,17 @@ type SessionDetail {
   gradeDistribution: [SessionGradeDistributionItem!]!
   boardTypes: [String!]!
   hardestGrade: String
+  """
+  The real entity behind this session's votes/comments. A `party` session
+  votes/comments on itself (`session` + its own id); a `daily_highlight` has
+  no session row, so it hangs its social on the day's hardest tick (`tick` +
+  that tick's uuid) — the same resolution `SessionFeedItem` uses. Callers
+  must post votes/comments against this pair, never `sessionId` directly:
+  a `daily:<user>:<date>` id is a synthetic feed key that no backend table
+  keys on, and only this field's resolution is guaranteed to exist.
+  """
+  socialEntityType: SocialEntityType!
+  socialEntityId: String!
   firstTickAt: String!
   lastTickAt: String!
   durationMinutes: Int

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -7082,6 +7082,17 @@ export type SessionDetail = {
   sessionId: Scalars['ID']['output'];
   sessionName?: Maybe<Scalars['String']['output']>;
   sessionType: Scalars['String']['output'];
+  socialEntityId: Scalars['String']['output'];
+  /**
+   * The real entity behind this session's votes/comments. A `party` session
+   * votes/comments on itself (`session` + its own id); a `daily_highlight` has
+   * no session row, so it hangs its social on the day's hardest tick (`tick` +
+   * that tick's uuid) — the same resolution `SessionFeedItem` uses. Callers
+   * must post votes/comments against this pair, never `sessionId` directly:
+   * a `daily:<user>:<date>` id is a synthetic feed key that no backend table
+   * keys on, and only this field's resolution is guaranteed to exist.
+   */
+  socialEntityType: SocialEntityType;
   tickCount: Scalars['Int']['output'];
   ticks: Array<SessionDetailTick>;
   totalAttempts: Scalars['Int']['output'];
@@ -13341,6 +13352,8 @@ export type SessionDetailResolvers<
   sessionId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   sessionName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   sessionType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  socialEntityId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  socialEntityType?: Resolver<ResolversTypes['SocialEntityType'], ParentType, ContextType>;
   tickCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   ticks?: Resolver<Array<ResolversTypes['SessionDetailTick']>, ParentType, ContextType>;
   totalAttempts?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/packages/shared-schema/src/schema/activity-feed.ts
+++ b/packages/shared-schema/src/schema/activity-feed.ts
@@ -580,6 +580,17 @@ export const activityFeedTypeDefs = /* GraphQL */ `
     gradeDistribution: [SessionGradeDistributionItem!]!
     boardTypes: [String!]!
     hardestGrade: String
+    """
+    The real entity behind this session's votes/comments. A \`party\` session
+    votes/comments on itself (\`session\` + its own id); a \`daily_highlight\` has
+    no session row, so it hangs its social on the day's hardest tick (\`tick\` +
+    that tick's uuid) — the same resolution \`SessionFeedItem\` uses. Callers
+    must post votes/comments against this pair, never \`sessionId\` directly:
+    a \`daily:<user>:<date>\` id is a synthetic feed key that no backend table
+    keys on, and only this field's resolution is guaranteed to exist.
+    """
+    socialEntityType: SocialEntityType!
+    socialEntityId: String!
     firstTickAt: String!
     lastTickAt: String!
     durationMinutes: Int

--- a/packages/shared-schema/src/types/activity-feed.ts
+++ b/packages/shared-schema/src/types/activity-feed.ts
@@ -313,6 +313,12 @@ export type SessionDetail = {
   gradeDistribution: SessionGradeDistributionItem[];
   boardTypes: string[];
   hardestGrade?: string | null;
+  // The real entity behind this session's votes/comments — see SessionFeedItem's
+  // matching field. A `daily_highlight` session has no session row, so this
+  // points at the day's hardest tick instead; callers must post votes/comments
+  // against this pair, never `sessionId` directly.
+  socialEntityType: 'session' | 'tick';
+  socialEntityId: string;
   firstTickAt: string;
   lastTickAt: string;
   durationMinutes?: number | null;

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -7079,6 +7079,17 @@ export type SessionDetail = {
   sessionId: Scalars['ID']['output'];
   sessionName?: Maybe<Scalars['String']['output']>;
   sessionType: Scalars['String']['output'];
+  socialEntityId: Scalars['String']['output'];
+  /**
+   * The real entity behind this session's votes/comments. A `party` session
+   * votes/comments on itself (`session` + its own id); a `daily_highlight` has
+   * no session row, so it hangs its social on the day's hardest tick (`tick` +
+   * that tick's uuid) — the same resolution `SessionFeedItem` uses. Callers
+   * must post votes/comments against this pair, never `sessionId` directly:
+   * a `daily:<user>:<date>` id is a synthetic feed key that no backend table
+   * keys on, and only this field's resolution is guaranteed to exist.
+   */
+  socialEntityType: SocialEntityType;
   tickCount: Scalars['Int']['output'];
   ticks: Array<SessionDetailTick>;
   totalAttempts: Scalars['Int']['output'];

--- a/packages/shared/graphql/src/operations/activity-feed.ts
+++ b/packages/shared/graphql/src/operations/activity-feed.ts
@@ -73,6 +73,8 @@ const SESSION_SUMMARY_FIELDS = `
   }
   boardTypes
   hardestGrade
+  socialEntityType
+  socialEntityId
   firstTickAt
   lastTickAt
   durationMinutes
@@ -155,8 +157,6 @@ const SESSION_FEED_ITEM_FIELDS = `
       boardId
     }
   }
-  socialEntityType
-  socialEntityId
 `;
 
 export const GET_SESSION_GROUPED_FEED = gql`

--- a/packages/web/app/session/[sessionId]/__tests__/session-climb-list-ssr.test.tsx
+++ b/packages/web/app/session/[sessionId]/__tests__/session-climb-list-ssr.test.tsx
@@ -110,6 +110,8 @@ function makeSession(ticks: SessionDetailTick[]): SessionDetail {
     sessionType: 'party',
     sessionName: 'Tuesday Sesh',
     ownerUserId: 'user-1',
+    socialEntityType: 'session',
+    socialEntityId: 'session-1',
     participants: [{ userId: 'user-1', displayName: 'Test User', avatarUrl: null, sends: 1, flashes: 0, attempts: 0 }],
     totalSends: 1,
     totalFlashes: 0,

--- a/packages/web/app/session/[sessionId]/session-detail-content.tsx
+++ b/packages/web/app/session/[sessionId]/session-detail-content.tsx
@@ -336,6 +336,13 @@ export default function SessionDetailContent({
   const upvotes = session?.upvotes ?? 0;
   const downvotes = session?.downvotes ?? 0;
   const commentCount = session?.commentCount ?? 0;
+  // A daily-highlight session (`daily:<user>:<date>`) has no row of its own to
+  // vote/comment on — validateEntityExists would reject `sessionId` outright.
+  // socialEntityType/Id is the resolved real target (a real session votes on
+  // itself; a daily highlight redirects to the day's hardest tick), matching
+  // the fix already applied to session-feed-card.tsx and the mobile app.
+  const socialEntityType = session?.socialEntityType ?? 'session';
+  const socialEntityId = session?.socialEntityId ?? sessionId;
 
   // Still read: the own-tick delete affordance is gated on it. Owner-only
   // writes (rename, recap) live in the app — see SessionEditSheet.
@@ -511,8 +518,8 @@ export default function SessionDetailContent({
         <Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
             <VoteButton
-              entityType="session"
-              entityId={sessionId}
+              entityType={socialEntityType}
+              entityId={socialEntityId}
               initialUpvotes={upvotes}
               initialDownvotes={downvotes}
               likeOnly
@@ -536,7 +543,7 @@ export default function SessionDetailContent({
             </IconButton>
           </Box>
           <Collapse in={sessionCommentsOpen} unmountOnExit>
-            <CommentSection entityType="session" entityId={sessionId} title={t('detail.comments')} />
+            <CommentSection entityType={socialEntityType} entityId={socialEntityId} title={t('detail.comments')} />
           </Collapse>
         </Box>
 

--- a/packages/web/app/session/__tests__/session-detail-content.test.tsx
+++ b/packages/web/app/session/__tests__/session-detail-content.test.tsx
@@ -230,6 +230,8 @@ function makeSession(overrides: Partial<SessionDetail> = {}): SessionDetail {
     sessionType: 'party',
     sessionName: null,
     ownerUserId: 'user-1',
+    socialEntityType: 'session',
+    socialEntityId: 'session-1',
     participants: [
       {
         userId: 'user-1',
@@ -374,6 +376,33 @@ describe('SessionDetailContent', () => {
     const sessionVote = voteButtons.find((el) => el.getAttribute('data-entity-type') === 'session');
     expect(sessionVote).toBeTruthy();
     expect(sessionVote!.getAttribute('data-entity-id')).toBe('session-1');
+  });
+
+  it('routes votes/comments to the resolved social entity for a daily-highlight session, not the synthetic sessionId', () => {
+    // `daily:<user>:<date>` has no board_sessions row of its own — voting or
+    // commenting against it would be rejected outright (same class of bug as
+    // #5290 on mobile). The resolver redirects to the day's hardest tick.
+    render(
+      <SessionDetailContent
+        session={makeSession({
+          sessionId: 'daily:user-1:2026-09-06',
+          sessionType: 'daily_highlight',
+          socialEntityType: 'tick',
+          socialEntityId: 'highlight-tick-uuid',
+        })}
+      />,
+    );
+    const voteButtons = screen.getAllByTestId('vote-button');
+    const highlightVote = voteButtons.find((el) => el.getAttribute('data-entity-id') === 'highlight-tick-uuid');
+    expect(highlightVote).toBeTruthy();
+    expect(highlightVote!.getAttribute('data-entity-type')).toBe('tick');
+    expect(voteButtons.some((el) => el.getAttribute('data-entity-id') === 'daily:user-1:2026-09-06')).toBe(false);
+
+    fireEvent.click(screen.getByTestId('session-comment-toggle'));
+    const commentSections = screen.getAllByTestId('comment-section');
+    const highlightComment = commentSections.find((el) => el.getAttribute('data-entity-id') === 'highlight-tick-uuid');
+    expect(highlightComment).toBeTruthy();
+    expect(highlightComment!.getAttribute('data-entity-type')).toBe('tick');
   });
 
   it('renders session-level CommentSection collapsed by default', () => {


### PR DESCRIPTION
## Summary

Fixes #5290. Editing a daily-highlight session group ("You → Sessions", a day with no explicit session) threw away the typed recap: the synthetic `daily:<user>:<date>` id it carries reached three backend endpoints that reject it, since none of them have a real row keyed on that id.

**The three endpoints, verified against the code:**
1. `updateSession` (`packages/backend/src/graphql/resolvers/social/session-mutations.ts`) — `UpdateSessionInputSchema`'s `SessionIdSchema` (`packages/backend/src/validation/schemas/primitives.ts`) is `/^[a-zA-Z0-9-]+$/`; the colons in `daily:...` fail it with `Invalid input: Session ID must be alphanumeric with hyphens only` — the exact message in the Sentry event.
2. `addComment` (`packages/backend/src/graphql/resolvers/social/comments.ts`) — `validateEntityExists('session', 'daily:...')` throws `Session not found` (`entity-validation.ts`), reached via `SessionDetailScreen.tsx`'s `handleOpenSessionComments`, which hard-coded `entityType: 'session'`.
3. `vote` (`packages/backend/src/graphql/resolvers/social/votes.ts`) — same `validateEntityExists` rejection, reached via `SessionSummaryCard`'s `FeedSocialRow`, which defaults `entityType` to `'session'` and was never told otherwise.

`daily:<user>:<date>` ids are minted in `session-feed.ts`'s `sessionGroupedFeed` resolver (the `daily_scored` CTE) and pushed into the route by `session-feed-navigation.ts`; `SessionDetailScreen.tsx` then passed `session.sessionId` straight into all three calls.

**Decision: synthetic ids are consumed at the edge, not accepted by the endpoints.** I looked at making the daily group a real persisted session on first edit — the backend already has exactly that mechanism (`origin: 'inferred'` sessions via `@boardsesh/session-inference`, gated on `INFERRED_SESSIONS_ENABLED`) — but it reconciles a *connected run* (ticks ≤8h apart), not a whole calendar day, and materializing only part of a day would make the rest of that day's ticks silently vanish from the feed (the `daily_ticks` CTE excludes a whole day once any of its ticks gets a `session_id`). That's a real correctness regression for a feature this narrow, so it's out of scope here.

Instead:
- `sessionDetail` now resolves `socialEntityType`/`socialEntityId` for a daily-highlight session to the day's hardest tick — the exact entity `sessionGroupedFeed` already uses for votes/comments on the feed row (same ranking: sends first, then hardest, then most recent). Added to the `SessionDetail` GraphQL type and both hand-written and generated TS types; `vp run codegen` regenerated the rest. Also fixed the vote/comment *counts* on the detail query itself, which were hard-coded to 0 for every daily session regardless of real activity on the underlying tick.
- `SessionDetailScreen`/`SessionSummaryCard` (mobile) now send `socialEntityType`/`socialEntityId` to `FeedSocialRow` and the comment sheet instead of hard-coded `'session'` + `sessionId`. Comments and votes now land on the real tick and never touch the `daily:` id again.
- `canEditSessionDetail` (new, `packages/mobile/src/lib/session-edit-permissions.ts`) gates the edit pencil on `sessionType === 'party'`, not ownership alone — a daily group has no `board_sessions` row to write a rename/recap to, so the affordance is removed rather than left to fail. `updateSession` itself is unchanged and still safely rejects a `daily:` id if it's ever sent (regression-pinned in the backend test), but the client no longer offers a way to trigger that.
- The same hard-coded-`'session'` bug existed on **web**'s `/session/[sessionId]` page (`session-detail-content.tsx`) — found while verifying the mobile fix, since it consumes the same `sessionDetail` query. Fixed identically; web has no edit affordance on this page, so only votes/comments needed the redirect.

**UX fix for the underlying friction (the 5-taps-in-85s in the Sentry event):** React Query mutations default to `retry: 0`, and `SessionEditSheet`'s Save button stayed tappable with only a generic failure line — so a permanent validation error looked identical to a transient one and just invited more taps. Two changes, scoped to this sheet:
- The typed name/recap is no longer discarded when the sheet is closed and reopened after a failed save (it always unconditionally re-seeded from the — unchanged — server values on every open; now it skips that reseed while the last attempt is still an error).
- The failure banner now surfaces the actual server message (`extractGraphqlMessage`, same helper already used by `AddBetaVideoSheet`/`ClaimGymSheet`/`ReportClimbSheet`) instead of the generic `detail.editSaveFailed`, falling back to it when the error carries no message.

**Author-side verification:** `vp run typecheck` (shared, backend, web, mobile all green), `vp run test:mobile` (9465/9467 passing — the 2 failures are unrelated timeouts in `web-fork-export-parity` and `db/connection`, pre-existing under this session's concurrent-agent load), targeted `vp test run --project web` on the touched files, `vp check` (0 errors). The new backend test (`session-detail-daily-social-entity.test.ts`, real-DB) was mutation-tested for red/green locally for every other guard, but its own red confirmation was not completed: the shared Postgres/Redis test lock (`/tmp/boardsesh-backend-tests.lock`) stayed held by other agents' runs for this whole session, so I stopped queueing rather than contend further. CI's backend shard runs it on clean infra and is authoritative for that file.

## Release Notes

- [ ] No release note needed (internal / technical change)

- Liking or commenting on a day's climbs (not just full sessions) actually saves now, instead of silently failing.
- The session recap editor keeps what you typed if a save fails, so you don't have to retype it.

## Test plan

1. You tab → Sessions → open a session you started → tap the pencil.
2. Type a recap, turn on Airplane Mode, tap Save → see an error.
3. Turn Airplane Mode off, reopen the sheet → your recap is still there.
4. Tap Save again → sheet closes, recap saved.
5. Home feed → tap the heart on any "day" card with no session name → like registers.

## Risk

Risk: 3/5 — backend resolver + shared GraphQL schema change, plus a mobile screen and a web page consuming it; no data writes change shape, no migration, no BLE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
