### PR TITLE
fix(backend): guard busboy's per-file stream, restore the R2 Sentry signal, answer sized reads

### DIFF
--- a/packages/backend/src/__tests__/helpers/uncaught-exceptions.ts
+++ b/packages/backend/src/__tests__/helpers/uncaught-exceptions.ts
@@ -1,0 +1,31 @@
+import { setTimeout as delay } from 'node:timers/promises';
+
+/**
+ * Run `body` with `process.on('uncaughtException')` swapped for a recorder, so a
+ * stream error thrown out of a `nextTick` is captured instead of taking down the
+ * worker. Node's own listeners are restored with `rawListeners`, which preserves
+ * `once` wrappers.
+ *
+ * This is the oracle for #5307 and #5359: production has no
+ * `uncaughtException` handler at all, so anything this records would have exited
+ * the replica and dropped every graphql-ws session on it.
+ */
+export async function recordUncaughtExceptions(body: () => Promise<void>): Promise<Error[]> {
+  const recorded: Error[] = [];
+  const original = process.rawListeners('uncaughtException') as NodeJS.UncaughtExceptionListener[];
+  process.removeAllListeners('uncaughtException');
+  process.on('uncaughtException', (error) => {
+    recorded.push(error);
+  });
+
+  try {
+    await body();
+    // Let a queued `emitErrorNT` land before we hand the process back.
+    await delay(100);
+  } finally {
+    process.removeAllListeners('uncaughtException');
+    for (const listener of original) process.on('uncaughtException', listener);
+  }
+
+  return recorded;
+}

--- a/packages/backend/src/__tests__/media-stream-pipe.test.ts
+++ b/packages/backend/src/__tests__/media-stream-pipe.test.ts
@@ -4,6 +4,7 @@ import type { AddressInfo } from 'node:net';
 import { once } from 'node:events';
 import { Readable } from 'node:stream';
 import { setTimeout as delay } from 'node:timers/promises';
+import { recordUncaughtExceptions } from './helpers/uncaught-exceptions';
 
 const isS3ConfiguredMock = vi.hoisted(() => vi.fn(() => true));
 const getFromS3Mock = vi.hoisted(() => vi.fn());
@@ -25,12 +26,14 @@ vi.mock('../services/user-data-export', () => ({
   requestUserDataExport: vi.fn(),
 }));
 
-const { handleStaticBetaThumbnail } = await import('../handlers/static');
+const { handleStaticAvatar, handleStaticBetaThumbnail } = await import('../handlers/static');
 const { handleUserDataExportDownload } = await import('../handlers/user-data-export');
 const { logger } = await import('../utils/logger');
 
 const THUMBNAIL_PATH = '/static/beta-link-thumbnails/instagram/ABC123.jpg';
 const EXPORT_PATH = '/api/user-data-export/download?boardType=kilter';
+const AVATAR_FILE = '11111111-1111-4111-8111-111111111111.jpg';
+const SIZED_AVATAR_PATH = `/static/avatars/${AVATAR_FILE}?size=128`;
 
 // Declared Content-Length far larger than the bytes we actually push, so a
 // truncated response is unambiguous to the client's HTTP parser.
