### PR TITLE
fix(web): tell climbers when a front-door section didn't load

### DIFF
--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -134,6 +134,22 @@ resolver path at all.
 hundred milliseconds, wrap the fall-through.** The Redis hit rate is not the
 safety property; the concurrency of the miss is.
 
+`similarClimbs` is the third read to take that shape (#4968,
+`graphql/resolvers/climbs/similar-climbs-cache.ts`). Measured on the dev
+catalogue — 893k climbs, 5.5M Kilter `board_climb_holds` rows, serial plan — a
+typical 18-hold Kilter climb runs **4 831 ms on a fresh Postgres and 205 ms
+warm**; the 198-hold tail is 7 860 ms cold and 1 542 ms warm. The cold figure
+for the typical case is 1.6x the front door's 3 s deadline, which is why #4968
+reads as a cold-cache failure rather than a slow-query one. (Parallelism is not
+the variable: warm serial 1 542 ms vs 1 566 ms with
+`max_parallel_workers_per_gather = 4`, and the planner chooses no `Gather` node
+for this shape — so `withSerialPlan` costs it nothing measurable.) It differs
+from the other two in one way: its key is
+per climb across the whole catalogue, so it takes **no** `REDISLESS_FALLBACK_TTL_MS`
+process-local copy. An unbounded local map in a long-lived process is a worse
+failure than re-running the statement, and single-flight alone still covers the
+concurrency of the miss, which is the half that protects the pool.
+
 ## Front-door read deadlines and pool sizing (#4461)
 
 The connect retry above bounds a _failed_ connect. It does nothing about a
@@ -196,7 +212,17 @@ one at the database.
 | read fails or deadlines, climb page | hung to the platform limit, then 404 | 500 at ~6 s per request                         |
 | read fails or deadlines, list page  | 200 with zero climbs                 | 500 at ~6 s                                     |
 | backend `boardBySlug` fails, `/b/…` | 404                                  | 500                                             |
-| backend GraphQL wedged              | climb page hung indefinitely         | similar climbs / beta links render empty at 3 s |
+| backend GraphQL wedged              | climb page hung indefinitely         | similar climbs / beta links degrade at 3 s      |
+
+Since #4968 "degrade" is not "render empty". Both sections return
+`{ status: 'unavailable' }` rather than `[]`, because `[]` is also what a climb
+nobody has filmed looks like and the page was publishing "No beta filmed yet."
+on the strength of a timeout — 6,922 + 748 renders in fourteen days. Each
+section now says it did not load, and similar climbs additionally ship WITHOUT a
+React Query seed so the reader's own browser refetches on hydration: the retry
+happens off the server-render budget and against the reader's IP rather than the
+web server's single shared one. There is deliberately no server-side retry — a
+second attempt spends another 3 s pushing work at the pool that just failed.
 
 The 5xx is the point. Google retries a 5xx and keeps the URL, while a 404 — or a
 200 with nothing on it — on a sitemapped URL reads as "drop this page".

