### PR TITLE
perf: block Yandex and stop crawlers driving Sentry and GraphQL writes

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -889,6 +889,10 @@ jobs:
           set -euo pipefail
           cp deploy/app-subdomain/_redirects   "$RUNNER_TEMP/app-standalone/_redirects"
           cp deploy/app-subdomain/_headers     "$RUNNER_TEMP/app-standalone/_headers"
+          # robots.txt must be a real file: _redirects' SPA catch-all would
+          # otherwise answer /robots.txt with index.html and crawlers would read
+          # no rules. See the file's own header.
+          cp deploy/app-subdomain/robots.txt   "$RUNNER_TEMP/app-standalone/robots.txt"
           # _routes.json scopes the Function below to the three asset prefixes,
           # so the shell and every SPA route stay pure static assets.
           cp deploy/app-subdomain/_routes.json "$RUNNER_TEMP/app-standalone/_routes.json"

--- a/deploy/app-subdomain/__tests__/robots.test.ts
+++ b/deploy/app-subdomain/__tests__/robots.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Guards the robots.txt shipped to the root of app.boardsesh.com, and the one
+// line in production-deploy.yml that puts it there.
+//
+// Both halves are load-bearing and neither is obvious from the other. Without
+// the file, `_redirects`' SPA catch-all answers /robots.txt with the app shell
+// and a crawler reads no rules; without the copy step, the file sits in the
+// repo and never reaches the published export. That was the live state on
+// 2026-09-11 — https://app.boardsesh.com/robots.txt returned index.html.
+
+const robots = readFileSync(resolve(import.meta.dirname, '..', 'robots.txt'), 'utf8');
+
+const WORKFLOW_PATH = resolve(import.meta.dirname, '..', '..', '..', '.github', 'workflows', 'production-deploy.yml');
+const workflow = readFileSync(WORKFLOW_PATH, 'utf8');
+
+/** Directive lines only — blank lines and `#` comments carry no meaning here. */
+function directives(source: string): string[] {
+  return source
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '' && !line.startsWith('#'));
+}
+
+describe('deploy/app-subdomain/robots.txt', () => {
+  it('closes the whole host to every crawler', () => {
+    // Parsed rather than string-matched, so a stray `Allow:` added later fails
+    // here instead of shipping.
+    expect(directives(robots)).toEqual(['User-agent: *', 'Disallow: /']);
+  });
+
+  it('carves out no exception for any individual agent', () => {
+    // A per-agent block would need its own `User-agent:` line. One group is the
+    // whole policy: the export is a single static shell with no per-route Open
+    // Graph tags, so there is nothing an unfurler could usefully read.
+    const lines = directives(robots);
+    expect(lines.filter((line) => line.toLowerCase().startsWith('user-agent:'))).toHaveLength(1);
+    // Directives only: the file's own comment explains why Disallow beats
+    // noindex here, and `Disallow` contains `allow`.
+    expect(lines.filter((line) => line.toLowerCase().startsWith('allow:'))).toHaveLength(0);
+  });
+
+  it('is copied into the published export by deploy-app-web', () => {
+    expect(workflow).toMatch(/cp deploy\/app-subdomain\/robots\.txt\s+"\$RUNNER_TEMP\/app-standalone\/robots\.txt"/);
+  });
+});

--- a/deploy/app-subdomain/robots.txt
+++ b/deploy/app-subdomain/robots.txt
@@ -1,0 +1,32 @@
+# Cloudflare Pages static file for the standalone Expo web export
+# (app.boardsesh.com). Copied into the publish dir by production-deploy.yml
+# alongside _headers / _redirects / _routes.json.
+#
+# Why this file has to exist as a real file: _redirects ends in the SPA
+# catch-all `/*  /index.html  200`, and Pages matches real files before that
+# catch-all. Without a robots.txt on disk, a request for /robots.txt falls
+# through to the shell — measured on 2026-09-11, https://app.boardsesh.com/
+# robots.txt returned the app's index.html. A crawler reading HTML where robots
+# syntax should be finds no rules at all and crawls the whole SPA.
+#
+# That is not free. The browser app boots and issues GraphQL against
+# ws.boardsesh.com, so every crawled route costs a backend query, not just a
+# static fetch. A 3-minute sample of boardsesh-backend on 2026-09-10 had
+# Applebot sending 173 of the 436 /graphql requests on the service.
+#
+# Disallow rather than relying on the existing `X-Robots-Tag: noindex` in
+# _headers. The two do different jobs: noindex stops a page being listed but
+# only after the crawler has fetched and rendered it, which is the entire cost.
+# Disallow stops the fetch. The usual caveat — that a disallowed URL can stay
+# indexed without content because the crawler never sees the noindex — does not
+# bite here: this host has been noindex since it launched (see
+# docs/expo-web-deployment.md, "Scope: what the browser app is"), so there is
+# nothing in an index to remove.
+#
+# There is no carve-out for share unfurlers on purpose. The export is one static
+# shell with a generic <title> and no per-route Open Graph tags, so an unfurler
+# that crawled it would render a generic card. Climb share cards are served from
+# https://ws.boardsesh.com/og/climb and never touch this host.
+
+User-agent: *
+Disallow: /

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -384,7 +384,15 @@ back because GraphQL, WebSockets, and `/og` share that hostname.
     first. The file is `deploy/app-subdomain/robots.txt`, copied into the
     published export by `production-deploy.yml`.
   - `ws.boardsesh.com` had no route at all. It is served by
-    `packages/backend/src/handlers/robots.ts`.
+    `packages/backend/src/handlers/robots.ts`, and it is a **deny-list**
+    (`/graphql`, `/api/`, `/health`, `/board-credentials/`) rather than
+    `Disallow: /` with carve-outs. That host is mostly an image CDN: `/og/climb`
+    is every climb page's `og:image`, `/render/board` its LCP image, and
+    `/static/*` serves avatars, gym logos, gym photos and beta thumbnails — all
+    of which a blanket block would have taken out by omission. Naming what to
+    refuse means a new image route is crawlable by default and only a new API
+    route needs a line. The render paths are edge-cached here anyway, so crawler
+    traffic to them is largely absorbed before it reaches the origin.
 
   Both matter because the browser app issues GraphQL against `ws`, so a crawler
   rendering the SPA turns one page fetch into a backend query: a 3-minute sample

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -335,22 +335,61 @@ back because GraphQL, WebSockets, and `/og` share that hostname.
 - **Crawler rules** — two rules in `http_request_firewall_custom`, in this order:
   1. `skip` (all remaining custom rules) for search engines and share-card
      unfurlers. Brave runs its **own** index rather than reselling Bing or
-     Google, so it is allowlisted explicitly.
+     Google, so it is allowlisted explicitly. **Scoped to `GET`.** `skip` with
+     `ruleset: current` walks an agent past every later rule in the ruleset,
+     which is what a search engine needs for reads and what nothing needs for a
+     write. Applebot executes our JavaScript and was measured on 2026-09-10
+     sending 190 of its 253 www requests as `POST /monitoring` (the Sentry
+     tunnel); the method gate is what keeps the ruleset composable so a rule
+     aimed at bot writes can still reach it.
   2. `block` for commercial SEO/backlink crawlers (Ahrefs, Semrush, DataForSEO,
      MJ12, DotBot, BLEXBot, Barkrowler, serpstat, Seznam, Zoominfo, Screaming
      Frog). Each was verified reaching our origin on 2026-08-24. They sell
      backlink data and send Boardsesh no traffic. The same rule also blocks
