### PR TITLE
fix(mobile): drive the #5366 guards to the ladder's real end

### DIFF
--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -1083,15 +1083,26 @@ describe('initializeDatabase lock contention (#4104)', () => {
     // asked for and only three exist.
     const live = createContendedDatabase();
     live.unlock();
+    // A handle published behind the chain's back, against a connection that is not the
+    // live one. Injected through the exported setter for the same reason the give-up
+    // twin below does it: with one gated publish nothing inside the lifecycle can reach
+    // this state, so the seam is what pins the retract on THIS exit as well. Without it
+    // the exhaustion path's `retractSupersededHandle()` can be deleted with the whole
+    // suite still green.
+    const stale = createContendedDatabase();
     const supersedingChain = [live];
     for (let index = 0; index < 4; index += 1) {
       const next = supersedingChain[0];
+      // The mount that brings in `live` is the one that asks for the fourth refund, so
+      // its remount is the moment the stale handle has to be in place to be retracted.
+      const isLastRemount = index === 0;
       let remounted = false;
       const earlier = createContendedDatabase({
         onExec: (source) => {
           if (remounted || !/pending_mutations/i.test(source)) return;
           remounted = true;
           void initializeDatabase(next.db);
+          if (isLastRemount) setDatabaseHandle(stale.db);
         },
       });
       earlier.unlock();

--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -1004,7 +1004,7 @@ describe('initializeDatabase lock contention (#4104)', () => {
     first.unlock();
 
     await initializeDatabase(first.db);
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(WHOLE_LADDER_MS);
 
     // The retarget really did run, and not one of its statements ran while a reader
     // could have been handed the connection SQLiteProvider had already closed.
@@ -1020,6 +1020,58 @@ describe('initializeDatabase lock contention (#4104)', () => {
     expect(reportErrorMock).toHaveBeenCalledTimes(1);
     const [, context] = reportErrorMock.mock.calls[0];
     expect(context.tags).toMatchObject({ kind: 'sqlite-init', sqlite_code: 5 });
+  });
+
+  // Where #5355 and #5371 actually meet, and the one path neither could have pinned:
+  // #5355 landed the interruptible backoff, #5371 landed the single gated publish, and
+  // each was reviewed against a tree without the other. A retarget the WAKE started,
+  // superseded again before it finishes, runs the publish gate on a connection the
+  // chain reached through the wake rather than through a slept-out gap — so it is the
+  // combination, not either change, that has to keep #5366's promise.
+  it('never publishes a woken retarget that is superseded before it finishes', async () => {
+    vi.useFakeTimers();
+    const contended = createContendedDatabase();
+
+    // What the chain ends up on. Every statement it runs must see a null handle: if the
+    // gate let the woken (and by then closed) retarget publish, that connection would
+    // already be on offer here.
+    const handlesSeenAfterSupersede: unknown[] = [];
+    const newest = createContendedDatabase({
+      onExec: () => {
+        handlesSeenAfterSupersede.push(getDatabaseHandle());
+      },
+    });
+    newest.unlock();
+
+    // The connection the wake retargets onto — closed out from under it by a third
+    // mount while its own setup is still running.
+    let supersededOnce = false;
+    const replacement = createContendedDatabase({
+      onExec: (source) => {
+        if (supersededOnce || !/pending_mutations/i.test(source)) return;
+        supersededOnce = true;
+        void initializeDatabase(newest.db);
+      },
+    });
+    replacement.unlock();
+
+    await initializeDatabase(contended.db);
+    // Park the chain in the first slow gap — the window a remount is invisible in
+    // without the wake, and the reason #5355 exists.
+    await vi.advanceTimersByTimeAsync(FAST_LADDER_MS);
+    expect(getDatabaseHandle()).toBeNull();
+
+    // The wake ends the gap and the loop retargets onto `replacement`.
+    await initializeDatabase(replacement.db);
+    await vi.advanceTimersByTimeAsync(1);
+
+    // The interleaving really happened: without this the assertions below hold
+    // vacuously against a chain that simply woke onto a connection nothing superseded.
+    expect(supersededOnce).toBe(true);
+    expect(handlesSeenAfterSupersede.length).toBeGreaterThan(0);
+    expect(handlesSeenAfterSupersede.every((handle) => handle === null)).toBe(true);
+    expect(getDatabaseHandle()).toBe(newest.db);
+    expect(isSchemaReady()).toBe(true);
   });
 
   // #5366: the other half. Once the refunds run out the guard used to fall through to
@@ -1077,7 +1129,7 @@ describe('initializeDatabase lock contention (#4104)', () => {
     expect(isSchemaReady()).toBe(false);
 
     // Still null after the whole window is spent, and still not ready.
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(WHOLE_LADDER_MS);
     expect(getDatabaseHandle()).toBeNull();
     expect(isSchemaReady()).toBe(false);
 
@@ -1105,7 +1157,7 @@ describe('initializeDatabase lock contention (#4104)', () => {
     setDatabaseHandle(stale.db);
     expect(getDatabaseHandle()).toBe(stale.db);
 
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(WHOLE_LADDER_MS);
 
     expect(getDatabaseHandle()).toBeNull();
     expect(isSchemaReady()).toBe(false);


### PR DESCRIPTION
## Summary

**The P1 protection was never broken in production. Only the tests were.** `main` was red because #5371 measured "the whole retry window" with a `30_000` literal, and #5355 had already moved that window to 227.5s.

The two PRs land in the same function and neither was reviewed against the other. #5355 (`994951ee1`, #4314) extended the ladder to `[500, 2000, 5000, 10000] + [30000, 60000, 60000, 60000]` and added `WHOLE_LADDER_MS` to the suite specifically so a test could "drive the chain to its true end without mirroring the numbers". #5371 (`4c1f019a4`, #5366) then landed 136 lines of pure test insertions carrying three fresh `30_000` literals — the pre-#5355 total. The merge was textually clean and semantically stale, so `pnpm` never had a conflict to show anyone.

### Evidence that no reader was served a closed connection

In all three failures, every assertion about the P1 property passed on broken `main`; the only failing line in each is the one that assumes the chain has already given up:

| Test | Failing line | Assertions that passed first |
| --- | --- | --- |
| `never serves the closed connection while it retargets` | the `reportErrorMock` count | the retarget never observed a non-null handle; handle null; `isSchemaReady()` false |
| `keeps schema readiness false…` | a later mount's handle | both null / not-ready checks, before and after the window |
| `retracts a superseded handle…` | a handle the **test** published through the exported setter | — (no lifecycle code can reach that state) |

Bisecting confirms one ladder with two sets of literals: emptying `INIT_LOCK_RETRY_DELAYS_MS` and putting the window back at 30s turns those three green and turns #5355's two red instead.

Pointing the three at `WHOLE_LADDER_MS` makes all 44 green **with no change to `connection.ts`**. That is the proof — the guards assert the #5366 properties directly, and they hold.

### What is actually new

One guard, at the seam the merge exposed: a retarget the **wake** started, superseded again before it finishes. #5355 only ever woke onto a connection that stayed live; #5371 only ever superseded a retarget the give-up path had started. Nobody could have pinned the combination. It fails under both mutations that reintroduce #5366 — dropping the `!superseded` gate, and republishing from `attemptInitialization`.

And the exhaustion-path `retractSupersededHandle()` is now pinned too. It was deletable with the suite still green, because the single gated publish leaves it nothing to clear — so it now uses the same exported-setter seam its give-up twin already used.

### Mutation results

13 mutations of `connection.ts`, one at a time; 12 killed.

| # | Mutation | Guard that goes red |
| --- | --- | --- |
| M1 | drop the `!superseded` publish gate | never serves the closed connection; never publishes a woken retarget |
| M2 | republish from `attemptInitialization` (#5366 itself) | same two |
| M3 | drop the give-up retract | retracts a superseded handle on the way out of a give-up |
| M4 | drop the exhaustion retract | reports rather than publishes when the restarts run out |
| M5 | drop `reportSupersededExhaustion` | reports rather than publishes when the restarts run out |
| M6 | drop the wake | wakes the backoff; spends the same budget; never publishes a woken retarget |
| M7 | let a wake refund its attempt | spends the same budget however many remounts wake it |
| M8 | shorten the ladder | keeps retrying past the fast window; wakes the backoff |
| M9 | leave `wakeFromBackoff` set after natural expiry | **survives** — see below |
| M10 | drop the synchronous retract on remount | retracts the closed connection when the remount starts |
| M11 | drop the superseded retarget | 4 guards |
| M12 | hold the single-flight guard past success | re-publishes the connection a remount opened |
| M13 | make `releaseDatabaseHandle` unconditional | ignores a teardown for a replaced connection |

M9 is a known, documented survivor: #5355's own comment records that dropping either `wakeFromBackoff = null` assignment "changes no observable behaviour" — the resolver closes over an already-settled timer and promise, and the next sleep overwrites the slot. The assignments are kept for the invariant, not for behaviour, so no guard is added for a line the author already proved neutral.

Refs #5366, #4314, #5355, #5371.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — test-only change; `connection.ts` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
