### PR TITLE
perf: stop PostHog counting crawlers as users

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -69,6 +69,10 @@ Read it like this:
 
 Locally it is the only way in: the browser PostHog client refuses to initialise off a production hostname, so on localhost there is no person and nothing to evaluate against.
 
+**Crawlers are in the same position, on purpose.** Since 2026-09-11 the client also refuses to initialise for a crawler user agent (`isAutomatedCrawlerUserAgent`, the same predicate the Sentry gate uses), so a crawler fetches no flags and every client flag reads as its shipped default. That is the intended answer for a crawler — it should see what an unflagged visitor sees — but it means "Googlebot renders the default UI" is correct behaviour, not a flag bug. Server flags are unaffected: `getPosthogDistinctId` returns `null` for anyone not signed in, so a crawler never had a person to evaluate against there either.
+
+The gate exists because crawlers were not a rounding error in this project. Applebot executes our JavaScript and holds no cookies, so every page load minted a fresh anonymous person and it parsed as "Safari / Mac OS X" — on 2026-09-10 that was 917 "people" against 29 real web visitors, roughly 90% of web product analytics. See the comment on `getPosthog()` in `packages/web/app/lib/analytics.ts` for the full measurement.
+
 In production it is the kill switch and the "I need this reachable now" lever — set it in the Vercel production environment and redeploy. It short-circuits before any network call, so it also keeps a flagged surface up during a PostHog outage. It outranks the dashboard silently, which is why the diagnostics endpoint always reports it.
 
 ## Adding a server flag

--- a/packages/web/app/lib/__tests__/analytics.test.ts
+++ b/packages/web/app/lib/__tests__/analytics.test.ts
@@ -23,6 +23,10 @@ vi.mock('posthog-js-lite', () => ({
 }));
 
 const originalLocation = window.location;