-     automated AI training and search crawlers, using the shared tokens in
-     `packages/web/app/lib/crawler-policy.ts`. Google, Bing, Yandex, Brave and
-     share-card unfurlers remain allowed. Human-triggered AI fetchers are not
-     added to this automated-crawler list.
+     automated AI training and search crawlers and **Yandex**, using the shared
+     tokens in `packages/web/app/lib/crawler-policy.ts`. Google, Bing, Apple,
+     Brave and share-card unfurlers remain allowed. Human-triggered AI fetchers
+     are not added to this automated-crawler list.
 
-  Web middleware rejects those AI agents before page rendering, including on
+  **Yandex moved from the allow list to the block list on 2026-09-11.** It was
+  added to the allow list four days earlier, in the AI-crawler commit, with no
+  stated reason. Production HTTP logs made the case against it: in a 5-minute
+  sample of `boardsesh-web` (2026-09-10 14:25 UTC, n=501) YandexBot was **36%**
+  of all requests against **3.6%** for real browsers, 171 of its 181 requests
+  were climb-view pages, and it averaged 510 ms per request against Applebot's
+  222 ms — the costliest crawler we carried, per page fetched. Boardsesh is an
+  English-language climbing site and Yandex returns no measurable traffic
+  against that. The rate limit could not reach it either: the Free plan caps the
+  period at 10 s and Yandex ran ~34 requests/min, nowhere near 60-per-10 s.
+
+  `COST_BLOCKED_CRAWLER_TOKENS` spells out `yandexbot` and
+  `yandexrenderresourcesbot` rather than a bare `yandex` on purpose. Yandex
+  Browser (`YaBrowser/…`) and Yandex's in-app search (`YandexSearch/…`) are real
+  people, and a substring match would block every one of them. Tests in
+  `scripts/cloudflare-apply.test.ts` and `packages/web/app/__tests__/middleware.test.ts`
+  pin both directions.
+
+  Web middleware rejects every blocked agent before page rendering, including on
   the direct Railway hostname. Robots.txt publishes the same opt-out plus
   `Google-Extended` (a robots-only token). Production logs on 2026-09-07 showed
   GPTBot using the Railway hostname and Claude-SearchBot reaching www despite
   synthetic Cloudflare probes returning 403; the managed AI block alone is
   insufficient. UA rules only catch agents that identify themselves.
+
+  **The other two hosts serve a robots.txt of their own now.** Until 2026-09-11
+  neither did, and Cloudflare's managed preamble carries no `Disallow`, so both
+  read as "crawl everything":
+  - `app.boardsesh.com` answered `/robots.txt` with the app shell, because
+    `_redirects` ends in an SPA catch-all and no real file existed to match
+    first. The file is `deploy/app-subdomain/robots.txt`, copied into the
+    published export by `production-deploy.yml`.
+  - `ws.boardsesh.com` had no route at all. It is served by
+    `packages/backend/src/handlers/robots.ts`.
+
+  Both matter because the browser app issues GraphQL against `ws`, so a crawler
+  rendering the SPA turns one page fetch into a backend query: a 3-minute sample
+  of `boardsesh-backend` on 2026-09-10 had Applebot issuing 173 of the 436
+  `/graphql` requests on the service.
 
   **Order is load-bearing and enforced by the tool.** `upsertCacheRule` rewrites
   our rules as one contiguous group in declared order, because a rule-by-rule

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { AI_CRAWLER_TOKENS } from '../../packages/web/app/lib/crawler-policy';
+import { BLOCKED_CRAWLER_TOKENS } from '../../packages/web/app/lib/crawler-policy';
 
 // Declarative desired-state for the Cloudflare-managed boardsesh.com zone. This
 // is plain typed data — no side effects, no API calls. scripts/cloudflare-apply.ts
