### PR TITLE
perf: managed-challenge the climb-view surface to stop the UA-rotating scrape

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -347,8 +347,9 @@ back because GraphQL, WebSockets, and `/og` share that hostname.
      Frog). Each was verified reaching our origin on 2026-08-24. They sell
      backlink data and send Boardsesh no traffic. The same rule also blocks
      automated AI training and search crawlers and **Yandex**, using the shared
-     tokens in `packages/web/app/lib/crawler-policy.ts`. Google, Bing, Apple,
-     Brave and share-card unfurlers remain allowed. Human-triggered AI fetchers
+     tokens in `packages/web/app/lib/crawler-policy.ts`. Google, Bing,
+     DuckDuckGo, Apple, Brave, Baidu, Qwant and the share-card unfurlers remain
+     allowed. Human-triggered AI fetchers
      are not added to this automated-crawler list.
 
   **Yandex moved from the allow list to the block list on 2026-09-11.** It was
@@ -398,6 +399,39 @@ back because GraphQL, WebSockets, and `/og` share that hostname.
   rendering the SPA turns one page fetch into a backend query: a 3-minute sample
   of `boardsesh-backend` on 2026-09-10 had Applebot issuing 173 of the 436
   `/graphql` requests on the service.
+
+  3. `managed_challenge` on the climb-view surface, **last**. This is the only
+     rule that can catch an ordinary browser string, so every agent we have a
+     verdict on has to be judged before it.
+
+  **The challenge exists because the biggest remaining population has no name.**
+  A 3.6-minute sample of production on 2026-09-11, taken after the #5385 gates
+  deployed, found nine ordinary Chrome, Edge and Safari user agents at roughly
+  45 requests each, walking 350 climb pages across all four locales — 84% of
+  what was left. No allow or block list reaches a rotating UA, and the rate
+  limit cannot either: it runs about 12 requests a minute per agent against a
+  Free-plan floor of 60 per 10 s (~360/min), and lowering the threshold that far
+  would take out a gym behind one NAT.
+
+  What separates it from a person is JavaScript. In that sample those nine
+  agents fetched 350 HTML pages and **zero** JS — not one `/_next/static` chunk,
+  not one Sentry tunnel POST. The single real visitor in the window did the
+  mirror image: 33 chunks, no climb pages. A managed challenge is exactly that
+  test, so it needs no list to maintain.
+
+  Two consequences worth knowing. `baiduspider` and `qwantify` had to join the
+  allow list in the same change — they send people back (Baidu 7, Qwant 1 over
+  30 days) and were relying on passing by default, which ends the moment an
+  unlisted agent gets challenged. And a first-time human landing on a climb page
+  from search now gets one sub-second check before a `cf_clearance` cookie
+  covers them.
+
+  Note the plan asymmetry: `managed_challenge` is refused in the **rate-limit**
+  phase on Free (see below) but accepted on a **custom rule**, which is why the
+  mitigation lives here rather than on the rate limit.
+
+  Caching cannot substitute for this. The scraper walks unique URLs, so every
+  request is a cache miss by construction — an edge cache only helps repeats.
 
   **Order is load-bearing and enforced by the tool.** `upsertCacheRule` rewrites
   our rules as one contiguous group in declared order, because a rule-by-rule

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -128,6 +128,10 @@ export const CRAWLER_ALLOW_RULE_DESCRIPTION =
   'boardsesh:allow-search-crawlers (managed by scripts/cloudflare-apply.ts)';
 export const CRAWLER_BLOCK_RULE_DESCRIPTION = 'boardsesh:block-seo-scrapers (managed by scripts/cloudflare-apply.ts)';
 
+/** Marker for the climb-view managed-challenge rule. Same never-rename contract as above. */
+export const CLIMB_VIEW_CHALLENGE_RULE_DESCRIPTION =
+  'boardsesh:climb-view-challenge (managed by scripts/cloudflare-apply.ts)';
+
 /** Marker for the climb-view rate-limit rule. Same never-rename contract as above. */
 export const CLIMB_VIEW_RATE_LIMIT_RULE_DESCRIPTION =
   'boardsesh:climb-view-rate-limit (managed by scripts/cloudflare-apply.ts)';
