### PR TITLE
perf: block Applebot — the largest crawler that sends nobody back

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -346,10 +346,40 @@ back because GraphQL, WebSockets, and `/og` share that hostname.
      MJ12, DotBot, BLEXBot, Barkrowler, serpstat, Seznam, Zoominfo, Screaming
      Frog). Each was verified reaching our origin on 2026-08-24. They sell
      backlink data and send Boardsesh no traffic. The same rule also blocks
-     automated AI training and search crawlers and **Yandex**, using the shared
-     tokens in `packages/web/app/lib/crawler-policy.ts`. Google, Bing, Apple,
-     Brave and share-card unfurlers remain allowed. Human-triggered AI fetchers
-     are not added to this automated-crawler list.
+     automated AI training and search crawlers, **Yandex** and **Apple**, using
+     the shared tokens in `packages/web/app/lib/crawler-policy.ts`. Google,
+     Bing, DuckDuckGo, Brave and share-card unfurlers remain allowed.
+     Human-triggered AI fetchers are not added to this automated-crawler list.
+
+  **The allow list is now "engines that send people back", and it is measured.**
+  Thirty days of `$referring_domain` on real web visitors, 2026-09-11:
+
+  | Source | Real people sent |
+  |---|---|
+  | Google (all properties) | 237 |
+  | DuckDuckGo | 25 |
+  | Baidu | 7 |
+  | Bing | 5 |
+  | Brave, Ecosia, Qwant | 9 |
+  | Apple | 0 |
+
+  Re-run that query before adding or removing a token. Two notes on reading it:
+  DuckDuckGo and Ecosia mostly resell Bing's index, so Bingbot earns its place
+  through them rather than through `bing.com` directly; and Baidu is not in
+  either list — it passes by default, which is consistent with the policy since
+  it does send people. Social referrers (Reddit 20, Instagram 10, Facebook 10)
+  are why the share-card unfurlers stay even though they are not search: they
+  deliver more traffic than Bing does, and blocking them breaks link previews
+  rather than saving a crawl.
+
+  **Applebot moved to the block list on 2026-09-11.** It was the largest
+  crawler we carried — 50.5% of www traffic before the Sentry and robots.txt
+  gates, 9.4% after — and the only large one absent from the referrer table
+  above. The honest caveat, and the reason to revisit: Apple strips referrers
+  aggressively, so "0 measurable" is not "0 actual". What the data supports is
+  that Apple is invisible where seven other engines name themselves. The known
+  cost is that Apple builds link previews (iMessage, Safari shared links) by
+  fetching the shared URL, and a blocked fetch means no preview card.
 
   **Yandex moved from the allow list to the block list on 2026-09-11.** It was
   added to the allow list four days earlier, in the AI-crawler commit, with no

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -496,7 +496,6 @@ export const CRAWLER_ALLOW_TOKENS = [
   'duckduckbot',
   'brave-search',
   'bravebot',
-  'applebot',
   // Share-card unfurlers. Blocking these breaks link previews, not crawling.
   'twitterbot',
   'facebookexternalhit',

--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -22,6 +22,10 @@ describe('blocked crawler origin rejection', () => {
     // SSR path. See COST_BLOCKED_CRAWLER_TOKENS in app/lib/crawler-policy.ts.
     'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)',
     'Mozilla/5.0 (compatible; YandexRenderResourcesBot/1.0; +http://yandex.com/bots)',
+    // Blocked on the same test, applied to "does it send anyone back": 30 days
+    // of referrers show Google 237, DuckDuckGo 25, Baidu 7, Bing 5, Brave 4,
+    // Apple 0, while Applebot was the largest crawler we carried.
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15 (Applebot/0.1; +http://www.apple.com/go/applebot)',
   ])('rejects %s before rendering', (userAgent) => {
     const response = middleware(
       new NextRequest('https://boardsesh-web-production.up.railway.app/fr/setter/test', {
@@ -36,7 +40,6 @@ describe('blocked crawler origin rejection', () => {
   it.each([
     'Googlebot/2.1',
     'bingbot/2.0',
-    'Applebot/0.1',
     'facebookexternalhit/1.1',
     'ChatGPT-User/1.0',
     'Claude-User/1.0',

--- a/packages/web/app/__tests__/robots.test.ts
+++ b/packages/web/app/__tests__/robots.test.ts
@@ -53,9 +53,14 @@ describe('robots', () => {
     const allRules = Array.isArray(rules) ? rules : [rules];
     const blockedRule = allRules.find((rule) => toList(rule.userAgent).includes('gptbot'));
     expect(toList(blockedRule?.userAgent)).toEqual(expect.arrayContaining(['yandexbot', 'yandexrenderresourcesbot']));
-    // Applebot stays out of it — it still indexes us. Only its writes are cut,
-    // and that happens in instrumentation-client.ts, not here.
-    expect(toList(blockedRule?.userAgent)).not.toContain('applebot');
+    // Applebot joined them on 2026-09-11: it was the largest crawler we carried
+    // and the only large one that sends nobody back (Apple is absent from 30
+    // days of referrers while seven other engines name themselves).
+    expect(toList(blockedRule?.userAgent)).toContain('applebot');
+    // The engines that do send people back must never land in this group.
+    for (const stillIndexing of ['googlebot', 'bingbot', 'duckduckbot', 'bravebot']) {
+      expect(toList(blockedRule?.userAgent)).not.toContain(stillIndexing);
+    }
   });
   it('allows crawling the root path', () => {
     const result = robots();

--- a/packages/web/app/lib/crawler-policy.ts
+++ b/packages/web/app/lib/crawler-policy.ts
@@ -28,11 +28,35 @@ export const AI_CRAWLER_TOKENS = [
  * reach it either — the Free plan caps the period at 10 s and Yandex ran ~34
  * requests/min, nowhere near the 60-per-10 s threshold.
  *
- * Both tokens are needed: `yandexrenderresourcesbot` does not contain
+ * Both Yandex tokens are needed: `yandexrenderresourcesbot` does not contain
  * `yandexbot` as a substring, and the renderer was 6% of the Yandex traffic in
  * the same sample.
+ *
+ * **Applebot** joined them on 2026-09-11 on the same test, applied to the
+ * question "which crawlers actually send people back". Thirty days of
+ * `$referring_domain` on real web visitors:
+ *
+ *   Google 237 · DuckDuckGo 25 · Baidu 7 · Bing 5 · Brave 4 · Ecosia 4 ·
+ *   Qwant 1 · **Apple 0**
+ *
+ * Google, DuckDuckGo, Bing, Brave, Baidu, Ecosia and Qwant all name themselves
+ * in a referrer. Apple never appears, while Applebot was 50.5% of www traffic
+ * before the Sentry and robots.txt gates and 9.4% after. It is the largest
+ * crawler we carry and the only large one that returns nothing measurable.
+ *
+ * The honest caveat, recorded because it is the reason to revisit this: Apple
+ * strips referrers aggressively, so "0 measurable" is not "0 actual". The
+ * largest referrer bucket is `(none)`. What the data supports is that Apple is
+ * invisible where seven other engines are visible.
+ *
+ * `applebot` also matches `Applebot-Extended` (Apple's AI-training crawler),
+ * which is already refused in robots.txt. Blocking both is the intent.
+ *
+ * Known cost, and the thing to weigh before merging: Apple generates link
+ * previews (iMessage, Safari shared links) by fetching the shared URL, and a
+ * blocked fetch means no preview card. Reverting is one token.
  */
-export const COST_BLOCKED_CRAWLER_TOKENS = ['yandexbot', 'yandexrenderresourcesbot'] as const;
+export const COST_BLOCKED_CRAWLER_TOKENS = ['yandexbot', 'yandexrenderresourcesbot', 'applebot'] as const;
 
 /**
  * Every crawler we refuse, whatever the reason. This is the single list behind

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -777,6 +777,7 @@ describe('www cost-control rules (#4650)', () => {
       'Screaming Frog SEO Spider/21.4',
       'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)',
       'Mozilla/5.0 (compatible; YandexRenderResourcesBot/1.0; +http://yandex.com/bots)',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15 (Applebot/0.1; +http://www.apple.com/go/applebot)',
     ];
     for (const userAgent of blockedUserAgents) {
       const matched = CRAWLER_BLOCK_TOKENS.some((token) => userAgent.toLowerCase().includes(token));


### PR DESCRIPTION
## Summary

Sets the crawler allow list by a measured rule — keep the engines that send people back, refuse the rest.

Thirty days of `$referring_domain` on real web visitors, measured 2026-09-11:

| Source | Real people sent |
|---|---|
| Google (all properties) | 237 |
| DuckDuckGo | 25 |
| Baidu | 7 |
| Bing | 5 |
| Brave, Ecosia, Qwant | 9 |
| ChatGPT | 4 |
| **Apple** | **0** |

Seven engines name themselves in a referrer. Apple never does, and Applebot was the largest crawler we carried — **50.5%** of www traffic before the Sentry and robots.txt gates in #5385, **9.4%** after.

**Most of the policy was already in place.** AI training and search crawlers have been blocked since 51a046118, the SEO backlink scrapers since #4650, and Yandex since #5385. Verified live just now: YandexBot gets `403`, Googlebot `200`. This PR moves the one remaining name.

### ⚠️ Read this before merging

Apple builds link previews — iMessage, Safari shared links — by fetching the shared URL. A blocked fetch means **no preview card when someone shares a climb into iMessage**. I could not find Applebot doing preview-shaped fetches in the samples I took (its pattern was bulk `/view/` crawling), but absence in a 5-minute window is not proof. Reverting is one token.

### Two deliberate exceptions to "search only"

Both recorded in `docs/cloudflare.md` so the next person does not "fix" them:

- **Bingbot stays.** DuckDuckGo and Ecosia mostly resell Bing's index, so it earns its place through them (25 + 4 people) rather than through `bing.com` directly (5).
- **The share-card unfurlers stay.** Reddit (20), Instagram (10) and Facebook (10) send more people than Bing does. Blocking these breaks link previews rather than saving a crawl — they fetch one URL when a human shares a link.

Baidu is in neither list. It passes by default, which is consistent with the policy since it does send people.

### The caveat worth recording

Apple strips referrers aggressively, so "0 measurable" is not "0 actual" — the largest referrer bucket is `(none)`. What the data supports is that Apple is invisible where seven other engines are visible. That reasoning is in the code and the doc, so a future reader can re-run the query rather than re-derive the argument.

### What this does not fix

Worth knowing before anyone reads the next bill as a win. A sample taken after #5385 deployed shows the remaining traffic is **84% a UA-rotating scraper farm** presenting as ordinary Chrome, Edge and Safari — nine user-agent strings, ~45 requests each, 350 climb pages in 3.6 minutes. No allow or block list can reach it. That needs the rate limit, and the current rule (60 per 10 s per IP per colo, the Free-plan ceiling) is evidently not catching it. Separate problem, separate PR.

### Author-side verification

- Full `web` project green: 394 files, 4575 tests. `scripts` + `deploy-app-subdomain`: 115 files, 2199 tests.
- `vp check` clean on all 6 files.
- **Mutation-tested both directions.** Restoring `applebot` to the allow list fails the allow/block disjointness test; dropping it from the block list fails the middleware 403 guard and the robots.txt guard.

Cloudflare rules are not applied by this PR — `cf:apply` runs on production deploy.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. Open boardsesh.com on your phone. Homepage loads.
2. Tap into any climb page. Board and grade appear.
3. Share that climb link into iMessage. Note whether a preview card appears.

## Risk

Risk: 2/5 — one token moves between two lists; the reachable downside is Apple link previews going blank, which step 3 checks and which reverts in one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KpFE1RPEpZxYXfDcFKQmg
