### PR TITLE
fix(backend): make a failed GitHub mirror loud and explainable

### DIFF
--- a/docs/crowdsourced-qa.md
+++ b/docs/crowdsourced-qa.md
@@ -272,12 +272,19 @@ token could carry scopes on both.
 
 Every backend log line for this feature is tagged `[qa]`.
 
-- **A verdict is missing from a PR.** `SELECT * FROM qa_verdicts WHERE github_comment_id IS NULL` —
-  those rows were recorded but never mirrored. The row is the record; the comment is a copy. The
-  usual cause is a missing or under-scoped App installation (grep `[github-app]` for the mint
-  failure, then `[qa] no GitHub App token available`) or a 403 (`[qa] posting the verdict comment`).
-  There is no retry queue: fix the App credentials, and new verdicts mirror again. Older rows can be
-  replayed by hand from the table.
+- **A verdict is missing from a PR.** You should not find this out by noticing. Every dropped
+  mirror — comment or label — files a Sentry event, `GithubMirrorDropError`, tagged
+  `github_mirror.operation` / `.reason` / `.status` and scoped to the tester whose write was lost.
+  The event's `github_mirror` context names the `qa_verdicts` row, the PR, GitHub's request id and
+  its (redacted) response body, plus the exact replay query. Same line on the backend logger under
+  `[github-mirror]`.
+
+  The standing query still works and is the way to sweep for older rows:
+  `SELECT * FROM qa_verdicts WHERE github_comment_id IS NULL` — those rows were recorded but never
+  mirrored. The row is the record; the comment is a copy. The usual cause is a missing or
+  under-scoped App installation (grep `[github-app]` for the mint failure) or a 403.
+  There is no retry queue, by decision: fix the App credentials, and new verdicts mirror again.
+  Older rows are replayed by hand from the table.
 
 - **Every GitHub write stopped at once.** Almost always the App key: expired, revoked, or the App
   uninstalled from the repo. `[github-app] could not mint an installation token` names the status —

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -63,7 +63,9 @@ Two rules to remember when adding an `error` log:
 
 The transport is gated to prod-like environments (`!isLocalDevelopment() && !isTestEnvironment()`, from `@boardsesh/db/client/config`), matching the same gate on `Sentry.init({ enabled })` in `instrument.ts`, so dev and test runs do not emit Sentry events even when an `Error` is attached. This is deliberately **not** a bare `NODE_ENV === 'production'` check: the Railway backend deploy leaves `NODE_ENV` unset, so the old equality gate silently disabled Sentry in production (issues #3603 / #3183).
 
-Specialised error paths still call `Sentry.captureException` directly (`graphql/yoga.ts`, `websocket/setup.ts`, `handlers/sync.ts`, `index.ts`) — those exist to attach finer-grained tags or filter out noisy client-input `GraphQLError`s before capture. The winston transport is the default; direct capture is the exception.
+Specialised error paths still call `Sentry.captureException` directly (`graphql/yoga.ts`, `websocket/setup.ts`, `handlers/sync.ts`, `index.ts`, `services/github-mirror-report.ts`) — those exist to attach finer-grained tags or filter out noisy client-input `GraphQLError`s before capture. The winston transport is the default; direct capture is the exception.
+
+`services/github-mirror-report.ts` is the pattern to copy when a failure needs per-event context. It pairs a **message-only** `logger.error` (which the transport deliberately skips) with its own `Sentry.withScope` capture, so the event carries the row that was lost and the user whose write it was — a `logger.error(msg, err)` there would file a second, poorer copy of the same failure.
 
 ### Dedup and DB-error masking
 

--- a/packages/backend/src/__tests__/github-feedback.test.ts
+++ b/packages/backend/src/__tests__/github-feedback.test.ts
@@ -14,6 +14,7 @@ import {
   redactSensitiveText,
   type FeedbackIssuePayload,
 } from '../services/github-feedback';
+import { githubErrorDetailOf } from '../lib/github-error';
 
 const originalRepo = process.env.FEEDBACK_GITHUB_REPO;
 const originalQaRepo = process.env.QA_GITHUB_REPO;
@@ -165,16 +166,18 @@ describe('createFeedbackGithubIssue', () => {
     else process.env.QA_GITHUB_REPO = originalQaRepo;
   });
 
-  it('no-ops (returns null, no fetch) when the GitHub App is not configured', async () => {
+  it('reports an unconfigured App (and makes no request) rather than returning quietly', async () => {
     installationToken = undefined;
-    const result = await createFeedbackGithubIssue(bugPayload());
-    expect(result).toBeNull();
+    // `unconfigured`, not a bare null: this is the exact shape of the 3h23m
+    // window where the App was live before it was installed on the repo and 19
+    // bug reports stored a row and filed nothing (#5294).
+    await expect(createFeedbackGithubIssue(bugPayload())).resolves.toEqual({ status: 'unconfigured' });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('returns null for a rating source even when configured', async () => {
+  it('skips a rating source even when configured', async () => {
     const result = await createFeedbackGithubIssue(bugPayload({ source: 'prompt', rating: 5, comment: null }));
-    expect(result).toBeNull();
+    expect(result).toEqual({ status: 'skipped' });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -184,7 +187,10 @@ describe('createFeedbackGithubIssue', () => {
 
     const result = await createFeedbackGithubIssue(bugPayload());
 
-    expect(result).toEqual({ number: 123, htmlUrl: 'https://github.com/boardsesh/boardsesh/issues/123' });
+    expect(result).toEqual({
+      status: 'created',
+      issue: { number: 123, htmlUrl: 'https://github.com/boardsesh/boardsesh/issues/123' },
+    });
     const issueCall = fetchSpy.mock.calls.find(([url]) => String(url).endsWith('/issues'));
     expect(issueCall).toBeTruthy();
     const [, init] = issueCall as [string, RequestInit];
@@ -192,20 +198,33 @@ describe('createFeedbackGithubIssue', () => {
     expect(init.body as string).not.toMatch(/user_id/);
   });
 
-  it('returns null (never throws) when the issue POST fails', async () => {
+  it('carries the status and GitHub message back when the issue POST fails', async () => {
     fetchSpy.mockImplementation((input: string | URL) => {
       const url = String(input);
       if (url.endsWith('/issues')) {
-        return Promise.resolve({ ok: false, status: 500, text: async () => 'boom', json: async () => ({}) });
+        return Promise.resolve(
+          new Response(JSON.stringify({ message: 'Not Found' }), {
+            status: 404,
+            headers: { 'x-github-request-id': 'D9F1:2233:44' },
+          }),
+        );
       }
-      return Promise.resolve({ ok: true, status: 201, text: async () => '', json: async () => ({}) });
+      return Promise.resolve(new Response('{}', { status: 201 }));
     });
 
-    await expect(createFeedbackGithubIssue(bugPayload())).resolves.toBeNull();
+    const outcome = await createFeedbackGithubIssue(bugPayload());
+
+    expect(outcome.status).toBe('rejected');
+    const detail = githubErrorDetailOf(outcome.status === 'rejected' ? outcome.cause : null);
+    expect(detail?.status).toBe(404);
+    expect(detail?.requestId).toBe('D9F1:2233:44');
+    expect(detail?.body).toContain('Not Found');
   });
 
-  it('returns null (never throws) when fetch rejects', async () => {
+  it('reports (never throws) when fetch rejects', async () => {
     fetchSpy.mockRejectedValue(new Error('network down'));
-    await expect(createFeedbackGithubIssue(bugPayload())).resolves.toBeNull();
+    const outcome = await createFeedbackGithubIssue(bugPayload());
+    expect(outcome.status).toBe('rejected');
+    expect((outcome as { cause: Error }).cause).toBeInstanceOf(Error);
   });
 });

--- a/packages/backend/src/graphql/resolvers/feedback/__tests__/submit-app-feedback.test.ts
+++ b/packages/backend/src/graphql/resolvers/feedback/__tests__/submit-app-feedback.test.ts
@@ -55,6 +55,10 @@ const SCREENSHOT_KEYS = [
 const SCREENSHOT_URLS = SCREENSHOT_KEYS.map((key) => `https://media.boardsesh.com/${key}`);
 
 const ISSUE = { number: 4321, htmlUrl: 'https://github.com/boardsesh/boardsesh/issues/4321' };
+// `createFeedbackGithubIssue` answers with an outcome, not a bare issue — the
+// resolver has to tell a created issue from a dropped one to report the drop at
+// all (#5294).
+const ISSUE_CREATED = { status: 'created', issue: ISSUE };
 
 const authCtx = (userId: string): ConnectionContext =>
   ({ connectionId: `conn-${userId}`, isAuthenticated: true, userId }) as ConnectionContext;
@@ -116,7 +120,7 @@ const issuePayload = (): FeedbackIssuePayload => createFeedbackGithubIssueMock.m
 
 beforeEach(async () => {
   await db.execute(sql`TRUNCATE TABLE "app_feedback", "community_roles", "users" RESTART IDENTITY CASCADE`);
-  createFeedbackGithubIssueMock.mockReset().mockResolvedValue(ISSUE);
+  createFeedbackGithubIssueMock.mockReset().mockResolvedValue(ISSUE_CREATED);
   sendBugReportIssueEmailMock.mockReset().mockResolvedValue(undefined);
 });
 
@@ -177,9 +181,10 @@ describe('submitAppFeedback', () => {
   });
 
   it('leaves the issue columns null when no issue was opened', async () => {
-    // A rating is not a bug: `createFeedbackGithubIssue` answers null for it,
-    // and nothing downstream may run.
-    createFeedbackGithubIssueMock.mockResolvedValue(null);
+    // A rating is not a bug: `createFeedbackGithubIssue` skips it, and nothing
+    // downstream may run — including the drop report, since a skipped rating is
+    // not a lost bug report.
+    createFeedbackGithubIssueMock.mockResolvedValue({ status: 'skipped' });
     const rater = await freshReporter();
 
     await feedbackMutations.submitAppFeedback(

--- a/packages/backend/src/graphql/resolvers/feedback/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/feedback/mutations.ts
@@ -8,6 +8,8 @@ import { applyRateLimit, validateInput } from '../shared/helpers';
 import { requireAdmin } from '../social/roles';
 import { SubmitAppFeedbackInputSchema, UpdateAppFeedbackStatusInputSchema } from '../../../validation/schemas';
 import { BUG_SOURCES, createFeedbackGithubIssue } from '../../../services/github-feedback';
+import { resolveGithubRepo } from '../../../lib/github-client';
+import { reportGithubMirrorDrop } from '../../../services/github-mirror-report';
 import { screenshotPublicUrls } from '../../../services/feedback-screenshot-urls';
 import { loadFeedbackReport } from './queries';
 import { logger } from '../../../utils/logger';
@@ -60,14 +62,16 @@ export const feedbackMutations = {
     // Fire-and-forget side effect for bug reports: open a GitHub issue, then —
     // if the reporter opted in to contact and is signed in — email them the
     // link. Bug-vs-rating gating lives in createFeedbackGithubIssue (rating
-    // sources return null and no email is sent). Errors are logged and never
-    // bubble up; this must not block or fail the mutation. Guard on row
-    // existence — a missing returned row means a DB-layer problem, not our
-    // contract, so skip the side effect.
+    // sources come back `skipped` and no email is sent). Errors never bubble
+    // up; this must not block or fail the mutation. But a report that files no
+    // issue is now announced through `reportGithubMirrorDrop` rather than
+    // returning quietly — that silence is what hid 19 lost bug reports across
+    // a 3h23m window. Guard on row existence — a missing returned row means a
+    // DB-layer problem, not our contract, so skip the side effect.
     if (row) {
       void (async () => {
         try {
-          const issue = await createFeedbackGithubIssue({
+          const outcome = await createFeedbackGithubIssue({
             feedbackId: row.id,
             rating,
             comment,
@@ -84,7 +88,8 @@ export const feedbackMutations = {
             screenshotUrls: screenshotPublicUrls(screenshotKeys),
           });
 
-          if (issue) {
+          if (outcome.status === 'created') {
+            const { issue } = outcome;
             // Persist the issue link so the admin dashboard can jump straight
             // to it. Kept inside the fire-and-forget block: a failure here must
             // not affect the already-committed feedback row.
@@ -107,6 +112,17 @@ export const feedbackMutations = {
                 });
               }
             }
+          } else if (outcome.status !== 'skipped') {
+            // A rating was never going to become an issue; anything else here
+            // is a bug report that reached us and never reached the tracker.
+            reportGithubMirrorDrop({
+              operation: 'feedback-issue',
+              reason: outcome.status,
+              record: { table: 'app_feedback', id: String(row.id) },
+              repo: resolveGithubRepo(),
+              userId,
+              cause: outcome.status === 'rejected' ? outcome.cause : undefined,
+            });
           }
         } catch (error) {
           logger.error('[feedback] issue/email side-effect failed:', error);

--- a/packages/backend/src/graphql/resolvers/feedback/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/feedback/mutations.ts
@@ -88,7 +88,10 @@ export const feedbackMutations = {
             screenshotUrls: screenshotPublicUrls(screenshotKeys),
           });
 
-          if (outcome.status === 'created') {
+          // `outcome?.` — same reason as the QA mirror: the issue-link write-back
+          // lives in this block, so an unreadable outcome degrades to a reported
+          // drop rather than a TypeError that loses the write-back too.
+          if (outcome?.status === 'created') {
             const { issue } = outcome;
             // Persist the issue link so the admin dashboard can jump straight
             // to it. Kept inside the fire-and-forget block: a failure here must
@@ -112,16 +115,15 @@ export const feedbackMutations = {
                 });
               }
             }
-          } else if (outcome.status !== 'skipped') {
+          } else if (outcome?.status !== 'skipped') {
             // A rating was never going to become an issue; anything else here
             // is a bug report that reached us and never reached the tracker.
             reportGithubMirrorDrop({
               operation: 'feedback-issue',
-              reason: outcome.status,
               record: { table: 'app_feedback', id: String(row.id) },
               repo: resolveGithubRepo(),
               userId,
-              cause: outcome.status === 'rejected' ? outcome.cause : undefined,
+              outcome,
             });
           }
         } catch (error) {

--- a/packages/backend/src/graphql/resolvers/qa/__tests__/qa-verdicts.test.ts
+++ b/packages/backend/src/graphql/resolvers/qa/__tests__/qa-verdicts.test.ts
@@ -201,10 +201,14 @@ beforeEach(async () => {
   getHeadCommitDatesMock
     .mockReset()
     .mockImplementation(async (shas: string[]) => new Map(shas.map((sha) => [sha, '2026-08-26T09:00:00Z'])));
-  postVerdictCommentMock
-    .mockReset()
-    .mockResolvedValue({ id: 555, htmlUrl: 'https://github.com/boardsesh/boardsesh/pull/4792#issuecomment-555' });
-  applyQaLabelMock.mockReset().mockResolvedValue(undefined);
+  // The mirror functions answer with an outcome, not a bare comment / void —
+  // the resolver has to tell a posted comment from a dropped one to report the
+  // drop at all (#5294).
+  postVerdictCommentMock.mockReset().mockResolvedValue({
+    status: 'posted',
+    comment: { id: 555, htmlUrl: 'https://github.com/boardsesh/boardsesh/pull/4792#issuecomment-555' },
+  });
+  applyQaLabelMock.mockReset().mockResolvedValue({ status: 'applied' });
   testerRole.readFails = false;
 });
 
@@ -501,7 +505,10 @@ describe('submitQaVerdict', () => {
     });
     postVerdictCommentMock.mockImplementation(async () => {
       await postPending;
-      return { id: 556, htmlUrl: 'https://github.com/boardsesh/boardsesh/pull/4792#issuecomment-556' };
+      return {
+        status: 'posted',
+        comment: { id: 556, htmlUrl: 'https://github.com/boardsesh/boardsesh/pull/4792#issuecomment-556' },
+      };
     });
 
     const verdict = await qaMutations.submitQaVerdict(null, { input: validInput() }, authCtx(TESTER));
@@ -602,6 +609,22 @@ describe('submitQaVerdict', () => {
     expect(verdict.prNumber).toBe(4792);
     const row = await readVerdictRow(verdict.id);
     expect(row.github_comment_id).toBeNull();
+  });
+
+  // The regression CI caught on #5294's first push. The mirror block also owns
+  // the comment-id write-back and the label swap, so a mirror that answers with
+  // something unreadable must degrade to a reported drop — not to a TypeError
+  // that takes the rest of the block down with it.
+  it('carries on with the label swap when the comment mirror answers unreadably', async () => {
+    postVerdictCommentMock.mockResolvedValue(undefined);
+
+    await qaMutations.submitQaVerdict(null, { input: validInput() }, authCtx(TESTER));
+
+    // The label is the proof the block survived: it runs after the comment
+    // handling, so reaching it at all means nothing threw on the way.
+    await vi.waitFor(() => {
+      expect(applyQaLabelMock).toHaveBeenCalledWith(4792, 'approved');
+    });
   });
 
   it('records a comment that did post even when the label swap then blows up', async () => {

--- a/packages/backend/src/graphql/resolvers/qa/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/qa/mutations.ts
@@ -184,8 +184,13 @@ export const qaMutations = {
         // Record the comment before touching labels: `github_comment_id IS NULL`
         // is the runbook's "replay this one by hand" signal, and a label failure
         // in between would otherwise strand a comment that did post.
+        // `posted?.` and not `posted.`: this block also owns the write-back
+        // below, so a mirror that answers with something unreadable must degrade
+        // to a reported drop, never to a TypeError that takes the write-back
+        // with it. The outcome is handed to the reporter uninspected — it does
+        // all the dereferencing, once, defensively.
         const posted = await postVerdictComment(row.prNumber, body);
-        if (posted.status === 'posted') {
+        if (posted?.status === 'posted') {
           await db
             .update(dbSchema.qaVerdicts)
             .set({ githubCommentId: posted.comment.id, githubCommentUrl: posted.comment.htmlUrl })
@@ -196,12 +201,11 @@ export const qaMutations = {
           // merged without its verdict.
           reportGithubMirrorDrop({
             operation: 'qa-verdict-comment',
-            reason: posted.status,
             record: { table: 'qa_verdicts', id: String(row.id) },
             repo: resolveGithubRepo(),
             prNumber: row.prNumber,
             userId: ctx.userId,
-            cause: posted.status === 'rejected' ? posted.cause : undefined,
+            outcome: posted,
           });
         }
 
@@ -222,15 +226,14 @@ export const qaMutations = {
           .limit(1);
         if (newestTesterVerdict) {
           const labelled = await applyQaLabel(row.prNumber, newestTesterVerdict.verdict);
-          if (labelled.status !== 'applied') {
+          if (labelled?.status !== 'applied') {
             reportGithubMirrorDrop({
               operation: 'qa-verdict-label',
-              reason: labelled.status,
               record: { table: 'qa_verdicts', id: String(row.id) },
               repo: resolveGithubRepo(),
               prNumber: row.prNumber,
               userId: ctx.userId,
-              cause: labelled.status === 'rejected' ? labelled.cause : undefined,
+              outcome: labelled,
             });
           }
         }

--- a/packages/backend/src/graphql/resolvers/qa/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/qa/mutations.ts
@@ -14,6 +14,8 @@ import {
   readOpenPullRequests,
 } from '../../../services/github-qa';
 import type { QaPullRequest } from '../../../services/github-qa';
+import { resolveGithubRepo } from '../../../lib/github-client';
+import { reportGithubMirrorDrop } from '../../../services/github-mirror-report';
 import { screenshotPublicUrls } from '../../../services/feedback-screenshot-urls';
 import { toQaVerdict } from './queries';
 import { logger } from '../../../utils/logger';
@@ -134,9 +136,13 @@ export const qaMutations = {
 
     if (!row) throw new Error('Could not record the verdict');
 
-    // Fire-and-forget mirror to GitHub. Failures are logged under `[qa]` and
-    // never surface to the caller; the row stands either way, and a row with
-    // github_comment_id IS NULL is the "not mirrored" signal for the runbook.
+    // Fire-and-forget mirror to GitHub. Failures never surface to the caller and
+    // the row stands either way — but they no longer pass unnoticed: anything
+    // short of a posted comment / applied label goes through
+    // `reportGithubMirrorDrop`, which logs it under `[github-mirror]` and files
+    // a Sentry event naming this row, this PR and GitHub's own response. A row
+    // with github_comment_id IS NULL is still the runbook's replay signal; the
+    // event is what tells someone to go look.
     void (async () => {
       try {
         const tally = await db
@@ -179,11 +185,24 @@ export const qaMutations = {
         // is the runbook's "replay this one by hand" signal, and a label failure
         // in between would otherwise strand a comment that did post.
         const posted = await postVerdictComment(row.prNumber, body);
-        if (posted) {
+        if (posted.status === 'posted') {
           await db
             .update(dbSchema.qaVerdicts)
-            .set({ githubCommentId: posted.id, githubCommentUrl: posted.htmlUrl })
+            .set({ githubCommentId: posted.comment.id, githubCommentUrl: posted.comment.htmlUrl })
             .where(eq(dbSchema.qaVerdicts.id, row.id));
+        } else {
+          // The drop that used to happen here in silence: the row keeps a NULL
+          // github_comment_id, nobody ran the query that finds it, and the PR
+          // merged without its verdict.
+          reportGithubMirrorDrop({
+            operation: 'qa-verdict-comment',
+            reason: posted.status,
+            record: { table: 'qa_verdicts', id: String(row.id) },
+            repo: resolveGithubRepo(),
+            prNumber: row.prNumber,
+            userId: ctx.userId,
+            cause: posted.status === 'rejected' ? posted.cause : undefined,
+          });
         }
 
         // Latest TESTER verdict wins — but "latest" is whatever the table says,
@@ -201,7 +220,20 @@ export const qaMutations = {
           .where(and(eq(dbSchema.qaVerdicts.prNumber, row.prNumber), eq(dbSchema.qaVerdicts.byTester, true)))
           .orderBy(desc(dbSchema.qaVerdicts.createdAt), desc(dbSchema.qaVerdicts.id))
           .limit(1);
-        if (newestTesterVerdict) await applyQaLabel(row.prNumber, newestTesterVerdict.verdict);
+        if (newestTesterVerdict) {
+          const labelled = await applyQaLabel(row.prNumber, newestTesterVerdict.verdict);
+          if (labelled.status !== 'applied') {
+            reportGithubMirrorDrop({
+              operation: 'qa-verdict-label',
+              reason: labelled.status,
+              record: { table: 'qa_verdicts', id: String(row.id) },
+              repo: resolveGithubRepo(),
+              prNumber: row.prNumber,
+              userId: ctx.userId,
+              cause: labelled.status === 'rejected' ? labelled.cause : undefined,
+            });
+          }
+        }
       } catch (error) {
         logger.error('[qa] verdict mirror side-effect failed:', error);
       }

--- a/packages/backend/src/lib/__tests__/github-error.test.ts
+++ b/packages/backend/src/lib/__tests__/github-error.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The body a failed GitHub call is allowed to remember.
+ *
+ * Two things are load-bearing and pull against each other. GitHub's own
+ * `message` is the only thing that ever explained the 403 that ate three QA
+ * verdicts, so it has to survive. And GitHub echoes the request back in some
+ * error shapes, so an installation token can ride along in that same body —
+ * which is why it used to be dropped whole. Every test here is one side of
+ * that trade.
+ */
+
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  GithubRequestError,
+  formatGithubErrorDetail,
+  githubErrorDetailOf,
+  readGithubErrorDetail,
+  redactGithubErrorBody,
+} from '../github-error';
+
+describe('redactGithubErrorBody', () => {
+  it('keeps the part that explains the failure', () => {
+    const redacted = redactGithubErrorBody(
+      JSON.stringify({ message: 'Resource not accessible by integration', documentation_url: 'https://docs.gh/rest' }),
+    );
+
+    expect(redacted).toContain('Resource not accessible by integration');
+    expect(redacted).toContain('docs.gh/rest');
+  });
+
+  // Assembled rather than written out. GitHub's push protection recognises the
+  // `v1.<40 hex>` installation-token shape and blocks a push carrying one, even
+  // as an obviously fake fixture — the literal never appears in this file.
+  const legacyInstallationToken = ['v1', 'a'.repeat(40)].join('.');
+
+  it.each([
+    ['installation token', 'ghs_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5'],
+    ['personal access token', 'ghp_ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ'],
+    ['fine-grained PAT', 'github_pat_11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuV'],
+    ['legacy installation token', legacyInstallationToken],
+  ])('strips an echoed %s', (_label, credential) => {
+    const redacted = redactGithubErrorBody(`{"message":"Bad credentials","token":"${credential}"}`);
+
+    expect(redacted).not.toContain(credential);
+    expect(redacted).toContain('[redacted credential]');
+    expect(redacted).toContain('Bad credentials');
+  });
+
+  it('strips an echoed Authorization header and the App JWT that signed the mint', () => {
+    const jwt = 'eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiIxMjM0NSJ9.c2lnbmF0dXJlLWhlcmU';
+    const redacted = redactGithubErrorBody(`{"headers":{"Authorization":"Bearer ${jwt}"}}`);
+
+    expect(redacted).not.toContain(jwt);
+    expect(redacted).toContain('[redacted credential]');
+  });
+
+  // Exact output, not `toContain`. A scheme pattern layered on top of a prefix
+  // pattern re-redacts the placeholder the first one wrote, and a shared
+  // callback renders the match offset as the scheme — both produce a string
+  // that still "contains" the placeholder while reading as garbage.
+  it('replaces an Authorization header exactly once, keeping the scheme', () => {
+    expect(
+      redactGithubErrorBody(
+        '{"message":"Bad credentials","headers":{"Authorization":"Bearer ghs_A1b2C3d4E5f6G7h8I9j0K1"}}',
+      ),
+    ).toBe('{"message":"Bad credentials","headers":{"Authorization":"Bearer [redacted credential]"}}');
+  });
+
+  it('caps a pathological body instead of flooding a log line', () => {
+    const redacted = redactGithubErrorBody('x'.repeat(5000));
+
+    expect(redacted.length).toBeLessThan(700);
+    expect(redacted.endsWith('...')).toBe(true);
+  });
+
+  it('reports an empty body as such rather than as an empty string', () => {
+    expect(redactGithubErrorBody('   \n  ')).toBe('<empty body>');
+  });
+});
+
+describe('readGithubErrorDetail', () => {
+  it('captures status, request id and the rate-limit pair', async () => {
+    const response = new Response(JSON.stringify({ message: 'API rate limit exceeded' }), {
+      status: 403,
+      headers: {
+        'x-github-request-id': 'C4E0:1F2A:9B',
+        'x-ratelimit-remaining': '0',
+        'x-ratelimit-reset': '1757340000',
+      },
+    });
+
+    const detail = await readGithubErrorDetail(response);
+
+    expect(detail).toMatchObject({
+      status: 403,
+      requestId: 'C4E0:1F2A:9B',
+      rateLimitRemaining: '0',
+      rateLimitReset: '1757340000',
+    });
+    expect(detail.body).toContain('API rate limit exceeded');
+  });
+
+  it('degrades to a marker when the body cannot be read', async () => {
+    const response = new Response('once', { status: 500 });
+    await response.text();
+
+    const detail = await readGithubErrorDetail(response);
+
+    expect(detail.status).toBe(500);
+    expect(detail.body).toBe('<empty body>');
+  });
+});
+
+describe('githubErrorDetailOf', () => {
+  it('finds the detail through a wrapping cause chain', () => {
+    const inner = new GithubRequestError('POST', '/repos/o/r/issues', {
+      status: 404,
+      body: '{"message":"Not Found"}',
+      requestId: 'AA11',
+      rateLimitRemaining: null,
+      rateLimitReset: null,
+    });
+    const wrapped = new Error('mirror failed', { cause: new Error('while posting', { cause: inner }) });
+
+    expect(githubErrorDetailOf(wrapped)?.status).toBe(404);
+    expect(githubErrorDetailOf(new Error('unrelated'))).toBeNull();
+    expect(githubErrorDetailOf(undefined)).toBeNull();
+  });
+
+  it('survives a self-referential cause chain', () => {
+    const looping = new Error('loop') as Error & { cause?: unknown };
+    looping.cause = looping;
+
+    expect(githubErrorDetailOf(looping)).toBeNull();
+  });
+});
+
+describe('formatGithubErrorDetail', () => {
+  it('renders one greppable line', () => {
+    expect(
+      formatGithubErrorDetail({
+        status: 403,
+        body: 'Resource not accessible by integration',
+        requestId: 'C4E0',
+        rateLimitRemaining: '4998',
+        rateLimitReset: null,
+      }),
+    ).toBe('status=403 request_id=C4E0 rate_limit_remaining=4998 body=Resource not accessible by integration');
+  });
+});

--- a/packages/backend/src/lib/github-app-auth.ts
+++ b/packages/backend/src/lib/github-app-auth.ts
@@ -18,6 +18,7 @@
 
 import { createPrivateKey } from 'node:crypto';
 import { SignJWT, importPKCS8 } from 'jose';
+import { GithubRequestError, readGithubErrorDetail } from './github-error';
 import { logger } from '../utils/logger';
 
 const GITHUB_API = 'https://api.github.com';
@@ -209,8 +210,11 @@ async function githubAppRequest<T>(path: string, jwt: string, method: 'GET' | 'P
     signal: AbortSignal.timeout(MINT_TIMEOUT_MS),
   });
   if (!response.ok) {
-    // The body is not logged: GitHub echoes the request in some error shapes.
-    throw new Error(`GitHub ${method} ${path} responded ${response.status}`);
+    // The body IS kept now, redacted. GitHub echoes the request in some error
+    // shapes, so it was previously dropped whole — which left the 404 window
+    // where the App was not yet installed (Sentry BOARDSESH-HQ) with nothing
+    // but a status, when GitHub's own `message` names the cause outright.
+    throw new GithubRequestError(method, path, await readGithubErrorDetail(response));
   }
   return (await response.json()) as T;
 }

--- a/packages/backend/src/lib/github-client.ts
+++ b/packages/backend/src/lib/github-client.ts
@@ -10,11 +10,13 @@
  * code by copy, so it lives here instead.
  *
  * Nothing in this module throws for a non-2xx response — callers decide. The
- * one exception is `githubRequest`, which surfaces the status so a caching
- * reader can negative-cache it.
+ * one exception is `githubRequest`, which surfaces the failure as a
+ * `GithubRequestError` so a caching reader can negative-cache on the status and
+ * a mirror that just lost a write can report why.
  */
 
 import { getInstallationAccessToken } from './github-app-auth';
+import { GithubRequestError, formatGithubErrorDetail, readGithubErrorDetail } from './github-error';
 import { logger } from '../utils/logger';
 
 export const GITHUB_API = 'https://api.github.com';
@@ -60,8 +62,11 @@ export async function ensureLabels(owner: string, repo: string, token: string, l
         body: JSON.stringify({ name: label, color: LABEL_COLORS[label] ?? 'ededed' }),
       });
       if (!response.ok && response.status !== 422) {
-        const errorText = await response.text().catch(() => '<unreadable>');
-        logger.warn(`[github] ensureLabel ${label}: ${response.status} ${errorText}`);
+        // Through the shared reader, not a raw `response.text()`: this line goes
+        // to the log drain, and an echoed request can carry the installation
+        // token that authenticated it.
+        const detail = await readGithubErrorDetail(response);
+        logger.warn(`[github] ensureLabel ${label}: ${formatGithubErrorDetail(detail)}`);
       }
     } catch (error) {
       logger.warn(`[github] ensureLabel ${label} error:`, error);
@@ -70,9 +75,15 @@ export async function ensureLabels(owner: string, repo: string, token: string, l
 }
 
 /**
- * A single GitHub REST call, JSON in and out. Throws on a non-2xx status with
- * the status in the message so a caller can negative-cache or log it; the body
- * is not included (it can carry a token echo in some error shapes).
+ * A single GitHub REST call, JSON in and out. Throws a {@link GithubRequestError}
+ * on a non-2xx, carrying the status, the request id and the response body so a
+ * caller can negative-cache on the status AND explain the failure afterwards.
+ *
+ * The body used to be dropped here on the grounds that GitHub echoes the
+ * request in some error shapes and could hand back the token that signed it.
+ * It is redacted now instead of discarded (`redactGithubErrorBody`): a 403 that
+ * silently ate three QA verdicts was unexplainable precisely because GitHub's
+ * own `message` never made it off the wire.
  *
  * `token` is optional: the public repo answers unauthenticated reads at 60/hr
  * per IP, which the caching readers stay under. Writes always need one.
@@ -91,7 +102,7 @@ export async function githubRequest<T>(path: string, init?: RequestInit, token?:
     headers: { ...headers, ...((init?.headers as Record<string, string> | undefined) ?? {}) },
   });
   if (!response.ok) {
-    throw new Error(`GitHub ${init?.method ?? 'GET'} ${path} responded ${response.status}`);
+    throw new GithubRequestError(init?.method ?? 'GET', path, await readGithubErrorDetail(response));
   }
   // 204 No Content (label DELETE) has no body to parse.
   if (response.status === 204) return undefined as T;

--- a/packages/backend/src/lib/github-error.ts
+++ b/packages/backend/src/lib/github-error.ts
@@ -1,0 +1,163 @@
+/**
+ * What a failed GitHub REST call is allowed to remember.
+ *
+ * Every GitHub write in this backend is best effort: the `qa_verdicts` /
+ * `app_feedback` row is the record, and a rejected mirror must never fail the
+ * mutation that wrote it. The cost of that design was that a rejection carried
+ * nothing but an HTTP status, so a 403 that ate three QA verdicts (Sentry
+ * BOARDSESH-GV / GT) could not be explained afterwards — GitHub's own
+ * `message` / `documentation_url`, which name the missing scope or the
+ * secondary rate limit, were read off the wire and thrown away.
+ *
+ * Both call sites that dropped the body did so for one stated reason: GitHub
+ * echoes parts of the request back in some error shapes, and a request carries
+ * an installation token in its `Authorization` header. So the body is kept —
+ * redacted and truncated — rather than discarded. `redactGithubErrorBody` is
+ * the whole of that mitigation; it runs before the text reaches a log line or a
+ * Sentry event.
+ *
+ * Lives in its own module (not `github-client.ts`) because `github-app-auth.ts`
+ * needs it too, and `github-client.ts` already imports from that file.
+ */
+
+/**
+ * How much of an error body to keep. GitHub's error JSON is a `message`, a
+ * `documentation_url` and sometimes an `errors` array — comfortably under this.
+ * The cap exists so a proxy's HTML error page or a pathological body cannot
+ * flood a log line or a Sentry event.
+ */
+const ERROR_BODY_LIMIT = 600;
+
+const REDACTED = '[redacted credential]';
+
+/**
+ * Credential shapes that could ride back out in an echoed request, and what
+ * replaces them.
+ *
+ * Order matters. `Bearer <x>` / `token <x>` runs FIRST and swallows the whole
+ * value, because a scheme pattern applied after a prefix pattern would match
+ * the placeholder the prefix pattern just wrote and redact half of it again.
+ *
+ * `ghs_` is the installation token this backend actually carries; the other
+ * `gh*_` prefixes and `github_pat_` cover the PAT era and anything a
+ * misconfigured deploy might still hold. `v1.<40 hex>` is the legacy
+ * installation-token format. The JWT pattern catches the App JWT that
+ * `github-app-auth.ts` signs, which is what the mint calls authenticate with.
+ *
+ * String replacements, not callbacks: `String.replace` passes the match OFFSET
+ * as the second callback argument when a pattern has no capture group, so a
+ * shared `(match, group) => ...` callback silently renders a number for the
+ * group-less patterns.
+ */
+const CREDENTIAL_PATTERNS: readonly (readonly [RegExp, string])[] = [
+  [/\b(Bearer|token)\s+[^\s"',}]+/gi, `$1 ${REDACTED}`],
+  [/\bgh[pousr]_[A-Za-z0-9]{16,}/g, REDACTED],
+  [/\bgithub_pat_[A-Za-z0-9_]{16,}/g, REDACTED],
+  [/\bv1\.[0-9a-f]{40}\b/g, REDACTED],
+  [/\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}/g, REDACTED],
+];
+
+/**
+ * Strip anything token-shaped out of a GitHub error body and squeeze it down to
+ * one bounded line.
+ *
+ * Best effort, like every redactor: it is a net over the shapes GitHub can
+ * plausibly echo, not a proof. It is paired with the rule that the body only
+ * ever reaches our own logs and Sentry — never a public issue comment.
+ */
+export function redactGithubErrorBody(body: string): string {
+  let redacted = body;
+  for (const [pattern, replacement] of CREDENTIAL_PATTERNS) {
+    redacted = redacted.replace(pattern, replacement);
+  }
+  const collapsed = redacted.replace(/\s+/g, ' ').trim();
+  if (!collapsed) return '<empty body>';
+  return collapsed.length > ERROR_BODY_LIMIT ? `${collapsed.slice(0, ERROR_BODY_LIMIT)}...` : collapsed;
+}
+
+/**
+ * Everything worth keeping about a non-2xx GitHub response.
+ *
+ * `requestId` is the one field GitHub Support asks for, and it is the only way
+ * to distinguish "our token is wrong" from "GitHub had a bad minute" after the
+ * fact. The rate-limit pair separates a primary 403 (budget exhausted, resets
+ * at a known time) from a permissions 403 (resets never).
+ */
+export type GithubErrorDetail = {
+  status: number;
+  /** Redacted, collapsed, length-capped response body. Never raw. */
+  body: string;
+  /** `x-github-request-id`, or null when the response carried none. */
+  requestId: string | null;
+  /** `x-ratelimit-remaining`, or null. */
+  rateLimitRemaining: string | null;
+  /** `x-ratelimit-reset` (epoch seconds), or null. */
+  rateLimitReset: string | null;
+};
+
+/**
+ * Read a failed response into a {@link GithubErrorDetail}.
+ *
+ * Consumes the body, so call it once per response and only on a non-2xx. A body
+ * that cannot be read (already consumed, socket gone) degrades to a marker
+ * rather than throwing over the original failure.
+ */
+export async function readGithubErrorDetail(response: Response): Promise<GithubErrorDetail> {
+  const raw = await response.text().catch(() => '');
+  return {
+    status: response.status,
+    body: redactGithubErrorBody(raw),
+    requestId: response.headers.get('x-github-request-id'),
+    rateLimitRemaining: response.headers.get('x-ratelimit-remaining'),
+    rateLimitReset: response.headers.get('x-ratelimit-reset'),
+  };
+}
+
+/** One-line rendering of a detail, for a log message or an Error message. */
+export function formatGithubErrorDetail(detail: GithubErrorDetail): string {
+  const parts = [`status=${detail.status}`];
+  if (detail.requestId) parts.push(`request_id=${detail.requestId}`);
+  if (detail.rateLimitRemaining) parts.push(`rate_limit_remaining=${detail.rateLimitRemaining}`);
+  parts.push(`body=${detail.body}`);
+  return parts.join(' ');
+}
+
+/**
+ * A non-2xx from the GitHub REST API, carrying why.
+ *
+ * Thrown instead of a bare `Error` so a caller three frames up can still reach
+ * the status and the body — `githubErrorDetailOf` is how, and it is what turns
+ * a dropped mirror into a diagnosable Sentry event rather than "mirror failed".
+ */
+export class GithubRequestError extends Error {
+  readonly method: string;
+  readonly path: string;
+  readonly detail: GithubErrorDetail;
+
+  constructor(method: string, path: string, detail: GithubErrorDetail) {
+    super(`GitHub ${method} ${path} responded ${detail.status}: ${detail.body}`);
+    this.name = 'GithubRequestError';
+    this.method = method;
+    this.path = path;
+    this.detail = detail;
+  }
+
+  /** Status alone, for a caller that only wants to negative-cache on it. */
+  get status(): number {
+    return this.detail.status;
+  }
+}
+
+/**
+ * The detail behind an unknown caught value, or null when it did not come from
+ * a GitHub call. Walks the `cause` chain, so wrapping stays allowed.
+ */
+export function githubErrorDetailOf(error: unknown): GithubErrorDetail | null {
+  let current: unknown = error;
+  // Bounded: a malformed cause chain must not spin here.
+  for (let depth = 0; depth < 8 && current; depth += 1) {
+    if (current instanceof GithubRequestError) return current.detail;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return null;
+}

--- a/packages/backend/src/lib/github-error.ts
+++ b/packages/backend/src/lib/github-error.ts
@@ -96,20 +96,41 @@ export type GithubErrorDetail = {
 };
 
 /**
+ * One header off a response that may not have any.
+ *
+ * A real `fetch` always hands back a `Response` with `headers`. This runs on the
+ * failure path, though, where the whole point is that things are already going
+ * wrong — a stub, a polyfill, or a mocked module boundary can hand over
+ * something thinner. Reading a header must never be the thing that turns one
+ * failure into two.
+ */
+function headerOf(response: Partial<Response> | null | undefined, name: string): string | null {
+  return response?.headers?.get?.(name) ?? null;
+}
+
+/**
  * Read a failed response into a {@link GithubErrorDetail}.
  *
- * Consumes the body, so call it once per response and only on a non-2xx. A body
- * that cannot be read (already consumed, socket gone) degrades to a marker
- * rather than throwing over the original failure.
+ * Consumes the body, so call it once per response and only on a non-2xx. Total
+ * on purpose: a body that cannot be read (already consumed, socket gone, no
+ * `text` at all) degrades to a marker, and a response with no `status` reports
+ * `0` rather than throwing over the original failure.
  */
-export async function readGithubErrorDetail(response: Response): Promise<GithubErrorDetail> {
-  const raw = await response.text().catch(() => '');
+export async function readGithubErrorDetail(
+  response: Partial<Response> | null | undefined,
+): Promise<GithubErrorDetail> {
+  let raw = '';
+  try {
+    raw = (await response?.text?.()) ?? '';
+  } catch {
+    raw = '';
+  }
   return {
-    status: response.status,
+    status: typeof response?.status === 'number' ? response.status : 0,
     body: redactGithubErrorBody(raw),
-    requestId: response.headers.get('x-github-request-id'),
-    rateLimitRemaining: response.headers.get('x-ratelimit-remaining'),
-    rateLimitReset: response.headers.get('x-ratelimit-reset'),
+    requestId: headerOf(response, 'x-github-request-id'),
+    rateLimitRemaining: headerOf(response, 'x-ratelimit-remaining'),
+    rateLimitReset: headerOf(response, 'x-ratelimit-reset'),
   };
 }
 

--- a/packages/backend/src/services/__tests__/github-mirror-report.test.ts
+++ b/packages/backend/src/services/__tests__/github-mirror-report.test.ts
@@ -1,0 +1,287 @@
+/**
+ * The regression net for #5294: when a GitHub mirror fails, the drop must not be
+ * silent and the cause must not be unrecoverable.
+ *
+ * Both halves are asserted on the POSITIVE artifact — the Sentry event that gets
+ * filed and the fields on it — never on "no log line was missing". A negative
+ * assertion here would pass vacuously the moment the reporter were gated behind
+ * anything (a sampler, a one-shot warn like `warnMissingTokenOnce`), which is
+ * exactly the failure mode being fixed.
+ *
+ * The failures are driven through the real `postVerdictComment` /
+ * `createFeedbackGithubIssue` against a stubbed `fetch`, so the test covers the
+ * whole path a dropped mirror actually travels: GitHub's response → the typed
+ * error → the resolver's outcome → the reported event.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
+
+const captureExceptionMock = vi.fn();
+const scopeRecord = {
+  user: null as { id: string } | null,
+  tags: {} as Record<string, unknown>,
+  contexts: {} as Record<string, unknown>,
+};
+
+vi.mock('@sentry/node', () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+  withScope: (callback: (scope: unknown) => void) =>
+    callback({
+      setUser: (user: { id: string }) => {
+        scopeRecord.user = user;
+      },
+      setTag: (key: string, value: unknown) => {
+        scopeRecord.tags[key] = value;
+      },
+      setContext: (key: string, value: unknown) => {
+        scopeRecord.contexts[key] = value;
+      },
+    }),
+}));
+
+// The QA service mints its token from the App; stub the mint, not the env.
+let installationToken: string | undefined = 'qa-token';
+vi.mock('../../lib/github-app-auth', () => ({
+  getInstallationAccessToken: async () => installationToken,
+}));
+
+import { reportGithubMirrorDrop } from '../github-mirror-report';
+import { postVerdictComment, resetGithubQaCaches } from '../github-qa';
+import { createFeedbackGithubIssue } from '../github-feedback';
+import { githubErrorDetailOf } from '../../lib/github-error';
+import { logger } from '../../utils/logger';
+
+/**
+ * A GitHub error response, headers and all — the request id is part of the fix.
+ *
+ * Handed to `fetch` as a FACTORY, never as one shared object: a body is a stream
+ * that can be read once, and `createFeedbackGithubIssue` calls `ensureLabels`
+ * before the issue POST. Reusing a single Response makes the second read come
+ * back empty and turns this suite into a test of its own stub.
+ */
+const errorResponse =
+  (body: unknown, status: number, headers: Record<string, string> = {}) =>
+  (): Response =>
+    new Response(typeof body === 'string' ? body : JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json', ...headers },
+    });
+
+let fetchMock: ReturnType<typeof vi.fn>;
+/** Every `[github-mirror]` line the reporter emitted during one test. */
+let loggedErrors: string[];
+
+beforeEach(() => {
+  installationToken = 'qa-token';
+  captureExceptionMock.mockClear();
+  scopeRecord.user = null;
+  scopeRecord.tags = {};
+  scopeRecord.contexts = {};
+  resetGithubQaCaches();
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  loggedErrors = [];
+  vi.spyOn(logger, 'error').mockImplementation((message: unknown) => {
+    loggedErrors.push(String(message));
+    return logger;
+  });
+  vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const mirrorContext = (): Record<string, unknown> => scopeRecord.contexts.github_mirror as Record<string, unknown>;
+
+describe('a rejected QA verdict mirror', () => {
+  it('carries GitHub status, request id and message back to the caller', async () => {
+    fetchMock.mockImplementation(
+      errorResponse(
+        { message: 'Resource not accessible by integration', documentation_url: 'https://docs.github.com/rest' },
+        403,
+        { 'x-github-request-id': 'C4E0:1F2A:9B', 'x-ratelimit-remaining': '4998' },
+      ),
+    );
+
+    const outcome = await postVerdictComment(4872, 'verdict body');
+
+    expect(outcome.status).toBe('rejected');
+    const detail = githubErrorDetailOf(outcome.status === 'rejected' ? outcome.cause : null);
+    expect(detail).not.toBeNull();
+    expect(detail?.status).toBe(403);
+    expect(detail?.requestId).toBe('C4E0:1F2A:9B');
+    expect(detail?.rateLimitRemaining).toBe('4998');
+    expect(detail?.body).toContain('Resource not accessible by integration');
+  });
+
+  it('files a Sentry event naming the verdict row, the PR and the tester', async () => {
+    fetchMock.mockImplementation(
+      errorResponse({ message: 'Resource not accessible by integration' }, 403, {
+        'x-github-request-id': 'C4E0:1F2A:9B',
+      }),
+    );
+
+    const outcome = await postVerdictComment(4872, 'verdict body');
+    reportGithubMirrorDrop({
+      operation: 'qa-verdict-comment',
+      reason: outcome.status === 'posted' ? 'rejected' : outcome.status,
+      record: { table: 'qa_verdicts', id: '3f1c9d2e-0000-4000-8000-000000000001' },
+      repo: 'boardsesh/boardsesh',
+      prNumber: 4872,
+      userId: 'tester-user-id',
+      cause: outcome.status === 'rejected' ? outcome.cause : undefined,
+    });
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    const [captured] = captureExceptionMock.mock.calls[0] as [Error];
+    expect(captured.message).toBe('GitHub mirror dropped qa-verdict-comment (rejected, 403)');
+
+    // Whose write was lost — the backend files no `setUser` anywhere else, which
+    // is why BOARDSESH-GV's "users impacted" was a count of Cloudflare edge IPs.
+    expect(scopeRecord.user).toEqual({ id: 'tester-user-id' });
+    expect(scopeRecord.tags).toMatchObject({
+      'github_mirror.operation': 'qa-verdict-comment',
+      'github_mirror.reason': 'rejected',
+      'github_mirror.status': '403',
+      'github_mirror.record_table': 'qa_verdicts',
+    });
+
+    // What was lost, and how to get it back.
+    expect(mirrorContext()).toMatchObject({
+      recordTable: 'qa_verdicts',
+      recordId: '3f1c9d2e-0000-4000-8000-000000000001',
+      prNumber: 4872,
+      repo: 'boardsesh/boardsesh',
+      status: 403,
+      requestId: 'C4E0:1F2A:9B',
+    });
+    expect(String(mirrorContext().responseBody)).toContain('Resource not accessible by integration');
+    expect(String(mirrorContext().replay)).toContain('qa_verdicts');
+  });
+
+  it('logs a [github-mirror] line naming the row that still holds the verdict', async () => {
+    fetchMock.mockImplementation(errorResponse({ message: 'forbidden' }, 403));
+
+    const outcome = await postVerdictComment(4872, 'verdict body');
+    reportGithubMirrorDrop({
+      operation: 'qa-verdict-comment',
+      reason: outcome.status === 'posted' ? 'rejected' : outcome.status,
+      record: { table: 'qa_verdicts', id: 'verdict-row-1' },
+      repo: 'boardsesh/boardsesh',
+      prNumber: 5107,
+      userId: 'tester-user-id',
+      cause: outcome.status === 'rejected' ? outcome.cause : undefined,
+    });
+
+    const logged = loggedErrors.join('\n');
+    expect(logged).toContain('[github-mirror]');
+    expect(logged).toContain('qa_verdicts verdict-row-1');
+    expect(logged).toContain('PR #5107');
+    expect(logged).toContain('status 403');
+    expect(logged).toContain('forbidden');
+  });
+});
+
+describe('an unconfigured mirror', () => {
+  it('reports the drop even though the missing-token warning is one-shot', async () => {
+    installationToken = undefined;
+
+    // Two verdicts, one process: `warnMissingTokenOnce` speaks for the first
+    // only. The drop report must not inherit that ceiling, or the second lost
+    // verdict is exactly as invisible as before.
+    for (const prNumber of [4872, 5107]) {
+      const outcome = await postVerdictComment(prNumber, 'verdict body');
+      expect(outcome.status).toBe('unconfigured');
+      reportGithubMirrorDrop({
+        operation: 'qa-verdict-comment',
+        reason: 'unconfigured',
+        record: { table: 'qa_verdicts', id: `verdict-${prNumber}` },
+        repo: 'boardsesh/boardsesh',
+        prNumber,
+        userId: 'tester-user-id',
+      });
+    }
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('a dropped bug report', () => {
+  it('names the app_feedback row that filed no issue', async () => {
+    fetchMock.mockImplementation(errorResponse({ message: 'Not Found' }, 404));
+
+    const outcome = await createFeedbackGithubIssue({
+      feedbackId: 4211,
+      rating: null,
+      comment: 'board art renders blank',
+      platform: 'ios',
+      appVersion: '2.4.0',
+      source: 'shake-bug',
+    });
+
+    expect(outcome.status).toBe('rejected');
+    reportGithubMirrorDrop({
+      operation: 'feedback-issue',
+      reason: outcome.status === 'rejected' ? 'rejected' : 'unconfigured',
+      record: { table: 'app_feedback', id: '4211' },
+      repo: 'boardsesh/boardsesh',
+      userId: 'reporter-user-id',
+      cause: outcome.status === 'rejected' ? outcome.cause : undefined,
+    });
+
+    expect(mirrorContext()).toMatchObject({ recordTable: 'app_feedback', recordId: '4211', status: 404 });
+    expect(String(mirrorContext().replay)).toContain('app_feedback');
+    expect(String(mirrorContext().responseBody)).toContain('Not Found');
+  });
+
+  it('reports the unconfigured App rather than returning quietly', async () => {
+    installationToken = undefined;
+
+    const outcome = await createFeedbackGithubIssue({
+      feedbackId: 4212,
+      rating: null,
+      comment: 'crash on open',
+      platform: 'android',
+      appVersion: '2.4.0',
+      source: 'drawer-bug',
+    });
+
+    expect(outcome.status).toBe('unconfigured');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('the response body it keeps', () => {
+  it('redacts an installation token GitHub echoed back', async () => {
+    fetchMock.mockImplementation(
+      errorResponse(
+        {
+          message: 'Bad credentials',
+          request: { headers: { Authorization: 'Bearer ghs_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5' } },
+        },
+        401,
+      ),
+    );
+
+    const outcome = await postVerdictComment(4872, 'verdict body');
+    reportGithubMirrorDrop({
+      operation: 'qa-verdict-comment',
+      reason: 'rejected',
+      record: { table: 'qa_verdicts', id: 'verdict-row-1' },
+      repo: 'boardsesh/boardsesh',
+      prNumber: 4872,
+      cause: outcome.status === 'rejected' ? outcome.cause : undefined,
+    });
+
+    const body = String(mirrorContext().responseBody);
+    expect(body).toContain('Bad credentials');
+    expect(body).not.toContain('ghs_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5');
+    expect(body).toContain('[redacted credential]');
+
+    const logged = loggedErrors.join('\n');
+    expect(logged).not.toContain('ghs_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5');
+  });
+});

--- a/packages/backend/src/services/__tests__/github-mirror-report.test.ts
+++ b/packages/backend/src/services/__tests__/github-mirror-report.test.ts
@@ -48,7 +48,7 @@ vi.mock('../../lib/github-app-auth', () => ({
 import { reportGithubMirrorDrop } from '../github-mirror-report';
 import { postVerdictComment, resetGithubQaCaches } from '../github-qa';
 import { createFeedbackGithubIssue } from '../github-feedback';
-import { githubErrorDetailOf } from '../../lib/github-error';
+import { githubErrorDetailOf, readGithubErrorDetail } from '../../lib/github-error';
 import { logger } from '../../utils/logger';
 
 /**
@@ -126,12 +126,11 @@ describe('a rejected QA verdict mirror', () => {
     const outcome = await postVerdictComment(4872, 'verdict body');
     reportGithubMirrorDrop({
       operation: 'qa-verdict-comment',
-      reason: outcome.status === 'posted' ? 'rejected' : outcome.status,
       record: { table: 'qa_verdicts', id: '3f1c9d2e-0000-4000-8000-000000000001' },
       repo: 'boardsesh/boardsesh',
       prNumber: 4872,
       userId: 'tester-user-id',
-      cause: outcome.status === 'rejected' ? outcome.cause : undefined,
+      outcome,
     });
 
     expect(captureExceptionMock).toHaveBeenCalledTimes(1);
@@ -167,12 +166,11 @@ describe('a rejected QA verdict mirror', () => {
     const outcome = await postVerdictComment(4872, 'verdict body');
     reportGithubMirrorDrop({
       operation: 'qa-verdict-comment',
-      reason: outcome.status === 'posted' ? 'rejected' : outcome.status,
       record: { table: 'qa_verdicts', id: 'verdict-row-1' },
       repo: 'boardsesh/boardsesh',
       prNumber: 5107,
       userId: 'tester-user-id',
-      cause: outcome.status === 'rejected' ? outcome.cause : undefined,
+      outcome,
     });
 
     const logged = loggedErrors.join('\n');
@@ -196,11 +194,11 @@ describe('an unconfigured mirror', () => {
       expect(outcome.status).toBe('unconfigured');
       reportGithubMirrorDrop({
         operation: 'qa-verdict-comment',
-        reason: 'unconfigured',
         record: { table: 'qa_verdicts', id: `verdict-${prNumber}` },
         repo: 'boardsesh/boardsesh',
         prNumber,
         userId: 'tester-user-id',
+        outcome,
       });
     }
 
@@ -225,11 +223,10 @@ describe('a dropped bug report', () => {
     expect(outcome.status).toBe('rejected');
     reportGithubMirrorDrop({
       operation: 'feedback-issue',
-      reason: outcome.status === 'rejected' ? 'rejected' : 'unconfigured',
       record: { table: 'app_feedback', id: '4211' },
       repo: 'boardsesh/boardsesh',
       userId: 'reporter-user-id',
-      cause: outcome.status === 'rejected' ? outcome.cause : undefined,
+      outcome,
     });
 
     expect(mirrorContext()).toMatchObject({ recordTable: 'app_feedback', recordId: '4211', status: 404 });
@@ -269,11 +266,10 @@ describe('the response body it keeps', () => {
     const outcome = await postVerdictComment(4872, 'verdict body');
     reportGithubMirrorDrop({
       operation: 'qa-verdict-comment',
-      reason: 'rejected',
       record: { table: 'qa_verdicts', id: 'verdict-row-1' },
       repo: 'boardsesh/boardsesh',
       prNumber: 4872,
-      cause: outcome.status === 'rejected' ? outcome.cause : undefined,
+      outcome,
     });
 
     const body = String(mirrorContext().responseBody);
@@ -283,5 +279,98 @@ describe('the response body it keeps', () => {
 
     const logged = loggedErrors.join('\n');
     expect(logged).not.toContain('ghs_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5');
+  });
+});
+
+/**
+ * The regression CI caught on the first push of this branch.
+ *
+ * The reporter runs inside the same fire-and-forget block that writes the GitHub
+ * id back onto the row. Dereferencing an outcome that turned out to be
+ * `undefined` threw a TypeError there, the block's outer catch swallowed it, and
+ * the write-back never ran — a mirror-drop reporter that itself throws is worse
+ * than the silent drop it was written to end, because it takes a healthy write
+ * down with it.
+ *
+ * So: every one of these must produce a record, and none of them may throw.
+ */
+describe('an outcome the reporter cannot read', () => {
+  const unreadable: Array<[string, unknown]> = [
+    ['undefined (a partially mocked module boundary)', undefined],
+    ['null (a caller still on the pre-#5294 contract)', null],
+    ['an object with no status at all', { id: 555, htmlUrl: 'https://github.com/x' }],
+    ['a status that is not one of ours', { status: 'weird' }],
+    ['a non-object', 42],
+  ];
+
+  it.each(unreadable)('still files a diagnosable record for %s', (_label, outcome) => {
+    expect(() =>
+      reportGithubMirrorDrop({
+        operation: 'qa-verdict-comment',
+        record: { table: 'qa_verdicts', id: 'verdict-row-9' },
+        repo: 'boardsesh/boardsesh',
+        prNumber: 4872,
+        userId: 'tester-user-id',
+        outcome,
+      }),
+    ).not.toThrow();
+
+    // The positive artifact, not "it didn't crash": an unreadable outcome is
+    // still a lost verdict, and it still has to name the row that holds it.
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(scopeRecord.tags['github_mirror.reason']).toBe('unexpected-response');
+    expect(mirrorContext()).toMatchObject({
+      recordTable: 'qa_verdicts',
+      recordId: 'verdict-row-9',
+      prNumber: 4872,
+    });
+    expect(loggedErrors.join('\n')).toContain('qa_verdicts verdict-row-9');
+  });
+
+  it('keeps the caller alive when the record itself is missing', () => {
+    expect(() =>
+      reportGithubMirrorDrop({
+        operation: 'feedback-issue',
+        record: undefined as unknown as { table: 'app_feedback'; id: string },
+        repo: 'boardsesh/boardsesh',
+        outcome: undefined,
+      }),
+    ).not.toThrow();
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The other half of the same rule: the detail reader runs on the failure path
+ * too, so a response missing the pieces it wants must degrade rather than throw
+ * a second error on top of the first.
+ */
+describe('a response the detail reader cannot fully read', () => {
+  const partialResponses: Array<[string, Partial<Response> | null | undefined]> = [
+    ['absent', undefined],
+    ['null', null],
+    ['no status and no headers', { text: async (): Promise<string> => '{"message":"nope"}' }],
+    ['no text method', { status: 500 }],
+    ['a text() that throws', { status: 502, text: (): Promise<string> => Promise.reject(new Error('socket gone')) }],
+  ];
+
+  it.each(partialResponses)('reads a detail from a response that is %s', async (_label, response) => {
+    const detail = await readGithubErrorDetail(response);
+
+    expect(typeof detail.status).toBe('number');
+    expect(typeof detail.body).toBe('string');
+    expect(detail.requestId).toBeNull();
+  });
+
+  it('keeps the body when only the headers are missing', async () => {
+    const detail = await readGithubErrorDetail({
+      status: 404,
+      text: async () => '{"message":"Not Found"}',
+    } as Partial<Response>);
+
+    expect(detail.status).toBe(404);
+    expect(detail.body).toContain('Not Found');
+    expect(detail.requestId).toBeNull();
   });
 });

--- a/packages/backend/src/services/__tests__/github-qa.test.ts
+++ b/packages/backend/src/services/__tests__/github-qa.test.ts
@@ -33,6 +33,7 @@ import {
   type QaPullRequest,
   type VerdictCommentPayload,
 } from '../github-qa';
+import { githubErrorDetailOf } from '../../lib/github-error';
 import { logger } from '../../utils/logger';
 
 const PR_BODY = [
@@ -95,10 +96,14 @@ const githubPull = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
-const jsonResponse = (body: unknown, status = 200): Response =>
+// `headers` is part of the stub because a failed call now reads
+// `x-github-request-id` and the rate-limit pair off the response — that trio is
+// what makes a rejected mirror explainable after the fact (#5294).
+const jsonResponse = (body: unknown, status = 200, headers: Record<string, string> = {}): Response =>
   ({
     ok: status >= 200 && status < 300,
     status,
+    headers: new Headers(headers),
     json: async () => body,
     text: async () => JSON.stringify(body),
   }) as Response;
@@ -676,8 +681,8 @@ describe('postVerdictComment', () => {
     );
 
     await expect(postVerdictComment(4792, 'body')).resolves.toEqual({
-      id: 987,
-      htmlUrl: 'https://github.com/boardsesh/boardsesh/pull/4792#issuecomment-987',
+      status: 'posted',
+      comment: { id: 987, htmlUrl: 'https://github.com/boardsesh/boardsesh/pull/4792#issuecomment-987' },
     });
     expect(fetchMock.mock.calls[0][0]).toBe('https://api.github.com/repos/boardsesh/boardsesh/issues/4792/comments');
     expect((fetchMock.mock.calls[0][1] as RequestInit).method).toBe('POST');
@@ -687,15 +692,34 @@ describe('postVerdictComment', () => {
     installationToken = undefined;
     vi.spyOn(logger, 'warn').mockImplementation(() => logger);
 
-    await expect(postVerdictComment(4792, 'body')).resolves.toBeNull();
+    await expect(postVerdictComment(4792, 'body')).resolves.toEqual({ status: 'unconfigured' });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('returns null instead of throwing when GitHub rejects the write', async () => {
-    vi.spyOn(logger, 'error').mockImplementation(() => logger);
-    fetchMock.mockResolvedValue(jsonResponse({ message: 'forbidden' }, 403));
+  it('reports the rejection with GitHub status, request id and message instead of throwing', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ message: 'Resource not accessible by integration' }, 403, {
+        'x-github-request-id': 'C4E0:1F2A:9B',
+        'x-ratelimit-remaining': '4998',
+      }),
+    );
 
-    await expect(postVerdictComment(4792, 'body')).resolves.toBeNull();
+    const outcome = await postVerdictComment(4792, 'body');
+    expect(outcome.status).toBe('rejected');
+
+    // The half of #5294 that made the 403 unrecoverable: a bare status told
+    // nobody whether the App was under-scoped or rate-limited.
+    const detail = githubErrorDetailOf(outcome.status === 'rejected' ? outcome.cause : null);
+    expect(detail?.status).toBe(403);
+    expect(detail?.requestId).toBe('C4E0:1F2A:9B');
+    expect(detail?.rateLimitRemaining).toBe('4998');
+    expect(detail?.body).toContain('Resource not accessible by integration');
+  });
+
+  it('flags a 2xx that did not carry a comment', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }));
+
+    await expect(postVerdictComment(4792, 'body')).resolves.toEqual({ status: 'unexpected-response' });
   });
 });
 
@@ -733,14 +757,31 @@ describe('applyQaLabel', () => {
       init?.method === 'DELETE' ? jsonResponse({ message: 'label not found' }, 404) : jsonResponse({}),
     );
 
-    await expect(applyQaLabel(4792, 'approved')).resolves.toBeUndefined();
+    await expect(applyQaLabel(4792, 'approved')).resolves.toEqual({ status: 'applied' });
   });
 
   it('makes no request at all when no token is configured', async () => {
     installationToken = undefined;
     vi.spyOn(logger, 'warn').mockImplementation(() => logger);
 
-    await applyQaLabel(4792, 'approved');
+    await expect(applyQaLabel(4792, 'approved')).resolves.toEqual({ status: 'unconfigured' });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reports a rejected label swap with the cause attached', async () => {
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) =>
+      init?.method === 'POST' && url.endsWith('/issues/4792/labels')
+        ? jsonResponse({ message: 'Resource not accessible by integration' }, 403, {
+            'x-github-request-id': 'AA11:BB22:CC',
+          })
+        : jsonResponse({}),
+    );
+
+    const outcome = await applyQaLabel(4792, 'approved');
+    expect(outcome.status).toBe('rejected');
+    const detail = githubErrorDetailOf(outcome.status === 'rejected' ? outcome.cause : null);
+    expect(detail?.status).toBe(403);
+    expect(detail?.requestId).toBe('AA11:BB22:CC');
+    expect(detail?.body).toContain('Resource not accessible by integration');
   });
 });

--- a/packages/backend/src/services/github-feedback.ts
+++ b/packages/backend/src/services/github-feedback.ts
@@ -14,8 +14,8 @@
 import type { AppFeedbackPlatform, AppFeedbackSource, FeedbackContextInput } from '@boardsesh/shared-schema';
 import { redactSensitiveText } from '@boardsesh/text-redaction';
 import { GITHUB_API, ensureLabels, githubHeaders, resolveGithubToken, resolveGithubRepo } from '../lib/github-client';
+import { GithubRequestError, readGithubErrorDetail } from '../lib/github-error';
 import { screenshotMarkdownSection } from './feedback-screenshot-urls';
-import { logger } from '../utils/logger';
 
 const TITLE_LIMIT = 120;
 
@@ -158,18 +158,33 @@ export function buildFeedbackIssue(payload: FeedbackIssuePayload): FeedbackIssue
 }
 
 /**
- * Create a GitHub issue from a bug report. Never throws. Returns the created
- * issue's number + html_url, or null when it no-ops or fails:
- *  - non-bug (rating) source → null,
- *  - the GitHub App unconfigured (local dev) → null,
- *  - any API error → logged and null.
+ * What became of a bug report's mirror.
+ *
+ * `skipped` is a rating, which never becomes an issue and is not a drop.
+ * Everything else that is not `created` IS a drop the caller has to report:
+ * `unconfigured` is the shape of the 3h23m window where the App was live in
+ * production but not yet installed on the repo and 19 reports filed nothing.
  */
-export async function createFeedbackGithubIssue(payload: FeedbackIssuePayload): Promise<CreatedIssue | null> {
+export type FeedbackIssueOutcome =
+  | { status: 'created'; issue: CreatedIssue }
+  | { status: 'skipped' }
+  | { status: 'unconfigured' }
+  | { status: 'unexpected-response' }
+  | { status: 'rejected'; cause: unknown };
+
+/**
+ * Create a GitHub issue from a bug report. Never throws.
+ *
+ * Returns an outcome rather than `CreatedIssue | null`: `null` meant five
+ * different things, three of which were a report quietly going nowhere, and the
+ * resolver could not tell them apart well enough to say what had been lost.
+ */
+export async function createFeedbackGithubIssue(payload: FeedbackIssuePayload): Promise<FeedbackIssueOutcome> {
   const draft = buildFeedbackIssue(payload);
-  if (!draft) return null;
+  if (!draft) return { status: 'skipped' };
 
   const token = await resolveGithubToken();
-  if (!token) return null;
+  if (!token) return { status: 'unconfigured' };
 
   // Via the shared resolver, not `process.env.X ?? default`: a dashboard hands
   // back '' for a variable someone cleared, which `??` would honour and turn
@@ -177,8 +192,7 @@ export async function createFeedbackGithubIssue(payload: FeedbackIssuePayload): 
   const repo = resolveGithubRepo();
   const [owner, name] = repo.split('/');
   if (!owner || !name) {
-    logger.error(`[GitHub feedback] Invalid feedback repo "${repo}" (expected owner/name)`);
-    return null;
+    return { status: 'rejected', cause: new Error(`invalid feedback repo "${repo}" (expected owner/name)`) };
   }
 
   try {
@@ -191,19 +205,19 @@ export async function createFeedbackGithubIssue(payload: FeedbackIssuePayload): 
     });
 
     if (!response.ok) {
-      const errorText = await response.text().catch(() => '<unreadable>');
-      logger.error(`[GitHub feedback] Create issue failed: ${response.status} ${errorText}`);
-      return null;
+      // Through the shared reader so the body is redacted rather than dumped —
+      // and so the status, request id and GitHub's own message reach the
+      // reporter instead of dying in a log line here.
+      const detail = await readGithubErrorDetail(response);
+      return { status: 'rejected', cause: new GithubRequestError('POST', `/repos/${repo}/issues`, detail) };
     }
 
     const created = (await response.json()) as { number?: number; html_url?: string };
     if (typeof created.number !== 'number' || typeof created.html_url !== 'string') {
-      logger.error('[GitHub feedback] Create issue returned an unexpected response shape');
-      return null;
+      return { status: 'unexpected-response' };
     }
-    return { number: created.number, htmlUrl: created.html_url };
+    return { status: 'created', issue: { number: created.number, htmlUrl: created.html_url } };
   } catch (error) {
-    logger.error('[GitHub feedback] Create issue error:', error);
-    return null;
+    return { status: 'rejected', cause: error };
   }
 }

--- a/packages/backend/src/services/github-mirror-report.ts
+++ b/packages/backend/src/services/github-mirror-report.ts
@@ -1,0 +1,146 @@
+/**
+ * One place to announce that a GitHub mirror never landed.
+ *
+ * Both mirrors — a QA verdict's comment + label (`docs/crowdsourced-qa.md`) and
+ * an in-app bug report's issue — are fire-and-forget by design: the
+ * `qa_verdicts` / `app_feedback` row is the record, and a GitHub outage must
+ * cost the copy, never the mutation. What it must NOT cost is knowing that a
+ * copy went missing.
+ *
+ * Two real incidents made that concrete. A 403 on the verdict mirror ate three
+ * comments across #4872 and #5107, neither PR ever got its verdict label, and
+ * both merged anyway — nobody ran the `github_comment_id IS NULL` query the
+ * runbook names, because nothing told them to. Separately, the App shipped to
+ * production before it was installed on the repo, and for 3h23m every in-app
+ * bug report stored its row and filed no issue.
+ *
+ * So a drop now produces two artifacts:
+ *
+ * 1. A structured `[github-mirror]` line on the backend logger — greppable, and
+ *    it names the row that still holds the truth.
+ * 2. A Sentry event with the row id, the operation, the failing status and
+ *    GitHub's own (redacted) response body, scoped to the user whose write was
+ *    lost. That is the alert; there is no polling job to write.
+ *
+ * Deliberately NOT a retry queue: that is a standing decision for this feature,
+ * and the mirror is reconstructible from the row it names, so the event carries
+ * the replay hint instead.
+ */
+
+import * as Sentry from '@sentry/node';
+import { githubErrorDetailOf } from '../lib/github-error';
+import { logger } from '../utils/logger';
+
+/** Which mirror was lost. Doubles as the Sentry grouping key. */
+export type GithubMirrorOperation = 'qa-verdict-comment' | 'qa-verdict-label' | 'feedback-issue';
+
+/**
+ * Why it was lost.
+ *
+ * `unconfigured` is the App having no usable token — the shape of the 3h23m
+ * outage, and the one an operator fixes in the deploy dashboard rather than in
+ * code. `rejected` is GitHub answering with a status. `unexpected-response` is
+ * a 2xx whose payload was not the shape we asked for.
+ */
+export type GithubMirrorDropReason = 'unconfigured' | 'rejected' | 'unexpected-response';
+
+export type GithubMirrorDrop = {
+  operation: GithubMirrorOperation;
+  reason: GithubMirrorDropReason;
+  /** The row that still holds what GitHub never got. */
+  record: { table: 'qa_verdicts' | 'app_feedback'; id: string };
+  repo: string;
+  /** PR the mirror targeted, for the QA operations. */
+  prNumber?: number | null;
+  /** Whose write was lost. Sizes the blast radius; never rendered publicly. */
+  userId?: string | null;
+  /** What the error actually was, when there was one. */
+  cause?: unknown;
+};
+
+/**
+ * The Sentry event's exception.
+ *
+ * A named class with a message built from operation + reason + status only —
+ * ids and bodies live in the event context, not the title — so Sentry groups
+ * one issue per failure mode instead of one per dropped row, and a spike in a
+ * single mode stays legible.
+ */
+export class GithubMirrorDropError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'GithubMirrorDropError';
+  }
+}
+
+/** How an operator replays one dropped mirror by hand. */
+function replayHint(drop: GithubMirrorDrop): string {
+  if (drop.record.table === 'qa_verdicts') {
+    return `SELECT * FROM qa_verdicts WHERE id = '${drop.record.id}' -- github_comment_id IS NULL`;
+  }
+  return `SELECT * FROM app_feedback WHERE id = '${drop.record.id}' -- github_issue_number IS NULL`;
+}
+
+/**
+ * Report a mirror that never landed.
+ *
+ * Never throws: it runs inside the same fire-and-forget block whose whole job is
+ * to not take the mutation down with it.
+ *
+ * The Sentry capture is direct rather than via `logger.error(msg, err)` because
+ * the winston transport captures with a fixed scope, and the two facts that make
+ * this event worth having — which row was lost, and whose write it was — have to
+ * be attached per event. The paired log line is therefore message-only, which is
+ * also what keeps the transport from filing a second, poorer copy of the same
+ * failure.
+ */
+export function reportGithubMirrorDrop(drop: GithubMirrorDrop): void {
+  try {
+    const detail = githubErrorDetailOf(drop.cause);
+    const target = drop.prNumber != null ? ` for PR #${drop.prNumber}` : '';
+    const summary =
+      `[github-mirror] ${drop.operation} was dropped (${drop.reason}` +
+      `${detail ? `, status ${detail.status}` : ''})${target}; ` +
+      `${drop.record.table} ${drop.record.id} still holds it. ` +
+      `repo=${drop.repo} replay=${replayHint(drop)}` +
+      `${detail ? ` request_id=${detail.requestId ?? 'none'} body=${detail.body}` : ''}`;
+
+    // Message-only on purpose — see the doc comment. The Sentry copy below is
+    // the one carrying context.
+    logger.error(summary);
+
+    const title = detail
+      ? `GitHub mirror dropped ${drop.operation} (${drop.reason}, ${detail.status})`
+      : `GitHub mirror dropped ${drop.operation} (${drop.reason})`;
+
+    Sentry.withScope((scope) => {
+      // The backend never calls setUser, so a backend issue's "users impacted"
+      // is a count of Cloudflare edge IPs. For this event it is the one number
+      // that sizes the loss, so set it here rather than nowhere.
+      if (drop.userId) scope.setUser({ id: drop.userId });
+      scope.setTag('github_mirror.operation', drop.operation);
+      scope.setTag('github_mirror.reason', drop.reason);
+      scope.setTag('github_mirror.record_table', drop.record.table);
+      if (detail) scope.setTag('github_mirror.status', String(detail.status));
+      scope.setContext('github_mirror', {
+        operation: drop.operation,
+        reason: drop.reason,
+        repo: drop.repo,
+        recordTable: drop.record.table,
+        recordId: drop.record.id,
+        prNumber: drop.prNumber ?? null,
+        replay: replayHint(drop),
+        status: detail?.status ?? null,
+        requestId: detail?.requestId ?? null,
+        rateLimitRemaining: detail?.rateLimitRemaining ?? null,
+        rateLimitReset: detail?.rateLimitReset ?? null,
+        responseBody: detail?.body ?? null,
+      });
+      Sentry.captureException(new GithubMirrorDropError(title, { cause: drop.cause }));
+    });
+  } catch (error) {
+    // A failure inside the reporter must not escape into the mirror block that
+    // called it, or one lost comment becomes a lost comment plus a lost label.
+    logger.warn('[github-mirror] could not report a dropped mirror:', error);
+  }
+}

--- a/packages/backend/src/services/github-mirror-report.ts
+++ b/packages/backend/src/services/github-mirror-report.ts
@@ -46,7 +46,6 @@ export type GithubMirrorDropReason = 'unconfigured' | 'rejected' | 'unexpected-r
 
 export type GithubMirrorDrop = {
   operation: GithubMirrorOperation;
-  reason: GithubMirrorDropReason;
   /** The row that still holds what GitHub never got. */
   record: { table: 'qa_verdicts' | 'app_feedback'; id: string };
   repo: string;
@@ -54,9 +53,46 @@ export type GithubMirrorDrop = {
   prNumber?: number | null;
   /** Whose write was lost. Sizes the blast radius; never rendered publicly. */
   userId?: string | null;
-  /** What the error actually was, when there was one. */
-  cause?: unknown;
+  /**
+   * Whatever the mirror function returned. Deliberately `unknown`: the caller
+   * hands it over without inspecting it, and every dereference happens here,
+   * once, defensively — see {@link dropReasonOf}.
+   */
+  outcome?: unknown;
+  /** Reason override, for a drop with no outcome object behind it. */
+  reason?: GithubMirrorDropReason;
 };
+
+const DROP_REASONS: ReadonlySet<string> = new Set<GithubMirrorDropReason>([
+  'unconfigured',
+  'rejected',
+  'unexpected-response',
+]);
+
+/**
+ * The reason behind a non-success outcome.
+ *
+ * Reads `.status` off a value that may be `undefined`, `null`, or a shape
+ * nobody planned for, and never throws doing it. That tolerance is the whole
+ * point rather than defensive noise: this runs inside a fire-and-forget block
+ * whose other job is writing the GitHub id back onto the row, so a TypeError
+ * here does not just lose the report — it takes the write-back down with it and
+ * leaves exactly the silent drop this module exists to end.
+ *
+ * An unrecognised shape is `unexpected-response`, which is honest: we asked for
+ * a mirror and got back something we cannot read as success.
+ */
+export function dropReasonOf(outcome: unknown): GithubMirrorDropReason {
+  const status = (outcome as { status?: unknown } | null | undefined)?.status;
+  return typeof status === 'string' && DROP_REASONS.has(status)
+    ? (status as GithubMirrorDropReason)
+    : 'unexpected-response';
+}
+
+/** The error an outcome carried, if it carried one. Never throws. */
+function dropCauseOf(outcome: unknown): unknown {
+  return (outcome as { cause?: unknown } | null | undefined)?.cause;
+}
 
 /**
  * The Sentry event's exception.
@@ -74,11 +110,10 @@ export class GithubMirrorDropError extends Error {
 }
 
 /** How an operator replays one dropped mirror by hand. */
-function replayHint(drop: GithubMirrorDrop): string {
-  if (drop.record.table === 'qa_verdicts') {
-    return `SELECT * FROM qa_verdicts WHERE id = '${drop.record.id}' -- github_comment_id IS NULL`;
-  }
-  return `SELECT * FROM app_feedback WHERE id = '${drop.record.id}' -- github_issue_number IS NULL`;
+function replayHint(record: GithubMirrorDrop['record'] | undefined): string {
+  const table = record?.table ?? 'qa_verdicts';
+  const nullColumn = table === 'qa_verdicts' ? 'github_comment_id' : 'github_issue_number';
+  return `SELECT * FROM ${table} WHERE id = '${record?.id ?? 'unknown'}' -- ${nullColumn} IS NULL`;
 }
 
 /**
@@ -96,13 +131,18 @@ function replayHint(drop: GithubMirrorDrop): string {
  */
 export function reportGithubMirrorDrop(drop: GithubMirrorDrop): void {
   try {
-    const detail = githubErrorDetailOf(drop.cause);
+    const reason = drop.reason ?? dropReasonOf(drop.outcome);
+    const cause = dropCauseOf(drop.outcome);
+    const detail = githubErrorDetailOf(cause);
+    const recordTable = drop.record?.table ?? 'qa_verdicts';
+    const recordId = drop.record?.id ?? 'unknown';
+    const replay = replayHint(drop.record);
     const target = drop.prNumber != null ? ` for PR #${drop.prNumber}` : '';
     const summary =
-      `[github-mirror] ${drop.operation} was dropped (${drop.reason}` +
+      `[github-mirror] ${drop.operation} was dropped (${reason}` +
       `${detail ? `, status ${detail.status}` : ''})${target}; ` +
-      `${drop.record.table} ${drop.record.id} still holds it. ` +
-      `repo=${drop.repo} replay=${replayHint(drop)}` +
+      `${recordTable} ${recordId} still holds it. ` +
+      `repo=${drop.repo} replay=${replay}` +
       `${detail ? ` request_id=${detail.requestId ?? 'none'} body=${detail.body}` : ''}`;
 
     // Message-only on purpose — see the doc comment. The Sentry copy below is
@@ -110,8 +150,8 @@ export function reportGithubMirrorDrop(drop: GithubMirrorDrop): void {
     logger.error(summary);
 
     const title = detail
-      ? `GitHub mirror dropped ${drop.operation} (${drop.reason}, ${detail.status})`
-      : `GitHub mirror dropped ${drop.operation} (${drop.reason})`;
+      ? `GitHub mirror dropped ${drop.operation} (${reason}, ${detail.status})`
+      : `GitHub mirror dropped ${drop.operation} (${reason})`;
 
     Sentry.withScope((scope) => {
       // The backend never calls setUser, so a backend issue's "users impacted"
@@ -119,24 +159,24 @@ export function reportGithubMirrorDrop(drop: GithubMirrorDrop): void {
       // that sizes the loss, so set it here rather than nowhere.
       if (drop.userId) scope.setUser({ id: drop.userId });
       scope.setTag('github_mirror.operation', drop.operation);
-      scope.setTag('github_mirror.reason', drop.reason);
-      scope.setTag('github_mirror.record_table', drop.record.table);
+      scope.setTag('github_mirror.reason', reason);
+      scope.setTag('github_mirror.record_table', recordTable);
       if (detail) scope.setTag('github_mirror.status', String(detail.status));
       scope.setContext('github_mirror', {
         operation: drop.operation,
-        reason: drop.reason,
+        reason,
         repo: drop.repo,
-        recordTable: drop.record.table,
-        recordId: drop.record.id,
+        recordTable,
+        recordId,
         prNumber: drop.prNumber ?? null,
-        replay: replayHint(drop),
+        replay,
         status: detail?.status ?? null,
         requestId: detail?.requestId ?? null,
         rateLimitRemaining: detail?.rateLimitRemaining ?? null,
         rateLimitReset: detail?.rateLimitReset ?? null,
         responseBody: detail?.body ?? null,
       });
-      Sentry.captureException(new GithubMirrorDropError(title, { cause: drop.cause }));
+      Sentry.captureException(new GithubMirrorDropError(title, { cause }));
     });
   } catch (error) {
     // A failure inside the reporter must not escape into the mirror block that

--- a/packages/backend/src/services/github-qa.ts
+++ b/packages/backend/src/services/github-qa.ts
@@ -111,6 +111,25 @@ export type VerdictCommentPayload = {
 
 export type PostedComment = { id: number; htmlUrl: string };
 
+/**
+ * What became of a verdict mirror.
+ *
+ * Anything other than `posted` is a dropped comment the caller has to report —
+ * `cause` is a `GithubRequestError` when GitHub answered, so the status, the
+ * request id and GitHub's own message survive the trip up to the reporter.
+ */
+export type VerdictCommentOutcome =
+  | { status: 'posted'; comment: PostedComment }
+  | { status: 'unconfigured' }
+  | { status: 'unexpected-response' }
+  | { status: 'rejected'; cause: unknown };
+
+/** Same contract for the label swap. */
+export type QaLabelOutcome =
+  | { status: 'applied' }
+  | { status: 'unconfigured' }
+  | { status: 'rejected'; cause: unknown };
+
 function normalizePullRequest(payload: GitHubPullRequestPayload): QaPullRequest | null {
   const { number, title, html_url: htmlUrl, updated_at: updatedAt } = payload;
   const headSha = payload.head?.sha;
@@ -613,14 +632,19 @@ function warnMissingTokenOnce(): void {
 }
 
 /**
- * Post the verdict comment on the PR. Never throws. Returns null when there is
- * no token (local dev) or the call failed — the row already holds the verdict.
+ * Post the verdict comment on the PR. Never throws.
+ *
+ * Returns an outcome rather than `PostedComment | null`, because the caller has
+ * to be able to tell the three "no comment" cases apart: an unconfigured App
+ * (the 3h23m outage shape), a rejection from GitHub (the 403 that ate three
+ * verdicts), and a 2xx whose payload was not a comment. `null` collapsed all
+ * three into silence, and the caller then had nothing to report.
  */
-export async function postVerdictComment(prNumber: number, body: string): Promise<PostedComment | null> {
+export async function postVerdictComment(prNumber: number, body: string): Promise<VerdictCommentOutcome> {
   const token = await resolveGithubToken();
   if (!token) {
     warnMissingTokenOnce();
-    return null;
+    return { status: 'unconfigured' };
   }
 
   try {
@@ -630,13 +654,14 @@ export async function postVerdictComment(prNumber: number, body: string): Promis
       token,
     );
     if (typeof comment.id !== 'number' || typeof comment.html_url !== 'string') {
-      logger.error('[qa] verdict comment returned an unexpected response shape');
-      return null;
+      return { status: 'unexpected-response' };
     }
-    return { id: comment.id, htmlUrl: comment.html_url };
+    return { status: 'posted', comment: { id: comment.id, htmlUrl: comment.html_url } };
   } catch (error) {
-    logger.error(`[qa] posting the verdict comment on #${prNumber} failed:`, error);
-    return null;
+    // Not logged here: the caller reports the drop once, with the verdict row
+    // id and the tester's user id attached. Logging it here too would file the
+    // same failure twice in Sentry, once without any of that.
+    return { status: 'rejected', cause: error };
   }
 }
 
@@ -644,19 +669,21 @@ export async function postVerdictComment(prNumber: number, body: string): Promis
  * Move the PR to the verdict's label: add the winner, drop the other. Latest
  * verdict wins, so a decline after an approval leaves only `qa-declined`.
  * Never throws; a 404 on the removal just means the label wasn't there.
+ *
+ * Reports its outcome for the same reason `postVerdictComment` does — a PR that
+ * silently kept the wrong label is half of what #5294 was about.
  */
-export async function applyQaLabel(prNumber: number, verdict: QaVerdictKind): Promise<void> {
+export async function applyQaLabel(prNumber: number, verdict: QaVerdictKind): Promise<QaLabelOutcome> {
   const token = await resolveGithubToken();
   if (!token) {
     warnMissingTokenOnce();
-    return;
+    return { status: 'unconfigured' };
   }
 
   const repo = resolveGithubRepo();
   const [owner, name] = repo.split('/');
   if (!owner || !name) {
-    logger.error(`[qa] invalid QA repo "${repo}" (expected owner/name)`);
-    return;
+    return { status: 'rejected', cause: new Error(`invalid QA repo "${repo}" (expected owner/name)`) };
   }
   const winner = QA_LABELS[verdict];
   const loser = verdict === 'approved' ? QA_LABELS.declined : QA_LABELS.approved;
@@ -669,16 +696,17 @@ export async function applyQaLabel(prNumber: number, verdict: QaVerdictKind): Pr
       token,
     );
   } catch (error) {
-    logger.error(`[qa] adding ${winner} to #${prNumber} failed:`, error);
-    return;
+    return { status: 'rejected', cause: error };
   }
 
   try {
     await githubRequest(`/repos/${repo}/issues/${prNumber}/labels/${loser}`, { method: 'DELETE' }, token);
   } catch (error) {
-    // 404 is the normal case: the PR never carried the opposite verdict.
+    // 404 is the normal case: the PR never carried the opposite verdict. Not a
+    // drop — the label that matters is already on.
     logger.debug(`[qa] removing ${loser} from #${prNumber} was a no-op:`, error);
   }
+  return { status: 'applied' };
 }
 
 /** Test-only: drop the module caches (and the one-shot missing-token warning). */


### PR DESCRIPTION
## Summary

Fixes #5294.

Two mirrors write to the public tracker and neither may fail the mutation that fed it: a QA verdict's comment + label, and an in-app bug report's issue. Both were fire-and-forget in a way that lost the write *and* the ability to explain it afterwards.

**The swallow sites, on `origin/main`:**

| What | Where | What it lost |
| --- | --- | --- |
| The cause | `packages/backend/src/lib/github-client.ts:94` — the throw that renders only `responded ${response.status}` | GitHub's own `message` / `documentation_url` were read off the wire and dropped, deliberately (the body can echo the request, and the request carries an installation token). A 403 was therefore just "403" — under-scoped App and secondary rate limit look identical. |
| The same, on the mint path | `packages/backend/src/lib/github-app-auth.ts:213` — same throw, same comment | The 404 window (App live in prod, not yet installed on the repo) named no cause. |
| The drop | `packages/backend/src/graphql/resolvers/qa/mutations.ts:182` — `if (posted) { …update… }` with no `else` | `postVerdictComment` returned `null` for "no token", "GitHub said no" and "odd payload" alike. The row kept `github_comment_id NULL`, the outer `catch` at `:206` never fired because nothing threw, and nobody ran the query that finds those rows. Three verdict comments on #4872 / #5107 were lost; neither PR ever got a `qa-approved` / `qa-declined` label, and both merged. |
| The drop, bug-report half | `packages/backend/src/services/github-feedback.ts:172` — `if (!token) return null;` | No log at all at this site. For 3h23m, every bug report stored its `app_feedback` row and filed nothing. |

**Requirement 1 — the drop stops being silent.** New `packages/backend/src/services/github-mirror-report.ts`. `postVerdictComment`, `applyQaLabel` and `createFeedbackGithubIssue` now return a discriminated outcome (`posted` / `created` / `unconfigured` / `unexpected-response` / `rejected`) instead of `null`-means-five-things, so the caller knows a mirror was lost *and* which way. Anything short of success routes to `reportGithubMirrorDrop`, which emits a structured `[github-mirror]` line on the winston logger and files a `GithubMirrorDropError` to Sentry — tagged `github_mirror.operation` / `.reason` / `.status`, scoped to the user whose write was lost, with a `github_mirror` context carrying the `qa_verdicts` / `app_feedback` row id, the PR, the repo and the exact replay query. That is the alert; there is no polling job to run.

The `setUser` is issue suggestion 3: the backend calls it nowhere, which is why BOARDSESH-HQ's "2 users impacted" was a count of Cloudflare edge IPs. Scoped to this event rather than set globally.

**Requirement 2 — the cause stops being unrecoverable.** New `packages/backend/src/lib/github-error.ts`. A non-2xx now becomes a `GithubRequestError` carrying status, `x-github-request-id`, the rate-limit pair, and the response body **redacted rather than discarded** — `redactGithubErrorBody` strips `ghs_` / `ghp_` / `github_pat_` / legacy `v1.<hex>` tokens, App JWTs and echoed `Authorization` headers, then caps the result at 600 chars. That is issue suggestion 2, and it also brings the two call sites that already kept the body (`ensureLabels`, the feedback issue POST) onto the same redactor instead of dumping raw text.

**Not built:** a retry queue. That is a standing decision for this feature and the issue rules it out explicitly. The mirror is reconstructible from the row, so the event carries the replay query instead.

**Mutation-tested.** Reverting the `github-client.ts` throw to the bare `Error` on main turns 6 assertions red across `github-qa.test.ts` and `github-mirror-report.test.ts` (`expected undefined to be 403`, `expected 'null' to contain 'Bad credentials'`). Separately, deleting the `Sentry.captureException` from `reportGithubMirrorDrop` turns 2 more red (`expected "vi.fn()" to be called 1 times, but got 0 times`). Both restored; 90/90 green.

The guard asserts the positive artifact — the captured Sentry event and the fields on it — never the absence of a log line, so it cannot pass vacuously if the path later goes behind a sampler. One test deliberately files two `unconfigured` drops in one process to prove the report does not inherit the one-shot ceiling of the existing `warnMissingTokenOnce` warning.

Author-side verification: `vp run typecheck` exits 0; `vp check` exits 0 (0 errors, 5553 files formatted). The four backend test files touching this change pass locally. The full backend suite was not run locally — the shared test-DB lock was an hour deep and the box was saturated by other agents — so CI is authoritative for it.

## Release Notes

- [x] No release note needed (internal / technical change)

none

## Test plan

1. CI green.

## Risk

Risk: 3/5 — backend resolvers and the shared GitHub client; changes what a failed mirror returns, never what a successful one does, and no schema or migration is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