+const originalUserAgent = navigator.userAgent;
+
+const BROWSER_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36';
 
 function setWindowLocation(url: string): void {
   Object.defineProperty(window, 'location', {
@@ -30,6 +34,10 @@ function setWindowLocation(url: string): void {
     writable: true,
     configurable: true,
   });
+}
+
+function setUserAgent(userAgent: string): void {
+  Object.defineProperty(navigator, 'userAgent', { value: userAgent, writable: true, configurable: true });
 }
 
 describe('analytics wrapper', () => {
@@ -44,6 +52,9 @@ describe('analytics wrapper', () => {
       return mocks.posthog;
     });
     setWindowLocation('https://boardsesh.com/b/kilter');
+    // Pinned so the crawler gate's outcome is a property of each test, not of
+    // whatever UA the test environment happens to present.
+    setUserAgent(BROWSER_UA);
   });
 
   afterEach(() => {
@@ -53,6 +64,52 @@ describe('analytics wrapper', () => {
       writable: true,
       configurable: true,
     });
+    Object.defineProperty(navigator, 'userAgent', {
+      value: originalUserAgent,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it.each([
+    [
+      'Applebot',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15 (Applebot/0.1; +http://www.apple.com/go/applebot)',
+    ],
+    ['YandexBot', 'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)'],
+    [
+      'Googlebot',
+      'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/153.0.8010.36 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+    ],
+  ])('never starts the SDK for %s, even on a production host', async (_label, userAgent) => {
+    // Applebot renders our JavaScript, so it booted this SDK like any browser
+    // and, holding no cookies, minted a new anonymous person on every page
+    // load. On 2026-09-10 that bucket was 917 "people" against 29 real web
+    // visitors. Not constructing the client is what stops it: no client means
+    // no flags fetch, no batch POST, and no person.
+    setUserAgent(userAgent);
+    const { track } = await import('../analytics');
+
+    track('Climb Opened');
+
+    expect(mocks.PostHog).not.toHaveBeenCalled();
+    expect(mocks.posthog.capture).not.toHaveBeenCalled();
+  });
+
+  it('keeps counting a real Yandex Search in-app browser user', async () => {
+    // The reason this gate uses isAutomatedCrawlerUserAgent rather than the
+    // locale gates' isCrawlerUserAgent: that predicate knowingly misclassifies
+    // `YandexSearch`, which is a person we want in the numbers.
+    setUserAgent(
+      'Mozilla/5.0 (Linux; Android 13; SM-A536B) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/106.0.0.0 Mobile Safari/537.36 YandexSearch/1.0',
+    );
+    const { track } = await import('../analytics');
+
+    track('Climb Opened');
+
+    expect(mocks.PostHog).toHaveBeenCalled();
+    // No properties passed through as undefined, which is what track() does.
+    expect(mocks.posthog.capture).toHaveBeenCalledWith('Climb Opened', undefined);
   });
 
   it('sends track events to PostHog on production hostnames', async () => {

--- a/packages/web/app/lib/analytics.ts
+++ b/packages/web/app/lib/analytics.ts
@@ -31,36 +31,9 @@ function getPosthog(): PostHog | null {
   // prod PostHog project (#3814).
   if (!isProductionHost(window.location.hostname)) return null;
 
-  // Never start the SDK for a crawler. Crawlers that execute JavaScript boot it
-  // exactly like a browser does, and because they hold no cookies every page
-  // load mints a fresh anonymous person — so a crawler does not just cost
-  // requests, it becomes the audience.
-  //
-  // It already had. Measured 2026-09-11 on `$pageview` where `$lib = 'js'`:
-  //
-  //   day      mobile app   web (other browsers)   web "Safari / Mac OS X"
-  //   Sep 10          454                     29                      917
-  //   Sep  9          488                     35                      363
-  //   Sep  8          523                     52                      354
-  //
-  // That third column is Applebot. Its user agent opens
-  // `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) … Safari/605.1.15` and only
-  // names itself in a trailing `(Applebot/0.1; …)`, which PostHog's parser does
-  // not read — so it files as Safari on Mac OS X. Three things say it is not
-  // people: the bucket runs at exactly 1.00 pageviews per person every single
-  // day (335/335, 917/917, 363/363) where every other browser runs 3-8; it is
-  // active at all 24 hours, showing 104-145 "people" at 01:00-03:00 UTC while
-  // the entire rest of the audience shows 4-8; and its volume tracks the crawl,
-  // peaking on the same day Applebot was 50.5% of www traffic at the edge.
-  //
-  // So roughly 90% of web product analytics was one crawler. This gate is a
-  // data-quality fix first and a cost fix second.
-  //
-  // `isAutomatedCrawlerUserAgent`, not the plain `isCrawlerUserAgent` the locale
-  // gates use: that one knowingly misclassifies Yandex's in-app search browser,
-  // which is a real person we would rather keep counting. Same predicate the
-  // Sentry gate uses (instrumentation-client.ts), so a visitor is classified
-  // identically by both.
+  // Crawlers that execute our JS boot this SDK and, holding no cookies, mint a
+  // fresh person per page load: Applebot was 917 of the 946 web "users" on 2026-09-10.
+  // Not isCrawlerUserAgent — that one counts real YandexSearch users as bots. docs/feature-flags.md.
   if (isAutomatedCrawlerUserAgent(navigator.userAgent)) return null;
 
   const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;

--- a/packages/web/app/lib/analytics.ts
+++ b/packages/web/app/lib/analytics.ts
@@ -3,6 +3,7 @@ import { PostHog } from 'posthog-js-lite';
 import { createAnalytics } from '@boardsesh/analytics';
 import { analyticsPathname, isAdminAnalyticsUrl } from './analytics-paths';
 import { getBackendHttpUrl } from './backend-url';
+import { isAutomatedCrawlerUserAgent } from './is-crawler';
 import { isProductionHost } from './production-hosts';
 
 // The property values a tracked event may carry. `undefined` is accepted at the
@@ -29,6 +30,38 @@ function getPosthog(): PostHog | null {
   // would pass a naive `.includes()` check, leaking preview sessions into the
   // prod PostHog project (#3814).
   if (!isProductionHost(window.location.hostname)) return null;
+
+  // Never start the SDK for a crawler. Crawlers that execute JavaScript boot it
+  // exactly like a browser does, and because they hold no cookies every page
+  // load mints a fresh anonymous person — so a crawler does not just cost
+  // requests, it becomes the audience.
+  //
+  // It already had. Measured 2026-09-11 on `$pageview` where `$lib = 'js'`:
+  //
+  //   day      mobile app   web (other browsers)   web "Safari / Mac OS X"
+  //   Sep 10          454                     29                      917
+  //   Sep  9          488                     35                      363
+  //   Sep  8          523                     52                      354
+  //
+  // That third column is Applebot. Its user agent opens
+  // `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) … Safari/605.1.15` and only
+  // names itself in a trailing `(Applebot/0.1; …)`, which PostHog's parser does
+  // not read — so it files as Safari on Mac OS X. Three things say it is not
+  // people: the bucket runs at exactly 1.00 pageviews per person every single
+  // day (335/335, 917/917, 363/363) where every other browser runs 3-8; it is
+  // active at all 24 hours, showing 104-145 "people" at 01:00-03:00 UTC while
+  // the entire rest of the audience shows 4-8; and its volume tracks the crawl,
+  // peaking on the same day Applebot was 50.5% of www traffic at the edge.
+  //
+  // So roughly 90% of web product analytics was one crawler. This gate is a
+  // data-quality fix first and a cost fix second.
+  //
+  // `isAutomatedCrawlerUserAgent`, not the plain `isCrawlerUserAgent` the locale
+  // gates use: that one knowingly misclassifies Yandex's in-app search browser,
+  // which is a real person we would rather keep counting. Same predicate the
+  // Sentry gate uses (instrumentation-client.ts), so a visitor is classified
+  // identically by both.
+  if (isAutomatedCrawlerUserAgent(navigator.userAgent)) return null;
 
   const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
   if (!apiKey) {


### PR DESCRIPTION
## Summary

PostHog has been counting Applebot as users, and it was most of the web audience.

Applebot renders our JavaScript, so it booted the PostHog client like any browser. It holds no cookies, so every page load minted a fresh anonymous person. And its user agent opens `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) … Safari/605.1.15`, only naming itself in a trailing `(Applebot/0.1; …)` that PostHog's parser does not read — so it filed as **Safari on Mac OS X**.

Daily actives on `$pageview` where `$lib = 'js'`, measured 2026-09-11:

| Day | Mobile app | Web, other browsers | Web, "Safari / Mac OS X" |
|---|---|---|---|
| Sep 10 | 454 | 29 | **917** |
| Sep 9 | 488 | 35 | **363** |
| Sep 8 | 523 | 52 | **354** |
| Sep 7 | 505 | 50 | **321** |

Three things say that column is not people:

1. **Exactly 1.00 pageviews per person, every single day** — 335/335, 917/917, 363/363, 307/307. Every other browser on the site runs 3 to 8.
2. **It never sleeps.** Between 01:00 and 03:00 UTC it shows 104 to 145 "people" while the entire rest of the audience shows 4 to 8.
3. **Its volume tracks the crawl**, peaking on 2026-09-10 — the same day Applebot was 50.5% of www traffic at the edge.

So roughly 90% of web product analytics was one crawler. This is a data-quality fix before it is a cost one, though it also removes the 8.67k `/api/posthog/flags/` and 1.26k `/api/posthog/batch/` requests a period that the Cloudflare endpoint breakdown showed. Follows #5385, which did the same for the Sentry tunnel.

### How

`getPosthog()` is the single construction point — `createAnalytics` takes it and the feature-flag client derives from the same instance — so refusing to build the client there stops the flags fetch, the batch POST and the person in one place.

It uses `isAutomatedCrawlerUserAgent`, not the locale gates' `isCrawlerUserAgent`. That one knowingly misclassifies Yandex's in-app search browser, which is a real person we want to keep counting; a test pins that case as still-counted. It is the same predicate the Sentry gate uses, so a visitor is classified identically by both.

Server flags are untouched. `getPosthogDistinctId` returns `null` for anyone not signed in, so a crawler never had a person to evaluate against there either.

### What changes in the numbers

Web daily actives will drop from roughly 350 to roughly 30 to 50. That is not a regression — it is the first honest reading. Anyone comparing week over week after this lands needs to know the denominator changed.

### Author-side verification

- Full `web` project green: 394 files, 4575 tests.
- `vp run typecheck:web` clean, `vp check` clean on all three files.
- **Mutation-tested.** Deleting the gate line fails 3 tests (Applebot, YandexBot, Googlebot).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. Open boardsesh.com on your phone. Homepage loads.
2. Tap into any climb page. Board and grade appear.

## Risk

Risk: 2/5 — one early return in the analytics client boot; worst case is under-counting a real visitor whose user agent looks automated, and the known near-miss is pinned by a test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KpFE1RPEpZxYXfDcFKQmg
