### PR TITLE
feat(backend): let a route be paced up to 60s a frame

### DIFF
--- a/packages/backend/src/__tests__/climb-frames-pace-bounds.test.ts
+++ b/packages/backend/src/__tests__/climb-frames-pace-bounds.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { SaveClimbInputSchema, UpdateClimbInputSchema } from '../validation/schemas';
+
+/**
+ * The server's ceiling on `framesPace`, guarded in both directions.
+ *
+ * The number is load-bearing across two packages that can't import each other:
+ * the mobile authoring control offers seconds-per-frame up to `MAX_PACE_MS`
+ * (`@boardsesh/playback-react`), and a save carrying that pace has to survive
+ * this schema. Drop the ceiling below the control's and a setter's slowest
+ * route is rejected at save time with nothing on screen explaining why; the
+ * catalogue already holds synced Aurora routes paced at exactly 60s.
+ */
+const MAX_FRAMES_PACE_MS = 60_000;
+
+const saveClimb = (framesPace: number) =>
+  SaveClimbInputSchema.safeParse({
+    boardType: 'kilter',
+    layoutId: 1,
+    name: 'Endurance lap',
+    isDraft: false,
+    frames: 'p1r12',
+    framesCount: 4,
+    framesPace,
+    angle: 40,
+  });
+
+const updateClimb = (framesPace: number) =>
+  UpdateClimbInputSchema.safeParse({ uuid: 'climb-1', boardType: 'kilter', framesPace });
+
+describe.each([
+  { name: 'save climb', parse: saveClimb },
+  { name: 'update climb', parse: updateClimb },
+])('$name frames pace bounds', ({ parse }) => {
+  it('accepts the slowest pace the authoring control can produce', () => {
+    expect(parse(MAX_FRAMES_PACE_MS).success).toBe(true);
+  });
+
+  it('accepts a pace synced in above the old 30s ceiling', () => {
+    expect(parse(45_000).success).toBe(true);
+  });
+
+  it('rejects a pace past the ceiling', () => {
+    expect(parse(MAX_FRAMES_PACE_MS + 1).success).toBe(false);
+  });
+
+  it('rejects a negative pace', () => {
+    expect(parse(-1).success).toBe(false);
+  });
+
+  it('keeps 0 legal — it means "use the default"', () => {
+    expect(parse(0).success).toBe(true);
+  });
+});

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -295,10 +295,11 @@ export const SaveClimbInputSchema = z
     frames: z.string().min(1).max(10000),
     framesCount: z.number().int().min(1).optional(),
     // Upper bound so a client bug can't publish a route that sits on one frame
-    // for hours. 30s is well past the 10s ceiling the authoring control offers,
-    // so it rejects nonsense without second-guessing a deliberate slow route or
-    // a pace synced in from Aurora. 0 stays legal: it means "use the default".
-    framesPace: z.number().int().min(0).max(30_000).optional(),
+    // for hours. 60s is both the slowest pace the authoring control offers and
+    // the slowest one the synced Aurora catalogue actually holds, so it rejects
+    // nonsense without truncating a deliberate endurance route. 0 stays legal:
+    // it means "use the default".
+    framesPace: z.number().int().min(0).max(60_000).optional(),
     angle: z.number().int().min(-5).max(90),
     characteristics: ToggleableCharacteristicsSchema,
     noMatch: RuleFlagSchema,
@@ -321,10 +322,11 @@ export const UpdateClimbInputSchema = z
     isDraft: z.boolean().optional(),
     framesCount: z.number().int().min(1).optional(),
     // Upper bound so a client bug can't publish a route that sits on one frame
-    // for hours. 30s is well past the 10s ceiling the authoring control offers,
-    // so it rejects nonsense without second-guessing a deliberate slow route or
-    // a pace synced in from Aurora. 0 stays legal: it means "use the default".
-    framesPace: z.number().int().min(0).max(30_000).optional(),
+    // for hours. 60s is both the slowest pace the authoring control offers and
+    // the slowest one the synced Aurora catalogue actually holds, so it rejects
+    // nonsense without truncating a deliberate endurance route. 0 stays legal:
+    // it means "use the default".
+    framesPace: z.number().int().min(0).max(60_000).optional(),
     characteristics: ToggleableCharacteristicsSchema,
     noMatch: RuleFlagSchema,
     anyFeet: RuleFlagSchema,


### PR DESCRIPTION
## Summary

Raises the server's `framesPace` ceiling from 30s to 60s a frame, in both
`SaveClimbInputSchema` and `UpdateClimbInputSchema`. No migration — `frames_pace`
is a plain `integer` column, and these two bounds are the only ones on the field.

The 30s number was chosen as "well past" the 10s ceiling the mobile authoring
control offered. Two things make it wrong now:

- **The catalogue already exceeds it.** Of 744 synced multi-frame routes, 359
  are paced slower than 10s a frame, and the slowest sit at exactly 60s. Kilter
  routes average 18.8 frames at 7.5s a frame, which is endurance training rather
  than animation.
- **The control is about to offer the full range.** #4633 replaces the play
  drawer's `1×` multiplier with seconds-per-frame and gives the creator and the
  reader one shared range. The server has to accept what a setter can choose.

**This lands ahead of that client change on purpose.** A production OTA
auto-publishes on every push to `main` and can reach a phone before the backend
deploy for the same merge finishes. A setter saving a 45s route in that window
would get a validation rejection with nothing on screen to explain it.

Author-side verification:

- New test file covers both schemas at 0, 45s, 60s, 60s + 1ms and -1ms.
- Mutation-tested: putting `max(30_000)` back fails 4 of the 10 cases.
- `vp run typecheck:backend` and `vp check` clean (the two `vp check` errors are
  pre-existing in `packages/db/scripts/`, untouched by this diff).

Part of #4633.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — one validation bound widened, covered in both directions by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwPHKuV2L68VJVcgCtnLCX
