### PR TITLE
fix(mobile): never publish a superseded SQLite connection

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -984,6 +984,20 @@ single-flight for the process but retargets onto the latest connection on every
 attempt; a failure against a superseded handle is a lifecycle artefact and is
 deliberately not reported to error tracking.
 
+A superseded target is therefore a CLOSED one, which fixes where the handle may be
+published: only from the ready branch in `beginInitialization`, and only when
+`latestDatabase` still names the target. That is the single publish site in the
+lifecycle — publishing from anywhere that cannot see the supersede check served a
+closed connection with `isSchemaReady()` true, which is #5292's symptom list on every
+local read (#5366). A chain that runs out of superseded refunds ends with nothing
+published and reports under its own `kind: 'sqlite-init-superseded'`, kept out of the
+`sqlite-init` aggregate because no lock was contended in that failure.
+
+The retraction hung off the provider (`DatabaseHandleLifecycle`) does NOT beat the
+close: expo-sqlite enters `closeAsync()` synchronously from the parent's cleanup, which
+React runs before this child's. What it buys is the window after the unmount commit —
+queries already in flight are carried by the process-lifetime reference (#5300).
+
 ## What stays the same
 
 | Component             | Status                                                                                                        |

--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -843,4 +843,140 @@ describe('initializeDatabase lock contention (#4104)', () => {
     expect(getDatabaseHandle()).toBeNull();
     expect(isSchemaReady()).toBe(false);
   });
+
+  // #5366: the retarget path the fix above introduced published the connection it was
+  // retargeting AWAY from. `SQLiteProvider` closes a connection before the replacement
+  // reaches `initializeDatabase`, so a superseded target is a closed one — and every
+  // reader that took it got `Access to closed resource`, which is #5292's own symptom
+  // list (offline search, climb detail, local ticks) reintroduced by #5292's fix.
+  it('never serves the closed connection while it retargets onto the replacement', async () => {
+    vi.useFakeTimers();
+    // The replacement is lock-contended and never comes good, so the retarget spends
+    // the whole ladder — the window a reader lives in.
+    const handlesSeenDuringRetarget: unknown[] = [];
+    const second = createContendedDatabase({
+      onExec: () => {
+        handlesSeenDuringRetarget.push(getDatabaseHandle());
+      },
+    });
+
+    let remounted = false;
+    // The remount lands mid-attempt, so this connection is torn down and closed the
+    // moment its own setup succeeds.
+    const first = createContendedDatabase({
+      onExec: (source) => {
+        if (remounted || !/pending_mutations/i.test(source)) return;
+        remounted = true;
+        void initializeDatabase(second.db);
+      },
+    });
+    first.unlock();
+
+    await initializeDatabase(first.db);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    // The retarget really did run, and not one of its statements ran while a reader
+    // could have been handed the connection SQLiteProvider had already closed.
+    expect(handlesSeenDuringRetarget.length).toBeGreaterThan(0);
+    expect(handlesSeenDuringRetarget.every((handle) => handle === null)).toBe(true);
+
+    // ...and the chain that gave up on the replacement leaves nothing published, so a
+    // reader arriving after it falls back to the network instead of throwing.
+    expect(getDatabaseHandle()).toBeNull();
+    expect(isSchemaReady()).toBe(false);
+    // The give-up is reported as the ordinary lock failure it is — the closed
+    // connection never reaches Sentry as a sqlite-init artefact.
+    expect(reportErrorMock).toHaveBeenCalledTimes(1);
+    const [, context] = reportErrorMock.mock.calls[0];
+    expect(context.tags).toMatchObject({ kind: 'sqlite-init', sqlite_code: 5 });
+  });
+
+  // #5366: the other half. Once the refunds run out the guard used to fall through to
+  // the SUCCESS path, publishing the superseded connection as ready with no report at
+  // all — the same dead storage as a give-up, and less diagnosable than the bug #5336
+  // fixed.
+  it('reports rather than publishes when the superseded restarts run out', async () => {
+    // Five mounts, each superseding the one before mid-attempt: four refunds are
+    // asked for and only three exist.
+    const live = createContendedDatabase();
+    live.unlock();
+    const supersedingChain = [live];
+    for (let index = 0; index < 4; index += 1) {
+      const next = supersedingChain[0];
+      let remounted = false;
+      const earlier = createContendedDatabase({
+        onExec: (source) => {
+          if (remounted || !/pending_mutations/i.test(source)) return;
+          remounted = true;
+          void initializeDatabase(next.db);
+        },
+      });
+      earlier.unlock();
+      supersedingChain.unshift(earlier);
+    }
+
+    await initializeDatabase(supersedingChain[0].db);
+    await vi.waitFor(() => {
+      expect(reportErrorMock).toHaveBeenCalled();
+    });
+
+    // Nothing published: every connection this chain prepared was closed behind it,
+    // and the live one was never reached.
+    expect(getDatabaseHandle()).toBeNull();
+    expect(isSchemaReady()).toBe(false);
+    expect(reportErrorMock).toHaveBeenCalledTimes(1);
+    const [, context] = reportErrorMock.mock.calls[0];
+    // Its own kind: there was no lock here, and #4314 reads `sqlite-init` to decide
+    // whether the lock problem is fixed.
+    expect(context.tags).toMatchObject({ source: 'offline-sync', kind: 'sqlite-init-superseded' });
+    expect(context.extra).toMatchObject({ attempts: 4, restarts: 3 });
+    // Outrunning a remount loop is not recovering from contention.
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+
+  // The readiness store is what `useSQLiteContext()` consumers gate their writes on,
+  // and they cannot see the handle at all. A null handle that still reads ready is the
+  // shape #5366 produced: `schemaReady: true` with every query throwing.
+  it('keeps schema readiness false for as long as the handle is null', async () => {
+    vi.useFakeTimers();
+    const contended = createContendedDatabase();
+
+    await initializeDatabase(contended.db);
+    expect(getDatabaseHandle()).toBeNull();
+    expect(isSchemaReady()).toBe(false);
+
+    // Still null after the whole window is spent, and still not ready.
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(getDatabaseHandle()).toBeNull();
+    expect(isSchemaReady()).toBe(false);
+
+    // ...and it only turns true against a handle a later mount actually publishes.
+    const healthy = createContendedDatabase();
+    healthy.unlock();
+    await initializeDatabase(healthy.db);
+    expect(getDatabaseHandle()).toBe(healthy.db);
+    expect(isSchemaReady()).toBe(true);
+  });
+
+  // The exit invariant behind the publish gate: a chain that stops must not leave a
+  // superseded connection published, whoever published it. Driven through the exported
+  // setter — the same seam the teardown test above uses — because with the single
+  // gated publish nothing inside the lifecycle can reach this state any more, and that
+  // is exactly the property a future second publish site would break.
+  it('retracts a superseded handle on the way out of a give-up', async () => {
+    vi.useFakeTimers();
+    const contended = createContendedDatabase();
+    const stale = createContendedDatabase();
+
+    await initializeDatabase(contended.db);
+
+    // Published behind the chain's back, against a connection that is not the live one.
+    setDatabaseHandle(stale.db);
+    expect(getDatabaseHandle()).toBe(stale.db);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(getDatabaseHandle()).toBeNull();
+    expect(isSchemaReady()).toBe(false);
+  });
 });

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -98,7 +98,9 @@ const MAX_INIT_WINDOW_MS = 30_000;
  * How many times a superseded attempt may be refunded (see the restart branch in
  * `beginInitialization`). Each refund needs its own remount — the retry immediately
  * retargets onto the connection that superseded it — so this only exists to stop a
- * pathological remount loop from keeping one chain alive forever.
+ * pathological remount loop from keeping one chain alive forever. Hitting it ends the
+ * chain with nothing published and a Sentry report (see `reportSupersededExhaustion`),
+ * not with the superseded connection presented as ready.
  */
 const MAX_SUPERSEDED_RESTARTS = 3;
 // Exported so the retry tests advance their fake clock by the real gap rather than
@@ -130,6 +132,25 @@ let activeInitialization: Promise<void> | null = null;
  * follows the LIVE connection.
  */
 let latestDatabase: SQLiteDatabase | null = null;
+
+/**
+ * Exit protocol for the init chain: whatever is published when a chain stops must be
+ * a connection `SQLiteProvider` still owns.
+ *
+ * The single gated publish in `beginInitialization` is what makes this hold, so today
+ * this never has anything to retract. It is called at every terminal `return` anyway
+ * because the failure it backstops is silent and expensive: a superseded handle reads
+ * as `isSchemaReady() === true` while every query throws `Access to closed resource`,
+ * and the chain that left it there has already dropped `activeInitialization`, so
+ * nothing retries until the next remount (#5366). A second publish site added later —
+ * the retry ladder and its wake path are both being retuned (#4314) — would be caught
+ * here instead of shipping as #5292 for a third time.
+ */
+function retractSupersededHandle(): void {
+  if (databaseHandle !== null && latestDatabase !== null && databaseHandle !== latestDatabase) {
+    setDatabaseHandle(null);
+  }
+}
 
 /**
  * At most one recovery event per process. A launch can only recover once, but the
@@ -221,6 +242,12 @@ export function initializeDatabase(db: SQLiteDatabase): Promise<void> {
 /**
  * Runs the setup sequence once. Never throws — the caller decides whether the
  * failure is worth another attempt.
+ *
+ * Deliberately does NOT publish the handle. It cannot tell whether the connection it
+ * just prepared is still the live one, and a remount landing during the winning
+ * attempt has already had `SQLiteProvider` close it — publishing from here handed
+ * every reader a closed connection (#5366). `beginInitialization` owns the single
+ * publish, where the supersede check already lives.
  */
 async function attemptInitialization(db: SQLiteDatabase): Promise<InitOutcome> {
   let phase: InitPhase = 'wal';
@@ -234,9 +261,6 @@ async function attemptInitialization(db: SQLiteDatabase): Promise<InitOutcome> {
     await ensureMutationQueueTable(db);
     phase = 'migrations';
     await runMigrations(db);
-    // Published only once the schema is actually in place: a handle whose migrations
-    // never ran would hand every consumer a database with no tables.
-    setDatabaseHandle(db);
     return { status: 'ready' };
   } catch (error) {
     const { locked, code } = classifySqliteLockError(error);
@@ -289,13 +313,25 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
       }
 
       if (outcome.status === 'ready') {
-        // A remount landed between the publish inside `attemptInitialization` and this
-        // line, so the connection just prepared is already closed. The remount was
-        // handed this (about to resolve) promise and nothing else will initialize its
-        // connection, so retarget here instead of returning and leaving offline
-        // storage dead for the session. Spends a superseded refund, not retry budget:
-        // no lock was contended, the file is simply behind a newer connection.
-        if (latestDatabase !== null && latestDatabase !== target && supersededRestarts < MAX_SUPERSEDED_RESTARTS) {
+        // A remount landed while this attempt was in flight, so `SQLiteProvider` has
+        // already closed the connection it just prepared — its teardown runs before the
+        // replacement reaches `initializeDatabase`, so a superseded target is a CLOSED
+        // target.
+        const superseded = latestDatabase !== null && latestDatabase !== target;
+        // THE publish, and the only one in the lifecycle. Two conditions, both
+        // load-bearing: the schema is actually in place (a handle whose migrations never
+        // ran hands every consumer a database with no tables), and this connection is
+        // still the live one. Publishing a superseded target is #5292's exact symptom —
+        // `Access to closed resource` on every local read — reintroduced by #5292's own
+        // fix, because neither exit below retracted it (#5366). Keeping it here rather
+        // than inside `attemptInitialization` means no return path can leave a closed
+        // connection published: there is only one place that could have published it.
+        if (!superseded) setDatabaseHandle(target);
+        // The remount was handed this (about to resolve) promise and nothing else will
+        // initialize its connection, so retarget here instead of returning and leaving
+        // offline storage dead for the session. Spends a superseded refund, not retry
+        // budget: no lock was contended, the file is simply behind a newer connection.
+        if (superseded && supersededRestarts < MAX_SUPERSEDED_RESTARTS) {
           markStartup('sqlite.recovery.start');
           supersededRestarts += 1;
           continue;
@@ -306,6 +342,21 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
         // a connection `SQLiteProvider` had since closed. Nothing awaits between here
         // and the `return`, so no mount can slip in after the clear and be stranded.
         activeInitialization = null;
+        if (superseded) {
+          // Out of refunds with the live connection never initialized: a remount loop
+          // outran the chain. Offline storage is off for the session — nothing is
+          // published, `isSchemaReady()` is false — and only another mount can restart
+          // it, so it has to be visible. Falling through to the success path published
+          // the closed connection as ready and reported nothing at all (#5366).
+          if (attempts > 1) markStartup('sqlite.recovery.end', 'error');
+          retractSupersededHandle();
+          reportSupersededExhaustion({
+            attempts,
+            elapsedMs: Date.now() - startedAt,
+            restarts: supersededRestarts,
+          });
+          return;
+        }
         if (attempts > 1) markStartup('sqlite.recovery.end', 'ready');
         // Only a chain that survived a GENUINE lock failure recovered from
         // contention. A chain whose only failure was against a superseded (closed)
@@ -390,6 +441,10 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
             extra: { attempts, retryable: outcome.retryable, elapsedMs: Date.now() - startedAt },
           });
         }
+        // Last thing before the chain stops, and after the awaited read-back above, so
+        // a remount landing during it is accounted for: nothing that survives this
+        // return may point at a connection `SQLiteProvider` has closed (#5366).
+        retractSupersededHandle();
         return;
       }
 
@@ -422,6 +477,27 @@ function reportInitRecovered(properties: {
   if (hasReportedRecovery) return;
   hasReportedRecovery = true;
   track(SHARED_EVENTS.OfflineSqliteInitRecovered, properties);
+}
+
+/**
+ * Report a chain that ran out of superseded-connection refunds without ever reaching
+ * the live database.
+ *
+ * The outcome is the same dead offline storage a give-up leaves — no handle, no schema
+ * readiness, every local read on the network path — so it needs the same visibility.
+ * Until #5366 this exit reported nothing at all: it fell through to the success path,
+ * published the closed connection, and looked from telemetry like a clean launch.
+ *
+ * Deliberately NOT `kind: 'sqlite-init'`. That aggregate is the lock-contention signal
+ * #4314 reads to decide whether the lock problem is fixed, and there is no lock in
+ * this failure — it is a remount loop outrunning one chain, and mixing the two is what
+ * made the closed-handle artefacts unreadable in the first place.
+ */
+function reportSupersededExhaustion(details: { attempts: number; elapsedMs: number; restarts: number }): void {
+  reportError(new Error('SQLite init ran out of superseded-connection restarts'), {
+    tags: { source: 'offline-sync', kind: 'sqlite-init-superseded' },
+    extra: details,
+  });
 }
 
 /**

--- a/packages/mobile/src/providers/__tests__/database-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/database-provider.test.tsx
@@ -4,7 +4,8 @@
 // connection to the sync scheduler and mutation drainer, neither of which is inside
 // React and neither of which can see a remount. Driven through the provider's own
 // lifecycle rather than by calling the retraction directly, because what has to hold
-// is an ordering: the handle is gone by the time the close lands.
+// is an ordering: the handle is gone by the time the unmount commit returns — NOT by
+// the time the close lands, which the fake used to pretend (#5366).
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
 
@@ -41,8 +42,9 @@ const sqlite = vi.hoisted(() => ({
   // A distinct object per mount, exactly like `openDatabaseAsync` — the identity is
   // what the retraction checks.
   openConnection: (): unknown => ({ connection: 'unset' }),
-  // What `getDatabaseHandle()` returned at the moment the provider closed a
-  // connection. Null means the retraction won the race, which is the point.
+  // What `getDatabaseHandle()` returned at the instant the provider entered
+  // `closeAsync()` — recorded synchronously, because that is when the real teardown
+  // enters it.
   closes: [] as { database: unknown; handleAtClose: unknown }[],
   readHandle: (): unknown => null,
 }));
@@ -71,14 +73,13 @@ vi.mock('expo-sqlite', async () => {
         databaseRef.current = null;
         setOpened(false);
         if (database === null) return;
-        // expo-sqlite's teardown is `async function teardown(db) { await
-        // db.closeAsync(); }` — started from the cleanup, settled a microtask later.
-        // Recording the handle at THAT point is the assertion that matters: whatever
-        // order React runs the cleanups in, no reader may still be holding this
-        // connection once it is actually closed.
-        void Promise.resolve().then(() => {
-          sqlite.closes.push({ database, handleAtClose: sqlite.readHandle() });
-        });
+        // Verbatim shape of `SQLiteProviderNonSuspense`'s cleanup: `teardown(db)` is
+        // called SYNCHRONOUSLY and `await db?.closeAsync()` is its first statement, so
+        // the close is entered here, not a microtask later. Record the handle at that
+        // instant — deferring the read through `Promise.resolve().then()` (what this
+        // fake used to do) hides the real ordering and manufactures a retraction that
+        // appears to beat the close (#5366).
+        sqlite.closes.push({ database, handleAtClose: sqlite.readHandle() });
       };
     }, [onInit]);
 
@@ -116,7 +117,7 @@ beforeEach(() => {
 });
 
 describe('DatabaseProvider', () => {
-  it('retracts the handle before the connection is closed', async () => {
+  it('retracts the handle in the same unmount commit that closes the connection', async () => {
     const view = render(
       <DatabaseProvider>
         <div data-testid="child" />
@@ -130,13 +131,18 @@ describe('DatabaseProvider', () => {
 
     view.unmount();
 
+    // What the retraction actually buys, and the whole of it: once the unmount commit
+    // has returned, every reader that starts from here on gets null and falls back to
+    // the network. Without <DatabaseHandleLifecycle /> the sync scheduler and the
+    // mutation drainer — neither inside React — go on holding a closed connection and
+    // throw `Access to closed resource` (#5292).
     expect(getDatabaseHandle()).toBeNull();
     expect(isSchemaReady()).toBe(false);
-    // The provider really did close the connection it had published, and by the time
-    // that close landed the handle no longer pointed at it. Without the retraction a
-    // reader here gets a connection that throws `Access to closed resource`.
-    await waitFor(() => {
-      expect(sqlite.closes).toEqual([{ database: published, handleAtClose: null }]);
-    });
+
+    // What it does NOT buy, pinned so the ordering stays honest: the parent's cleanup
+    // runs first and enters `closeAsync()` while the handle still points at this very
+    // connection. Queries already in flight are narrowed by the retraction not at all —
+    // the process-lifetime reference (#5300) is what carries them.
+    expect(sqlite.closes).toEqual([{ database: published, handleAtClose: published }]);
   });
 });

--- a/packages/mobile/src/providers/database-provider.tsx
+++ b/packages/mobile/src/providers/database-provider.tsx
@@ -13,14 +13,21 @@ function handleDatabaseError(error: Error): void {
  * Renders nothing; exists to hang the handle retraction off `SQLiteProvider`'s own
  * lifecycle.
  *
- * The provider's effect teardown closes the connection (expo-sqlite
- * `build/hooks.js`), and it does so asynchronously — `await db.closeAsync()`, started
- * from the cleanup. Every cleanup in the torn-down subtree runs in that same
- * synchronous commit, so retracting from here lands before the close itself does,
- * whichever order React visits them in. Without it the window between the close and
- * the replacement connection's migrations belongs to whoever reads
- * `getDatabaseHandle()` — the sync scheduler and mutation drainer, neither of which is
- * inside React and neither of which can see the provider remount (#5292).
+ * It does NOT beat the close. `SQLiteProvider`'s cleanup calls `teardown(db)`
+ * synchronously and `await db?.closeAsync()` is its first statement (expo-sqlite
+ * `build/hooks.js`), so the close is ENTERED from the parent's cleanup — and React
+ * runs the parent's cleanup before this child's. By the time the retraction runs, the
+ * connection is already closing. Queries that were already in flight are narrowed by
+ * nothing here: what keeps them off freed memory is the process-lifetime reference
+ * `initializeAndRetainDatabase` takes below (#5300), not this ordering.
+ *
+ * What it buys is the window AFTER the unmount commit: every reader that starts from
+ * then on gets null and falls back to the network instead of a closed connection that
+ * throws `Access to closed resource` (~249 users/30d, #5292). That is the sync
+ * scheduler on its interval and the mutation drainer on its listener — neither is
+ * inside React, so neither can see the provider go away. `initializeDatabase` covers
+ * the remount case as soon as the replacement connection's `onInit` runs; this covers
+ * the gap until then, and the plain unmount where no replacement is coming at all.
  *
  * Mounted as a sibling of `children` rather than wrapping them: it must not add a
  * component boundary to the tree every screen renders under.


### PR DESCRIPTION
## Summary

PR #5336 fixed #5292 (`getDatabaseHandle()` serving a connection `SQLiteProvider` had
closed, ~249 users/30d) and reintroduced the same symptom through the retarget path its
own tests never reach. `attemptInitialization` published the handle unconditionally on
success — including when `latestDatabase` had already superseded the target, i.e. when
`SQLiteProvider` had already closed it — and neither the retarget `continue` nor the
give-up return retracted it. Measured route: a remount lands during the winning attempt
on `db1`, the chain publishes the closed `db1`, retargets to `db2`, `db2` exhausts the
ladder, and every fresh reader gets `Access to closed resource` with
`isSchemaReady() === true`. A second hole: once `supersededRestarts` hit 3 the guard fell
through to the success path and published the superseded connection as ready with **zero**
Sentry reports.

The fix moves the publish out of `attemptInitialization` and into the one place that
already knows whether the target was superseded, so there is a single gated publish site
and no return path can leave a closed connection published. Running out of superseded
restarts now ends the chain with nothing published and its own Sentry kind
(`sqlite-init-superseded`), deliberately kept out of the `sqlite-init` aggregate #4314
reads — no lock was ever contended in that failure. `retractSupersededHandle()` runs at
the terminal returns as the exit invariant for whatever publishes next. Schema readiness
already tracks the handle, so #5366's F4 (readiness never toggling across a retarget)
falls out: there is no first publish to toggle from.

Also corrects the `DatabaseHandleLifecycle` comment, which claimed the retraction "lands
before the close itself does". It does not: expo-sqlite calls `teardown(db)`
synchronously with `await db?.closeAsync()` as its first statement, and React runs the
parent's cleanup before this child's — measured, and now pinned by the test. #5336's fake
recorded the close through `void Promise.resolve().then(...)`, deferring the observation a
microtask and manufacturing exactly the ordering the comment claimed; it now asserts at
the instant `closeAsync()` is called. What the retraction actually buys is the window
*after* the unmount commit; in-flight queries are carried by the process-lifetime
reference from #5300 (#5358), not by this ordering. Anyone sizing that work against the
old comment would have believed otherwise.

### Sequencing

**This should land before or with #5355** (issue #4314). #5355 extends the init ladder to
~227 s, holding `activeInitialization` roughly 7× longer and funnelling far more remounts
onto one chain — which widens exactly the window F1/F2 live in. The two compose cleanly:
#5355's interruptible backoff wakes the chain sooner so a replacement connection is picked
up faster, and this change makes that woken retarget safe — the handle goes `null` rather
than presenting a closed connection as ready. A woken retarget is precisely the path that
republished a superseded connection today. Commented on #5355 to the same effect.

### Guards, each mutation-confirmed

Five new, red when reverted: the publish gate; the superseded-exhaustion report; schema
readiness tracking a null handle; the provider test recording the close synchronously; the
give-up exit retraction. #5336's five existing mutations were re-run with this change in
place — drop `activeInitialization = null` on success, drop the synchronous retraction,
make `releaseDatabaseHandle` unconditional, remove `<DatabaseHandleLifecycle />`, disable
the retarget branch — and all five still go red.

Fixes #5366

## Release Notes

Offline search, climb details and your logbook no longer go blank after the app reloads
itself. When local storage can't come up, the app now falls back to the network cleanly
instead of serving a dead connection until you restart.

## Test plan

1. Open the app offline, search climbs, see results.
2. Force-quit and reopen the app twice, quickly.
3. Search again — results still appear, no error.
4. Open a climb, then your logbook: ticks listed.
5. Toggle Offline mode on and off, repeat step 3.

## Risk

Risk: 4/5 — it is the offline-storage lifecycle, and a mistake here reproduces a ~249-user bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
