### PR TITLE
feat: sort by average user grade + stiff/soft grade badge

### DIFF
--- a/packages/db/src/queries/climbs/__tests__/search-climbs.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/search-climbs.test.ts
@@ -483,3 +483,47 @@ void describe('community-hidden climbs (#5049)', () => {
     assert.doesNotMatch(pageWhere, /is_hidden/);
   });
 });
+
+void describe('ungraded climbs sort last on either direction, for grade sorts only', () => {
+  void it('forces NULLS LAST on ascending difficulty, unlike a non-grade sort', async () => {
+    const { fakeDb: gradeDb, queries: gradeQueries } = createFakeSearchDb();
+    await searchClimbs(gradeDb as unknown as DbInstance, SEARCH_PARAMS, {
+      page: 0,
+      pageSize: 20,
+      sortBy: 'difficulty',
+      sortOrder: 'asc',
+    });
+    assert.match(gradeQueries[0].orderBy[0] ?? '', /nulls last/i);
+
+    const { fakeDb: otherDb, queries: otherQueries } = createFakeSearchDb();
+    await searchClimbs(otherDb as unknown as DbInstance, SEARCH_PARAMS, {
+      page: 0,
+      pageSize: 20,
+      sortBy: 'quality',
+      sortOrder: 'asc',
+    });
+    assert.match(otherQueries[0].orderBy[0] ?? '', /nulls first/i);
+  });
+
+  void it('forces NULLS LAST on ascending userGrade too', async () => {
+    const { fakeDb, queries } = createFakeSearchDb();
+    await searchClimbs(fakeDb as unknown as DbInstance, SEARCH_PARAMS, {
+      page: 0,
+      pageSize: 20,
+      sortBy: 'userGrade',
+      sortOrder: 'asc',
+    });
+    assert.match(queries[0].orderBy[0] ?? '', /nulls last/i);
+  });
+
+  void it('keeps NULLS LAST on descending grade sorts (already the default)', async () => {
+    const { fakeDb, queries } = createFakeSearchDb();
+    await searchClimbs(fakeDb as unknown as DbInstance, SEARCH_PARAMS, {
+      page: 0,
+      pageSize: 20,
+      sortBy: 'userGrade',
+      sortOrder: 'desc',
+    });
+    assert.match(queries[0].orderBy[0] ?? '', /nulls last/i);
+  });
+});

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -464,6 +464,11 @@ async function runStandardSearch(
   const allowedSortColumns: Record<string, ReturnType<typeof sql>> = {
     ascents: sql`${boardClimbStats.ascensionistCount}`,
     difficulty: sql`ROUND(${boardClimbStats.displayDifficulty}::numeric, 0)`,
+    // Boardsesh grade (community/model grade), as opposed to `difficulty` above
+    // (the setter-assigned grade). Uses the already-joined board_climb_grades
+    // row for the searched angle; NULL (no grade row) sorts last via the
+    // NULLS LAST/FIRST handling below, same as every other sort here.
+    boardseshGrade: sql`COALESCE(${boardClimbGrades.universalGrade}, ${boardClimbGrades.localGrade})`,
     name: sql`${boardClimbs.name}`,
     quality: sql`${boardClimbStats.qualityAverage}`,
     creation: sql`${boardClimbs.createdAt}`,

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -540,10 +540,15 @@ async function runStandardSearch(
     boardsesh_confidence: boardClimbGrades.confidence,
   };
 
+  // Ungraded climbs (no board_climb_stats row yet — no ascents/votes) sort to the
+  // bottom on either direction for the two grade sorts, rather than flipping to
+  // the top on ASC like every other sort's NULLs do: a climber picking "grade,
+  // easiest first" wants the softest known grade first, not a pile of unknowns.
+  const isGradeSort = sortBy === 'difficulty' || sortBy === 'userGrade';
   const orderByClause = randomOrderExpr
     ? sql`${randomOrderExpr} ASC`
     : sortOrder === 'asc'
-      ? sql`${sortColumn} ASC NULLS FIRST`
+      ? sql`${sortColumn} ASC ${isGradeSort ? sql`NULLS LAST` : sql`NULLS FIRST`}`
       : sql`${sortColumn} DESC NULLS LAST`;
 
   // Stats-presence key, used ONLY by the stats-driven fallback (issue #1971). It

--- a/packages/db/src/queries/climbs/search-climbs.ts
+++ b/packages/db/src/queries/climbs/search-climbs.ts
@@ -464,11 +464,12 @@ async function runStandardSearch(
   const allowedSortColumns: Record<string, ReturnType<typeof sql>> = {
     ascents: sql`${boardClimbStats.ascensionistCount}`,
     difficulty: sql`ROUND(${boardClimbStats.displayDifficulty}::numeric, 0)`,
-    // Boardsesh grade (community/model grade), as opposed to `difficulty` above
-    // (the setter-assigned grade). Uses the already-joined board_climb_grades
-    // row for the searched angle; NULL (no grade row) sorts last via the
-    // NULLS LAST/FIRST handling below, same as every other sort here.
-    boardseshGrade: sql`COALESCE(${boardClimbGrades.universalGrade}, ${boardClimbGrades.localGrade})`,
+    // Raw (unrounded) mean of every ascent's submitted grade, as opposed to
+    // `difficulty` above (Aurora's official display grade, which can diverge
+    // from the plain average — see difficulty_error). Populated on every
+    // board including MoonBoard, unlike the Boardsesh grade model
+    // (board_climb_grades), which MoonBoard is deliberately excluded from.
+    userGrade: sql`${boardClimbStats.difficultyAverage}`,
     name: sql`${boardClimbs.name}`,
     quality: sql`${boardClimbStats.qualityAverage}`,
     creation: sql`${boardClimbs.createdAt}`,

--- a/packages/db/src/queries/climbs/types.ts
+++ b/packages/db/src/queries/climbs/types.ts
@@ -33,7 +33,16 @@ export type ClimbSearchParams = {
   page?: number;
   pageSize?: number;
   // Sorting
-  sortBy?: 'ascents' | 'difficulty' | 'name' | 'quality' | 'popular' | 'creation' | 'random' | (string & {});
+  sortBy?:
+    | 'ascents'
+    | 'difficulty'
+    | 'boardseshGrade'
+    | 'name'
+    | 'quality'
+    | 'popular'
+    | 'creation'
+    | 'random'
+    | (string & {});
   sortOrder?: 'asc' | 'desc' | (string & {});
   // Seed for the 'random' sort. Salts md5(uuid || sortSeed) so a shuffle stays
   // stable across OFFSET-paginated pages; a new seed reshuffles.
@@ -125,6 +134,7 @@ export type ClimbSearchInputLike = {
 const SEARCH_SORT_ALIASES: Record<string, NonNullable<ClimbSearchParams['sortBy']>> = {
   ascents: 'ascents',
   difficulty: 'difficulty',
+  boardseshGrade: 'boardseshGrade',
   name: 'name',
   quality: 'quality',
   popular: 'popular',

--- a/packages/db/src/queries/climbs/types.ts
+++ b/packages/db/src/queries/climbs/types.ts
@@ -36,7 +36,7 @@ export type ClimbSearchParams = {
   sortBy?:
     | 'ascents'
     | 'difficulty'
-    | 'boardseshGrade'
+    | 'userGrade'
     | 'name'
     | 'quality'
     | 'popular'
@@ -134,7 +134,7 @@ export type ClimbSearchInputLike = {
 const SEARCH_SORT_ALIASES: Record<string, NonNullable<ClimbSearchParams['sortBy']>> = {
   ascents: 'ascents',
   difficulty: 'difficulty',
-  boardseshGrade: 'boardseshGrade',
+  userGrade: 'userGrade',
   name: 'name',
   quality: 'quality',
   popular: 'popular',

--- a/packages/mobile/src/components/ClimbAttributeIcons.tsx
+++ b/packages/mobile/src/components/ClimbAttributeIcons.tsx
@@ -10,6 +10,7 @@ import {
   isNoKickboard,
   isNoMatch,
 } from '@boardsesh/shared-schema';
+import { resolveGradeErrorBadge } from '@boardsesh/logbook';
 import { Icon } from './Icon';
 import { useTheme } from '../providers/theme-provider';
 
@@ -26,6 +27,12 @@ type ClimbAttributeIconsProps = {
    * (e.g. session-tick rows). Ignored when `characteristics` is provided.
    */
   isNoMatch?: boolean | null;
+  /** board_climb_stats.difficulty_average − display_difficulty, for the
+   *  "stiff/soft" grade-discrepancy badge. See resolveGradeErrorBadge. */
+  difficultyError?: string | number | null;
+  /** Ascent count backing `difficultyError` — gates the badge off for climbs
+   *  with too few grade opinions to trust the average. */
+  ascensionistCount?: number | null;
   /** Glyph size; defaults to 14 to sit beside body-sized climb names. */
   size?: number;
 };
@@ -66,6 +73,22 @@ function extraCharacteristicLabels(characteristics: string[] | null | undefined,
 }
 
 /**
+ * The "stiff/soft" grade-discrepancy badge label, or null when the crowd
+ * average doesn't notably disagree with the display grade (or there aren't
+ * enough ascents to trust it yet). Web parity: resolveGradeErrorLabel in
+ * packages/web/app/lib/climb-method.ts — same shared resolveGradeErrorBadge.
+ */
+function gradeErrorLabel(
+  difficultyError: string | number | null | undefined,
+  ascensionistCount: number | null | undefined,
+  t: TFunction<'climbs'>,
+): string | null {
+  const badge = resolveGradeErrorBadge(difficultyError, ascensionistCount);
+  if (!badge) return null;
+  return badge.direction === 'stiff' ? t('mobile.climbRow.gradeError.stiff') : t('mobile.climbRow.gradeError.soft');
+}
+
+/**
  * Grey glyph cluster for a climb's intrinsic attributes, rendered inline after a
  * climb name (web parity: `packages/web/.../climb-card/climb-icons.tsx`).
  * Order matches web — © benchmark/classic, then ⊘ no-match. Monochrome so it
@@ -76,6 +99,8 @@ export const ClimbAttributeIcons = memo(function ClimbAttributeIcons({
   benchmarkDifficulty,
   characteristics,
   isNoMatch: isNoMatchFallback,
+  difficultyError,
+  ascensionistCount,
   size = 14,
 }: ClimbAttributeIconsProps) {
   const { t } = useTranslation('climbs');
@@ -88,6 +113,8 @@ export const ClimbAttributeIcons = memo(function ClimbAttributeIcons({
   const isNoMatchClimb = characteristics != null ? isNoMatch(characteristics) : (isNoMatchFallback ?? false);
   const method = methodLabel(characteristics, t);
   const extraLabels = extraCharacteristicLabels(characteristics, t);
+  const gradeError = gradeErrorLabel(difficultyError, ascensionistCount, t);
+  if (gradeError) extraLabels.push(gradeError);
 
   if (!isBenchmark && !isNoMatchClimb && !method && extraLabels.length === 0) return null;
 

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -47,6 +47,7 @@ import { PinToggle } from './search/PinToggle';
 import { getCollectionFilter, getClimbTypeFilter, type CollectionFilter } from '../lib/collection-filter';
 import { useTheme } from '../providers/theme-provider';
 import { useManagedSheet } from '../providers/sheet-presentation-provider';
+import { useBoardseshGradesActive } from '../hooks/use-display-grade';
 import { androidSafeSnapPoints } from './sheet-snap-points';
 import { useSheetColumnStyle } from './use-sheet-column-style';
 import { useSheetDetentProbe } from './sheet-detent-probe';
@@ -175,6 +176,7 @@ export function ClimbFilterSheet({
 }: ClimbFilterSheetProps) {
   const { t } = useTranslation('climbs');
   const { t: tCommon } = useTranslation('common');
+  const boardseshGradesActive = useBoardseshGradesActive();
   const theme = useTheme();
   const { systemColors } = theme;
   const { isAuthenticated } = useAuth();
@@ -313,12 +315,21 @@ export function ClimbFilterSheet({
       ascents: t('mobile.filter.sort.ascents'),
       quality: t('mobile.filter.sort.quality'),
       difficulty: t('mobile.filter.sort.difficulty'),
+      boardseshGrade: t('mobile.filter.sort.boardseshGrade'),
       name: t('mobile.filter.sort.name'),
       popular: t('mobile.filter.sort.popular'),
       creation: t('mobile.filter.sort.creation'),
       random: t('mobile.filter.sort.random'),
     }),
     [t],
+  );
+
+  // Only offer the Boardsesh-grade sort once the climber has actually turned
+  // Boardsesh grades on (see useBoardseshGradesActive) — otherwise it sorts by
+  // a grade concept they've never seen and haven't opted into.
+  const visibleSortOptions = useMemo(
+    () => (boardseshGradesActive ? SORT_OPTIONS : SORT_OPTIONS.filter((option) => option !== 'boardseshGrade')),
+    [boardseshGradesActive],
   );
 
   const progressLabels = useMemo<Record<ProgressFilter, string>>(
@@ -1117,7 +1128,7 @@ export function ClimbFilterSheet({
                   native bottom sheet collapsed the chip row's height on iOS and
                   clipped the labels. SORT_OPTIONS is short, so wrapping is fine. */}
               <View style={styles.chipRow}>
-                {SORT_OPTIONS.map((option) => (
+                {visibleSortOptions.map((option) => (
                   <Chip
                     key={option}
                     label={sortLabels[option]}

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -47,7 +47,6 @@ import { PinToggle } from './search/PinToggle';
 import { getCollectionFilter, getClimbTypeFilter, type CollectionFilter } from '../lib/collection-filter';
 import { useTheme } from '../providers/theme-provider';
 import { useManagedSheet } from '../providers/sheet-presentation-provider';
-import { useBoardseshGradesActive } from '../hooks/use-display-grade';
 import { androidSafeSnapPoints } from './sheet-snap-points';
 import { useSheetColumnStyle } from './use-sheet-column-style';
 import { useSheetDetentProbe } from './sheet-detent-probe';
@@ -176,7 +175,6 @@ export function ClimbFilterSheet({
 }: ClimbFilterSheetProps) {
   const { t } = useTranslation('climbs');
   const { t: tCommon } = useTranslation('common');
-  const boardseshGradesActive = useBoardseshGradesActive();
   const theme = useTheme();
   const { systemColors } = theme;
   const { isAuthenticated } = useAuth();
@@ -315,21 +313,13 @@ export function ClimbFilterSheet({
       ascents: t('mobile.filter.sort.ascents'),
       quality: t('mobile.filter.sort.quality'),
       difficulty: t('mobile.filter.sort.difficulty'),
-      boardseshGrade: t('mobile.filter.sort.boardseshGrade'),
+      userGrade: t('mobile.filter.sort.userGrade'),
       name: t('mobile.filter.sort.name'),
       popular: t('mobile.filter.sort.popular'),
       creation: t('mobile.filter.sort.creation'),
       random: t('mobile.filter.sort.random'),
     }),
     [t],
-  );
-
-  // Only offer the Boardsesh-grade sort once the climber has actually turned
-  // Boardsesh grades on (see useBoardseshGradesActive) — otherwise it sorts by
-  // a grade concept they've never seen and haven't opted into.
-  const visibleSortOptions = useMemo(
-    () => (boardseshGradesActive ? SORT_OPTIONS : SORT_OPTIONS.filter((option) => option !== 'boardseshGrade')),
-    [boardseshGradesActive],
   );
 
   const progressLabels = useMemo<Record<ProgressFilter, string>>(
@@ -1128,7 +1118,7 @@ export function ClimbFilterSheet({
                   native bottom sheet collapsed the chip row's height on iOS and
                   clipped the labels. SORT_OPTIONS is short, so wrapping is fine. */}
               <View style={styles.chipRow}>
-                {visibleSortOptions.map((option) => (
+                {SORT_OPTIONS.map((option) => (
                   <Chip
                     key={option}
                     label={sortLabels[option]}

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -50,6 +50,9 @@ export type ClimbListItemClimb = {
   is_no_match?: boolean | null;
   benchmark_difficulty?: string | null;
   characteristics?: string[] | null;
+  /** board_climb_stats.difficulty_average − display_difficulty, for the
+   *  "stiff/soft" grade-discrepancy badge. See resolveGradeErrorBadge. */
+  difficulty_error?: string | number | null;
   // Boardsesh grade (data-science difficulty + confidence), carried on every climb
   // from PR #3554. Optional + permissive so both the web-schema `Climb` and the
   // `@boardsesh/queue` `Climb` satisfy this shape; `resolveGrade` renders the
@@ -387,6 +390,8 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
             benchmarkDifficulty={climb.benchmark_difficulty}
             characteristics={climb.characteristics}
             isNoMatch={climb.is_no_match}
+            difficultyError={climb.difficulty_error}
+            ascensionistCount={climb.ascensionist_count}
           />
           {climb.is_hidden ? <HiddenChip /> : null}
         </View>

--- a/packages/mobile/src/components/__tests__/ClimbAttributeIcons.test.tsx
+++ b/packages/mobile/src/components/__tests__/ClimbAttributeIcons.test.tsx
@@ -126,4 +126,31 @@ describe('ClimbAttributeIcons', () => {
     expect(icons(container)).toEqual(['benchmark', 'no.match']);
     expect(badgeTexts(container)).toEqual(['mobile.climbRow.campus · mobile.climbRow.noKickboard']);
   });
+
+  it('renders a "Stiff" badge when the crowd average notably outgrades the display grade', () => {
+    const { container } = render(<ClimbAttributeIcons difficultyError={0.8} ascensionistCount={10} />);
+    expect(badgeTexts(container)).toEqual(['mobile.climbRow.gradeError.stiff']);
+  });
+
+  it('renders a "Soft" badge when the crowd average notably undergrades the display grade', () => {
+    const { container } = render(<ClimbAttributeIcons difficultyError={-0.8} ascensionistCount={10} />);
+    expect(badgeTexts(container)).toEqual(['mobile.climbRow.gradeError.soft']);
+  });
+
+  it('does not render a grade-error badge below the notability threshold or ascent floor', () => {
+    expect(icons(render(<ClimbAttributeIcons difficultyError={0.1} ascensionistCount={10} />).container)).toEqual([]);
+    expect(badgeTexts(render(<ClimbAttributeIcons difficultyError={0.1} ascensionistCount={10} />).container)).toEqual(
+      [],
+    );
+    expect(badgeTexts(render(<ClimbAttributeIcons difficultyError={2.0} ascensionistCount={1} />).container)).toEqual(
+      [],
+    );
+  });
+
+  it('joins the grade-error badge with other text badges', () => {
+    const { container } = render(
+      <ClimbAttributeIcons characteristics={['campus']} difficultyError={0.8} ascensionistCount={10} />,
+    );
+    expect(badgeTexts(container)).toEqual(['mobile.climbRow.campus · mobile.climbRow.gradeError.stiff']);
+  });
 });

--- a/packages/mobile/src/components/search/FilterChipRow.android.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.android.tsx
@@ -52,7 +52,6 @@ import {
   climbTypeChipLabel,
 } from './FilterChipRow.logic';
 import { buildSortLabel } from '../../lib/filter-labels';
-import { useBoardseshGradesActive } from '../../hooks/use-display-grade';
 import { COLLECTION_VALUES } from '../../lib/collection-filter';
 import type { FilterChipRowProps } from './FilterChipRow.types';
 
@@ -215,15 +214,9 @@ function FilterChipRowComponent({
   const { t } = useTranslation('climbs');
   const { brandColors, colorScheme } = useTheme();
   const chipColors = filterChipBrandColors(brandColors);
-  const boardseshGradesActive = useBoardseshGradesActive();
   // Built once per render (and only when Sort is actually pinned), reused for the
   // resting label + every menu item.
   const sortLabelFor = pinnedChips.includes('sort') ? buildSortLabel(t) : null;
-  // Only offer the Boardsesh-grade sort once the climber has turned Boardsesh
-  // grades on (see useBoardseshGradesActive) — matches ClimbFilterSheet.
-  const visibleSortOptions = boardseshGradesActive
-    ? SORT_OPTIONS
-    : SORT_OPTIONS.filter((option) => option !== 'boardseshGrade');
 
   // Angle rides as the first chip: it re-grades the whole list, so it belongs with
   // the other list-refinement chips rather than in the app bar. Self-contained (reads
@@ -511,7 +504,7 @@ function FilterChipRowComponent({
               colors={chipColors}
               renderItems={(close) => (
                 <>
-                  {visibleSortOptions.map((value) => (
+                  {SORT_OPTIONS.map((value) => (
                     <MenuItem
                       key={value}
                       label={sortLabelFor?.(value) ?? value}

--- a/packages/mobile/src/components/search/FilterChipRow.android.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.android.tsx
@@ -52,6 +52,7 @@ import {
   climbTypeChipLabel,
 } from './FilterChipRow.logic';
 import { buildSortLabel } from '../../lib/filter-labels';
+import { useBoardseshGradesActive } from '../../hooks/use-display-grade';
 import { COLLECTION_VALUES } from '../../lib/collection-filter';
 import type { FilterChipRowProps } from './FilterChipRow.types';
 
@@ -214,9 +215,15 @@ function FilterChipRowComponent({
   const { t } = useTranslation('climbs');
   const { brandColors, colorScheme } = useTheme();
   const chipColors = filterChipBrandColors(brandColors);
+  const boardseshGradesActive = useBoardseshGradesActive();
   // Built once per render (and only when Sort is actually pinned), reused for the
-  // resting label + all 7 menu items.
+  // resting label + every menu item.
   const sortLabelFor = pinnedChips.includes('sort') ? buildSortLabel(t) : null;
+  // Only offer the Boardsesh-grade sort once the climber has turned Boardsesh
+  // grades on (see useBoardseshGradesActive) — matches ClimbFilterSheet.
+  const visibleSortOptions = boardseshGradesActive
+    ? SORT_OPTIONS
+    : SORT_OPTIONS.filter((option) => option !== 'boardseshGrade');
 
   // Angle rides as the first chip: it re-grades the whole list, so it belongs with
   // the other list-refinement chips rather than in the app bar. Self-contained (reads
@@ -504,7 +511,7 @@ function FilterChipRowComponent({
               colors={chipColors}
               renderItems={(close) => (
                 <>
-                  {SORT_OPTIONS.map((value) => (
+                  {visibleSortOptions.map((value) => (
                     <MenuItem
                       key={value}
                       label={sortLabelFor?.(value) ?? value}

--- a/packages/mobile/src/components/search/FilterChipRow.ios.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.ios.tsx
@@ -54,7 +54,6 @@ import {
   isClimbType,
 } from './FilterChipRow.logic';
 import { buildSortLabel } from '../../lib/filter-labels';
-import { useBoardseshGradesActive } from '../../hooks/use-display-grade';
 import { COLLECTION_VALUES } from '../../lib/collection-filter';
 import type { FilterChipRowProps } from './FilterChipRow.types';
 
@@ -95,15 +94,9 @@ function FilterChipRowComponent({
 }: FilterChipRowProps) {
   const { t } = useTranslation('climbs');
   const { brandColors } = useTheme();
-  const boardseshGradesActive = useBoardseshGradesActive();
   // Built once per render (and only when Sort is actually pinned), reused for the
   // resting label + every menu item.
   const sortLabelFor = pinnedChips.includes('sort') ? buildSortLabel(t) : null;
-  // Only offer the Boardsesh-grade sort once the climber has turned Boardsesh
-  // grades on (see useBoardseshGradesActive) — matches ClimbFilterSheet.
-  const visibleSortOptions = boardseshGradesActive
-    ? SORT_OPTIONS
-    : SORT_OPTIONS.filter((option) => option !== 'boardseshGrade');
 
   // Popularity / rating chip wording lives in FilterChipRow.logic (shared with the
   // Android tree) so a filter is never worded two ways across platforms.
@@ -372,7 +365,7 @@ function FilterChipRowComponent({
                   onChangeSort(value);
                 }}
               >
-                {visibleSortOptions.map((value) => (
+                {SORT_OPTIONS.map((value) => (
                   <Text key={value} modifiers={[tag(value)]}>
                     {sortLabelFor?.(value) ?? value}
                   </Text>

--- a/packages/mobile/src/components/search/FilterChipRow.ios.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.ios.tsx
@@ -54,6 +54,7 @@ import {
   isClimbType,
 } from './FilterChipRow.logic';
 import { buildSortLabel } from '../../lib/filter-labels';
+import { useBoardseshGradesActive } from '../../hooks/use-display-grade';
 import { COLLECTION_VALUES } from '../../lib/collection-filter';
 import type { FilterChipRowProps } from './FilterChipRow.types';
 
@@ -94,9 +95,15 @@ function FilterChipRowComponent({
 }: FilterChipRowProps) {
   const { t } = useTranslation('climbs');
   const { brandColors } = useTheme();
+  const boardseshGradesActive = useBoardseshGradesActive();
   // Built once per render (and only when Sort is actually pinned), reused for the
-  // resting label + all 7 menu items.
+  // resting label + every menu item.
   const sortLabelFor = pinnedChips.includes('sort') ? buildSortLabel(t) : null;
+  // Only offer the Boardsesh-grade sort once the climber has turned Boardsesh
+  // grades on (see useBoardseshGradesActive) — matches ClimbFilterSheet.
+  const visibleSortOptions = boardseshGradesActive
+    ? SORT_OPTIONS
+    : SORT_OPTIONS.filter((option) => option !== 'boardseshGrade');
 
   // Popularity / rating chip wording lives in FilterChipRow.logic (shared with the
   // Android tree) so a filter is never worded two ways across platforms.
@@ -365,7 +372,7 @@ function FilterChipRowComponent({
                   onChangeSort(value);
                 }}
               >
-                {SORT_OPTIONS.map((value) => (
+                {visibleSortOptions.map((value) => (
                   <Text key={value} modifiers={[tag(value)]}>
                     {sortLabelFor?.(value) ?? value}
                   </Text>

--- a/packages/mobile/src/components/search/FilterChipRow.web.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.web.tsx
@@ -29,7 +29,6 @@ import {
   climbTypeChipLabel,
 } from './FilterChipRow.logic';
 import { buildSortLabel } from '../../lib/filter-labels';
-import { useBoardseshGradesActive } from '../../hooks/use-display-grade';
 import type { FilterChipRowProps } from './FilterChipRow.types';
 
 // A chip that anchors a controlled Paper Menu. The `children` render-prop receives
@@ -106,7 +105,6 @@ function FilterChipRowComponent({
     close: closeAngle,
     change: changeAngle,
   } = useMaterialAngleControl();
-  const boardseshGradesActive = useBoardseshGradesActive();
 
   const currentRecentKey = getFilterKey(currentFilters, currentSearchText);
   const hasActivePopularity = minAscents != null;
@@ -118,11 +116,6 @@ function FilterChipRowComponent({
   // Built once per render (and only when Sort is actually pinned), reused for the
   // resting label + every menu item.
   const sortLabelFor = pinnedChips.includes('sort') ? buildSortLabel(t) : null;
-  // Only offer the Boardsesh-grade sort once the climber has turned Boardsesh
-  // grades on (see useBoardseshGradesActive) — matches ClimbFilterSheet.
-  const visibleSortOptions = boardseshGradesActive
-    ? SORT_OPTIONS
-    : SORT_OPTIONS.filter((option) => option !== 'boardseshGrade');
 
   return (
     <>
@@ -363,7 +356,7 @@ function FilterChipRowComponent({
             selected={sortActive}
           >
             {(close) =>
-              visibleSortOptions.map((value) => (
+              SORT_OPTIONS.map((value) => (
                 <Menu.Item
                   key={value}
                   title={sortLabelFor?.(value) ?? value}

--- a/packages/mobile/src/components/search/FilterChipRow.web.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.web.tsx
@@ -29,6 +29,7 @@ import {
   climbTypeChipLabel,
 } from './FilterChipRow.logic';
 import { buildSortLabel } from '../../lib/filter-labels';
+import { useBoardseshGradesActive } from '../../hooks/use-display-grade';
 import type { FilterChipRowProps } from './FilterChipRow.types';
 
 // A chip that anchors a controlled Paper Menu. The `children` render-prop receives
@@ -105,6 +106,7 @@ function FilterChipRowComponent({
     close: closeAngle,
     change: changeAngle,
   } = useMaterialAngleControl();
+  const boardseshGradesActive = useBoardseshGradesActive();
 
   const currentRecentKey = getFilterKey(currentFilters, currentSearchText);
   const hasActivePopularity = minAscents != null;
@@ -114,8 +116,13 @@ function FilterChipRowComponent({
       ? t('mobile.search.chips.filtersWithCount', { count: activeFilterCount })
       : t('mobile.filter.title');
   // Built once per render (and only when Sort is actually pinned), reused for the
-  // resting label + all 7 menu items.
+  // resting label + every menu item.
   const sortLabelFor = pinnedChips.includes('sort') ? buildSortLabel(t) : null;
+  // Only offer the Boardsesh-grade sort once the climber has turned Boardsesh
+  // grades on (see useBoardseshGradesActive) — matches ClimbFilterSheet.
+  const visibleSortOptions = boardseshGradesActive
+    ? SORT_OPTIONS
+    : SORT_OPTIONS.filter((option) => option !== 'boardseshGrade');
 
   return (
     <>
@@ -356,7 +363,7 @@ function FilterChipRowComponent({
             selected={sortActive}
           >
             {(close) =>
-              SORT_OPTIONS.map((value) => (
+              visibleSortOptions.map((value) => (
                 <Menu.Item
                   key={value}
                   title={sortLabelFor?.(value) ?? value}

--- a/packages/mobile/src/db/queries/__tests__/search-climbs-local.test.ts
+++ b/packages/mobile/src/db/queries/__tests__/search-climbs-local.test.ts
@@ -322,6 +322,24 @@ describe('searchClimbsLocal', () => {
     expect(page1.hasMore).toBe(false);
   });
 
+  // Mirrors the server's override in search-climbs.ts's runStandardSearch: an
+  // ungraded climb (no stats row at all) sorts to the bottom on either
+  // direction for the two grade sorts, unlike every other sort's SQLite
+  // default (NULLS FIRST on ASC).
+  it('sorts ungraded climbs to the bottom on ascending difficulty and userGrade', async () => {
+    await insertClimb(db, { uuid: 'soft' });
+    await insertClimb(db, { uuid: 'stiff' });
+    await insertClimb(db, { uuid: 'ungraded' });
+    await insertStat(db, { climbUuid: 'soft', displayDifficulty: 10, difficultyAverage: 10, ascensionistCount: 1 });
+    await insertStat(db, { climbUuid: 'stiff', displayDifficulty: 20, difficultyAverage: 20, ascensionistCount: 1 });
+
+    const byDifficultyAsc = await searchClimbsLocal(db, makeInput({ sortBy: 'difficulty', sortOrder: 'asc' }));
+    expect(uuids(byDifficultyAsc)).toEqual(['soft', 'stiff', 'ungraded']);
+
+    const byUserGradeAsc = await searchClimbsLocal(db, makeInput({ sortBy: 'userGrade', sortOrder: 'asc' }));
+    expect(uuids(byUserGradeAsc)).toEqual(['soft', 'stiff', 'ungraded']);
+  });
+
   it('supports name (case-insensitive), quality sort, and present-hold filters', async () => {
     await insertClimb(db, { uuid: 'crimpy', name: 'Crimpy Line', frames: 'p11r15p22r12' });
     await insertClimb(db, { uuid: 'juggy', name: 'JUGGY roof', frames: 'p33r15' });

--- a/packages/mobile/src/db/queries/search-climbs-local.ts
+++ b/packages/mobile/src/db/queries/search-climbs-local.ts
@@ -23,8 +23,10 @@ import { getGradeLabel, getClimbStars } from '../../lib/grade-label';
  *    than the server's NOT NULL boolean, so the browse predicate COALESCEs the NULL
  *    of a pre-v5 row to "visible" instead of dropping it.
  *
- * SQLite's default NULL ordering (NULLs first on ASC, last on DESC) already matches
- * the server's explicit NULLS FIRST/LAST, so no explicit clause is needed. Personal
+ * SQLite's default NULL ordering (NULLs first on ASC, last on DESC) matches the
+ * server's default NULLS FIRST/LAST, so most sorts need no explicit clause — except
+ * the two grade sorts (difficulty, userGrade), which force NULLS LAST on ASC too
+ * (see the `nullsLastOnAsc` build below), mirroring the server's override. Personal
  * progress reads the local boardsesh_ticks (the device holds one user's ticks).
  *
  * Filters that need tables we don't sync (hold-state, zone, tall/wide, beta videos,
@@ -556,9 +558,15 @@ export async function searchClimbsLocal(db: OfflineDatabase, input: ClimbSearchI
   // seed falls back to 1 rather than silently pinning every shuffle to seed 0.
   const seedInt = Number(input.sortSeed);
   const randomSeedBind = input.sortSeed && Number.isFinite(seedInt) ? Math.trunc(seedInt) : 1;
+  // Ungraded climbs (no stats row) sort to the bottom on either direction for the
+  // two grade sorts, matching the server's explicit NULLS LAST override — see the
+  // comment in search-climbs.ts's runStandardSearch. SQLite defaults to NULLS
+  // FIRST on ASC otherwise, which every other sort here still relies on.
+  const isGradeSort = sortBy === 'difficulty' || sortBy === 'userGrade';
+  const nullsLastOnAsc = isGradeSort && sortOrder === 'ASC' ? ' NULLS LAST' : '';
   const orderBy = isRandom
     ? `${RANDOM_ORDER_EXPR} ASC, c.uuid DESC`
-    : `${sortColumnSql(sortBy)} ${sortOrder}, c.uuid DESC`;
+    : `${sortColumnSql(sortBy)} ${sortOrder}${nullsLastOnAsc}, c.uuid DESC`;
 
   const query = `
     SELECT

--- a/packages/mobile/src/db/queries/search-climbs-local.ts
+++ b/packages/mobile/src/db/queries/search-climbs-local.ts
@@ -45,6 +45,7 @@ const DEFAULT_PAGE_SIZE = 20;
 const SORT_ALIASES: Record<string, string> = {
   ascents: 'ascents',
   difficulty: 'difficulty',
+  boardseshGrade: 'boardseshGrade',
   name: 'name',
   quality: 'quality',
   popular: 'popular',
@@ -385,6 +386,8 @@ function sortColumnSql(sortBy: string): string {
       return 's.ascensionist_count';
     case 'difficulty':
       return 'CAST(ROUND(s.display_difficulty) AS INTEGER)';
+    case 'boardseshGrade':
+      return 'CAST(ROUND(COALESCE(g.universal_grade, g.local_grade)) AS INTEGER)';
     case 'name':
       // NOCASE so 'apple' sorts before 'Zebra', matching Postgres's locale
       // collation (SQLite's default BINARY puts all uppercase first). ASCII

--- a/packages/mobile/src/db/queries/search-climbs-local.ts
+++ b/packages/mobile/src/db/queries/search-climbs-local.ts
@@ -45,7 +45,7 @@ const DEFAULT_PAGE_SIZE = 20;
 const SORT_ALIASES: Record<string, string> = {
   ascents: 'ascents',
   difficulty: 'difficulty',
-  boardseshGrade: 'boardseshGrade',
+  userGrade: 'userGrade',
   name: 'name',
   quality: 'quality',
   popular: 'popular',
@@ -386,8 +386,10 @@ function sortColumnSql(sortBy: string): string {
       return 's.ascensionist_count';
     case 'difficulty':
       return 'CAST(ROUND(s.display_difficulty) AS INTEGER)';
-    case 'boardseshGrade':
-      return 'CAST(ROUND(COALESCE(g.universal_grade, g.local_grade)) AS INTEGER)';
+    case 'userGrade':
+      // Raw mean of submitted grades — see the matching comment in the server's
+      // search-climbs.ts allowedSortColumns.
+      return 's.difficulty_average';
     case 'name':
       // NOCASE so 'apple' sorts before 'Zebra', matching Postgres's locale
       // collation (SQLite's default BINARY puts all uppercase first). ASCII

--- a/packages/mobile/src/lib/filter-labels.ts
+++ b/packages/mobile/src/lib/filter-labels.ts
@@ -89,6 +89,7 @@ export function buildSortLabel(t: TFunction<'climbs'>): (sortBy: string) => stri
     ascents: t('mobile.filter.sort.ascents'),
     quality: t('mobile.filter.sort.quality'),
     difficulty: t('mobile.filter.sort.difficulty'),
+    boardseshGrade: t('mobile.filter.sort.boardseshGrade'),
     name: t('mobile.filter.sort.name'),
     popular: t('mobile.filter.sort.popular'),
     creation: t('mobile.filter.sort.creation'),

--- a/packages/mobile/src/lib/filter-labels.ts
+++ b/packages/mobile/src/lib/filter-labels.ts
@@ -89,7 +89,7 @@ export function buildSortLabel(t: TFunction<'climbs'>): (sortBy: string) => stri
     ascents: t('mobile.filter.sort.ascents'),
     quality: t('mobile.filter.sort.quality'),
     difficulty: t('mobile.filter.sort.difficulty'),
-    boardseshGrade: t('mobile.filter.sort.boardseshGrade'),
+    userGrade: t('mobile.filter.sort.userGrade'),
     name: t('mobile.filter.sort.name'),
     popular: t('mobile.filter.sort.popular'),
     creation: t('mobile.filter.sort.creation'),

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -181,7 +181,7 @@ input ClimbSearchInput {
   minAscents: Int
   "Minimum quality rating"
   minRating: Float
-  "Field to sort by ('ascents', 'difficulty', 'boardseshGrade', 'name', 'quality', 'popular', 'creation', 'random')"
+  "Field to sort by ('ascents', 'difficulty', 'userGrade', 'name', 'quality', 'popular', 'creation', 'random')"
   sortBy: String
   "Sort direction ('asc' or 'desc')"
   sortOrder: String

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -181,7 +181,7 @@ input ClimbSearchInput {
   minAscents: Int
   "Minimum quality rating"
   minRating: Float
-  "Field to sort by ('ascents', 'difficulty', 'name', 'quality', 'popular', 'creation', 'random')"
+  "Field to sort by ('ascents', 'difficulty', 'boardseshGrade', 'name', 'quality', 'popular', 'creation', 'random')"
   sortBy: String
   "Sort direction ('asc' or 'desc')"
   sortOrder: String

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1219,7 +1219,7 @@ export type ClimbSearchInput = {
   showOnlyCompleted?: InputMaybe<Scalars['Boolean']['input']>;
   /** Size ID */
   sizeId: Scalars['Int']['input'];
-  /** Field to sort by ('ascents', 'difficulty', 'boardseshGrade', 'name', 'quality', 'popular', 'creation', 'random') */
+  /** Field to sort by ('ascents', 'difficulty', 'userGrade', 'name', 'quality', 'popular', 'creation', 'random') */
   sortBy?: InputMaybe<Scalars['String']['input']>;
   /** Sort direction ('asc' or 'desc') */
   sortOrder?: InputMaybe<Scalars['String']['input']>;

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -1219,7 +1219,7 @@ export type ClimbSearchInput = {
   showOnlyCompleted?: InputMaybe<Scalars['Boolean']['input']>;
   /** Size ID */
   sizeId: Scalars['Int']['input'];
-  /** Field to sort by ('ascents', 'difficulty', 'name', 'quality', 'popular', 'creation', 'random') */
+  /** Field to sort by ('ascents', 'difficulty', 'boardseshGrade', 'name', 'quality', 'popular', 'creation', 'random') */
   sortBy?: InputMaybe<Scalars['String']['input']>;
   /** Sort direction ('asc' or 'desc') */
   sortOrder?: InputMaybe<Scalars['String']['input']>;

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -177,7 +177,7 @@ export const climbTypeDefs = /* GraphQL */ `
     minAscents: Int
     "Minimum quality rating"
     minRating: Float
-    "Field to sort by ('ascents', 'difficulty', 'boardseshGrade', 'name', 'quality', 'popular', 'creation', 'random')"
+    "Field to sort by ('ascents', 'difficulty', 'userGrade', 'name', 'quality', 'popular', 'creation', 'random')"
     sortBy: String
     "Sort direction ('asc' or 'desc')"
     sortOrder: String

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -177,7 +177,7 @@ export const climbTypeDefs = /* GraphQL */ `
     minAscents: Int
     "Minimum quality rating"
     minRating: Float
-    "Field to sort by ('ascents', 'difficulty', 'name', 'quality', 'popular', 'creation', 'random')"
+    "Field to sort by ('ascents', 'difficulty', 'boardseshGrade', 'name', 'quality', 'popular', 'creation', 'random')"
     sortBy: String
     "Sort direction ('asc' or 'desc')"
     sortOrder: String

--- a/packages/shared/climb-filters/src/filter-state.ts
+++ b/packages/shared/climb-filters/src/filter-state.ts
@@ -4,7 +4,7 @@ export const SORT_OPTIONS = [
   'ascents',
   'quality',
   'difficulty',
-  'boardseshGrade',
+  'userGrade',
   'name',
   'popular',
   'creation',

--- a/packages/shared/climb-filters/src/filter-state.ts
+++ b/packages/shared/climb-filters/src/filter-state.ts
@@ -1,6 +1,15 @@
 import type { ClimbSearchInput } from '@boardsesh/shared-schema';
 
-export const SORT_OPTIONS = ['ascents', 'quality', 'difficulty', 'name', 'popular', 'creation', 'random'] as const;
+export const SORT_OPTIONS = [
+  'ascents',
+  'quality',
+  'difficulty',
+  'boardseshGrade',
+  'name',
+  'popular',
+  'creation',
+  'random',
+] as const;
 export type SortOption = (typeof SORT_OPTIONS)[number];
 
 export const SORT_ORDERS = ['asc', 'desc'] as const;

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1216,7 +1216,7 @@ export type ClimbSearchInput = {
   showOnlyCompleted?: InputMaybe<Scalars['Boolean']['input']>;
   /** Size ID */
   sizeId: Scalars['Int']['input'];
-  /** Field to sort by ('ascents', 'difficulty', 'boardseshGrade', 'name', 'quality', 'popular', 'creation', 'random') */
+  /** Field to sort by ('ascents', 'difficulty', 'userGrade', 'name', 'quality', 'popular', 'creation', 'random') */
   sortBy?: InputMaybe<Scalars['String']['input']>;
   /** Sort direction ('asc' or 'desc') */
   sortOrder?: InputMaybe<Scalars['String']['input']>;

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -1216,7 +1216,7 @@ export type ClimbSearchInput = {
   showOnlyCompleted?: InputMaybe<Scalars['Boolean']['input']>;
   /** Size ID */
   sizeId: Scalars['Int']['input'];
-  /** Field to sort by ('ascents', 'difficulty', 'name', 'quality', 'popular', 'creation', 'random') */
+  /** Field to sort by ('ascents', 'difficulty', 'boardseshGrade', 'name', 'quality', 'popular', 'creation', 'random') */
   sortBy?: InputMaybe<Scalars['String']['input']>;
   /** Sort direction ('asc' or 'desc') */
   sortOrder?: InputMaybe<Scalars['String']['input']>;

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -435,6 +435,7 @@
         "ascents": "Begehungen",
         "quality": "Qualität",
         "difficulty": "Schwierigkeit",
+        "boardseshGrade": "Boardsesh-Grad",
         "name": "Name",
         "popular": "Beliebt",
         "creation": "Neueste",

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -100,7 +100,11 @@
       "footlessKickboard": "Ohne Füße + KB",
       "noKickboard": "Ohne KB"
     },
-    "anyFeet": "Freie Füße"
+    "anyFeet": "Freie Füße",
+    "gradeError": {
+      "stiff": "Hart",
+      "soft": "Weich"
+    }
   },
   "boardseshGrade": {
     "title": "Boardsesh-Grad",
@@ -549,6 +553,10 @@
         "footless": "Ohne Füße",
         "footlessKickboard": "Ohne Füße + KB",
         "noKickboard": "Ohne KB"
+      },
+      "gradeError": {
+        "stiff": "Hart",
+        "soft": "Weich"
       }
     },
     "climbRules": {

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -435,7 +435,7 @@
         "ascents": "Begehungen",
         "quality": "Qualität",
         "difficulty": "Schwierigkeit",
-        "boardseshGrade": "Boardsesh-Grad",
+        "userGrade": "Nutzergrad",
         "name": "Name",
         "popular": "Beliebt",
         "creation": "Neueste",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -435,7 +435,7 @@
         "ascents": "Ascents",
         "quality": "Quality",
         "difficulty": "Difficulty",
-        "boardseshGrade": "Boardsesh grade",
+        "userGrade": "User grade",
         "name": "Name",
         "popular": "Popular",
         "creation": "Newest",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -435,6 +435,7 @@
         "ascents": "Ascents",
         "quality": "Quality",
         "difficulty": "Difficulty",
+        "boardseshGrade": "Boardsesh grade",
         "name": "Name",
         "popular": "Popular",
         "creation": "Newest",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -100,7 +100,11 @@
       "footlessKickboard": "Footless + KB",
       "noKickboard": "No KB"
     },
-    "anyFeet": "Any feet"
+    "anyFeet": "Any feet",
+    "gradeError": {
+      "stiff": "Stiff",
+      "soft": "Soft"
+    }
   },
   "boardseshGrade": {
     "title": "Boardsesh grade",
@@ -549,6 +553,10 @@
         "footless": "Footless",
         "footlessKickboard": "Footless + KB",
         "noKickboard": "No KB"
+      },
+      "gradeError": {
+        "stiff": "Stiff",
+        "soft": "Soft"
       }
     },
     "climbRules": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -435,6 +435,7 @@
         "ascents": "Ascensos",
         "quality": "Calidad",
         "difficulty": "Dificultad",
+        "boardseshGrade": "Grado Boardsesh",
         "name": "Nombre",
         "popular": "Populares",
         "creation": "Más recientes",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -435,7 +435,7 @@
         "ascents": "Ascensos",
         "quality": "Calidad",
         "difficulty": "Dificultad",
-        "boardseshGrade": "Grado Boardsesh",
+        "userGrade": "Grado de usuarios",
         "name": "Nombre",
         "popular": "Populares",
         "creation": "Más recientes",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -100,7 +100,11 @@
       "footlessKickboard": "Sin pies + KB",
       "noKickboard": "Sin KB"
     },
-    "anyFeet": "Pies libres"
+    "anyFeet": "Pies libres",
+    "gradeError": {
+      "stiff": "Duro",
+      "soft": "Suave"
+    }
   },
   "boardseshGrade": {
     "title": "Grado Boardsesh",
@@ -549,6 +553,10 @@
         "footless": "Sin pies",
         "footlessKickboard": "Sin pies + KB",
         "noKickboard": "Sin KB"
+      },
+      "gradeError": {
+        "stiff": "Duro",
+        "soft": "Suave"
       }
     },
     "climbRules": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -100,7 +100,11 @@
       "footlessKickboard": "Sans pieds + KB",
       "noKickboard": "Sans KB"
     },
-    "anyFeet": "Pieds libres"
+    "anyFeet": "Pieds libres",
+    "gradeError": {
+      "stiff": "Sévère",
+      "soft": "Douce"
+    }
   },
   "boardseshGrade": {
     "title": "Grade Boardsesh",
@@ -549,6 +553,10 @@
         "footless": "Sans pieds",
         "footlessKickboard": "Sans pieds + KB",
         "noKickboard": "Sans KB"
+      },
+      "gradeError": {
+        "stiff": "Sévère",
+        "soft": "Douce"
       }
     },
     "climbRules": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -435,7 +435,7 @@
         "ascents": "Ascensions",
         "quality": "Qualité",
         "difficulty": "Difficulté",
-        "boardseshGrade": "Grade Boardsesh",
+        "userGrade": "Cotation grimpeurs",
         "name": "Nom",
         "popular": "Populaires",
         "creation": "Plus récentes",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -435,6 +435,7 @@
         "ascents": "Ascensions",
         "quality": "Qualité",
         "difficulty": "Difficulté",
+        "boardseshGrade": "Grade Boardsesh",
         "name": "Nom",
         "popular": "Populaires",
         "creation": "Plus récentes",

--- a/packages/shared/logbook/src/__tests__/grade-display.test.ts
+++ b/packages/shared/logbook/src/__tests__/grade-display.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { deriveLogbookGradeDisplay, resolveCrowdDifficulty } from '../grade-display';
+import { deriveLogbookGradeDisplay, resolveCrowdDifficulty, resolveGradeErrorBadge } from '../grade-display';
 
 describe('deriveLogbookGradeDisplay', () => {
   it('shows no consensus secondary when the logged grade matches the consensus', () => {
@@ -90,5 +90,41 @@ describe('resolveCrowdDifficulty', () => {
     // surfaces the grade instead of being silently dropped. See the comment
     // on the guard in grade-display.ts.
     expect(resolveCrowdDifficulty({ boardseshDifficulty: 18, boardseshConfidence: undefined }, true)).toBe(18);
+  });
+});
+
+describe('resolveGradeErrorBadge', () => {
+  it('flags a climb as stiff when the crowd average runs harder than the display grade', () => {
+    expect(resolveGradeErrorBadge(0.7, 10)).toEqual({ direction: 'stiff', amount: 0.7 });
+  });
+
+  it('flags a climb as soft when the crowd average runs easier than the display grade', () => {
+    expect(resolveGradeErrorBadge(-0.6, 10)).toEqual({ direction: 'soft', amount: 0.6 });
+  });
+
+  it('parses a string difficulty_error, the shape the wire format carries', () => {
+    expect(resolveGradeErrorBadge('0.55', 10)).toEqual({ direction: 'stiff', amount: 0.55 });
+    expect(resolveGradeErrorBadge('-0.55', 10)).toEqual({ direction: 'soft', amount: 0.55 });
+  });
+
+  it('returns null below the notability threshold, even with plenty of ascents', () => {
+    expect(resolveGradeErrorBadge(0.2, 100)).toBeNull();
+    expect(resolveGradeErrorBadge(-0.49, 100)).toBeNull();
+  });
+
+  it('returns null below the minimum ascent count, even with a large gap', () => {
+    expect(resolveGradeErrorBadge(2.0, 4)).toBeNull();
+    expect(resolveGradeErrorBadge(2.0, 0)).toBeNull();
+    expect(resolveGradeErrorBadge(2.0, null)).toBeNull();
+  });
+
+  it('returns null for a missing or unparsable difficulty_error', () => {
+    expect(resolveGradeErrorBadge(null, 100)).toBeNull();
+    expect(resolveGradeErrorBadge(undefined, 100)).toBeNull();
+    expect(resolveGradeErrorBadge('not-a-number', 100)).toBeNull();
+  });
+
+  it('treats the threshold and ascent-count boundaries as inclusive', () => {
+    expect(resolveGradeErrorBadge(0.5, 5)).toEqual({ direction: 'stiff', amount: 0.5 });
   });
 });

--- a/packages/shared/logbook/src/grade-display.ts
+++ b/packages/shared/logbook/src/grade-display.ts
@@ -127,3 +127,48 @@ export function consensusDeltaDirection(
   if (loggedDifficulty === consensusDifficulty) return null;
   return loggedDifficulty > consensusDifficulty ? 'up' : 'down';
 }
+
+/**
+ * Minimum ascents before a climb's crowd-average grade is trusted enough to
+ * carry a "stiff/soft" badge — a couple of outlier votes on a fresh climb
+ * shouldn't flicker a grade-discrepancy badge on.
+ */
+export const MIN_ASCENTS_FOR_GRADE_ERROR_BADGE = 5;
+
+/**
+ * Minimum |difficulty_error| (difficulty-id units, the same ordinal scale
+ * minGrade/maxGrade use) before the gap reads as a real discrepancy rather
+ * than noise.
+ */
+export const GRADE_ERROR_BADGE_THRESHOLD = 0.5;
+
+export type GradeErrorBadge = { direction: 'stiff' | 'soft'; amount: number };
+
+/**
+ * Whether a climb's card should show a "stiff/soft" badge, and which way,
+ * from `difficulty_error` — `board_climb_stats.difficulty_average −
+ * display_difficulty`, computed server-side and already carried on every
+ * climb row (search results, GraphQL `Climb`, the offline SQLite mapping).
+ * Positive means the crowd's actual grade opinions run harder than the
+ * displayed grade ("stiff"); negative means they run easier ("soft") — the
+ * same higher-id-is-harder convention as `consensusDeltaDirection` above,
+ * just at the climb level (crowd average vs. display) instead of the ascent
+ * level (one climber's log vs. consensus).
+ *
+ * Pure and platform-agnostic on purpose: works for any board, including
+ * MoonBoard, where `difficulty_error` is populated the same way but the
+ * Boardsesh grade model (`board_climb_grades`) is deliberately unavailable.
+ *
+ * Accepts `difficulty_error` as the string the wire format carries it as, or
+ * a number for callers that already parsed it.
+ */
+export function resolveGradeErrorBadge(
+  difficultyError: string | number | null | undefined,
+  ascensionistCount: number | null | undefined,
+): GradeErrorBadge | null {
+  const parsed = typeof difficultyError === 'string' ? Number(difficultyError) : difficultyError;
+  if (parsed == null || !Number.isFinite(parsed)) return null;
+  if ((ascensionistCount ?? 0) < MIN_ASCENTS_FOR_GRADE_ERROR_BADGE) return null;
+  if (Math.abs(parsed) < GRADE_ERROR_BADGE_THRESHOLD) return null;
+  return { direction: parsed > 0 ? 'stiff' : 'soft', amount: Math.abs(parsed) };
+}

--- a/packages/web/app/components/climb-card/climb-icons.tsx
+++ b/packages/web/app/components/climb-card/climb-icons.tsx
@@ -15,6 +15,11 @@ type ClimbIconsProps = {
   /** Already-translated "any feet" label, or null when the climb keeps the marked
    *  holds. Same shape as `methodLabel` — the parent resolves it via i18n. */
   anyFeetLabel?: string | null;
+  /** Already-translated "stiff"/"soft" grade-discrepancy badge, or null when the
+   *  crowd average doesn't notably disagree with the display grade (or there
+   *  aren't enough ascents to trust it yet). Same shape as `methodLabel` — the
+   *  parent resolves it via resolveGradeErrorLabel. */
+  gradeErrorLabel?: string | null;
 };
 
 const benchmarkIconSx = {
@@ -48,6 +53,7 @@ export default function ClimbIcons({
   isNoMatch = false,
   methodLabel = null,
   anyFeetLabel = null,
+  gradeErrorLabel = null,
 }: ClimbIconsProps) {
   const benchmarkValue = benchmarkDifficulty != null ? Number(benchmarkDifficulty) : null;
   const isBenchmarkOrClassic =
@@ -65,6 +71,11 @@ export default function ClimbIcons({
       {anyFeetLabel && (
         <Typography component="span" sx={methodLabelSx}>
           {anyFeetLabel}
+        </Typography>
+      )}
+      {gradeErrorLabel && (
+        <Typography component="span" sx={methodLabelSx}>
+          {gradeErrorLabel}
         </Typography>
       )}
     </>

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -11,7 +11,7 @@ import { themeTokens } from '@/app/theme/theme-config';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
 import { formatSends, formatQuality } from '@/app/lib/format-climb-stats';
 import { useGradeFormat } from '@/app/hooks/use-grade-format';
-import { resolveAnyFeetLabel, resolveMoonBoardMethodLabel } from '@/app/lib/climb-method';
+import { resolveAnyFeetLabel, resolveMoonBoardMethodLabel, resolveGradeErrorLabel } from '@/app/lib/climb-method';
 import { getMoonBoardMethod, isAnyFeet, isCampus } from '@boardsesh/shared-schema';
 
 export type ClimbTitleData = {
@@ -26,6 +26,9 @@ export type ClimbTitleData = {
   communityGrade?: string | null;
   is_no_match?: boolean | null;
   characteristics?: string[] | null;
+  /** board_climb_stats.difficulty_average − display_difficulty, for the
+   *  "stiff/soft" grade-discrepancy badge. See resolveGradeErrorLabel. */
+  difficulty_error?: string | number | null;
 };
 
 export type ClimbTitleProps = {
@@ -261,6 +264,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
     const resolvedIsNoMatch = isNoMatch || Boolean(climb.is_no_match);
     const methodLabel = resolveMoonBoardMethodLabel(climb.characteristics, t);
     const anyFeetLabel = resolveAnyFeetLabel(climb.characteristics, t);
+    const gradeErrorLabel = resolveGradeErrorLabel(climb.difficulty_error, climb.ascensionist_count, t);
 
     const renderDifficultyText = () => {
       if (hasGrade) {
@@ -284,6 +288,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
             isNoMatch={resolvedIsNoMatch}
             methodLabel={methodLabel}
             anyFeetLabel={anyFeetLabel}
+            gradeErrorLabel={gradeErrorLabel}
           />
         </Typography>
       </MarqueeText>
@@ -473,6 +478,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
       prevClimb.angle === nextClimb.angle &&
       prevClimb.setter_username === nextClimb.setter_username &&
       prevClimb.ascensionist_count === nextClimb.ascensionist_count &&
+      prevClimb.difficulty_error === nextClimb.difficulty_error &&
       prevClimb.is_draft === nextClimb.is_draft &&
       prevClimb.communityGrade === nextClimb.communityGrade &&
       prevClimb.is_no_match === nextClimb.is_no_match &&

--- a/packages/web/app/lib/__tests__/climb-method.test.ts
+++ b/packages/web/app/lib/__tests__/climb-method.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import type { TFunction } from 'i18next';
+import { resolveGradeErrorLabel } from '../climb-method';
+
+// t() returns the key, so the label is directly assertable.
+const t = ((key: string) => key) as unknown as TFunction<'climbs'>;
+
+describe('resolveGradeErrorLabel', () => {
+  it('returns the "stiff" label when the crowd average notably outgrades the display grade', () => {
+    expect(resolveGradeErrorLabel(0.8, 10, t)).toBe('card.gradeError.stiff');
+  });
+
+  it('returns the "soft" label when the crowd average notably undergrades the display grade', () => {
+    expect(resolveGradeErrorLabel(-0.8, 10, t)).toBe('card.gradeError.soft');
+  });
+
+  it('returns null below the notability threshold', () => {
+    expect(resolveGradeErrorLabel(0.1, 10, t)).toBeNull();
+  });
+
+  it('returns null below the minimum ascent count', () => {
+    expect(resolveGradeErrorLabel(2.0, 1, t)).toBeNull();
+  });
+
+  it('returns null for a missing difficulty_error', () => {
+    expect(resolveGradeErrorLabel(null, 10, t)).toBeNull();
+    expect(resolveGradeErrorLabel(undefined, 10, t)).toBeNull();
+  });
+
+  it('parses a string difficulty_error, the shape the wire format carries', () => {
+    expect(resolveGradeErrorLabel('0.6', 10, t)).toBe('card.gradeError.stiff');
+  });
+});

--- a/packages/web/app/lib/climb-method.ts
+++ b/packages/web/app/lib/climb-method.ts
@@ -1,5 +1,6 @@
 import type { TFunction } from 'i18next';
 import { getMoonBoardMethod, isAnyFeet, isCampus, CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema';
+import { resolveGradeErrorBadge } from '@boardsesh/logbook';
 
 /**
  * Resolve the translated short label for a climb's MoonBoard method
@@ -37,4 +38,20 @@ export function resolveAnyFeetLabel(
 ): string | null {
   if (isCampus(characteristics) || !isAnyFeet(characteristics)) return null;
   return t('card.anyFeet');
+}
+
+/**
+ * The short "stiff/soft" badge label for a climb whose crowd-average grade
+ * (difficulty_error) notably disagrees with its displayed grade — works on
+ * every board, including MoonBoard, unlike the Boardsesh-grade comparison
+ * shown elsewhere. See resolveGradeErrorBadge for the notability gate.
+ */
+export function resolveGradeErrorLabel(
+  difficultyError: string | number | null | undefined,
+  ascensionistCount: number | null | undefined,
+  t: TFunction<'climbs'>,
+): string | null {
+  const badge = resolveGradeErrorBadge(difficultyError, ascensionistCount);
+  if (!badge) return null;
+  return badge.direction === 'stiff' ? t('card.gradeError.stiff') : t('card.gradeError.soft');
 }

--- a/packages/web/app/lib/types.ts
+++ b/packages/web/app/lib/types.ts
@@ -139,7 +139,7 @@ export type SearchRequest = {
   minAscents: number;
   minGrade: number;
   minRating: number;
-  sortBy: 'ascents' | 'difficulty' | 'name' | 'quality' | 'popular' | 'creation' | 'random';
+  sortBy: 'ascents' | 'difficulty' | 'boardseshGrade' | 'name' | 'quality' | 'popular' | 'creation' | 'random';
   sortOrder: 'asc' | 'desc';
   // Seed for the 'random' sort; empty for every other sort. Keeps a shuffle stable
   // across paginated fetches (see newSortSeed / md5(uuid || seed) in the DB query).

--- a/packages/web/app/lib/types.ts
+++ b/packages/web/app/lib/types.ts
@@ -139,7 +139,7 @@ export type SearchRequest = {
   minAscents: number;
   minGrade: number;
   minRating: number;
-  sortBy: 'ascents' | 'difficulty' | 'boardseshGrade' | 'name' | 'quality' | 'popular' | 'creation' | 'random';
+  sortBy: 'ascents' | 'difficulty' | 'userGrade' | 'name' | 'quality' | 'popular' | 'creation' | 'random';
   sortOrder: 'asc' | 'desc';
   // Seed for the 'random' sort; empty for every other sort. Keeps a shuffle stable
   // across paginated fetches (see newSortSeed / md5(uuid || seed) in the DB query).


### PR DESCRIPTION
## Summary

Three related changes, all stemming from "let me tell if a climb is easy or hard for its grade":

1. **Sort by average user grade.** Adds a `userGrade` sort option next to the existing `difficulty` (Aurora's displayed grade) sort, on both the Postgres and offline SQLite search paths. Sorts by `board_climb_stats.difficulty_average` — the raw mean of every ascent's submitted grade — which is populated on every board **including MoonBoard**, unlike the Boardsesh-grade model (`board_climb_grades`), which MoonBoard is deliberately excluded from.
2. **Ungraded climbs sort to the bottom, either direction.** A climb with no ascents yet used to jump to the *top* of an ascending Difficulty/User-grade sort (SQL/SQLite's default `NULLS FIRST` on `ASC`), burying every actually-graded climb below a pile of unknowns. Forced `NULLS LAST` on both directions for the two grade sorts specifically.
3. **A "Stiff"/"Soft" badge on the climb card.** A sort only lets you reorder climbs — it doesn't show whether one climb in particular is easy or hard for its grade. `board_climb_stats.difficulty_error` (crowd average − displayed grade) was already computed for every climb on every board but never rendered anywhere. Added a small badge next to the climb name (web `ClimbIcons`, mobile `ClimbAttributeIcons`) driven by a new shared pure function (`resolveGradeErrorBadge` in `@boardsesh/logbook`), gated on ascent count and a minimum gap so a freshly-set climb with one or two grade opinions doesn't flicker a badge on from noise.

**Revision history:** the first version of this PR sorted by the "Boardsesh grade" (the data-science model grade) instead of (1). A QA verdict from Jay declined it — Boardsesh grade doesn't exist for MoonBoard, so that sort was useless for the exact case that motivated the request. Swapped to `difficulty_average`. Jay then asked for (2) and (3) as follow-ups in the same conversation.

Verified locally: `vp run typecheck:db`, `vp run typecheck:web`, `vp run typecheck:mobile`, `vp check`, `vp run check:i18n`, `vp run check:i18n:orphans`, `vp run check:mobile-bundle` all clean. DB search tests, mobile filter/sort/attribute-icon tests, web climb-title/climb-method tests, and the shared `@boardsesh/logbook` and i18n catalog-completeness tests all pass.

## Release Notes

- Sort your climb list by User grade — the average of grades climbers submit — right alongside the classic Difficulty sort. Works on every board, MoonBoard included.
- Ungraded climbs no longer jump to the top when sorting easiest-first.
- Spot climbs that grade stiff or soft for their label at a glance, with a new badge on the climb card.

## Test plan

1. Go to a board's climb list, tap the Sort chip.
2. Pick "User grade" — list re-sorts, no crash.
3. Sort ascending — climbs with no ascents yet sit at the bottom, not the top.
4. Look for a "Stiff" or "Soft" badge next to well-voted climbs whose grade reads off.
5. Switch to a MoonBoard list, repeat steps 2-4 — all work there too.

## Risk

Risk: 3/5 — new sort key + NULLS handling on the shared search query (web + mobile + offline SQLite), plus a new badge touching the shared climb-card components on both platforms; no data writes or migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KjE8burZg6iJhP1SkB9DYU