@@ -242,7 +246,14 @@ export interface SslDesired {
 export interface WafRuleDesired {
   description: string;
   expression: string;
-  action: 'block' | 'skip';
+  /**
+   * `managed_challenge` is the softest of the three and the only one that can
+   * separate a headless fetcher from a person: passing it requires executing
+   * JavaScript, which a real browser does transparently. Unlike the rate-limit
+   * phase — where the Free plan refused it outright (see the note on
+   * RateLimitRuleDesired) — custom rules accept it on every plan.
+   */
+  action: 'block' | 'skip' | 'managed_challenge';
   action_parameters?: { ruleset: 'current' };
   enabled: boolean;
 }
@@ -497,6 +508,12 @@ export const CRAWLER_ALLOW_TOKENS = [
   'brave-search',
   'bravebot',
   'applebot',
+  // Added 2026-09-11 with the climb-view challenge below. Both send people back
+  // (Baidu 7, Qwant 1 over 30 days) and neither was on either list, so they
+  // passed by default — which stopped working the moment an unlisted agent
+  // started getting challenged.
+  'baiduspider',
+  'qwantify',
   // Share-card unfurlers. Blocking these breaks link previews, not crawling.
   'twitterbot',
   'facebookexternalhit',
@@ -599,7 +616,48 @@ export const CRAWLER_BLOCK_EXPRESSION = buildUserAgentExpression(CRAWLER_BLOCK_T
  * page are counted along with real page loads. That is why the threshold
  * below carries headroom rather than a tight ~60/min budget.
  */
-export const CLIMB_VIEW_RATE_LIMIT_EXPRESSION = `(http.host eq "${WWW_HOSTNAME}" and http.request.uri.path contains "/view/")`;
+export const CLIMB_VIEW_SURFACE_EXPRESSION = `(http.host eq "${WWW_HOSTNAME}" and http.request.uri.path contains "/view/")`;
+
+/** The rate limit and the challenge deliberately cover the same surface. */
+export const CLIMB_VIEW_RATE_LIMIT_EXPRESSION = CLIMB_VIEW_SURFACE_EXPRESSION;
+
+/**
+ * Managed-challenge the climb-view surface for anything the allow rule did not
+ * already wave through.
+ *
+ * **Why a challenge and not a UA rule or a tighter rate limit.** The population
+ * this exists for rotates user agents: a 3.6-minute sample of production on
+ * 2026-09-11 found nine ordinary Chrome, Edge and Safari strings at roughly 45
+ * requests each, walking 350 climb pages across all four locales. No allow or
+ * block list can name it. The rate limit cannot reach it either — it runs about
+ * 12 requests a minute per agent against a Free-plan floor of 60 per 10 s
+ * (~360/min), and lowering the threshold far enough to catch it would take out
+ * a gym behind one NAT, which is exactly the failure the rate-limit rule's own
+ * comment warns about.
+ *
+ * **What it can be caught by.** In that same sample those nine agents fetched
+ * 350 HTML pages and **zero** JavaScript — not one `/_next/static` chunk, not
+ * one Sentry tunnel POST. The one real visitor in the window did the mirror
+ * image: 33 chunks and no climb pages. A managed challenge is precisely that
+ * test, so it separates the two with no list to maintain.
+ *
+ * **Who never sees it.** The allow rule is first and its action is `skip` over
+ * the current ruleset, so every search engine and share unfurler on
+ * CRAWLER_ALLOW_TOKENS bypasses this. That is why `baiduspider` and `qwantify`
+ * were added there in the same change: they send people back and were relying
+ * on passing by default, which this rule ends.
+ *
+ * **What it costs.** A first-time human visitor landing on a climb page from
+ * search gets one sub-second check, then a `cf_clearance` cookie covers them.
+ * At roughly 30-50 real web visitors a day that is a small price for dropping
+ * the majority of origin renders.
+ *
+ * Deliberately NOT excluding signed-in visitors on a session-cookie check. The
+ * WAF can only test that a cookie NAME is present, so `Cookie:
+ * <session-name>=anything` would be a one-line bypass for the scraper. The
+ * clearance cookie already keeps a logged-in climber from being re-challenged.
+ */
+export const CLIMB_VIEW_CHALLENGE_EXPRESSION = CLIMB_VIEW_SURFACE_EXPRESSION;
 
 /**
  * The apex, and only the apex. `http.host` is the request's Host header, so this
@@ -787,6 +845,15 @@ export const desiredCloudflareState: CloudflareDesiredState = {
       description: CRAWLER_BLOCK_RULE_DESCRIPTION,
       expression: CRAWLER_BLOCK_EXPRESSION,
       action: 'block',
+      enabled: true,
+    },
+    // MUST stay last. It is the only rule here that can catch an ordinary
+    // browser string, so every agent we have an opinion about — allowed or
+    // blocked — has to be judged before it.
+    {
+      description: CLIMB_VIEW_CHALLENGE_RULE_DESCRIPTION,
+      expression: CLIMB_VIEW_CHALLENGE_EXPRESSION,
+      action: 'managed_challenge',
       enabled: true,
     },
   ],

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -17,6 +17,7 @@ import {
   CACHE_RULE_DESCRIPTION,
   CRAWLER_ALLOW_RULE_DESCRIPTION,
   CRAWLER_ALLOW_TOKENS,
+  CLIMB_VIEW_CHALLENGE_RULE_DESCRIPTION,
   CRAWLER_BLOCK_RULE_DESCRIPTION,
   CRAWLER_BLOCK_TOKENS,
   CLIMB_VIEW_PATH_SEGMENT,
@@ -721,9 +722,12 @@ describe('www cost-control rules (#4650)', () => {
   it('lowercases the user agent in every WAF expression', () => {
     // Cloudflare's `contains` is CASE-SENSITIVE. Without lower(), the rule installs
     // cleanly and matches nothing — the worst kind of failure, because it looks done.
+    // Not every rule matches on user agent — the climb-view challenge is
+    // path-only, because the population it exists for rotates its UA. The
+    // invariant is narrower than "every rule names an agent": every READ of the
+    // header must be a lowered one.
     for (const rule of desired.wafRules) {
       const comparisons = [...rule.expression.matchAll(/lower\(http\.user_agent\) contains "([^"]*)"/g)];
-      expect(comparisons.length).toBeGreaterThan(0);
       for (const [, token] of comparisons) {
         expect(token).toBe(token.toLowerCase());
       }
@@ -734,6 +738,13 @@ describe('www cost-control rules (#4650)', () => {
       // fragments carrying the wrapper.
       const headerReads = rule.expression.split('http.user_agent').length - 1;
       expect(headerReads).toBe(comparisons.length);
+    }
+
+    // And the guard must not pass by matching nothing: the two rules that are
+    // ABOUT user agents still have to carry lowered comparisons.
+    for (const description of [CRAWLER_ALLOW_RULE_DESCRIPTION, CRAWLER_BLOCK_RULE_DESCRIPTION]) {
+      const rule = desired.wafRules.find((candidate) => candidate.description === description);
+      expect(rule?.expression).toMatch(/lower\(http\.user_agent\) contains "/);
     }
   });
 
@@ -805,6 +816,38 @@ describe('www cost-control rules (#4650)', () => {
     }
   });
 
+  it('challenges the climb-view surface, and does it last', () => {
+    // The scraper this exists for rotates ordinary Chrome/Edge/Safari strings,
+    // so no token list reaches it. What separates it from a person is that it
+    // executes no JavaScript — 350 climb pages and zero `/_next/static` chunks
+    // in a 2026-09-11 sample — and a managed challenge is exactly that test.
+    const challengeRule = desired.wafRules.find((rule) => rule.description === CLIMB_VIEW_CHALLENGE_RULE_DESCRIPTION);
+    expect(challengeRule?.action).toBe('managed_challenge');
+    expect(challengeRule?.expression).toContain('/view/');
+    expect(challengeRule?.expression).toContain(`http.host eq "${WWW_HOSTNAME}"`);
+
+    // Last, because it is the only rule that can catch a real browser string.
+    // Anything we have a verdict on must be judged before it.
+    expect(desired.wafRules.indexOf(challengeRule!)).toBe(desired.wafRules.length - 1);
+    expect(desired.wafRules.indexOf(challengeRule!)).toBeGreaterThan(desired.wafRules.indexOf(blockRule!));
+  });
+
+  it('never challenges an engine that sends people back', () => {
+    // The allow rule skips the whole ruleset, so an allow-listed agent cannot
+    // reach the challenge. That is load-bearing for SEO and it is why Baidu and
+    // Qwant had to be added: they were passing by default, which stops working
+    // the moment an unlisted agent gets challenged.
+    const challengeIndex = desired.wafRules.findIndex(
+      (rule) => rule.description === CLIMB_VIEW_CHALLENGE_RULE_DESCRIPTION,
+    );
+    expect(desired.wafRules.indexOf(allowRule!)).toBeLessThan(challengeIndex);
+    expect(allowRule?.action).toBe('skip');
+    expect(allowRule?.action_parameters).toEqual({ ruleset: 'current' });
+    for (const sendsTraffic of ['googlebot', 'bingbot', 'duckduckbot', 'bravebot', 'baiduspider', 'qwantify']) {
+      expect(CRAWLER_ALLOW_TOKENS).toContain(sendsTraffic);
+    }
+  });
+
   it('declares the allow rule before the block rule', () => {
     // Precedence is the whole safety mechanism: skip-remaining only protects a
     // crawler if it is evaluated first.
@@ -837,6 +880,9 @@ describe('managed rule ordering and foreign-rule safety', () => {
     expect(rules.map((rule) => rule.description)).toEqual([
       CRAWLER_ALLOW_RULE_DESCRIPTION,
       CRAWLER_BLOCK_RULE_DESCRIPTION,
+      // Last on purpose: it is the only rule that can catch an ordinary browser
+      // string, so both UA verdicts must be reached first.
+      CLIMB_VIEW_CHALLENGE_RULE_DESCRIPTION,
     ]);
     // The pre-existing rule keeps its Cloudflare-assigned id rather than being
     // recreated, so its analytics and history survive.


### PR DESCRIPTION
> Rebased onto `main` on 2026-09-11 and no longer stacked. #5389 (block Applebot) was closed unmerged: the gates in #5385 had already cut Applebot by 74%, from ~71,400 requests a day to ~18,800, so blocking it was down to roughly $7-10/month against the risk of breaking Apple link previews for shared climbs. **Applebot stays allowed.**

## Summary

After #5385 and #5388 cleared the named crawlers, the biggest remaining population turns out to have no name.

A 3.6-minute sample of production on 2026-09-11, taken after those gates deployed: **nine ordinary Chrome, Edge and Safari user agents at roughly 45 requests each, walking 350 climb pages across all four locales.** 84% of what was left. Applebot is down to 9.4% and Yandex is gone, so this is now the load.

**Nothing on the current shelf reaches it.**

- No allow or block list can name a rotating user agent.
- The rate limit cannot either. It runs about 12 requests a minute per agent against a Free-plan floor of 60 per 10 s (~360/min), and lowering the threshold that far would take out a gym behind one NAT — the exact failure that rule's own comment warns about.
- Caching cannot substitute. The scrape walks unique URLs, so every request is a cache miss by construction; an edge cache only helps repeats.

**But it has one clean tell: it does not run JavaScript.**

| Agent group | HTML pages | JS chunks | Telemetry |
|---|---|---|---|
| Windows UAs × 5 | 253 | **0** | **0** |
| Mac UAs × 3 | 97 | **0** | **0** |
| Real iPhone visitor | 0 | 33 | 7 |

350 pages, not one `/_next/static` chunk, not one Sentry tunnel POST. The single real visitor in the window did the mirror image. A managed challenge is precisely that test, so it needs no list to maintain and cannot be evaded by changing a string.

### The rule

`managed_challenge` on `www.boardsesh.com` + `/view/`, placed **last** in the WAF ruleset. It is the only rule that can catch an ordinary browser string, so every agent we have a verdict on must be judged first — and the allow rule's `skip` means no search engine ever reaches it.

Two things fall out of that:

- **`baiduspider` and `qwantify` join the allow list here** (the only part of this PR that is not the rule itself). Both send people back (Baidu 7, Qwant 1 over 30 days) and both were relying on passing by default, which ends the moment an unlisted agent gets challenged. Missing this would have silently dropped two engines.
- **No session-cookie carve-out.** The WAF can only test that a cookie *name* is present, so `Cookie: <session-name>=anything` would be a one-line bypass. The clearance cookie already stops a logged-in climber being re-challenged.

The plan asymmetry that makes this possible is worth recording: the Free plan refused `managed_challenge` in the **rate-limit** phase (#5035), but accepts it on a **custom rule**.

### What it costs real people

A first-time visitor landing on a climb page from search gets one sub-second Cloudflare check, then a `cf_clearance` cookie covers them. At roughly 30 to 50 real web visitors a day, that is the price of dropping most origin renders.

### Author-side verification

- `web` green (394 files, 4575 tests); `scripts` + `deploy-app-subdomain` green (115 files, 2201 tests).
- `vp check` clean.
- **Mutation-tested three ways.** Turning the challenge into a hard block fails 1 test; moving it before the block rule fails 2; dropping `baiduspider` from the allow list fails 1.

Cloudflare rules are not applied by this PR — `cf:apply` runs on production deploy, and its dry-run will also confirm the Free plan accepts the action here.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. Open a climb page on boardsesh.com in your phone browser.
2. You may see a brief Cloudflare check. Page then loads normally.
3. Open a second climb page. No check this time.

## Risk

Risk: 3/5 — adds an interstitial to the main content path for signed-out visitors; wrong scope or a missed search engine costs real traffic, so the allow-list and ordering guards are the ones to read

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KpFE1RPEpZxYXfDcFKQmg