@@ -106,39 +109,19 @@ function closeServer(server: Server): Promise<void> {
  */
 const CLIENT_DEADLINE_MS = 2000;
 
-/**
- * Run `body` with `process.on('uncaughtException')` swapped for a recorder, so a
- * stream error thrown out of a `nextTick` is captured instead of taking down the
- * worker. Node's own listeners are restored with `rawListeners`, which preserves
- * `once` wrappers.
- */
-async function recordUncaughtExceptions(body: () => Promise<void>): Promise<Error[]> {
-  const recorded: Error[] = [];
-  const original = process.rawListeners('uncaughtException') as NodeJS.UncaughtExceptionListener[];
-  process.removeAllListeners('uncaughtException');
-  process.on('uncaughtException', (error) => {
-    recorded.push(error);
-  });
-
-  try {
-    await body();
-    // Let a queued `emitErrorNT` land before we hand the process back.
-    await delay(100);
-  } finally {
-    process.removeAllListeners('uncaughtException');
-    for (const listener of original) process.on('uncaughtException', listener);
-  }
-
-  return recorded;
-}
-
 let infoSpy: ReturnType<typeof vi.spyOn>;
 let warnSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   isS3ConfiguredMock.mockReturnValue(true);
+  // Three separate spies on purpose. `SentryWinstonTransport` is constructed at
+  // `level: 'error'`, so the level IS the alerting behaviour — merging these and
+  // asserting only that *something* logged is what let #5343's regression
+  // through (#5359).
   infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
   warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+  errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
 });
 
 afterEach(() => {
@@ -178,7 +161,7 @@ describe('media streaming: an S3 body that fails mid-response', () => {
     expect(serverResponse?.writableEnded).toBe(false);
   });
 
-  it('logs the failed read with its route and object key', async () => {
+  it('logs the failed read at error, with its route, object key and the error', async () => {
     getFromS3Mock.mockResolvedValue(s3Object(abortingSource()));
 
     const { baseUrl, server } = await startServer((req, res) =>
@@ -196,17 +179,55 @@ describe('media streaming: an S3 body that fails mid-response', () => {
       await closeServer(server);
     }
 
-    // `aborted` is whitelisted in isClientAbortError, so this classifies as an
-    // abort and logs at info — the point is that it is logged, with the key,
-    // instead of killing the replica.
-    const logged = [...infoSpy.mock.calls, ...warnSpy.mock.calls];
-    expect(logged.length).toBeGreaterThan(0);
-    const streamLog = logged.find((call) => String(call[0]).startsWith('Stream to client'));
-    expect(streamLog).toBeDefined();
-    expect(streamLog?.[1]).toMatchObject({
-      route: THUMBNAIL_PATH,
-      source: 'beta-link-thumbnails/instagram/ABC123.jpg',
-    });
+    // `error`, not `warn` or `info`: SentryWinstonTransport only takes `error`,
+    // so anything quieter means the next R2 degradation is invisible — which is
+    // exactly what #5343 shipped. The error object rides along for the stack.
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Upstream read failed',
+      expect.objectContaining({
+        route: THUMBNAIL_PATH,
+        source: 'beta-link-thumbnails/instagram/ABC123.jpg',
+      }),
+      expect.any(Error),
+    );
+    // And it is not ALSO filed as a routine client abort.
+    expect(infoSpy).not.toHaveBeenCalledWith('Stream to client aborted', expect.anything());
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('answers a sized request whose buffered read dies, instead of hanging', async () => {
+    // `?size=` on a mutable key (`cacheVariant: false`) buffers the original
+    // rather than piping it — the one S3 body not routed through
+    // `pipeStreamToResponse`. Unguarded, the rejection unwound past the router,
+    // which read `aborted` as a client abort and returned without writing, so
+    // the connection sat open until the client gave up (#5359).
+    getFromS3Mock.mockResolvedValue(s3Object(abortingSource()));
+
+    const { baseUrl, server } = await startServer((req, res) => handleStaticAvatar(req, res, AVATAR_FILE, 128));
+
+    try {
+      const recorded = await recordUncaughtExceptions(async () => {
+        // The deadline is the assertion: a regression fails here in 2s rather
+        // than hanging the suite.
+        const response = await fetch(`${baseUrl}${SIZED_AVATAR_PATH}`, {
+          signal: AbortSignal.timeout(CLIENT_DEADLINE_MS),
+        });
+        expect(response.status).toBe(502);
+        await expect(response.json()).resolves.toEqual({ error: 'Upstream read failed' });
+      });
+
+      expect(recorded.map((error) => error.message)).toEqual([]);
+    } finally {
+      await closeServer(server);
+    }
+
+    // Headers were still unsent here, so the 502 branch is reachable — and the
+    // failure still has to reach Sentry.
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Upstream read failed',
+      expect.objectContaining({ source: `avatars/${AVATAR_FILE}`, headersSent: false }),
+      expect.any(Error),
+    );
   });
 
   it('guards the user-data-export download too', async () => {
@@ -270,10 +291,13 @@ describe('media streaming: a client that walks away mid-download', () => {
     // Without pipeline this upstream socket would keep draining into a dead
     // response; with it, the client's disconnect tears the S3 read down.
     expect(source.destroyed).toBe(true);
-    expect(warnSpy).not.toHaveBeenCalled();
+    // The other half of the classification: a tab close must NOT page. If this
+    // ever logs at `error`, every closed tab becomes a Sentry event.
     expect(infoSpy).toHaveBeenCalledWith(
       'Stream to client aborted',
       expect.objectContaining({ route: THUMBNAIL_PATH }),
     );
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/__tests__/upload-file-stream-guard.test.ts
+++ b/packages/backend/src/__tests__/upload-file-stream-guard.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { once } from 'node:events';
+import { recordUncaughtExceptions } from './helpers/uncaught-exceptions';
+
+const validateTokenMock = vi.hoisted(() => vi.fn());
+const isS3ConfiguredMock = vi.hoisted(() => vi.fn(() => true));
+const uploadToS3Mock = vi.hoisted(() => vi.fn());
+
+vi.mock('../middleware/auth', () => ({
+  validateToken: validateTokenMock,
+}));
+
+vi.mock('../storage/s3', async () => {
+  const actual = await vi.importActual<typeof import('../storage/s3')>('../storage/s3');
+  return { ...actual, isS3Configured: isS3ConfiguredMock, uploadToS3: uploadToS3Mock };
+});
+
+const { handleAvatarUpload } = await import('../handlers/avatars');
+const { handleFeedbackScreenshotUpload } = await import('../handlers/feedback-screenshots');
+const { logger } = await import('../utils/logger');
+
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const BOUNDARY = 'boardsesh5359boundary';
+
+/**
+ * A complete, ordinary multipart POST that busboy cannot finish parsing: a
+ * well-formed prologue and file part with **no closing boundary**. `fetch`
+ * derives an accurate `Content-Length` from the body, so this is not an abort,
+ * a truncated socket, or a network fault — the server reads every byte the
+ * client promised and busboy still ends mid-part.
+ *
+ * busboy answers that with `Unexpected end of form` on the parser *and*
+ * `fileStream.destroy(...)` on the per-file stream. The parser error has a
+ * listener; before #5359 the file stream did not, so Node rethrew it from a
+ * `nextTick` and — with no `process.on('uncaughtException')` in the backend —
+ * the replica exited, taking every graphql-ws session with it.
+ */
+function unterminatedMultipartBody(fileField: string): string {
+  return [
+    `--${BOUNDARY}`,
+    'Content-Disposition: form-data; name="userId"',
+    '',
+    USER_ID,
+    `--${BOUNDARY}`,
+    `Content-Disposition: form-data; name="${fileField}"; filename="avatar.png"`,
+    'Content-Type: image/png',
+    '',
+    'PNGBYTESPNGBYTESPNGBYTES',
+  ].join('\r\n');
+}
+
+async function startServer(handle: (req: IncomingMessage, res: ServerResponse) => Promise<void>) {
+  const server = createServer((req, res) => {
+    void handle(req, res);
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const { port } = server.address() as AddressInfo;
+  return { baseUrl: `http://127.0.0.1:${port}`, server };
+}
+
+function closeServer(server: Server): Promise<void> {
+  server.closeAllConnections();
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+/** Bounded so a handler that never answers fails fast instead of hanging. */
+const CLIENT_DEADLINE_MS = 3000;
+
+beforeEach(() => {
+  validateTokenMock.mockResolvedValue({ userId: USER_ID });
+  isS3ConfiguredMock.mockReturnValue(true);
+  vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+  vi.spyOn(logger, 'error').mockImplementation(() => logger);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe('multipart upload: a part busboy cannot finish parsing', () => {
+  it('answers the avatar upload with 400 and never reaches uncaughtException', async () => {
+    const { baseUrl, server } = await startServer((req, res) => handleAvatarUpload(req, res));
+
+    let status: number | undefined;
+    try {
+      const recorded = await recordUncaughtExceptions(async () => {
+        const response = await fetch(`${baseUrl}/api/avatars`, {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer upload-token',
+            'Content-Type': `multipart/form-data; boundary=${BOUNDARY}`,
+          },
+          body: unterminatedMultipartBody('avatar'),
+          signal: AbortSignal.timeout(CLIENT_DEADLINE_MS),
+        });
+        status = response.status;
+        await response.text();
+      });
+
+      // The oracle. Production installs no uncaughtException handler, so a
+      // single entry here is a replica exit in prod.
+      expect(recorded.map((error) => error.message)).toEqual([]);
+    } finally {
+      await closeServer(server);
+    }
+
+    // The rejected upload still answers, rather than holding the connection.
+    expect(status).toBe(400);
+  });
+
+  it('logs the failed part with its route and field instead of throwing it', async () => {
+    const { baseUrl, server } = await startServer((req, res) => handleAvatarUpload(req, res));
+
+    try {
+      await recordUncaughtExceptions(async () => {
+        const response = await fetch(`${baseUrl}/api/avatars`, {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer upload-token',
+            'Content-Type': `multipart/form-data; boundary=${BOUNDARY}`,
+          },
+          body: unterminatedMultipartBody('avatar'),
+          signal: AbortSignal.timeout(CLIENT_DEADLINE_MS),
+        });
+        await response.text();
+      });
+    } finally {
+      await closeServer(server);
+    }
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Upload file stream failed',
+      expect.objectContaining({ route: '/api/avatars', field: 'avatar' }),
+      expect.any(Error),
+    );
+  });
+
+  it('answers the feedback-screenshot upload with 400 and never reaches uncaughtException', async () => {
+    const { baseUrl, server } = await startServer((req, res) => handleFeedbackScreenshotUpload(req, res));
+
+    let status: number | undefined;
+    try {
+      const recorded = await recordUncaughtExceptions(async () => {
+        const response = await fetch(`${baseUrl}/api/feedback-screenshots`, {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer upload-token',
+            'Content-Type': `multipart/form-data; boundary=${BOUNDARY}`,
+          },
+          body: unterminatedMultipartBody('screenshot'),
+          signal: AbortSignal.timeout(CLIENT_DEADLINE_MS),
+        });
+        status = response.status;
+        await response.text();
+      });
+
+      expect(recorded.map((error) => error.message)).toEqual([]);
+    } finally {
+      await closeServer(server);
+    }
+
+    expect(status).toBe(400);
+  });
+});

--- a/packages/backend/src/handlers/avatars.ts
+++ b/packages/backend/src/handlers/avatars.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { randomUUID } from 'crypto';
 import { mkdir, writeFile, unlink } from 'fs/promises';
 import { applyCorsHeaders } from './cors';
+import { guardUploadFileStream } from './http-utils';
 import { validateToken } from '../middleware/auth';
 import { isS3Configured, uploadToS3, deleteUserAvatarsFromS3 } from '../storage/s3';
 import { logger } from '../utils/logger';
@@ -187,6 +188,10 @@ export async function handleAvatarUpload(req: IncomingMessage, res: ServerRespon
     });
 
     busboy.on('file', (name: string, stream: NodeJS.ReadableStream, info: { mimeType: string }) => {
+      // Before every early return: busboy destroys this stream with an error on
+      // any truncated part, and an unlistened one exits the process (#5359).
+      guardUploadFileStream(stream, { route: req.url ?? '/api/avatars', field: name });
+
       if (name !== 'avatar') {
         stream.resume();
         return;

--- a/packages/backend/src/handlers/feedback-screenshots.ts
+++ b/packages/backend/src/handlers/feedback-screenshots.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto';
 import { mkdir, writeFile } from 'fs/promises';
 import { FEEDBACK_SCREENSHOT_MAX_UPLOAD_BYTES, FEEDBACK_SCREENSHOT_PREFIX } from '@boardsesh/shared-schema';
 import { applyCorsHeaders } from './cors';
+import { guardUploadFileStream } from './http-utils';
 import { validateToken } from '../middleware/auth';
 import { isS3Configured, uploadToS3 } from '../storage/s3';
 import {
@@ -178,6 +179,10 @@ export async function handleFeedbackScreenshotUpload(req: IncomingMessage, res: 
     let invalidMimeType = false;
 
     busboy.on('file', (name: string, stream: NodeJS.ReadableStream, info: { mimeType: string }) => {
+      // Before every early return: busboy destroys this stream with an error on
+      // any truncated part, and an unlistened one exits the process (#5359).
+      guardUploadFileStream(stream, { route: req.url ?? '/api/feedback-screenshots', field: name });
+
       if (name !== 'screenshot') {
         stream.resume();
         return;

--- a/packages/backend/src/handlers/gym-image-upload.ts
+++ b/packages/backend/src/handlers/gym-image-upload.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto';
 import { mkdir, writeFile, unlink } from 'fs/promises';
 import { eq, and, isNull } from 'drizzle-orm';
 import { applyCorsHeaders } from './cors';
+import { guardUploadFileStream } from './http-utils';
 import { validateToken } from '../middleware/auth';
 import { isS3Configured, uploadToS3 } from '../storage/s3';
 import { MUTABLE_IMAGE_CACHE_CONTROL, writeImageVariants } from '../lib/image-resize';
@@ -267,6 +268,11 @@ export function createGymImageUploadHandler(
       });
 
       busboy.on('file', (name: string, stream: NodeJS.ReadableStream, info: { mimeType: string }) => {
+        // Before every early return: busboy destroys this stream with an error
+        // on any truncated part, and an unlistened one exits the process
+        // (#5359).
+        guardUploadFileStream(stream, { route: req.url ?? `/api/${config.storagePrefix}`, field: name });
+
         if (name !== config.fileFieldName) {
           stream.resume();
           return;

--- a/packages/backend/src/handlers/http-utils.ts
+++ b/packages/backend/src/handlers/http-utils.ts
@@ -1,7 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import type { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
-import { isClientAbortError } from '../utils/http-errors';
 import { logger } from '../utils/logger';
 
 /**
@@ -49,6 +48,46 @@ export function sendJson(
   res.end(JSON.stringify(body));
 }
 
+/** Which upload part a per-file stream belongs to, so a failure is triageable. */
+export type UploadStreamContext = {
+  /** Request path handling the upload, e.g. `/api/avatars`. */
+  route: string;
+  /** Multipart field name busboy reported for the part. */
+  field: string;
+};
+
+/**
+ * Guard the per-file stream busboy hands to `busboy.on('file')`.
+ *
+ * `req.pipe(busboy)` involves three streams and only two of them are safe. `req`
+ * is an `IncomingMessage`, whose `_destroy` suppresses an error with no
+ * listeners; the busboy parser has an explicit `'error'` listener in every
+ * upload handler. The per-file `FileStream` has neither — it `extends Readable`
+ * with no suppression (busboy 1.6.0 `lib/types/multipart.js:174`) and the
+ * handlers only ever attach `data`/`end`/`limit`. busboy destroys it *with an
+ * error* whenever the parse ends mid-part: `checkEndState` (:603-613) and
+ * `_destroy` (:572-583) both call `fileStream.destroy(new Error(...))`.
+ *
+ * A complete, ordinary `POST` — well-formed prologue, correct `Content-Length`,
+ * no closing boundary — is enough to reach that. With no `'error'` listener Node
+ * rethrows from a `nextTick`, and the backend installs no
+ * `process.on('uncaughtException')`, so the process exits and drops every
+ * graphql-ws session on the replica: the blast radius of #5307, reachable by any
+ * logged-in user (#5359).
+ *
+ * Log-only on purpose. busboy emits its own `'error'` for the same failure and
+ * each handler's `busboy.on('error')` already answers the client with a 400;
+ * writing a second response from here would make that `writeHead` throw
+ * ERR_HTTP_HEADERS_SENT from inside an event listener — one crash traded for
+ * another. `warn`, not `error`: a truncated body is the client's doing, so it
+ * belongs in the log rather than in Sentry.
+ */
+export function guardUploadFileStream(stream: NodeJS.ReadableStream, context: UploadStreamContext): void {
+  stream.on('error', (error: Error) => {
+    logger.warn('Upload file stream failed', { route: context.route, field: context.field }, error);
+  });
+}
+
 /** Where the bytes came from, so a failure is triageable from one log line. */
 export type StreamPipeContext = {
   /** Request path being served, e.g. `/static/beta-link-thumbnails/instagram/abc.jpg`. */
@@ -58,15 +97,46 @@ export type StreamPipeContext = {
 };
 
 /**
+ * Report a body we could not read from upstream (S3/R2, or a local file) and
+ * close the request out.
+ *
+ * Logged at `error` on purpose. `SentryWinstonTransport` is constructed with
+ * `level: 'error'` (`utils/sentry-transport.ts`), so `warn` and `info` stay in
+ * the Railway log and never reach Sentry — an upstream media failure that only
+ * warns is a degradation nobody is paged for (#5359).
+ *
+ * Before the headers there is still a status to send, so the client gets a 502
+ * (the `?size=` buffered read reaches this branch). Past them there is not:
+ * `writeHead` would throw ERR_HTTP_HEADERS_SENT — a second failure — and
+ * `res.end()` would hand back a short body as if it were complete. Destroying
+ * truncates the response below its Content-Length, so the client's parser
+ * errors and no cache stores a partial object.
+ */
+export function failUpstreamRead(res: ServerResponse, context: StreamPipeContext, error: unknown): void {
+  logger.error(
+    'Upstream read failed',
+    { route: context.route, source: context.source, headersSent: res.headersSent },
+    error,
+  );
+
+  if (!res.headersSent) {
+    sendJson(res, 502, { error: 'Upstream read failed' });
+    return;
+  }
+  res.destroy();
+}
+
+/**
  * Stream a body (an S3 object, a local file) to the response with both ends
  * guarded.
  *
  * `readable.pipe(res)` attaches an `'error'` listener to the *destination
  * only*, so a source that fails mid-body emits an unhandled `'error'` — which
- * Node throws from a `nextTick`, landing on `process.on('uncaughtException')`
- * and killing the process along with every graphql-ws session on the replica
- * (issue #5307). The request handler's `try/catch` can't help: its `await`
- * resolved when the *headers* arrived, long before the body died.
+ * Node rethrows from a `nextTick`. The backend installs no
+ * `process.on('uncaughtException')`, so that exits the process along with every
+ * graphql-ws session on the replica (issue #5307). The request handler's
+ * `try/catch` can't help: its `await` resolved when the *headers* arrived, long
+ * before the body died.
  *
  * `pipeline` listens on both streams and destroys both on failure, which also
  * closes the reverse leak — a client that disconnects mid-download no longer
@@ -80,31 +150,35 @@ export async function pipeStreamToResponse(
   res: ServerResponse,
   context: StreamPipeContext,
 ): Promise<void> {
+  // Which side died has to be observed while it happens. `pipeline` destroys
+  // *both* streams with the same error, so afterwards `source.errored` is set
+  // either way, and the error itself is no help: `isClientAbortError` whitelists
+  // the bare message `aborted` plus ECONNRESET and ERR_STREAM_PREMATURE_CLOSE,
+  // which is the whole realistic vocabulary of a failed backend→R2 read. Using
+  // it here filed every upstream failure as a routine client abort (#5359).
+  //
+  // The source failing while the response is still writable is the upstream
+  // case; the response being gone already means the client left and `pipeline`
+  // is only tearing the read down behind them.
+  let upstreamFailed = false;
+  source.on('error', () => {
+    if (!res.destroyed && !res.writableEnded) upstreamFailed = true;
+  });
+
   try {
     await pipeline(source, res);
   } catch (error) {
-    const clientAborted = isClientAbortError(error, {
-      responseDestroyed: res.destroyed,
-      socketDestroyed: res.socket?.destroyed,
+    if (upstreamFailed) {
+      failUpstreamRead(res, context, error);
+      return;
+    }
+
+    // A client walking away is routine and stays out of Sentry.
+    logger.info('Stream to client aborted', {
+      route: context.route,
+      source: context.source,
+      headersSent: res.headersSent,
     });
-
-    // A client walking away is routine; anything else is an upstream read we
-    // could not finish, and someone got a truncated file.
-    const details = { route: context.route, source: context.source, headersSent: res.headersSent };
-    if (clientAborted) {
-      logger.info('Stream to client aborted', details);
-    } else {
-      logger.warn('Stream to client failed', details, error);
-    }
-
-    // Past the headers there is no status left to send: `writeHead` would throw
-    // ERR_HTTP_HEADERS_SENT (a second crash) and `res.end()` would hand back a
-    // short body as if it were complete. Destroying truncates the response below
-    // its Content-Length, so the client's parser errors and no cache stores it.
-    if (!res.headersSent) {
-      sendJson(res, 502, { error: 'Upstream read failed' });
-    } else {
-      res.destroy();
-    }
+    res.destroy();
   }
 }

--- a/packages/backend/src/handlers/ocr-test-data.ts
+++ b/packages/backend/src/handlers/ocr-test-data.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import Busboy from 'busboy';
 import { v4 as uuidv4 } from 'uuid';
 import { applyCorsHeaders } from './cors';
+import { guardUploadFileStream } from './http-utils';
 import { validateToken } from '../middleware/auth';
 import { isS3Configured, uploadToS3 } from '../storage/s3';
 import { logger } from '../utils/logger';
@@ -133,6 +134,10 @@ export async function handleOcrTestDataUpload(req: IncomingMessage, res: ServerR
     });
 
     busboy.on('file', (name: string, stream: NodeJS.ReadableStream, info: { filename: string; mimeType: string }) => {
+      // Before every early return: busboy destroys this stream with an error on
+      // any truncated part, and an unlistened one exits the process (#5359).
+      guardUploadFileStream(stream, { route: req.url ?? '/api/ocr-test-data', field: name });
+
       if (name !== 'image') {
         stream.resume();
         return;

--- a/packages/backend/src/handlers/static.ts
+++ b/packages/backend/src/handlers/static.ts
@@ -3,7 +3,7 @@ import { createReadStream } from 'fs';
 import { stat } from 'fs/promises';
 import path, { extname } from 'path';
 import { applyCorsHeaders } from './cors';
-import { pipeStreamToResponse } from './http-utils';
+import { failUpstreamRead, pipeStreamToResponse } from './http-utils';
 import { getAvatarsDir } from './avatars';
 import { getGymLogosDir } from './gym-logos';
 import { getGymPhotosDir } from './gym-photos';
@@ -54,7 +54,21 @@ async function serveResizedImageFromS3(
   const original = await getFromS3('media', baseKey);
   if (!original) return false;
 
-  const originalBuffer = await streamToBuffer(original.stream);
+  // The one S3 body not routed through `pipeStreamToResponse`, and `for await`
+  // rethrows. Unguarded, an R2 body that died here unwound past the router,
+  // where `isClientAbortError` read `aborted` as a client walking away and
+  // returned having written nothing — headers unsent, response unended, the
+  // connection held open until the client timed out (#5359). Every sized avatar
+  // / gym-logo / gym-photo request reaches this line (`cacheVariant: false`),
+  // so answer it.
+  let originalBuffer: Buffer;
+  try {
+    originalBuffer = await streamToBuffer(original.stream);
+  } catch (error) {
+    failUpstreamRead(res, { route: options.route, source: baseKey }, error);
+    return true;
+  }
+
   let body = originalBuffer;
   let contentType = original.contentType || 'application/octet-stream';
   try {


### PR DESCRIPTION
## Summary

Fixes #5359. Finishes the hardening PR #5343 claimed for #5307. All three
findings come from an adversarial review of that merge, each with a repro.

**F1 (P1) — busboy's per-file stream is still unguarded.** `req.pipe(busboy)`
involves three streams and #5343's reasoning covered two. `req` is an
`IncomingMessage`, whose `_destroy` suppresses an error with no listeners, and
the parser has an explicit `'error'` listener in all four upload handlers. The
per-file `FileStream` from `busboy.on('file')` has neither: it `extends
Readable` with no suppression (busboy 1.6.0 `lib/types/multipart.js:174`), and
the handlers only ever attach `data`/`end`/`limit`. busboy destroys it *with an
error* whenever the parse ends mid-part — `checkEndState` (:603-613) and
`_destroy` (:572-583) both call `fileStream.destroy(new Error(...))`.

An authenticated `POST /api/avatars` with a well-formed prologue, a file part,
no closing boundary and a correct `Content-Length` is enough. That is an
ordinary complete request — no abort, no network fault — and the unlistened
error exits the process, dropping every graphql-ws session on the replica. Same
blast radius as #5307, reachable by any logged-in user. `guardUploadFileStream`
attaches the missing listener ahead of every early return in `avatars`,
`feedback-screenshots`, `ocr-test-data` and `gym-image-upload`. It logs and
nothing else: busboy's own `'error'` already answers the client with a 400, and
a second `writeHead` from inside an event listener would throw
`ERR_HTTP_HEADERS_SENT` — one crash traded for another.

**F2 — R2 failures lost their Sentry signal. This is a regression #5343
introduced.** That PR classified pipe failures with `isClientAbortError`, which
whitelists the bare message `aborted` alongside `ECONNRESET` and
`ERR_STREAM_PREMATURE_CLOSE` — the entire realistic vocabulary of a failed
backend→R2 read. So every upstream failure took the `info` branch, which also
drops the error object, and `SentryWinstonTransport` is constructed at
`level: 'error'` (`utils/sentry-transport.ts`, stated at `server.ts:114-117`).
The R2 degradation that produced 8 fatal Sentry events in three weeks now
produced none: the next one would have been silent.

`pipeStreamToResponse` no longer asks the error who died. `pipeline` destroys
*both* streams with the same error, so after the fact `source.errored` is set
either way — I probed all four cases (upstream `aborted`, upstream
`ECONNRESET`, graceful client abort, client RST) to confirm. It now observes the
source failing *while the response is still writable*, which is true only of an
upstream failure, and logs that at `error` with the error object attached. A
genuine client disconnect still logs at `info` and stays out of Sentry.

**F3 — the `?size=` path hung.** `streamToBuffer` in `serveResizedImageFromS3`
sat outside the try and was the one S3 body consumer not routed through
`pipeStreamToResponse`. `for await` rethrows, the rejection reached
`server.ts:692-707`, `isClientAbortError` called it a client abort, and the
handler returned having written nothing — `headersSent` false, `writableEnded`
false, connection held until the client timed out. Every sized avatar,
gym-logo and gym-photo request reaches that line (`cacheVariant: false`), plus
beta thumbnails on a variant cache miss. It now answers 502.

**Also.** The `if (!res.headersSent) sendJson(res, 502, …)` fallback was
unreachable — all seven call sites `writeHead` first. Rather than delete a
fallback or leave one that advertises behaviour it can't deliver, it moved into
`failUpstreamRead`, shared with F3's pre-header path. Both branches are now live
and each has a test.

**Correcting the record.** #5343's body says the unhandled stream error "landed
on `process.on('uncaughtException')`". No such handler exists anywhere in the
backend — `grep -rn uncaughtException packages/backend/src` matches only that
PR's own comment. That absence is precisely why these errors exit the process
rather than being logged. The comment is fixed.

**Verification.** Three guards, each mutation-tested with the fix reverted and
the red output pasted into the PR thread:

- F1 — the no-closing-boundary upload. Reverted, the recorder captures
  `Unexpected end of form`, which in production is a replica exit.
- F2 — pinned in both directions on **separate** spies. Reverting to #5343's
  classification gives `logger.error` "Number of calls: 0"; forcing the opposite
  misclassification reds the client-disconnect case. The old test merged
  `infoSpy` and `warnSpy` and asserted only that *something* logged, which is
  what let the regression through.
- F3 — a sized request during an R2 failure, bounded by a 2 s client deadline.
  Reverted, it fails in 2005 ms with `TimeoutError` instead of hanging the suite.

`vp run typecheck:backend` passes. `vp check` reports 2 errors / 365 warnings,
identical to the base commit and all in `packages/db/scripts/`, none in this
diff. Tests were run off the shared backend lock: the DB-free files under a
throwaway config without `globalSetup`/`setupFiles`, and the DB-backed upload
handlers against a private `postgres:17` on port 5477 (torn down; working tree
clean). 58 tests across 8 backend files green, including the pre-existing
avatar, gym-logo, gym-photo, feedback-screenshot and beta-thumbnail suites. CI
runs the full shard.

Refs #5307, #5343.

## Release Notes

Uploads and images can't take your session down with them any more. A photo that
failed to finish uploading, or a hiccup fetching an avatar or beta thumbnail,
used to knock out the server everyone in your party was connected to. Now a bad
upload is just a bad upload, a slow image gives up instead of spinning forever,
and we actually get told when image storage is having a bad day.

## Test plan

1. Sign in on two phones. Start a party session together.
2. Upload a new avatar, then kill wifi mid-upload.
3. Upload fails. Both phones stay in the session.
4. Restore wifi, upload the avatar again. It saves.
5. Open a climb with beta videos. Thumbnails load.

## Risk

Risk: 3/5 — touches all four multipart upload handlers and every media-serving
path on the backend, including the live data-export download. No schema, env or
route changes; the happy paths are untouched and covered by the existing upload
and thumbnail suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