@@ -497,7 +497,6 @@ export const CRAWLER_ALLOW_TOKENS = [
   'brave-search',
   'bravebot',
   'applebot',
-  'yandexbot',
   // Share-card unfurlers. Blocking these breaks link previews, not crawling.
   'twitterbot',
   'facebookexternalhit',
@@ -517,6 +516,10 @@ export const CRAWLER_ALLOW_TOKENS = [
  * `dotbot/` keeps its slash because the bare token is short enough to collide with
  * an unrelated UA; the rest are distinctive on their own.
  *
+ * Yandex is here rather than in the allow list: 2026-09-10 origin logs put it at
+ * 36% of www requests against 3.6% for real browsers, on the most expensive SSR
+ * path we have. See COST_BLOCKED_CRAWLER_TOKENS in crawler-policy.ts.
+ *
  * AI training/search crawlers are explicit too: September 7 origin logs showed
  * Claude-SearchBot on www and GPTBot bypassing Cloudflare via the Railway domain,
  * despite synthetic probes receiving 403. The shared list also drives robots.txt
@@ -527,7 +530,7 @@ export const CRAWLER_ALLOW_TOKENS = [
  *   it is low volume, and excluding it is a values call rather than a cost one.
  */
 export const CRAWLER_BLOCK_TOKENS = [
-  ...AI_CRAWLER_TOKENS,
+  ...BLOCKED_CRAWLER_TOKENS,
   'ahrefsbot',
   'ahrefssiteaudit',
   'semrushbot',
@@ -551,7 +554,29 @@ export function buildUserAgentExpression(tokens: readonly string[]): string {
   return tokens.map((token) => `lower(http.user_agent) contains "${token}"`).join(' or ');
 }
 
-export const CRAWLER_ALLOW_EXPRESSION = buildUserAgentExpression(CRAWLER_ALLOW_TOKENS);
+/**
+ * Scoped to GET on purpose.
+ *
+ * The allow rule's action is `skip` with `ruleset: 'current'`, so an agent that
+ * matches it walks past every later rule in the WAF custom ruleset. That is the
+ * intent for reads — a search engine must never be caught by a rule aimed at
+ * scrapers — but it also meant an allow-listed agent could never be constrained
+ * on a write, and no rule added after this one would apply to it.
+ *
+ * A crawler has no legitimate POST. Applebot has one: it executes our
+ * JavaScript, and a 2026-09-10 sample of boardsesh-web caught it sending 190 of
+ * its 253 requests as `POST /monitoring` (the Sentry tunnel from
+ * next.config.mjs). The origin-side fix for that ships in
+ * instrumentation-client.ts; this gate is what keeps the ruleset composable, so
+ * the next rule aimed at bot writes is actually reachable.
+ *
+ * HEAD is not included: crawlers that HEAD a URL before fetching it are doing a
+ * read, but nothing in this ruleset blocks them today, so widening the skip
+ * would buy nothing.
+ */
+export const CRAWLER_ALLOW_EXPRESSION = `(http.request.method eq "GET" and (${buildUserAgentExpression(
+  CRAWLER_ALLOW_TOKENS,
+)}))`;
 export const CRAWLER_BLOCK_EXPRESSION = buildUserAgentExpression(CRAWLER_BLOCK_TOKENS);
 
 /**

--- a/packages/backend/src/__tests__/robots.test.ts
+++ b/packages/backend/src/__tests__/robots.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { describe, expect, it } from 'vitest';
+
+import { handleRobotsTxt, ROBOTS_TXT_BODY } from '../handlers/robots';
+
+type MockRes = {
+  statusCode: number;
+  body: string | undefined;
+  ended: boolean;
+  headers: Record<string, string>;
+  writeHead: (status: number, headers?: Record<string, string>) => void;
+  end: (body?: string) => void;
+};
+
+function makeResponse(): MockRes {
+  return {
+    statusCode: 0,
+    body: undefined,
+    ended: false,
+    headers: {},
+    writeHead(status, headers) {
+      this.statusCode = status;
+      if (headers) Object.assign(this.headers, headers);
+    },
+    end(body) {
+      this.ended = true;
+      this.body = body;
+    },
+  };
+}
+
+const request = (method: string) => ({ method }) as IncomingMessage;
+const respond = (method: string) => {
+  const res = makeResponse();
+  handleRobotsTxt(request(method), res as unknown as ServerResponse);
+  return res;
+};
+
+/** Directive lines only — blank lines and `#` comments carry no meaning. */
+function directives(source: string): string[] {
+  return source
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '' && !line.startsWith('#'));
+}
+
+describe('GET /robots.txt on the backend host', () => {
+  it('closes ws.boardsesh.com to every crawler', () => {
+    const res = respond('GET');
+    expect(res.statusCode).toBe(200);
+    // Parsed, not string-matched: a stray `Allow:` added later fails here.
+    expect(directives(res.body ?? '')).toEqual(['User-agent: *', 'Disallow: /']);
+  });
+
+  it('serves robots syntax, not HTML', () => {
+    // The failure this guards against is the one app.boardsesh.com actually
+    // shipped: a /robots.txt that answers with a page. A crawler reading HTML
+    // where robots syntax should be finds no rules and crawls everything.
+    const res = respond('GET');
+    expect(res.headers['Content-Type']).toBe('text/plain; charset=utf-8');
+    expect(res.body).not.toContain('<');
+  });
+
+  it('is cacheable, since the answer never varies by request', () => {
+    expect(respond('GET').headers['Cache-Control']).toBe('public, max-age=86400');
+  });
+
+  it('answers HEAD with the same headers and no body', () => {
+    const res = respond('HEAD');
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Content-Type']).toBe('text/plain; charset=utf-8');
+    expect(res.ended).toBe(true);
+    expect(res.body).toBeUndefined();
+  });
+});
+
+describe('server.ts routing', () => {
+  // handleRobotsTxt is only worth anything if the dispatcher calls it. The
+  // route lives inside startServer's closure and cannot be imported, so this
+  // reads the source — the one case where a text assertion is the only option.
+  const serverSource = readFileSync(resolve(import.meta.dirname, '..', 'server.ts'), 'utf8');
+
+  it('routes /robots.txt to the handler for GET and HEAD', () => {
+    expect(serverSource).toContain("import { handleRobotsTxt } from './handlers/robots';");
+    expect(serverSource).toMatch(
+      /pathname === '\/robots\.txt' && \(req\.method === 'GET' \|\| req\.method === 'HEAD'\)[\s\S]{0,120}handleRobotsTxt\(req, res\);/,
+    );
+  });
+
+  it('keeps the body a single source of truth', () => {
+    // Nothing should re-declare the policy inline next to the route.
+    expect(serverSource).not.toContain('Disallow: /');
+    expect(ROBOTS_TXT_BODY).toContain('Disallow: /');
+  });
+});

--- a/packages/backend/src/__tests__/robots.test.ts
+++ b/packages/backend/src/__tests__/robots.test.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { describe, expect, it } from 'vitest';
 
-import { handleRobotsTxt, ROBOTS_TXT_BODY } from '../handlers/robots';
+import { DISALLOWED_ROBOTS_PATHS, handleRobotsTxt, ROBOTS_TXT_BODY } from '../handlers/robots';
 
 type MockRes = {
   statusCode: number;
@@ -46,12 +46,61 @@ function directives(source: string): string[] {
     .filter((line) => line !== '' && !line.startsWith('#'));
 }
 
+/**
+ * Evaluate a path the way a crawler does. The policy carries no `Allow`, so a
+ * path is crawlable exactly when no `Disallow` prefix matches it (RFC 9309
+ * §2.2.2 — longest match wins, and there is nothing to win against).
+ */
+function isPathCrawlable(body: string, path: string): boolean {
+  return !directives(body)
+    .filter((line) => line.toLowerCase().startsWith('disallow:'))
+    .map((line) => line.slice('disallow:'.length).trim())
+    .some((prefix) => path.startsWith(prefix));
+}
+
 describe('GET /robots.txt on the backend host', () => {
-  it('closes ws.boardsesh.com to every crawler', () => {
+  it('refuses the API surface', () => {
     const res = respond('GET');
     expect(res.statusCode).toBe(200);
-    // Parsed, not string-matched: a stray `Allow:` added later fails here.
-    expect(directives(res.body ?? '')).toEqual(['User-agent: *', 'Disallow: /']);
+    expect(directives(res.body ?? '')).toEqual([
+      'User-agent: *',
+      'Disallow: /graphql',
+      'Disallow: /api/',
+      'Disallow: /health',
+      'Disallow: /board-credentials/',
+    ]);
+  });
+
+  it.each(['/graphql', '/api/posthog/batch/', '/health', '/health/db', '/board-credentials/kilter/start'])(
+    'refuses %s',
+    (path) => {
+      expect(isPathCrawlable(respond('GET').body ?? '', path)).toBe(false);
+    },
+  );
+
+  it.each([
+    // og:image and twitter:image on every climb page, emitted as an absolute
+    // URL by buildOgBoardRenderUrl. Blocking it drops the share preview.
+    '/og/climb',
+    // The climb page's LCP image and the traced art behind it.
+    '/render/board',
+    '/render/geometry',
+    // Avatars, gym logos, gym photos and beta thumbnails, all <img> on
+    // indexable pages.
+    '/static/avatars/x.png',
+    '/static/gym-photos/y.jpg',
+    '/static/beta-link-thumbnails/z.jpg',
+  ])('still lets a crawler fetch %s', (path) => {
+    // This host is mostly an image CDN. A blanket `Disallow: /` would have
+    // taken all of these out by omission, which is why the policy is a
+    // deny-list.
+    expect(isPathCrawlable(respond('GET').body ?? '', path)).toBe(true);
+  });
+
+  it('carries no Allow line, so the deny-list is the whole policy', () => {
+    // An `Allow` would mean someone had switched to carve-outs; the ordering
+    // rules then start to matter and this file's reasoning no longer holds.
+    expect(directives(respond('GET').body ?? '').some((line) => line.toLowerCase().startsWith('allow:'))).toBe(false);
   });
 
   it('serves robots syntax, not HTML', () => {
@@ -91,7 +140,9 @@ describe('server.ts routing', () => {
 
   it('keeps the body a single source of truth', () => {
     // Nothing should re-declare the policy inline next to the route.
-    expect(serverSource).not.toContain('Disallow: /');
-    expect(ROBOTS_TXT_BODY).toContain('Disallow: /');
+    expect(serverSource).not.toContain('Disallow:');
+    for (const path of DISALLOWED_ROBOTS_PATHS) {
+      expect(ROBOTS_TXT_BODY).toContain(`Disallow: ${path}`);
+    }
   });
 });

--- a/packages/backend/src/handlers/robots.ts
+++ b/packages/backend/src/handlers/robots.ts
@@ -1,20 +1,49 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
 /**
- * `ws.boardsesh.com` is an API and image host, not a search surface.
- *
- * It served no robots.txt of its own until 2026-09-11 — a request returned only
- * Cloudflare's managed preamble, which carries no `Disallow` — so crawlers
- * treated `/graphql`, `/og/climb` and `/render/*` as fair game. That is not a
- * cheap mistake: the browser app at app.boardsesh.com issues GraphQL against
- * this host, so a crawler rendering the SPA turns one page fetch into a backend
+ * `ws.boardsesh.com` served no robots.txt of its own until 2026-09-11 — a
+ * request returned only Cloudflare's managed preamble, which carries no
+ * `Disallow` — so crawlers treated `/graphql` as fair game. That is not a cheap
+ * mistake: the browser app at app.boardsesh.com issues GraphQL against this
+ * host, so a crawler rendering the SPA turns one page fetch into a backend
  * query. A 3-minute sample of this service on 2026-09-10 had Applebot issuing
  * 173 of the 436 `/graphql` requests on it.
+ *
+ * **A deny-list, not `Disallow: /` with carve-outs.** This host is mostly an
+ * image CDN, and blanket-blocking it would silently break things a crawler
+ * legitimately needs:
+ * - `/og/climb` is the climb share card. `buildOgBoardRenderUrl`
+ *   (`packages/web/app/components/board-renderer/util.ts`) emits it as an
+ *   absolute URL into every climb page's `og:image` and `twitter:image`, so an
+ *   unfurler that honours robots would drop the preview.
+ * - `/render/board` is the climb page's LCP image, and `/render/geometry` the
+ *   traced art behind it.
+ * - `/static/*` serves avatars, gym logos, gym photos and beta thumbnails, all
+ *   of which appear in `<img>` on indexable pages.
+ *
+ * Blocking those by omission is exactly the failure `packages/web/app/robots.ts`
+ * already guards against on www with its `/api/og/` and
+ * `/api/internal/board-render` allows. Listing what to refuse instead means a
+ * new image route is crawlable by default and only a new *API* route needs a
+ * line here. The expensive render paths are edge-cached at Cloudflare anyway
+ * (see the og and board-render cache rules in `infra/cloudflare/config.ts`), so
+ * crawler traffic to them is largely absorbed before it reaches this process.
  *
  * Cloudflare prepends its managed block to whatever the origin returns, so this
  * body is appended to that rather than replacing it.
  */
-export const ROBOTS_TXT_BODY = 'User-agent: *\nDisallow: /\n';
+export const DISALLOWED_ROBOTS_PATHS = [
+  // The measured cost, and never useful to a crawler.
+  '/graphql',
+  // Every JSON API, including the PostHog proxy and the upload endpoints.
+  '/api/',
+  // Prefix-matches /health/db too.
+  '/health',
+  // The Kilter OAuth handoff. GET routes, but not content.
+  '/board-credentials/',
+] as const;
+
+export const ROBOTS_TXT_BODY = `User-agent: *\n${DISALLOWED_ROBOTS_PATHS.map((path) => `Disallow: ${path}`).join('\n')}\n`;
 
 /** A day. The answer never varies by request and crawlers re-read it constantly. */
 export const ROBOTS_TXT_MAX_AGE_SECONDS = 86400;

--- a/packages/backend/src/handlers/robots.ts
+++ b/packages/backend/src/handlers/robots.ts
@@ -1,0 +1,29 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+/**
+ * `ws.boardsesh.com` is an API and image host, not a search surface.
+ *
+ * It served no robots.txt of its own until 2026-09-11 — a request returned only
+ * Cloudflare's managed preamble, which carries no `Disallow` — so crawlers
+ * treated `/graphql`, `/og/climb` and `/render/*` as fair game. That is not a
+ * cheap mistake: the browser app at app.boardsesh.com issues GraphQL against
+ * this host, so a crawler rendering the SPA turns one page fetch into a backend
+ * query. A 3-minute sample of this service on 2026-09-10 had Applebot issuing
+ * 173 of the 436 `/graphql` requests on it.
+ *
+ * Cloudflare prepends its managed block to whatever the origin returns, so this
+ * body is appended to that rather than replacing it.
+ */
+export const ROBOTS_TXT_BODY = 'User-agent: *\nDisallow: /\n';
+
+/** A day. The answer never varies by request and crawlers re-read it constantly. */
+export const ROBOTS_TXT_MAX_AGE_SECONDS = 86400;
+
+export function handleRobotsTxt(req: IncomingMessage, res: ServerResponse): void {
+  res.writeHead(200, {
+    'Content-Type': 'text/plain; charset=utf-8',
+    'Cache-Control': `public, max-age=${ROBOTS_TXT_MAX_AGE_SECONDS}`,
+  });
+  // HEAD must carry the same headers and no body.
+  res.end(req.method === 'HEAD' ? undefined : ROBOTS_TXT_BODY);
+}

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -22,6 +22,7 @@ import {
 } from './handlers/static';
 import { staticPathToMediaRedirect } from './lib/media-url';
 import { getMediaPublicBaseUrl } from './storage/s3';
+import { handleRobotsTxt } from './handlers/robots';
 import { handleOgClimb } from './handlers/og-climb';
 import { handleBoardRender, isBoardRenderPath } from './handlers/board-render';
 import { handleBoardGeometry, isBoardGeometryPath } from './handlers/board-geometry';
@@ -356,6 +357,13 @@ export async function startServer(): Promise<ServerResources> {
       // here, not at /health (see handlers/health.ts for why).
       if (pathname === '/health/db' && req.method === 'GET') {
         await handleDatabaseHealthCheck(req, res);
+        return;
+      }
+
+      // Close this host to crawlers. See handlers/robots.ts for what it was
+      // costing us while it answered with nothing.
+      if (pathname === '/robots.txt' && (req.method === 'GET' || req.method === 'HEAD')) {
+        handleRobotsTxt(req, res);
         return;
       }
 

--- a/packages/web/__tests__/instrumentation-client.test.ts
+++ b/packages/web/__tests__/instrumentation-client.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+// Guards the crawler half of the Sentry client gate.
+//
+// `tunnelRoute: '/monitoring'` in next.config.mjs means every browser event the
+// SDK sends is first a POST to our own origin. Crawlers that execute JavaScript
+// boot this SDK exactly like a browser does, so they generate that POST too. A
+// 5-minute sample of production boardsesh-web on 2026-09-10 caught Applebot
+// sending 190 of its 253 requests to `/monitoring` — the single most-requested
+// path on the service, ahead of every climb page. Those events have no user
+// behind them and no session to replay, so they cost origin CPU, egress and
+// Sentry quota for nothing.
+//
+// The module calls Sentry.init at import time, so each case re-imports it with
+// a fresh module registry.
+
+const mocks = vi.hoisted(() => ({
+  init: vi.fn(),
+  captureRouterTransitionStart: vi.fn(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  init: mocks.init,
+  captureRouterTransitionStart: mocks.captureRouterTransitionStart,
+}));
+
+const originalLocation = window.location;
+const originalUserAgent = navigator.userAgent;
+
+function setWindowLocation(url: string): void {
+  Object.defineProperty(window, 'location', { value: new URL(url), writable: true, configurable: true });
+}
+
+function setUserAgent(userAgent: string): void {
+  Object.defineProperty(navigator, 'userAgent', { value: userAgent, writable: true, configurable: true });
+}
+
+/** Import the module fresh and hand back the options it passed to Sentry.init. */
+async function initOptions(): Promise<{ enabled: boolean }> {
+  await import('../instrumentation-client');
+  expect(mocks.init).toHaveBeenCalledTimes(1);
+  return mocks.init.mock.calls[0][0] as { enabled: boolean };
+}
+
+const BROWSER_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36';
+
+describe('Sentry client gate', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    setWindowLocation('https://www.boardsesh.com/kilter/original/12x12-square/screw_bolt/40/list');
+    setUserAgent(BROWSER_UA);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true, configurable: true });
+    Object.defineProperty(navigator, 'userAgent', { value: originalUserAgent, writable: true, configurable: true });
+  });
+
+  it('stays enabled for a real browser on a production host', async () => {
+    // The control. Without this, a gate that disabled Sentry outright would
+    // pass every other case in this file.
+    expect((await initOptions()).enabled).toBe(true);
+  });
+
+  it.each([
+    [
+      'Applebot',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15 (Applebot/0.1; +http://www.apple.com/go/applebot)',
+    ],
+    ['YandexBot', 'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)'],
+    [
+      'Googlebot',
+      'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/153.0.8010.36 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+    ],
+  ])('never initialises for %s, even on a production host', async (_label, userAgent) => {
+    setUserAgent(userAgent);
+    expect((await initOptions()).enabled).toBe(false);
+  });
+
+  it('still refuses a non-production host', async () => {
+    // The host gate predates this one and must survive it — preview deploys at
+    // <pr>.preview.boardsesh.com leaked into the prod project once already
+    // (#3808). See app/lib/production-hosts.ts.
+    setWindowLocation('https://1234.preview.boardsesh.com/');
+    expect((await initOptions()).enabled).toBe(false);
+  });
+
+  it('keeps a real Yandex Browser user reporting', async () => {
+    // `yandex` as a bare substring would take out real people. The crawler
+    // tokens are spelled out in full precisely so this case stays enabled.
+    setUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 YaBrowser/23.9.1.962 Yowser/2.5 Safari/537.36',
+    );
+    expect((await initOptions()).enabled).toBe(true);
+  });
+});

--- a/packages/web/__tests__/instrumentation-client.test.ts
+++ b/packages/web/__tests__/instrumentation-client.test.ts
@@ -87,12 +87,22 @@ describe('Sentry client gate', () => {
     expect((await initOptions()).enabled).toBe(false);
   });
 
-  it('keeps a real Yandex Browser user reporting', async () => {
-    // `yandex` as a bare substring would take out real people. The crawler
-    // tokens are spelled out in full precisely so this case stays enabled.
-    setUserAgent(
+  it.each([
+    [
+      'Yandex Browser',
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 YaBrowser/23.9.1.962 Yowser/2.5 Safari/537.36',
-    );
+    ],
+    [
+      // The reason this file uses isAutomatedCrawlerUserAgent rather than the
+      // locale gates' isCrawlerUserAgent: the in-app browser spells itself
+      // `YandexSearch`, which contains Next's `yandex` token. Costing this
+      // visitor a default-locale page is acceptable; silently dropping their
+      // error reports is not.
+      'Yandex Search in-app browser',
+      'Mozilla/5.0 (Linux; Android 13; SM-A536B) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/106.0.0.0 Mobile Safari/537.36 YandexSearch/1.0',
+    ],
+  ])('keeps a real %s user reporting', async (_label, userAgent) => {
+    setUserAgent(userAgent);
     expect((await initOptions()).enabled).toBe(true);
   });
 });

--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -12,8 +12,17 @@ function sp(params: Record<string, string> = {}): URLSearchParams {
   return new URLSearchParams(params);
 }
 
-describe('AI crawler origin rejection', () => {
-  it.each(['GPTBot/1.4', 'Claude-SearchBot/1.0', 'AMZN-SEARCHBOT/0.1'])('rejects %s before rendering', (userAgent) => {
+describe('blocked crawler origin rejection', () => {
+  it.each([
+    'GPTBot/1.4',
+    'Claude-SearchBot/1.0',
+    'AMZN-SEARCHBOT/0.1',
+    // Blocked on cost, not on what it does with the content: 36% of www
+    // requests on 2026-09-10 against 3.6% for real browsers, on the climb-view
+    // SSR path. See COST_BLOCKED_CRAWLER_TOKENS in app/lib/crawler-policy.ts.
+    'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)',
+    'Mozilla/5.0 (compatible; YandexRenderResourcesBot/1.0; +http://yandex.com/bots)',
+  ])('rejects %s before rendering', (userAgent) => {
     const response = middleware(
       new NextRequest('https://boardsesh-web-production.up.railway.app/fr/setter/test', {
         headers: { 'user-agent': userAgent },
@@ -27,11 +36,18 @@ describe('AI crawler origin rejection', () => {
   it.each([
     'Googlebot/2.1',
     'bingbot/2.0',
-    'YandexBot/3.0',
+    'Applebot/0.1',
     'facebookexternalhit/1.1',
     'ChatGPT-User/1.0',
     'Claude-User/1.0',
     'Mozilla/5.0',
+    // The reason COST_BLOCKED_CRAWLER_TOKENS spells out `yandexbot` and
+    // `yandexrenderresourcesbot` instead of a bare `yandex`: these three are
+    // real people on Yandex's browser and in-app search, and a substring match
+    // on `yandex` would 403 every one of them.
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 YaBrowser/23.9.1.962 Yowser/2.5 Safari/537.36',
+    'Mozilla/5.0 (Linux; arm_64; Android 13; SM-A536B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 YaBrowser/22.11.3.104.00 SA/3 Mobile Safari/537.36',
+    'Mozilla/5.0 (Linux; Android 13; SM-A536B) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/106.0.0.0 Mobile Safari/537.36 YandexSearch/1.0',
   ])('preserves %s', (userAgent) => {
     const response = middleware(
       new NextRequest('https://www.boardsesh.com/', { headers: { 'user-agent': userAgent } }),

--- a/packages/web/app/__tests__/robots.test.ts
+++ b/packages/web/app/__tests__/robots.test.ts
@@ -33,16 +33,29 @@ function isPathCrawlable(rules: ReturnType<typeof getRules>, url: string): boole
 }
 
 describe('robots', () => {
-  it('opts AI crawlers out without closing traditional search or share previews', () => {
+  it('opts blocked crawlers out without closing traditional search or share previews', () => {
     const rules = robots().rules;
     expect(Array.isArray(rules)).toBe(true);
     const allRules = Array.isArray(rules) ? rules : [rules];
-    const aiRule = allRules.find((rule) => toList(rule.userAgent).includes('gptbot'));
-    expect(aiRule?.disallow).toBe('/');
-    expect(aiRule?.allow).toBeUndefined();
-    expect(toList(aiRule?.userAgent)).toEqual(expect.arrayContaining(['claude-searchbot', 'Google-Extended']));
-    expect(toList(aiRule?.userAgent)).not.toContain('googlebot');
-    expect(toList(aiRule?.userAgent)).not.toContain('facebookexternalhit');
+    const blockedRule = allRules.find((rule) => toList(rule.userAgent).includes('gptbot'));
+    expect(blockedRule?.disallow).toBe('/');
+    expect(blockedRule?.allow).toBeUndefined();
+    expect(toList(blockedRule?.userAgent)).toEqual(expect.arrayContaining(['claude-searchbot', 'Google-Extended']));
+    expect(toList(blockedRule?.userAgent)).not.toContain('googlebot');
+    expect(toList(blockedRule?.userAgent)).not.toContain('facebookexternalhit');
+  });
+
+  it('names Yandex in the disallow group, so the block is declared and not only enforced', () => {
+    // robots.txt is the polite half of the Yandex block; the Cloudflare WAF
+    // rule and the middleware 403 are the enforcing halves. Declaring it here
+    // is what lets a well-behaved crawler stop before it costs us a render.
+    const rules = robots().rules;
+    const allRules = Array.isArray(rules) ? rules : [rules];
+    const blockedRule = allRules.find((rule) => toList(rule.userAgent).includes('gptbot'));
+    expect(toList(blockedRule?.userAgent)).toEqual(expect.arrayContaining(['yandexbot', 'yandexrenderresourcesbot']));
+    // Applebot stays out of it — it still indexes us. Only its writes are cut,
+    // and that happens in instrumentation-client.ts, not here.
+    expect(toList(blockedRule?.userAgent)).not.toContain('applebot');
   });
   it('allows crawling the root path', () => {
     const result = robots();

--- a/packages/web/app/lib/__tests__/is-crawler.test.ts
+++ b/packages/web/app/lib/__tests__/is-crawler.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect } from 'vite-plus/test';
 // are still a superset of it. Production code never takes this path — see the
 // header of `is-crawler.ts`.
 import { isBot } from 'next/dist/server/web/spec-extension/user-agent';
-import { CRAWLER_USER_AGENT_PATTERN, isCrawlerUserAgent } from '@/app/lib/is-crawler';
+import { CRAWLER_USER_AGENT_PATTERN, isAutomatedCrawlerUserAgent, isCrawlerUserAgent } from '@/app/lib/is-crawler';
 
 /**
  * Pull the alternatives out of the installed Next's `isBot` source rather than
@@ -88,36 +88,38 @@ describe('isCrawlerUserAgent covers the scrapers Next omits', () => {
   });
 });
 
+/** Real people, shared by both predicates: neither may ever classify these as a crawler. */
+const BROWSER_UAS: [string, string][] = [
+  [
+    'Chrome on Windows',
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+  ],
+  ['Firefox on Linux', 'Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0'],
+  [
+    'Safari on iOS',
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Mobile/15E148 Safari/604.1',
+  ],
+  [
+    'Edge on Windows',
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 Edg/128.0.2739.42',
+  ],
+  [
+    'Samsung Internet',
+    'Mozilla/5.0 (Linux; Android 14; SAMSUNG SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/25.0 Chrome/121.0.0.0 Mobile Safari/537.36',
+  ],
+  [
+    'Yandex Browser desktop',
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 YaBrowser/23.9.1.962 Yowser/2.5 Safari/537.36',
+  ],
+  [
+    'Yandex Browser Android',
+    'Mozilla/5.0 (Linux; arm_64; Android 13; SM-A536B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 YaBrowser/22.11.3.104.00 SA/3 Mobile Safari/537.36',
+  ],
+];
+
 describe('isCrawlerUserAgent leaves real browsers alone', () => {
   // A false positive costs a real visitor their sticky locale, so these are the
   // cases that must never regress.
-  const BROWSER_UAS: [string, string][] = [
-    [
-      'Chrome on Windows',
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
-    ],
-    ['Firefox on Linux', 'Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0'],
-    [
-      'Safari on iOS',
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Mobile/15E148 Safari/604.1',
-    ],
-    [
-      'Edge on Windows',
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 Edg/128.0.2739.42',
-    ],
-    [
-      'Samsung Internet',
-      'Mozilla/5.0 (Linux; Android 14; SAMSUNG SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/25.0 Chrome/121.0.0.0 Mobile Safari/537.36',
-    ],
-    [
-      'Yandex Browser desktop',
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 YaBrowser/23.9.1.962 Yowser/2.5 Safari/537.36',
-    ],
-    [
-      'Yandex Browser Android',
-      'Mozilla/5.0 (Linux; arm_64; Android 13; SM-A536B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 YaBrowser/22.11.3.104.00 SA/3 Mobile Safari/537.36',
-    ],
-  ];
 
   it.each(BROWSER_UAS)('does not classify %s as a crawler', (_label, userAgentHeader) => {
     expect(isCrawlerUserAgent(userAgentHeader)).toBe(false);
@@ -133,6 +135,41 @@ describe('isCrawlerUserAgent leaves real browsers alone', () => {
       'Mozilla/5.0 (Linux; Android 13; SM-A536B) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/106.0.0.0 Mobile Safari/537.36 YandexSearch/1.0';
     expect(isBot(yandexSearchInAppUa)).toBe(true);
     expect(isCrawlerUserAgent(yandexSearchInAppUa)).toBe(true);
+  });
+});
+
+describe('isAutomatedCrawlerUserAgent', () => {
+  it('drops the one false positive isCrawlerUserAgent knowingly carries', () => {
+    // Both predicates exist because the cost of a false positive differs. The
+    // locale gates can afford one (the visitor gets the URL they asked for);
+    // telemetry cannot (we lose a real session's errors and never know).
+    const yandexSearchInAppUa =
+      'Mozilla/5.0 (Linux; Android 13; SM-A536B) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/106.0.0.0 Mobile Safari/537.36 YandexSearch/1.0';
+    expect(isCrawlerUserAgent(yandexSearchInAppUa)).toBe(true);
+    expect(isAutomatedCrawlerUserAgent(yandexSearchInAppUa)).toBe(false);
+  });
+
+  it.each([
+    ['YandexBot', 'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)'],
+    [
+      'Applebot',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15 (Applebot/0.1; +http://www.apple.com/go/applebot)',
+    ],
+    [
+      'Googlebot',
+      'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/153.0.8010.36 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+    ],
+  ])('still catches %s', (_label, userAgentHeader) => {
+    expect(isAutomatedCrawlerUserAgent(userAgentHeader)).toBe(true);
+  });
+
+  it.each(BROWSER_UAS)('does not classify %s as a crawler', (_label, userAgentHeader) => {
+    expect(isAutomatedCrawlerUserAgent(userAgentHeader)).toBe(false);
+  });
+
+  it('returns false for a missing header', () => {
+    expect(isAutomatedCrawlerUserAgent(null)).toBe(false);
+    expect(isAutomatedCrawlerUserAgent(undefined)).toBe(false);
   });
 });
 

--- a/packages/web/app/lib/crawler-policy.ts
+++ b/packages/web/app/lib/crawler-policy.ts
@@ -12,7 +12,37 @@ export const AI_CRAWLER_TOKENS = [
   'meta-externalagent',
 ] as const;
 
-export function isBlockedAiCrawler(userAgent: string | null): boolean {
+/**
+ * Crawlers blocked on cost rather than on what they do with the content.
+ *
+ * Yandex was added to CRAWLER_ALLOW_TOKENS on 2026-09-07 (51a046118) without a
+ * stated reason, bundled into the AI-crawler commit. Production HTTP logs four
+ * days later made the case against it. In a 5-minute sample of boardsesh-web
+ * (2026-09-10 14:25 UTC, n=501) YandexBot was 36% of all requests against 3.6%
+ * for real browsers, and 171 of its 181 requests were climb-view pages — the
+ * most expensive SSR path we have. It also averaged 510 ms per request against
+ * Applebot's 222 ms, so it is the costliest crawler we carry per page fetched.
+ *
+ * Boardsesh is an English-language climbing site; Yandex sends back no
+ * measurable traffic to set against that. The Cloudflare rate limit cannot
+ * reach it either — the Free plan caps the period at 10 s and Yandex ran ~34
+ * requests/min, nowhere near the 60-per-10 s threshold.
+ *
+ * Both tokens are needed: `yandexrenderresourcesbot` does not contain
+ * `yandexbot` as a substring, and the renderer was 6% of the Yandex traffic in
+ * the same sample.
+ */
+export const COST_BLOCKED_CRAWLER_TOKENS = ['yandexbot', 'yandexrenderresourcesbot'] as const;
+
+/**
+ * Every crawler we refuse, whatever the reason. This is the single list behind
+ * all three enforcement points — the Cloudflare WAF block rule, `robots.ts`,
+ * and the origin fallback in `middleware.ts` — so a token can never be blocked
+ * at one layer and allowed at another.
+ */
+export const BLOCKED_CRAWLER_TOKENS = [...AI_CRAWLER_TOKENS, ...COST_BLOCKED_CRAWLER_TOKENS] as const;
+
+export function isBlockedCrawler(userAgent: string | null): boolean {
   const normalizedUserAgent = userAgent?.toLowerCase() ?? '';
-  return AI_CRAWLER_TOKENS.some((token) => normalizedUserAgent.includes(token));
+  return BLOCKED_CRAWLER_TOKENS.some((token) => normalizedUserAgent.includes(token));
 }

--- a/packages/web/app/lib/is-crawler.ts
+++ b/packages/web/app/lib/is-crawler.ts
@@ -121,3 +121,33 @@ export const CRAWLER_USER_AGENT_PATTERN = new RegExp(
 export function isCrawlerUserAgent(userAgentHeader: string | null | undefined): boolean {
   return userAgentHeader ? CRAWLER_USER_AGENT_PATTERN.test(userAgentHeader) : false;
 }
+
+/**
+ * The one real-user agent `CRAWLER_USER_AGENT_PATTERN` misclassifies: Yandex's
+ * in-app search browser spells itself `YandexSearch`, which contains Next's
+ * `yandex` token. Documented and pinned by the "inherits one Yandex false
+ * positive from Next" case in `__tests__/is-crawler.test.ts`.
+ *
+ * Yandex Browser proper is not here — it spells itself `YaBrowser`, which the
+ * pattern never matched.
+ */
+const CRAWLER_FALSE_POSITIVE_PATTERN = /YandexSearch/i;
+
+/**
+ * `isCrawlerUserAgent` minus its known false positive.
+ *
+ * Which of the two you want depends on what a false positive costs. For the
+ * locale gates the cost lands on the visitor as a default-locale 200 for the
+ * URL they asked for — the bot branch's deliberate behaviour, not an error — so
+ * the superset is fine there and staying aligned with Next is worth more.
+ *
+ * Where a false positive costs us *observability of a real session*, it is not.
+ * `instrumentation-client.ts` uses this one: misclassifying a Yandex Search
+ * visitor there silently drops their errors and diagnostics, and we would never
+ * know we had lost them.
+ */
+export function isAutomatedCrawlerUserAgent(userAgentHeader: string | null | undefined): boolean {
+  if (!userAgentHeader) return false;
+  if (CRAWLER_FALSE_POSITIVE_PATTERN.test(userAgentHeader)) return false;
+  return CRAWLER_USER_AGENT_PATTERN.test(userAgentHeader);
+}

--- a/packages/web/app/robots.ts
+++ b/packages/web/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next';
 import { absoluteUrl } from '@/app/lib/seo/base-url';
-import { AI_CRAWLER_TOKENS } from './lib/crawler-policy';
+import { BLOCKED_CRAWLER_TOKENS } from './lib/crawler-policy';
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -22,7 +22,7 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ['/api/', '/auth/', '/settings'],
       },
       {
-        userAgent: [...AI_CRAWLER_TOKENS, 'Google-Extended'],
+        userAgent: [...BLOCKED_CRAWLER_TOKENS, 'Google-Extended'],
         disallow: '/',
       },
     ],

--- a/packages/web/instrumentation-client.ts
+++ b/packages/web/instrumentation-client.ts
@@ -3,6 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
+import { isCrawlerUserAgent } from './app/lib/is-crawler';
 import { isProductionHost } from './app/lib/production-hosts';
 
 // Only enable Sentry on the production boardsesh.com hosts. Exact-host match
@@ -14,11 +15,29 @@ import { isProductionHost } from './app/lib/production-hosts';
 // analytics.ts's PostHog gate so the two production-checks can't drift apart.
 const isProductionDomain = typeof window !== 'undefined' && isProductionHost(window.location.hostname);
 
+// Crawlers that execute our JavaScript boot this SDK like any browser would, and
+// every event they generate is tunnelled back through `/monitoring` (tunnelRoute
+// in next.config.mjs), which is a POST to our own origin before it is a request
+// to Sentry.
+//
+// That is not hypothetical. A 5-minute sample of production boardsesh-web logs
+// on 2026-09-10 caught Applebot sending 190 of its 253 requests as
+// `POST /monitoring` — the single most-requested path on the service, ahead of
+// every climb page. Applebot alone was 50% of www traffic that window against
+// 3.6% for real browsers.
+//
+// Bot sessions have no user to be affected by an error and no session to replay,
+// so the events are worthless as well as expensive: they burn origin CPU, egress
+// and Sentry quota. `isCrawlerUserAgent` is the same superset the locale gates in
+// `middleware.ts` use, so a crawler is classified identically on both sides.
+const isCrawler = typeof navigator !== 'undefined' && isCrawlerUserAgent(navigator.userAgent);
+
 Sentry.init({
   dsn: 'https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400',
 
-  // Only send errors when running on the production boardsesh.com hosts
-  enabled: isProductionDomain,
+  // Only send errors when running on the production boardsesh.com hosts, and
+  // never for a crawler executing the page (see isCrawler above).
+  enabled: isProductionDomain && !isCrawler,
 
   // Sentry only initializes here on a production host (see the gate above), so
   // tag events accordingly for the environment:production filter.

--- a/packages/web/instrumentation-client.ts
+++ b/packages/web/instrumentation-client.ts
@@ -3,7 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
-import { isCrawlerUserAgent } from './app/lib/is-crawler';
+import { isAutomatedCrawlerUserAgent } from './app/lib/is-crawler';
 import { isProductionHost } from './app/lib/production-hosts';
 
 // Only enable Sentry on the production boardsesh.com hosts. Exact-host match
@@ -28,9 +28,13 @@ const isProductionDomain = typeof window !== 'undefined' && isProductionHost(win
 //
 // Bot sessions have no user to be affected by an error and no session to replay,
 // so the events are worthless as well as expensive: they burn origin CPU, egress
-// and Sentry quota. `isCrawlerUserAgent` is the same superset the locale gates in
-// `middleware.ts` use, so a crawler is classified identically on both sides.
-const isCrawler = typeof navigator !== 'undefined' && isCrawlerUserAgent(navigator.userAgent);
+// and Sentry quota.
+//
+// `isAutomatedCrawlerUserAgent`, not the plain `isCrawlerUserAgent` the locale
+// gates use: that one knowingly misclassifies Yandex's in-app search browser,
+// which is a real person. Costing them a default-locale page is acceptable;
+// silently dropping their error reports is not.
+const isCrawler = typeof navigator !== 'undefined' && isAutomatedCrawlerUserAgent(navigator.userAgent);
 
 Sentry.init({
   dsn: 'https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400',

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -15,7 +15,7 @@ import {
   isSupportedLocale,
 } from './app/lib/i18n/config';
 import { detectLocale } from './app/lib/i18n/detect-locale';
-import { isBlockedAiCrawler } from './app/lib/crawler-policy';
+import { isBlockedCrawler } from './app/lib/crawler-policy';
 
 const SPECIAL_ROUTES = ['angles', 'grades']; // routes that don't need board validation
 
@@ -47,7 +47,7 @@ export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Cheap origin fallback for crawlers that bypass Cloudflare's public hostname.
-  if (isBlockedAiCrawler(request.headers.get('user-agent'))) {
+  if (isBlockedCrawler(request.headers.get('user-agent'))) {
     return new NextResponse(null, {
       status: 403,
       headers: { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex, nofollow' },

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -722,11 +722,18 @@ describe('www cost-control rules (#4650)', () => {
     // Cloudflare's `contains` is CASE-SENSITIVE. Without lower(), the rule installs
     // cleanly and matches nothing — the worst kind of failure, because it looks done.
     for (const rule of desired.wafRules) {
-      const comparisons = rule.expression.split(' or ');
+      const comparisons = [...rule.expression.matchAll(/lower\(http\.user_agent\) contains "([^"]*)"/g)];
       expect(comparisons.length).toBeGreaterThan(0);
-      for (const comparison of comparisons) {
-        expect(comparison).toMatch(/^lower\(http\.user_agent\) contains "[^A-Z]*"$/);
+      for (const [, token] of comparisons) {
+        expect(token).toBe(token.toLowerCase());
       }
+      // Every read of the header must be a lowered one. Counting occurrences
+      // rather than splitting on ' or ' is what makes this hold when an
+      // expression is wrapped — the allow rule gates its alternation on
+      // http.request.method, and a split would leave the first and last
+      // fragments carrying the wrapper.
+      const headerReads = rule.expression.split('http.user_agent').length - 1;
+      expect(headerReads).toBe(comparisons.length);
     }
   });
 
@@ -742,6 +749,11 @@ describe('www cost-control rules (#4650)', () => {
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/126.0.0.0 Safari/537.36',
       'facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)',
       'Twitterbot/1.0',
+      // Real people on Yandex's browser and in-app search. They share the
+      // `yandex` substring with the crawler and are the reason
+      // COST_BLOCKED_CRAWLER_TOKENS spells out the two bot tokens in full.
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 YaBrowser/23.9.1.962 Yowser/2.5 Safari/537.36',
+      'Mozilla/5.0 (Linux; Android 13; SM-A536B) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/106.0.0.0 Mobile Safari/537.36 YandexSearch/1.0',
     ];
     for (const userAgent of allowedUserAgents) {
       for (const token of CRAWLER_BLOCK_TOKENS) {
@@ -763,6 +775,8 @@ describe('www cost-control rules (#4650)', () => {
       'Mozilla/5.0 (compatible; MJ12bot/v1.4.8; http://mj12bot.com/)',
       'Mozilla/5.0 (compatible; DotBot/1.2; +https://opensiteexplorer.org/dotbot;)',
       'Screaming Frog SEO Spider/21.4',
+      'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)',
+      'Mozilla/5.0 (compatible; YandexRenderResourcesBot/1.0; +http://yandex.com/bots)',
     ];
     for (const userAgent of blockedUserAgents) {
       const matched = CRAWLER_BLOCK_TOKENS.some((token) => userAgent.toLowerCase().includes(token));
@@ -775,6 +789,19 @@ describe('www cost-control rules (#4650)', () => {
       for (const allowToken of CRAWLER_ALLOW_TOKENS) {
         expect(blockToken.includes(allowToken) || allowToken.includes(blockToken)).toBe(false);
       }
+    }
+  });
+
+  it('skips the ruleset only for GET, so a bot POST stays governable', () => {
+    // `skip` with `ruleset: current` takes an allow-listed agent past every
+    // later rule in the ruleset. Scoping it to GET keeps that protection for
+    // reads while leaving writes reachable — Applebot executes our JavaScript
+    // and was measured POSTing 190 of its 253 www requests to the Sentry
+    // tunnel on 2026-09-10.
+    expect(allowRule?.expression.startsWith('(http.request.method eq "GET" and (')).toBe(true);
+    expect(allowRule?.expression.endsWith('))')).toBe(true);
+    for (const token of CRAWLER_ALLOW_TOKENS) {
+      expect(allowRule?.expression).toContain(`lower(http.user_agent) contains "${token}"`);
     }
   });
 


### PR DESCRIPTION
## Summary

Railway is running at **$295/month** against **$139** for the previous billing period (Jul 26 – Aug 26). Per-service attribution reconstructed from the Railway usage API reconciles with `railway usage` to within 1%, and production HTTP logs explain the increase: almost none of our traffic is people.

A 5-minute sample of `boardsesh-web` (2026-09-10 14:25 UTC, n=501):

| Agent | Share |
|---|---|
| Applebot | 50.5% |
| YandexBot | 36.1% |
| Googlebot | 6.2% |
| Other bots | 3.6% |
| **Real browsers** | **3.6%** |

Two other things moved in the same window and are **not** regressions: www finished its cut-over from Vercel onto Railway (that service billed $0 last period and $53/mo now), and `ota-clickhouse` was added on Sep 1 ($33/mo, staying).

### What this changes

**Yandex moves from the allow list to the block list.** It was added to the allow list four days ago in 51a046118, bundled into the AI-crawler commit with no stated reason. It is the costliest crawler we carry per page fetched — 510 ms average against Applebot's 222 ms — and 171 of its 181 requests in that sample were climb-view pages, our most expensive SSR path. Boardsesh is an English-language climbing site; Yandex returns no measurable traffic against that. The Cloudflare rate limit could not reach it either: the Free plan caps the period at 10 s and Yandex ran ~34 req/min, nowhere near 60-per-10 s.

The tokens are spelled out as `yandexbot` and `yandexrenderresourcesbot` rather than a bare `yandex`, because Yandex Browser (`YaBrowser/…`) and Yandex in-app search (`YandexSearch/…`) are real people who share that substring. Tests pin both directions.

**Applebot keeps indexing HTML** — Apple and Siri search are preserved — but stops costing us writes:

- **Sentry no longer initialises for a crawler.** `tunnelRoute: '/monitoring'` makes every browser event a POST to our own origin before it is a request to Sentry, and Applebot executes our JavaScript: 190 of its 253 requests in that sample were `POST /monitoring`, the single most-requested path on the service, ahead of every climb page. Those events have no user behind them and no session to replay.
- **`app.boardsesh.com` and `ws.boardsesh.com` each serve a real robots.txt.** `app` is a blanket `Disallow: /` (it is a `noindex` utility surface with no per-route Open Graph tags); `ws` is a **deny-list** — `/graphql`, `/api/`, `/health`, `/board-credentials/` — because that host is mostly an image CDN and a blanket block would silently drop `/og/climb` (every climb page's `og:image`), `/render/board` (its LCP image) and `/static/*` (avatars, gym logos, photos, beta thumbnails). Neither host served one before — Cloudflare's managed preamble carries no `Disallow`, so both read as "crawl everything", and `app.boardsesh.com/robots.txt` answered with the app shell because `_redirects` ends in an SPA catch-all and no real file matched first. That crawl is expensive because the browser app issues GraphQL against `ws`: a crawler rendering the SPA turns one page fetch into a backend query, and Applebot was 173 of the 436 `/graphql` requests in a 3-minute backend sample.
- **The crawler-allow WAF rule is scoped to `GET`.** `skip` with `ruleset: current` walks an allow-listed agent past every later rule, which reads need and writes do not. This keeps the ruleset composable so a future rule aimed at bot writes is reachable.

### Review round

Codex raised two findings on `045ac00`, both correct, both fixed in `7e28af6`:

- **P1, `/og/climb` blocked.** The first pass used `Disallow: /` on `ws`, which would have stopped unfurlers fetching climb share cards. The fix is wider than the one path — `/render/board`, `/render/geometry` and `/static/*` were caught by the same blanket rule — so the policy is now a deny-list rather than carve-outs. A new image route on that host is crawlable by default; only a new API route needs a line.
- **P2, Sentry disabled for Yandex Search users.** The gate reused `isCrawlerUserAgent`, whose own test documents `YandexSearch/1.0` as a known real-user false positive. `is-crawler.ts` now also exports `isAutomatedCrawlerUserAgent`, which drops it, and telemetry uses that. The locale gates keep the superset on purpose.

### Author-side verification

- Full `web` project green (4571 tests), `scripts` + `deploy-app-subdomain` green (2199), backend robots suite green (18).
- `vp run typecheck:web` and `vp run typecheck:backend` clean; `vp check` clean on all 14 files with the new ones staged.
- **Every new guard mutation-tested.** Eight mutations, eight caught: dropping the Sentry crawler gate (3 failures), re-allowing Yandex (2), dropping the `GET` gate (1), dropping the workflow copy step (1), reopening `robots.txt` to `Allow: /` (2), unrouting `/robots.txt` on the backend (1), reverting the telemetry predicate to the loose one (1), and reverting `ws` to a blanket `Disallow: /` (7).

Cloudflare rules are **not** applied by this PR. `cf:apply` runs on production deploy; the dry-run diff should be read before that.

### Expected effect

Estimates, to be replaced by measurement 48h after deploy: roughly $25–30/mo from the Yandex block and $15–20/mo from Applebot's writes, against a separate ~$30–38/mo already arriving from the PostGIS memory cap applied this week. Google, Bing, Apple, Brave and every share-card unfurler keep indexing normally.

Worth noting beyond cost: `boardsesh-web` began returning 5xx under this load, up to 1,893 in a single 3-hour bucket on Sep 10.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. Open boardsesh.com in your phone browser. Homepage loads.
2. Tap into any climb page. Board and grade appear.
3. Open app.boardsesh.com. App shell loads and you can sign in.

## Risk

Risk: 3/5 — a user-agent rule runs on every www request, so a bad token would 403 real people; Yandex Browser and in-app search are pinned by tests as the near-miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KpFE1RPEpZxYXfDcFKQmg