--- a/packages/backend/src/graphql/resolvers/climbs/__tests__/similar-climbs-cache.test.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/__tests__/similar-climbs-cache.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+/**
+ * #4968: the similar-climbs statement is a catalogue-wide aggregate, and until
+ * this module the only cache in front of it lived in the web app's
+ * `unstable_cache` — instance-local storage a new build starts empty, thrown
+ * away 41 times in the fourteen days Sentry measured 6,922 timed-out renders.
+ *
+ * Two properties, and they are not the same property:
+ *   - the CACHE decides how often the statement runs;
+ *   - `singleFlight` decides how many copies run at once, which per
+ *     `docs/db-connectivity.md` is the one that keeps a cold window from
+ *     emptying the connection pool.
+ */
+
+const { findSimilarClimbsMock, redisStore, redisState, getMock, setMock, loggerErrorMock } = vi.hoisted(() => ({
+  findSimilarClimbsMock: vi.fn(),
+  redisStore: new Map<string, string>(),
+  redisState: { connected: true },
+  getMock: vi.fn(),
+  setMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}));
+
+vi.mock('../climb-similarity', () => ({ findSimilarClimbs: findSimilarClimbsMock }));
+
+vi.mock('../../../../utils/logger', () => ({ logger: { error: loggerErrorMock, info: vi.fn(), warn: vi.fn() } }));
+
+vi.mock('../../../../redis/client', () => ({
+  redisClientManager: {
+    isRedisConnected: () => redisState.connected,
+    getClients: () => ({ publisher: { get: getMock, set: setMock } }),
+  },
+}));
+
+import { findSimilarClimbsCached, SIMILAR_CLIMBS_CACHE_TTL_SECONDS } from '../similar-climbs-cache';
+import { resetSingleFlightForTests } from '../../../../utils/single-flight';
+
+const ROWS = [{ uuid: 'NEIGHBOUR-1', similarity: 0.8 }];
+
+function argsFor(overrides: Record<string, unknown> = {}) {
+  return {
+    boardType: 'kilter' as const,
+    layoutId: 8,
+    holds: [
+      { holdId: 12, holdState: 'HAND' },
+      { holdId: 7, holdState: 'STARTING' },
+    ],
+    threshold: 0.5,
+    limit: 10,
+    statsAngle: 40,
+    ...overrides,
+  } as Parameters<typeof findSimilarClimbsCached>[0];
+}
+
+describe('findSimilarClimbsCached', () => {
+  beforeEach(() => {
+    redisStore.clear();
+    redisState.connected = true;
+    findSimilarClimbsMock.mockReset();
+    findSimilarClimbsMock.mockResolvedValue(ROWS);
+    loggerErrorMock.mockReset();
+    getMock.mockReset();
+    getMock.mockImplementation(async (key: string) => redisStore.get(key) ?? null);
+    setMock.mockReset();
+    setMock.mockImplementation(async (key: string, value: string) => {
+      redisStore.set(key, value);
+      return 'OK';
+    });
+    resetSingleFlightForTests();
+  });
+
+  afterEach(() => {
+    resetSingleFlightForTests();
+  });
+
+  it('runs the statement once and answers the second call from Redis', async () => {
+    expect(await findSimilarClimbsCached(argsFor())).toEqual(ROWS);
+    expect(await findSimilarClimbsCached(argsFor())).toEqual(ROWS);
+
+    expect(findSimilarClimbsMock).toHaveBeenCalledTimes(1);
+    expect(setMock).toHaveBeenCalledTimes(1);
+    expect(setMock.mock.calls[0]?.[2]).toBe('EX');
+    expect(setMock.mock.calls[0]?.[3]).toBe(SIMILAR_CLIMBS_CACHE_TTL_SECONDS);
+  });
+
+  it('keys on the hold SET, not the row order Postgres happens to return', async () => {
+    await findSimilarClimbsCached(
+      argsFor({
+        holds: [
+          { holdId: 12, holdState: 'HAND' },
+          { holdId: 7, holdState: 'STARTING' },
+        ],
+      }),
+    );
+    await findSimilarClimbsCached(
+      argsFor({
+        holds: [
+          { holdId: 7, holdState: 'STARTING' },
+          { holdId: 12, holdState: 'HAND' },
+        ],
+      }),
+    );
+
+    expect(findSimilarClimbsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['layoutId', { layoutId: 9 }],
+    ['threshold', { threshold: 0.7 }],
+    ['limit', { limit: 25 }],
+    ['statsAngle', { statsAngle: 20 }],
+    ['sizeId', { sizeId: 2 }],
+    ['excludeUuid', { excludeUuid: 'SELF' }],
+    ['holds', { holds: [{ holdId: 99, holdState: 'HAND' }] }],
+  ])('does not serve one climb the answer computed for a different %s', async (_label, overrides) => {
+    await findSimilarClimbsCached(argsFor());
+    await findSimilarClimbsCached(argsFor(overrides));
+
+    expect(findSimilarClimbsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('collapses concurrent misses onto one statement', async () => {
+    // Settles on a macrotask, so both callers are provably inside the helper
+    // before the first statement finishes — the situation single-flight exists
+    // for. An already-settled promise would let call 1 complete and clear the
+    // map before call 2 ever looked, and the test would pass for the wrong
+    // reason.
+    findSimilarClimbsMock.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve(ROWS), 10)));
+
+    const [first, second] = await Promise.all([findSimilarClimbsCached(argsFor()), findSimilarClimbsCached(argsFor())]);
+
+    // The concurrency of the miss is the pool-safety property, not the hit rate.
+    expect(findSimilarClimbsMock).toHaveBeenCalledTimes(1);
+    expect(first).toEqual(ROWS);
+    expect(second).toEqual(ROWS);
+  });
+
+  it('falls through to the statement when Redis is unreachable', async () => {
+    getMock.mockRejectedValue(new Error('ECONNREFUSED'));
+    setMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    expect(await findSimilarClimbsCached(argsFor())).toEqual(ROWS);
+    expect(loggerErrorMock).toHaveBeenCalled();
+  });
+
+  it('still runs, and still single-flights, with no Redis at all', async () => {
+    redisState.connected = false;
+    findSimilarClimbsMock.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve(ROWS), 10)));
+
+    await Promise.all([findSimilarClimbsCached(argsFor()), findSimilarClimbsCached(argsFor())]);
+
+    expect(findSimilarClimbsMock).toHaveBeenCalledTimes(1);
+    expect(getMock).not.toHaveBeenCalled();
+    expect(setMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -23,7 +23,8 @@ import {
 import { isValidBoardName } from '../../../db/queries/util/table-select';
 import { applyRateLimit, requireAuthenticated, validateInput } from '../shared/helpers';
 import { findMoonBoardDuplicateMatches } from './moonboard-duplicates';
-import { findSimilarClimbs, parseFramesToHoldEntries, type NormalizedHold } from './climb-similarity';
+import { parseFramesToHoldEntries, type NormalizedHold } from './climb-similarity';
+import { findSimilarClimbsCached } from './similar-climbs-cache';
 import {
   BoardNameSchema,
   CheckMoonBoardClimbDuplicatesInputSchema,
@@ -158,7 +159,10 @@ export const climbQueries = {
     // that isn't saved yet) have to start sending one.
     if (isSizeScopedSimilarityBoard(boardType) && sizeId === undefined) return [];
 
-    return findSimilarClimbs({
+    // Redis-cached and single-flighted (#4968). The statement is a catalogue-wide
+    // aggregate — see `similar-climbs-cache.ts` for the measured cost and for why
+    // the cache had to move off the web instance's `unstable_cache`.
+    return findSimilarClimbsCached({
       boardType,
       layoutId: validated.layoutId,
       holds,

--- a/packages/backend/src/graphql/resolvers/climbs/similar-climbs-cache.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/similar-climbs-cache.ts
@@ -1,0 +1,134 @@
+import { createHash } from 'crypto';
+import { redisClientManager } from '../../../redis/client';
+import { logger } from '../../../utils/logger';
+import { singleFlight } from '../../../utils/single-flight';
+import { findSimilarClimbs, type SimilarClimbResult } from './climb-similarity';
+
+/**
+ * A shared cache and a concurrency gate in front of `findSimilarClimbs`.
+ *
+ * ## Why the cache moved here (#4968)
+ *
+ * The similar-climbs read was already cached — on the web side, in
+ * `unstable_cache`. That cache is per web instance and per deploy: Next's data
+ * cache is instance-local storage that a new build starts empty. Sentry counted
+ * 6,922 climb-view renders losing the section to the 3 s deadline across **41
+ * web releases** in fourteen days, and a cache thrown away 41 times is a cache
+ * that is cold most of the time it matters.
+ *
+ * Behind the resolver it is neither. One Redis entry answers:
+ *
+ *  - both web page trees for the same climb (`/{board}/…/view/…` and
+ *    `/b/{slug}/…/view/…`), across all four locales;
+ *  - the browser-side fetch the front door now makes when its server read
+ *    degraded, which is the same query again seconds later;
+ *  - the mobile app and the play drawer, which hit this resolver directly and
+ *    were never covered by anything.
+ *
+ * It also survives a web deploy, and it is shared by every web instance rather
+ * than warmed once per instance.
+ *
+ * ## Why single-flight, separately from the cache
+ *
+ * The cache changes how OFTEN the statement runs. `singleFlight` changes how
+ * many copies run AT ONCE, and per `docs/db-connectivity.md` that is the
+ * property that keeps a cold window from emptying the pool: "the Redis hit rate
+ * is not the safety property; the concurrency of the miss is." A crawler
+ * arriving on one climb's several URLs in the same second is exactly the shape
+ * #4463 documents.
+ *
+ * ## What this is NOT
+ *
+ * It is not a fix for the statement's cost, and the numbers say why it does not
+ * have to be. On the dev catalogue (893k climbs, 5.5M kilter hold rows, serial
+ * plan) a TYPICAL 18-hold Kilter climb runs **4 831 ms on a fresh Postgres and
+ * 205 ms warm** — a 23x spread, and the cold figure is 1.6x the front door's 3 s
+ * deadline. The long tail (198 holds) is 7 860 ms cold, 1 542 ms warm. So the
+ * failure #4968 reports is a cold-cache failure almost by definition, and
+ * keeping one warm copy somewhere shared is a proportionate answer to it.
+ *
+ * Making the statement itself fast is a different job and belongs to #5352. No
+ * b-tree index does it: `COUNT(DISTINCT hold_id)` per candidate is a set
+ * intersection, so the answer there is a set-overlap structure (a GIN-indexed
+ * hold-id array per climb, or a materialised neighbour table). Nothing here
+ * touches the query — a rewrite drops in behind this wrapper unchanged.
+ */
+
+/** Bump when a code change alters what this query RETURNS for an existing key. */
+const CACHE_VERSION = 'v1';
+
+/**
+ * One hour, matching the web front door's own `revalidate`. The rows behind it
+ * move slowly — a newly published climb changes one target's neighbours, and a
+ * tick changes a candidate's ascent count — and neither is worth a shorter
+ * window on a discovery section.
+ */
+export const SIMILAR_CLIMBS_CACHE_TTL_SECONDS = 3600;
+
+const CACHE_KEY_PREFIX = 'boardsesh:similar-climbs';
+
+type CachedSimilarClimbsArgs = Parameters<typeof findSimilarClimbs>[0];
+
+/**
+ * Everything that changes the answer, in a fixed order so two callers
+ * describing the same request produce the same key. `holds` is sorted because
+ * the resolver builds it from a row order Postgres does not promise.
+ */
+function buildCacheKey(args: CachedSimilarClimbsArgs): string {
+  const holdIds = Array.from(new Set(args.holds.map(({ holdId }) => holdId))).sort((a, b) => a - b);
+  const shape = JSON.stringify({
+    holdIds,
+    threshold: args.threshold,
+    limit: args.limit ?? null,
+    sizeId: args.sizeId ?? null,
+    excludeUuid: args.excludeUuid ?? null,
+    statsAngle: args.statsAngle ?? null,
+  });
+  const shapeHash = createHash('sha256').update(shape).digest('hex').slice(0, 32);
+
+  return [CACHE_KEY_PREFIX, CACHE_VERSION, args.boardType, args.layoutId, shapeHash].join(':');
+}
+
+/**
+ * `findSimilarClimbs`, cached in Redis and collapsed to one in-flight copy per
+ * key per process.
+ *
+ * Every failure mode falls through to the underlying read rather than to an
+ * error: an unreachable Redis must degrade this to today's behaviour, never
+ * take the section down.
+ *
+ * Deliberately without the process-local fallback map that
+ * `getCachedRecentBetaLinks` keeps for Redis-less deployments. That read has a
+ * handful of scopes; this one is keyed per climb across a catalogue of nearly a
+ * million, so a local map would be an unbounded cache in a long-lived process.
+ * With no Redis, single-flight alone still collapses the concurrent burst,
+ * which is the half that protects the pool.
+ */
+export async function findSimilarClimbsCached(args: CachedSimilarClimbsArgs): Promise<SimilarClimbResult[]> {
+  const cacheKey = buildCacheKey(args);
+
+  if (redisClientManager.isRedisConnected()) {
+    try {
+      const cached = await redisClientManager.getClients().publisher.get(cacheKey);
+      if (cached) return JSON.parse(cached) as SimilarClimbResult[];
+    } catch (error) {
+      logger.error('[SimilarClimbs] Redis read failed:', error);
+    }
+  }
+
+  return singleFlight(cacheKey, async () => {
+    const rows = await findSimilarClimbs(args);
+
+    if (redisClientManager.isRedisConnected()) {
+      try {
+        await redisClientManager
+          .getClients()
+          .publisher.set(cacheKey, JSON.stringify(rows), 'EX', SIMILAR_CLIMBS_CACHE_TTL_SECONDS);
+      } catch (error) {
+        logger.error('[SimilarClimbs] Redis write failed:', error);
+      }
+    }
+
+    return rows;
+  });
+}

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -790,13 +790,15 @@
     },
     "beta": {
       "heading": "Beta-Videos",
-      "empty": "Noch keine Beta gefilmt."
+      "empty": "Noch keine Beta gefilmt.",
+      "unavailable": "Die Beta wurde nicht geladen. Lad die Seite neu, um es nochmal zu probieren."
     },
     "community": {
       "heading": "Community"
     },
     "similar": {
-      "heading": "Boulder wie dieser"
+      "heading": "Boulder wie dieser",
+      "unavailable": "Ähnliche Boulder wurden nicht geladen. Wird erneut geladen…"
     },
     "cta": {
       "climbThis": "Boulder jetzt",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -790,13 +790,15 @@
     },
     "beta": {
       "heading": "Beta videos",
-      "empty": "No beta filmed yet."
+      "empty": "No beta filmed yet.",
+      "unavailable": "Beta didn't load this time. Reload the page to try again."
     },
     "community": {
       "heading": "Community"
     },
     "similar": {
-      "heading": "Climbs like this one"
+      "heading": "Climbs like this one",
+      "unavailable": "Climbs like this one didn't load. Trying again…"
     },
     "cta": {
       "climbThis": "Climb this",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -790,13 +790,15 @@
     },
     "beta": {
       "heading": "Vídeos de beta",
-      "empty": "Todavía nadie ha grabado beta."
+      "empty": "Todavía nadie ha grabado beta.",
+      "unavailable": "La beta no cargó esta vez. Recarga la página para volver a intentarlo."
     },
     "community": {
       "heading": "Comunidad"
     },
     "similar": {
-      "heading": "Bloques parecidos a este"
+      "heading": "Bloques parecidos a este",
+      "unavailable": "Los bloques parecidos no cargaron. Volviendo a intentarlo…"
     },
     "cta": {
       "climbThis": "Escala este bloque",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -790,13 +790,15 @@
     },
     "beta": {
       "heading": "Vidéos de beta",
-      "empty": "Aucune beta filmée pour l’instant."
+      "empty": "Aucune beta filmée pour l’instant.",
+      "unavailable": "La beta n’a pas chargé cette fois. Recharge la page pour réessayer."
     },
     "community": {
       "heading": "Communauté"
     },
     "similar": {
-      "heading": "Des blocs dans le même esprit"
+      "heading": "Des blocs dans le même esprit",
+      "unavailable": "Les blocs similaires n’ont pas chargé. Rechargement en cours…"
     },
     "cta": {
       "climbThis": "Grimper ce bloc",

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/__tests__/read-failure-status.test.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/__tests__/read-failure-status.test.tsx
@@ -32,8 +32,8 @@ vi.mock('@/app/lib/data/queries', () => ({
 }));
 
 vi.mock('@/app/lib/data/front-door-data.server', () => ({
-  getFrontDoorSimilarClimbs: vi.fn(async () => []),
-  getFrontDoorBetaLinks: vi.fn(async () => []),
+  getFrontDoorSimilarClimbs: vi.fn(async () => ({ status: 'loaded', items: [] })),
+  getFrontDoorBetaLinks: vi.fn(async () => ({ status: 'loaded', items: [] })),
 }));
 
 vi.mock('@/app/lib/url-utils.server', () => ({

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/__tests__/redirect.test.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/__tests__/redirect.test.tsx
@@ -120,8 +120,8 @@ vi.mock('@/app/components/board-renderer/util', () => ({
   buildOverlayUrl: vi.fn(() => '/api/internal/board-render'),
 }));
 vi.mock('@/app/lib/data/front-door-data.server', () => ({
-  getFrontDoorSimilarClimbs: vi.fn(async () => []),
-  getFrontDoorBetaLinks: vi.fn(async () => []),
+  getFrontDoorSimilarClimbs: vi.fn(async () => ({ status: 'loaded', items: [] })),
+  getFrontDoorBetaLinks: vi.fn(async () => ({ status: 'loaded', items: [] })),
 }));
 vi.mock('@/app/components/climb-front-door/climb-front-door', () => ({ default: () => null }));
 

--- a/packages/web/app/__tests__/climb-canonical-parity.test.ts
+++ b/packages/web/app/__tests__/climb-canonical-parity.test.ts
@@ -71,8 +71,8 @@ vi.mock('@/app/lib/data/queries', () => ({
 }));
 
 vi.mock('@/app/lib/data/front-door-data.server', () => ({
-  getFrontDoorSimilarClimbs: vi.fn(async () => []),
-  getFrontDoorBetaLinks: vi.fn(async () => []),
+  getFrontDoorSimilarClimbs: vi.fn(async () => ({ status: 'loaded', items: [] })),
+  getFrontDoorBetaLinks: vi.fn(async () => ({ status: 'loaded', items: [] })),
 }));
 
 vi.mock('@/app/lib/data/list-page-data.server', () => ({

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/page-metadata.test.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/page-metadata.test.tsx
@@ -113,8 +113,8 @@ vi.mock('@/app/components/board-renderer/util', () => ({
 // Stubs for the page body's imports — generateMetadata never uses them, but
 // importing the page module pulls them in.
 vi.mock('@/app/lib/data/front-door-data.server', () => ({
-  getFrontDoorSimilarClimbs: vi.fn(async () => []),
-  getFrontDoorBetaLinks: vi.fn(async () => []),
+  getFrontDoorSimilarClimbs: vi.fn(async () => ({ status: 'loaded', items: [] })),
+  getFrontDoorBetaLinks: vi.fn(async () => ({ status: 'loaded', items: [] })),
 }));
 vi.mock('@/app/components/climb-front-door/climb-front-door', () => ({
   default: () => null,

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/read-failure-status.test.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/read-failure-status.test.tsx
@@ -22,8 +22,8 @@ vi.mock('@/app/lib/data/queries', () => ({
 }));
 
 vi.mock('@/app/lib/data/front-door-data.server', () => ({
-  getFrontDoorSimilarClimbs: vi.fn(async () => []),
-  getFrontDoorBetaLinks: vi.fn(async () => []),
+  getFrontDoorSimilarClimbs: vi.fn(async () => ({ status: 'loaded', items: [] })),
+  getFrontDoorBetaLinks: vi.fn(async () => ({ status: 'loaded', items: [] })),
 }));
 
 vi.mock('@/app/lib/board-slug-utils', () => ({

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/view-seo-fragment.test.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/view-seo-fragment.test.tsx
@@ -126,8 +126,8 @@ vi.mock('@/app/lib/data/queries', () => ({
 }));
 
 vi.mock('@/app/lib/data/front-door-data.server', () => ({
-  getFrontDoorSimilarClimbs: vi.fn(async () => []),
-  getFrontDoorBetaLinks: vi.fn(async () => []),
+  getFrontDoorSimilarClimbs: vi.fn(async () => ({ status: 'loaded', items: [] })),
+  getFrontDoorBetaLinks: vi.fn(async () => ({ status: 'loaded', items: [] })),
 }));
 
 vi.mock('@/app/lib/warm-overlay-cache', () => ({ scheduleOgImageWarming: vi.fn() }));

--- a/packages/web/app/components/climb-front-door/__tests__/section-unavailable.test.tsx
+++ b/packages/web/app/components/climb-front-door/__tests__/section-unavailable.test.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vite-plus/test';
+import { renderToString } from 'react-dom/server';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { SimilarClimb } from '@boardsesh/shared-schema';
+import { resolveServerTree } from '@/app/lib/__tests__/helpers/resolve-server-tree';
+import type { FrontDoorSection } from '@/app/lib/data/front-door-data.server';
+import type { BetaLink } from '@/app/lib/beta-video-url';
+import type { BoardDetails, Climb } from '@/app/lib/types';
+
+/**
+ * #4968: the front door has to tell "nobody filmed this" apart from "the
+ * backend did not answer in three seconds", and say the true one.
+ *
+ * Before this suite both read paths degraded to `[]`, so a 3 s deadline on a
+ * cold cache rendered "No beta filmed yet." and "No similar climbs on this
+ * layout." — factual claims about the climb, published to readers and to Google
+ * on an indexed page, 6,922 + 748 times in the 14 days Sentry measured.
+ *
+ * Three assertions, one per state, because two of them are only meaningful next
+ * to the third: an unavailable section must not borrow the empty section's copy,
+ * an empty section must keep it, and a loaded section must render content.
+ */
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/app/lib/i18n/server', () => ({
+  getServerTranslation: vi.fn(async () => ({
+    t: (key: string) => key,
+    locale: 'en-US',
+  })),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en-US' } }),
+}));
+
+// Every band of the page except the two under test. They pull in client
+// islands, posthog and the board renderer, none of which this file asserts.
+vi.mock('../front-door-breadcrumb', () => ({ default: () => null }));
+vi.mock('../climb-creative-work-json-ld', () => ({ default: () => null }));
+vi.mock('../climb-facts', () => ({ default: () => null }));
+vi.mock('../climb-handoff-cta', () => ({ default: () => null }));
+vi.mock('../angle-cross-links', () => ({ default: () => null }));
+vi.mock('@/app/components/climb-detail/climb-view-seo-fragment', () => ({ default: () => null }));
+vi.mock('@/app/components/social/climb-social-section', () => ({ default: () => null }));
+
+vi.mock('@/app/components/board-renderer/util', () => ({
+  buildBoardArtLayers: vi.fn(() => ({ backgroundUrls: [], overlayUrl: null })),
+  toDarkArtUrl: (url: string) => url,
+}));
+
+// Kept real below the fold — the similar-climbs half of the fix is exactly what
+// this component does with (and without) a seed, so stubbing it out would leave
+// the assertion checking a prop rather than the rendered section.
+vi.mock('@/app/components/board-renderer/board-image-layers', () => ({ default: () => null }));
+vi.mock('@/app/components/board-renderer/board-canvas-renderer', () => ({ default: () => null }));
+vi.mock('@/app/lib/board-render-worker/worker-manager', () => ({ useCanvasRendererReady: () => false }));
+vi.mock('@/app/hooks/use-is-dark-mode', () => ({ useIsDarkMode: () => false }));
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ formatGrade: (grade?: string) => grade, getGradeColor: () => undefined }),
+}));
+vi.mock('@/app/components/i18n/locale-link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+vi.mock('@/app/lib/analytics', () => ({ track: vi.fn(), trackBeforeNavigation: vi.fn() }));
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({
+    request: () => {
+      throw new Error('server render must not reach the network');
+    },
+  }),
+}));
+
+const ClimbFrontDoor = (await import('../climb-front-door')).default;
+
+function makeClimb(): Climb {
+  return {
+    uuid: 'CLIMB-UNDER-TEST',
+    name: 'Test Climb',
+    difficulty: 'V5',
+    setter_username: 'setter-person',
+    quality_average: '4.20',
+    ascensionist_count: 12,
+    frames: 'p1r12',
+    description: null,
+  } as unknown as Climb;
+}
+
+function makeBoardDetails(): BoardDetails {
+  return {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 10,
+    set_ids: [1, 20],
+    layout_name: 'Kilter Board Original',
+    size_name: '12 x 12',
+    size_description: 'Commercial',
+    set_names: ['Bolt Ons', 'Screw Ons'],
+    images_to_holds: {},
+    holdsData: {},
+    boardWidth: 1080,
+    boardHeight: 1350,
+  } as unknown as BoardDetails;
+}
+
+function makeBetaLink(): BetaLink {
+  return { link: 'https://www.instagram.com/p/abc/', foreignUsername: 'filmer' } as unknown as BetaLink;
+}
+
+function makeSimilarClimb(): SimilarClimb {
+  return {
+    uuid: 'SIMILAR0',
+    name: 'Similar Boulder',
+    layoutId: 1,
+    angle: 40,
+    frames: 'p1r14',
+    difficultyName: 'V4',
+    setterUsername: 'setter',
+    qualityAverage: 3,
+    ascensionistCount: 7,
+    compatibleSizeIds: [10],
+  } as unknown as SimilarClimb;
+}
+
+async function renderFrontDoor(sections: {
+  similarClimbs: FrontDoorSection<SimilarClimb>;
+  betaLinks: FrontDoorSection<BetaLink>;
+}): Promise<string> {
+  const element = (
+    <ClimbFrontDoor
+      climb={makeClimb()}
+      boardDetails={makeBoardDetails()}
+      angle={40}
+      canonicalAngle={40}
+      angleStats={[]}
+      similarClimbs={sections.similarClimbs}
+      betaLinks={sections.betaLinks}
+      handoffPath="/kilter/1/10/1,20/40/view/CLIMB-UNDER-TEST"
+      tree="config-tuple"
+    />
+  );
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return renderToString(
+    <QueryClientProvider client={queryClient}>{await resolveServerTree(element)}</QueryClientProvider>,
+  );
+}
+
+describe('front-door sections whose backend read timed out', () => {
+  it('says beta did not load instead of claiming nobody has filmed it', async () => {
+    const html = await renderFrontDoor({
+      similarClimbs: { status: 'loaded', items: [] },
+      betaLinks: { status: 'unavailable' },
+    });
+
+    expect(html).toContain('frontDoor.beta.unavailable');
+    expect(html).not.toContain('frontDoor.beta.empty');
+  });
+
+  it('says similar climbs did not load instead of claiming the layout has none', async () => {
+    const html = await renderFrontDoor({
+      similarClimbs: { status: 'unavailable' },
+      betaLinks: { status: 'loaded', items: [] },
+    });
+
+    expect(html).toContain('frontDoor.similar.unavailable');
+    expect(html).not.toContain('similarClimbs.emptyOnLayout');
+    // Prose, not a spinner: this page is indexed, and a crawler reads the
+    // loading state as the section's final content.
+    expect(html).not.toContain('MuiCircularProgress');
+  });
+
+  it('still says the sections are empty when the backend actually answered', async () => {
+    const html = await renderFrontDoor({
+      similarClimbs: { status: 'loaded', items: [] },
+      betaLinks: { status: 'loaded', items: [] },
+    });
+
+    expect(html).toContain('frontDoor.beta.empty');
+    expect(html).toContain('similarClimbs.emptyOnLayout');
+    expect(html).not.toContain('frontDoor.beta.unavailable');
+    expect(html).not.toContain('frontDoor.similar.unavailable');
+  });
+
+  it('renders the content when the backend answered with rows', async () => {
+    const html = await renderFrontDoor({
+      similarClimbs: { status: 'loaded', items: [makeSimilarClimb()] },
+      betaLinks: { status: 'loaded', items: [makeBetaLink()] },
+    });
+
+    expect(html).toContain('/view/similar-boulder-SIMILAR0');
+    expect(html).not.toContain('frontDoor.beta.empty');
+    expect(html).not.toContain('frontDoor.beta.unavailable');
+    expect(html).not.toContain('frontDoor.similar.unavailable');
+  });
+});

--- a/packages/web/app/components/climb-front-door/climb-front-door.tsx
+++ b/packages/web/app/components/climb-front-door/climb-front-door.tsx
@@ -13,6 +13,7 @@ import { getServerTranslation } from '@/app/lib/i18n/server';
 import { formatBoardDisplayName, resolveClimbDisplayName } from '@/app/lib/string-utils';
 import { themeTokens } from '@/app/theme/theme-config';
 import type { ClimbStatsForAngle } from '@/app/lib/data/queries';
+import type { FrontDoorSection } from '@/app/lib/data/front-door-data.server';
 import type { BetaLink } from '@/app/lib/beta-video-url';
 import type { BoardDetails, BoardName, Climb } from '@/app/lib/types';
 import AngleCrossLinks from './angle-cross-links';
@@ -27,8 +28,13 @@ type ClimbFrontDoorProps = {
   angle: number;
   canonicalAngle: number;
   angleStats: ClimbStatsForAngle[];
-  similarClimbs: SimilarClimb[];
-  betaLinks: BetaLink[];
+  /**
+   * Both sections carry their own provenance rather than a bare array, so the
+   * page can tell "nobody has filmed this" apart from "the backend did not
+   * answer in three seconds" and say the true one. See `FrontDoorSection`.
+   */
+  similarClimbs: FrontDoorSection<SimilarClimb>;
+  betaLinks: FrontDoorSection<BetaLink>;
   /**
    * The pathname the "Climb this" CTA hands to the app — the URL the reader is
    * actually on. Deliberately NOT the page's canonical: on `/b/{slug}` the
@@ -85,6 +91,9 @@ const sectionSx = { mt: 4 };
 
 const sectionHeadingSx = { fontWeight: themeTokens.typography.fontWeight.semibold, mb: 1.5 };
 
+// Shared by the "nothing here yet" and the "this did not load" lines. Same
+// muted weight for both: a degraded read is not an error the reader caused, and
+// shouting about a supplementary section would be louder than the climb.
 const emptySectionSx = { m: 0, color: 'var(--neutral-400)' };
 
 /**
@@ -273,8 +282,17 @@ export default async function ClimbFrontDoor({
         <Typography variant="h5" component="h2" sx={sectionHeadingSx}>
           {t('frontDoor.beta.heading')}
         </Typography>
-        {betaLinks.length > 0 ? (
-          <BoardseshBetaList links={betaLinks} isLoading={false} source="drawer" />
+        {/* Three states, not two. `frontDoor.beta.empty` says nobody has filmed
+            this climb, which is a claim about the climb — it may only be
+            rendered when the backend actually answered. This section has no
+            client-side query to recover it, so the degraded copy asks for the
+            one thing that does. */}
+        {betaLinks.status === 'unavailable' ? (
+          <Typography variant="body2" component="p" sx={emptySectionSx}>
+            {t('frontDoor.beta.unavailable')}
+          </Typography>
+        ) : betaLinks.items.length > 0 ? (
+          <BoardseshBetaList links={betaLinks.items} isLoading={false} source="drawer" />
         ) : (
           <Typography variant="body2" component="p" sx={emptySectionSx}>
             {t('frontDoor.beta.empty')}
@@ -286,6 +304,14 @@ export default async function ClimbFrontDoor({
         <Typography variant="h5" component="h2" sx={sectionHeadingSx}>
           {t('frontDoor.similar.heading')}
         </Typography>
+        {/* On an unavailable read the list gets NO seed, which is the retry:
+            React Query treats a seeded query as fresh for five minutes, so
+            handing it `[]` would pin "No similar climbs on this layout." on the
+            page for the whole visit. Unseeded, the browser fetches the section
+            itself on hydration — off the server-render budget, and against the
+            reader's own IP rather than the web server's single shared one.
+            `pendingMessage` is what the crawler (and the reader, for that one
+            round trip) reads meanwhile: prose, never a bare spinner. */}
         <SimilarClimbsList
           boardType={boardDetails.board_name as BoardName}
           layoutId={boardDetails.layout_id}
@@ -294,7 +320,8 @@ export default async function ClimbFrontDoor({
           angle={angle}
           threshold={0.5}
           limit={10}
-          initialClimbs={similarClimbs}
+          initialClimbs={similarClimbs.status === 'loaded' ? similarClimbs.items : undefined}
+          pendingMessage={similarClimbs.status === 'unavailable' ? t('frontDoor.similar.unavailable') : undefined}
           emptyMessage={t('similarClimbs.emptyOnLayout')}
         />
       </Box>

--- a/packages/web/app/components/similar-climbs/__tests__/similar-climbs-degraded.test.tsx
+++ b/packages/web/app/components/similar-climbs/__tests__/similar-climbs-degraded.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vite-plus/test';
+import { renderToString } from 'react-dom/server';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { SimilarClimb } from '@boardsesh/shared-schema';
+import type { BoardDetails } from '@/app/lib/types';
+import SimilarClimbsList from '../similar-climbs-list';
+
+/**
+ * The recovery half of #4968.
+ *
+ * When the front door's server-side read times out it hands this list NO seed,
+ * on purpose. React Query stamps a seeded query fresh for the full staleTime,
+ * so seeding it with `[]` would pin "No similar climbs on this layout." to the
+ * page for the reader's whole visit and never fetch. Unseeded, the browser
+ * fetches the section itself the moment it hydrates.
+ *
+ * That leaves one server render with nothing to show, which on an indexed page
+ * may not be a bare spinner — a crawler reads the loading state as the
+ * section's final content. `pendingMessage` is the prose that stands there
+ * instead. `similar-climbs-ssr.test.tsx` covers the seeded (healthy) path.
+ */
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/app/components/i18n/locale-link', () => ({
+  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/app/components/board-renderer/board-image-layers', () => ({ default: () => null }));
+vi.mock('@/app/components/board-renderer/board-canvas-renderer', () => ({ default: () => null }));
+vi.mock('@/app/lib/board-render-worker/worker-manager', () => ({ useCanvasRendererReady: () => false }));
+vi.mock('@/app/hooks/use-is-dark-mode', () => ({ useIsDarkMode: () => false }));
+vi.mock('@/app/hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({ formatGrade: (grade?: string) => grade, getGradeColor: () => undefined }),
+}));
+
+const graphqlRequest = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: graphqlRequest }),
+}));
+
+const PENDING_MESSAGE = 'frontDoor.similar.unavailable';
+
+function makeBoardDetails(): BoardDetails {
+  return {
+    board_name: 'kilter',
+    layout_id: 1,
+    size_id: 10,
+    set_ids: [1, 20],
+    layout_name: 'Kilter Board Original',
+    size_name: '12 x 12',
+    size_description: 'Commercial',
+    set_names: ['Bolt Ons', 'Screw Ons'],
+    images_to_holds: {},
+    holdsData: {},
+    boardHeight: 100,
+    boardWidth: 100,
+  } as unknown as BoardDetails;
+}
+
+function makeSimilarClimb(): SimilarClimb {
+  return {
+    uuid: 'RECOVERED0',
+    name: 'Recovered Boulder',
+    layoutId: 1,
+    angle: 40,
+    frames: 'p1r14',
+    difficultyName: 'V4',
+    setterUsername: 'setter',
+    qualityAverage: 3,
+    ascensionistCount: 7,
+    compatibleSizeIds: [10],
+  } as unknown as SimilarClimb;
+}
+
+function degradedList(queryClient: QueryClient) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <SimilarClimbsList
+        boardType="kilter"
+        layoutId={1}
+        viewerBoardDetails={makeBoardDetails()}
+        climbUuid="ORIGIN-CLIMB"
+        angle={40}
+        emptyMessage="similarClimbs.emptyOnLayout"
+        pendingMessage={PENDING_MESSAGE}
+      />
+    </QueryClientProvider>
+  );
+}
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+describe('SimilarClimbsList with no seed and a pending message', () => {
+  it('server-renders the pending prose rather than a spinner', () => {
+    graphqlRequest.mockImplementation(async () => ({ similarClimbs: [] }));
+    const html = renderToString(degradedList(makeQueryClient()));
+
+    expect(html).toContain(PENDING_MESSAGE);
+    expect(html).not.toContain('MuiCircularProgress');
+    // Non-vacuous: the degraded copy must not be the empty copy. The whole
+    // point is that they are different claims.
+    expect(html).not.toContain('similarClimbs.emptyOnLayout');
+  });
+
+  it('fetches from the browser on hydration and swaps the real climbs in', async () => {
+    graphqlRequest.mockClear();
+    graphqlRequest.mockImplementation(async () => ({ similarClimbs: [makeSimilarClimb()] }));
+    const { render, screen, cleanup } = await import('@testing-library/react');
+
+    render(degradedList(makeQueryClient()));
+    await screen.findByText('Recovered Boulder');
+
+    // One fetch, from the reader's own browser: the section the server could
+    // not resolve recovers without the reader doing anything.
+    expect(graphqlRequest).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(PENDING_MESSAGE)).toBeNull();
+    cleanup();
+  });
+
+  it('keeps the spinner for every caller that passes no pending message', () => {
+    graphqlRequest.mockImplementation(async () => ({ similarClimbs: [] }));
+    const html = renderToString(
+      <QueryClientProvider client={makeQueryClient()}>
+        <SimilarClimbsList
+          boardType="kilter"
+          layoutId={1}
+          viewerBoardDetails={makeBoardDetails()}
+          climbUuid="ORIGIN-CLIMB"
+          angle={40}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(html).toContain('MuiCircularProgress');
+  });
+});

--- a/packages/web/app/components/similar-climbs/similar-climbs-list.tsx
+++ b/packages/web/app/components/similar-climbs/similar-climbs-list.tsx
@@ -54,6 +54,16 @@ type SimilarClimbsListProps = {
    *  not refetch what the server just resolved. The climb front door passes
    *  it; the in-app callers don't and keep the client fetch. */
   initialClimbs?: SimilarClimb[];
+  /**
+   * Prose to render instead of the spinner while the first fetch is in flight.
+   *
+   * Only the climb front door passes it, and only when its server-side read
+   * came back `unavailable` (#4968). That page is indexed, so the section may
+   * not server-render as a bare spinner — a crawler reads the loading state as
+   * the page's final content. Everywhere else the list opens behind an
+   * interaction, where a spinner is the right thing and nobody indexes it.
+   */
+  pendingMessage?: string;
 } & ({ climbUuid: string; frames?: never } | { climbUuid?: never; frames: string });
 
 export default function SimilarClimbsList({
@@ -66,6 +76,7 @@ export default function SimilarClimbsList({
   viewerBoardDetails,
   enabled = true,
   initialClimbs,
+  pendingMessage,
   climbUuid,
   frames,
 }: SimilarClimbsListProps) {
@@ -119,6 +130,13 @@ export default function SimilarClimbsList({
   if (!enabled) return null;
 
   if (isLoading) {
+    if (pendingMessage) {
+      return (
+        <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
+          {pendingMessage}
+        </Typography>
+      );
+    }
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
         <CircularProgress size={24} />

--- a/packages/web/app/lib/data/__tests__/front-door-degraded-read.test.ts
+++ b/packages/web/app/lib/data/__tests__/front-door-degraded-read.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+/**
+ * #4968, at the read layer: a backend that did not answer must not be reported
+ * as a backend that answered with nothing.
+ *
+ * The distinction is invisible in a test that only counts array length, which
+ * is how this shipped: both helpers used to `return []` on any rejection, so an
+ * AbortError from the 3 s deadline and a genuinely unfilmed climb produced the
+ * identical value and the page rendered its "nothing here yet" copy for both.
+ */
+const { queryImpl, captureMessageMock } = vi.hoisted(() => ({
+  queryImpl: { current: async () => ({ similarClimbs: [], betaLinks: [] }) as unknown },
+  captureMessageMock: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/app/lib/graphql/server-cached-client', () => ({
+  createCachedGraphQLQuery: () => async () => queryImpl.current(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({ captureMessage: captureMessageMock }));
+
+import { getFrontDoorBetaLinks, getFrontDoorSimilarClimbs } from '../front-door-data.server';
+
+/** What `AbortController.abort()` produces once graphql-request rethrows it. */
+function abortError(): Error {
+  return Object.assign(new Error('AbortError: This operation was aborted'), { name: 'AbortError' });
+}
+
+describe('front-door reads distinguish "timed out" from "empty"', () => {
+  beforeEach(async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Drive both sections back to "recovered" so the module's once-per-outage
+    // dedupe Set cannot carry state in from another test file in this worker.
+    queryImpl.current = async () => ({ similarClimbs: [], betaLinks: [] });
+    await getFrontDoorSimilarClimbs({ boardType: 'kilter', layoutId: 8, climbUuid: 'warmup', angle: 40 });
+    await getFrontDoorBetaLinks({ boardType: 'kilter', climbUuid: 'warmup' });
+  });
+
+  it('reports similar climbs as unavailable when the deadline fires', async () => {
+    queryImpl.current = async () => {
+      throw abortError();
+    };
+
+    const section = await getFrontDoorSimilarClimbs({
+      boardType: 'kilter',
+      layoutId: 8,
+      climbUuid: 'climb-1',
+      angle: 40,
+    });
+
+    expect(section).toEqual({ status: 'unavailable' });
+  });
+
+  it('reports beta links as unavailable when the deadline fires', async () => {
+    queryImpl.current = async () => {
+      throw abortError();
+    };
+
+    const section = await getFrontDoorBetaLinks({ boardType: 'kilter', climbUuid: 'climb-1' });
+
+    expect(section).toEqual({ status: 'unavailable' });
+  });
+
+  it('reports a genuinely empty answer as loaded, so the page can say so', async () => {
+    queryImpl.current = async () => ({ similarClimbs: [], betaLinks: [] });
+
+    expect(
+      await getFrontDoorSimilarClimbs({ boardType: 'kilter', layoutId: 8, climbUuid: 'climb-1', angle: 40 }),
+    ).toEqual({ status: 'loaded', items: [] });
+    expect(await getFrontDoorBetaLinks({ boardType: 'kilter', climbUuid: 'climb-1' })).toEqual({
+      status: 'loaded',
+      items: [],
+    });
+  });
+
+  it('degrades on the first failure rather than retrying into a wedged backend', async () => {
+    let attempts = 0;
+    queryImpl.current = async () => {
+      attempts += 1;
+      throw abortError();
+    };
+
+    await getFrontDoorSimilarClimbs({ boardType: 'kilter', layoutId: 8, climbUuid: 'climb-1', angle: 40 });
+
+    // A second attempt would spend another 3 s of the reader's page load on
+    // the same pool that just failed to answer in three. The retry belongs in
+    // the browser, not here.
+    expect(attempts).toBe(1);
+  });
+});

--- a/packages/web/app/lib/data/front-door-data.server.ts
+++ b/packages/web/app/lib/data/front-door-data.server.ts
@@ -20,17 +20,54 @@ import type { BoardName } from '@/app/lib/types';
  * crawler walking a few hundred thousand climb pages is precisely the workload
  * that saturates both.
  *
- * Both helpers swallow their errors and return an empty list. A 429 or a
- * backend blip must degrade the section, never 500 an indexed page.
+ * Since #4968 it is no longer the ONLY cache on that path. `unstable_cache` is
+ * per web instance and starts empty on every build, so a second one lives
+ * behind the resolver in Redis
+ * (`packages/backend/src/graphql/resolvers/climbs/similar-climbs-cache.ts`),
+ * shared across instances and surviving a web deploy. This one still earns its
+ * keep: it saves the round trip entirely.
+ *
+ * Both helpers swallow their errors. A 429 or a backend blip must degrade the
+ * section, never 500 an indexed page.
+ *
+ * What they must NOT do is degrade to `[]`. See {@link FrontDoorSection}.
  */
+
+/**
+ * What one supplemental front-door section resolved to.
+ *
+ * `unavailable` is deliberately not "loaded, with nothing in it", and that
+ * distinction is the whole of #4968. Until this type existed both helpers
+ * returned a bare array, so a backend deadline and a climb nobody has filmed
+ * were the same value — and the page rendered the section's empty copy for
+ * both. "No beta filmed yet." and "No similar climbs on this layout." are
+ * factual claims about the climb; a 3 s deadline that fired on a cold cache is
+ * no evidence for either. Sentry counted 6,922 similar-climbs and 748
+ * beta-links renders publishing those claims in 14 days, to readers and to
+ * Google, on a search surface whose whole job is being trustworthy.
+ *
+ * The caller decides what an unavailable section says. It has to say something:
+ * an indexable page may not render a section as a blank div or a bare spinner.
+ */
+export type FrontDoorSection<Item> = { status: 'loaded'; items: Item[] } | { status: 'unavailable' };
 
 const SIMILAR_CLIMBS_REVALIDATE_SECONDS = 3600;
 const BETA_LINKS_REVALIDATE_SECONDS = 3600;
 /**
  * Wall-clock ceiling on each backend round trip. Both callers already degrade to
- * an empty section, so this turns "the page hangs behind a wedged backend" into
- * "the page renders without that section". Shorter than the DB read deadline:
- * these two sections are supplementary, the climb itself is not.
+ * an honest "didn't load" state, so this turns "the page hangs behind a wedged
+ * backend" into "the page renders and says so". Shorter than the DB read
+ * deadline: these two sections are supplementary, the climb itself is not.
+ *
+ * **Deliberately not raised, and deliberately not retried.** Both would trade
+ * the reader's time for a section they can live without, and both push MORE
+ * work at the backend that just failed to answer in three seconds — a second
+ * attempt from the same wedged pool is the load that made the first one slow.
+ * The similar-climbs section retries instead from the reader's own browser
+ * (`SimilarClimbsList` re-runs the query on hydration when the server hands it
+ * no seed), which costs the crawler nothing, spends nobody's server-render
+ * budget, and bills the resolver's 30/min rate limit against the reader's IP
+ * rather than the web server's single shared one.
  */
 const FRONT_DOOR_BACKEND_TIMEOUT_MS = 3000;
 
@@ -53,7 +90,7 @@ function reportFrontDoorOutage(
   reportedFrontDoorFailures.add(section);
 
   const compactError = compactErrorMessage(error);
-  console.error(`Front door: ${section} unavailable, rendering the section empty`, {
+  console.error(`Front door: ${section} unavailable, rendering the section's degraded state`, {
     boardType: params.boardType,
     climbUuid: params.climbUuid,
     error: compactError,
@@ -83,7 +120,7 @@ export async function getFrontDoorSimilarClimbs(params: {
   angle: number;
   threshold?: number;
   limit?: number;
-}): Promise<SimilarClimb[]> {
+}): Promise<FrontDoorSection<SimilarClimb>> {
   const query = createCachedGraphQLQuery<SimilarClimbsResponse, SimilarClimbsQueryVariables>(
     SIMILAR_CLIMBS_QUERY,
     'similar-climbs',
@@ -103,14 +140,17 @@ export async function getFrontDoorSimilarClimbs(params: {
       },
     });
     reportFrontDoorRecovered('similar-climbs');
-    return response.similarClimbs ?? [];
+    return { status: 'loaded', items: response.similarClimbs ?? [] };
   } catch (error) {
     reportFrontDoorOutage('similar-climbs', params, error);
-    return [];
+    return { status: 'unavailable' };
   }
 }
 
-export async function getFrontDoorBetaLinks(params: { boardType: BoardName; climbUuid: string }): Promise<BetaLink[]> {
+export async function getFrontDoorBetaLinks(params: {
+  boardType: BoardName;
+  climbUuid: string;
+}): Promise<FrontDoorSection<BetaLink>> {
   const query = createCachedGraphQLQuery<GetBetaLinksQueryResponse, { boardType: string; climbUuid: string }>(
     GET_BETA_LINKS,
     `beta-links-${params.climbUuid}`,
@@ -121,9 +161,9 @@ export async function getFrontDoorBetaLinks(params: { boardType: BoardName; clim
   try {
     const response = await query({ boardType: params.boardType, climbUuid: params.climbUuid });
     reportFrontDoorRecovered('beta-links');
-    return dedupeBetaLinks(mapBetaLinksResponse(response.betaLinks ?? []));
+    return { status: 'loaded', items: dedupeBetaLinks(mapBetaLinksResponse(response.betaLinks ?? [])) };
   } catch (error) {
     reportFrontDoorOutage('beta-links', params, error);
-    return [];
+    return { status: 'unavailable' };
   }
 }


### PR DESCRIPTION
## Summary

Fixes #4968.

The climb front door's two supplemental sections — **beta videos** and **climbs like this one** — degraded to `[]` when their GraphQL read hit the 3 s deadline. `[]` is also what a climb nobody has filmed looks like, so the page rendered *"No beta filmed yet."* and *"No similar climbs on this layout."* — factual claims about the climb — on the strength of a timeout. Sentry counted **6,922 similar-climbs and 748 beta-links renders** doing that in fourteen days, to 658 and 284 users, on a search surface whose whole job is being trustworthy.

Verified against the code first: `getFrontDoorSimilarClimbs` / `getFrontDoorBetaLinks` both `return []` in their catch, and `climb-front-door.tsx` had exactly two branches per section. The issue is not stale.

### Is this the same thing as #5352 (Postgres `53100`)?

Mostly no, and the issue's own event counts settle it. A `53100` is SQLSTATE class 53, which `isDatabaseUnavailableCode` (`graphql/mask-error.ts:110`) turns into an HTTP 503 carrying *"Something went wrong on our end."* — that is **BOARDSESH-FT + FV, 169 events**. The section this PR is about is **BOARDSESH-F3 + F6, 7,670 events** of `AbortError: This operation was aborted`, which is our own 3 s `AbortController` firing on a query that was still running. **97.8% slow, 2.2% crashed.**

One thing worth handing to #5352, because it is the obvious suspect and the measurement clears it: `findSimilarClimbs` already runs under `withSerialPlan` *because* of that DSM exhaustion (the comment in `climb-similarity.ts` names BOARDSESH-AK and `53100`), so the natural theory is that turning parallelism off is what pushed latency past 3 s. On this dataset it is not. Warm, the same statement runs **1 542 ms serial vs 1 566 ms with `max_parallel_workers_per_gather = 4`**, and the planner picks no `Gather` node for this shape at all. `withSerialPlan` is not costing this query anything measurable.

**No resolver internals touched here.** `climb-similarity.ts` — the CTE, the plan, the indexes — is unchanged; #5352 owns it. This PR adds a cache *in front of* `findSimilarClimbs` and swaps two lines at the call site, so a rewritten query drops straight in behind it.

### What changed

`FrontDoorSection<Item>` is now `{ status: 'loaded'; items }` or `{ status: 'unavailable' }`, so the page can tell the two apart, and both sections render three states instead of two.

**Similar climbs also recover on their own.** The list was seeded from the server with `initialData` + `initialDataUpdatedAt: Date.now()`, so a `[]` seed was marked *fresh for five minutes* — the browser never refetched, and the false empty state stuck for the reader's whole visit. On an unavailable read the server now passes **no seed**, and the browser fetches the section itself on hydration. The one server render that has nothing to show renders prose (`pendingMessage`), never a bare spinner: this page is indexed and a crawler reads a loading state as the section's final content.

### Design decisions

**1. What renders on a cold-cache timeout.** An honest line in the section's own voice, following `docs/offline-reads.md`'s "No signal / Can't reach Boardsesh right now" split — the degraded copy names the failure and what happens next, and never borrows the empty copy. Beta has no client-side query to recover it, so it asks for a reload; similar climbs say a retry is already running, because one is. Both are new i18n keys in all four locales, not hardcoded strings.

**2. Whether to cache the expensive query, and where.** It was already cached — in the web app's `unstable_cache`, which is **instance-local storage a new build starts empty**. The 6,922 events span **41 web releases**: a cache thrown away 41 times in fourteen days is cold most of the time it matters. So the cache moves *behind the resolver*, into Redis, with `singleFlight` on the miss (`similar-climbs-cache.ts`). One entry now answers both web page trees for a climb across all four locales, the browser-side retry this PR adds, and the mobile app and play drawer — which hit the resolver directly and were never covered by anything. It survives a web deploy and is shared across web instances.

`singleFlight` is a separate property from the cache and is the one that matters for the pool: per `docs/db-connectivity.md`, *"the Redis hit rate is not the safety property; the concurrency of the miss is."* Deliberately **no** process-local fallback map (unlike `getCachedRecentBetaLinks`): that read has a handful of scopes, this one is keyed per climb across ~900k, so a local map would be an unbounded cache in a long-lived process. With no Redis, single-flight alone still collapses the burst.

**3. Retry once, or degrade immediately.** Degrade immediately. A second attempt spends another 3 s of the reader's page load pushing more work at the pool that just failed to answer in three — it is the load that made the first attempt slow. The retry moves to the browser instead: it costs a crawler nothing, spends no server-render budget, and bills the resolver's 30/min rate limit against the reader's own IP rather than the web server's single shared one. Pinned by a test that counts attempts.

**4. The timeout stays at 3000 ms, and here is what the query costs.** Measured on the dev catalogue (893,156 climbs; 5,482,192 Kilter `board_climb_holds` rows), Kilter layout 8, serial plan:

| target climb | first run on a fresh Postgres | warm repeat |
| --- | --- | --- |
| **18 holds — typical** | **4 831 ms** | **205 ms** |
| 198 holds — long tail | 7 860 ms | 1 542 ms |

**That is the bug, in two numbers.** A *typical* climb's similar-climbs query blows the 3 s deadline by 1.6× on a cold buffer cache and finishes in a fifteenth of it once warm — a 23× spread. "Cold cache" in the issue title is not a figure of speech; it is the mechanism, and it is why the failures track deploys and cache expiry rather than any particular climb. Raising the ceiling to cover 4.8 s would make every reader wait 4.8 s for a supplementary section.

What the work actually is, from the 198-hold plan: 198 index searches on `board_climb_holds_search_idx` emit **282,152 rows**, the hash join to `board_climbs` (28,385 layout-8 rows) leaves **225,300**, and those get **sorted** — 1 575→1 699 ms of the warm total — so `GroupAggregate` can run `COUNT(DISTINCT hold_id)` over 28,110 candidate groups. The `HAVING` prune then keeps **one**. A quarter of a million rows sorted to return one row, and on a cold cache every one of those pages is a read.

**No b-tree index removes that**, which is why this PR does not add one. Layout does not prune the hold rows (Kilter hold ids are already layout-scoped — the five holds I sampled had 100% of their rows in layout 8), and the cost is a set intersection, which a b-tree cannot answer. The real answers are a set-overlap structure — a GIN-indexed hold-id array per climb — or a materialised neighbour table, either of which is a migration plus a backfill plus a rewrite of the CTE. **That is #5352's call, not this PR's.** Caching buys warmth; it does not buy speed.

### Trade-off worth knowing

During a brownout every *reader's* browser now fires the similar-climbs query once, where before it fired none. It is one request per reader per climb, rate-limited per IP, and served from the new Redis entry after the first. Crawlers do not run it at all.

## Release Notes

- Climb pages now say when beta or similar climbs didn't load, instead of pretending there are none — and similar climbs load themselves in a moment later.

## Test plan

1. Open any climb page on boardsesh.com in your browser.
2. Scroll to "Beta videos" — videos, or "No beta filmed yet."
3. Scroll to "Climbs like this one" — a row of climbs appears.
4. Tap one of those climbs — its own page opens.
5. Switch the site to Spanish, French or German — sections still read right.

## Risk

Risk: 3/5 — touches an indexed page's server render and adds a Redis cache in front of a hot backend resolver. Bounded: the cache key covers every input that changes the answer, both Redis paths fall through to today's behaviour on any failure, and no schema or write path is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
