### PR TITLE
fix(mobile): let a confirmed lock-screen mirror reach the widget and the wall

### DIFF
--- a/docs/live-activity-board-control.md
+++ b/docs/live-activity-board-control.md
@@ -53,9 +53,30 @@ slot even when optimistic navigation already selected another climb. Native queu
 snapshots reject older sequences; a fresh socket
 subscription can rebaseline after a server sequence reset. Queue sequence metadata
 travels with the rendered JS state so older renders cannot overwrite native mirror
-confirmations. ActivityKit updates read the latest committed snapshot before publishing,
-and BLE rechecks ownership and receipt freshness immediately before writing.
+confirmations. ActivityKit updates read the latest committed snapshot before publishing.
 Woods reflects its per-size native LED map using the same row geometry as JS.
+
+**A confirmed mirror always reaches the widget and the wall.** The 200 is the
+authority, so `MirrorClimbIntent` publishes the committed snapshot to ActivityKit
+and writes the board from it rather than making either conditional on the local
+bookkeeping agreeing. `SharedMirrorState.apply` finds the slot by queue-item uuid,
+so a widget Next landing mid-request cannot discard a confirmed result, and an
+older receipt leaves the committed snapshot alone instead of displacing it. The
+freshness recheck before the BLE write asserts same slot, same orientation, still
+holding the board — never sequence equality, because the write happens after an
+await on Bluetooth readiness and any unrelated queue event in that window would
+otherwise cancel it silently. The pre-request gate is `connectedByMe` plus the
+queue containing the tapped item; `navigationAllowed` is deliberately not checked,
+for the same drift reason Prev/Next dropped it.
+
+**A tap the server never answered is parked, not lost.** A retryable failure writes
+`bs_pending_mirror_request` and the main app hands it to JS as a `request`-kind
+`queueMirror` event once a listener is attached, which replays it through the same
+mutation the Android notification button uses. Distinct from `bs_pending_mirror`,
+which holds a receipt the server already confirmed. The widget falls back to the
+committed App Group snapshot for orientation and queue slot when the pushed fields
+are absent — mirroring is an absolute write, so a stale label would make the next
+tap send the opposite orientation.
 
 Deploy the additive backend schema/endpoint before shipping new native iOS and
 Android builds. Old binaries omit the new optional fields and keep existing controls.

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -45,8 +45,80 @@ final class LiveActivityWidgetTests: XCTestCase {
         prepareMirror()
         XCTAssertTrue(SharedMirrorState.persist(items: [makeQueueItem(mirrored: false)], currentIndex: 0, sequence: 7, in: defaults))
         let receipt = SharedMirrorConfirmation(sessionId: "session", queueItemUuid: "queue-1", mirrored: true, sequence: 6, stateHash: "hash", stateHashOrdered: nil)
-        XCTAssertNil(SharedMirrorState.apply(receipt, in: defaults))
+        // The newer native snapshot wins, but the caller still gets it back so
+        // it republishes current truth instead of leaving the widget stale.
+        let snapshot = SharedMirrorState.apply(receipt, in: defaults)
+        XCTAssertEqual(snapshot?.items.first?.mirrored, false)
         XCTAssertEqual(SharedQueueState.load(from: defaults).0.first?.mirrored, false)
+        XCTAssertEqual(SharedMirrorState.sequence(in: defaults), 7)
+        // A stale receipt is not stored, so it cannot displace a newer one.
+        XCTAssertNil(SharedMirrorState.pending(in: defaults))
+    }
+
+    func testMirrorCommitsWhenTheCurrentSlotMovedWhileTheRequestWasInFlight() {
+        prepareMirror()
+        // A widget Next landed between the tap and the 200. The tapped item is
+        // no longer at the current index, but the server already refused a stale
+        // slot, so the confirmed orientation still has to reach the wall.
+        SharedQueueState.save(
+            items: [makeQueueItem(uuid: "queue-1"), makeQueueItem(uuid: "queue-2", climbUuid: "climb-2")],
+            currentIndex: 1,
+            to: defaults
+        )
+        let receipt = SharedMirrorConfirmation(sessionId: "session", queueItemUuid: "queue-1", mirrored: true, sequence: 9, stateHash: "hash", stateHashOrdered: nil)
+        let snapshot = SharedMirrorState.apply(receipt, in: defaults)
+        XCTAssertEqual(snapshot?.items.first?.mirrored, true)
+        XCTAssertEqual(snapshot?.index, 1)
+        XCTAssertEqual(SharedQueueState.load(from: defaults).0.first?.mirrored, true)
+    }
+
+    func testMirrorTapSurvivesAMovedIndexAtThePreRequestGate() {
+        prepareMirror()
+        SharedQueueState.save(
+            items: [makeQueueItem(uuid: "queue-1"), makeQueueItem(uuid: "queue-2", climbUuid: "climb-2")],
+            currentIndex: 1,
+            to: defaults
+        )
+        XCTAssertTrue(SharedMirrorState.canMirror(sessionId: "session", queueItemUuid: "queue-1", in: defaults))
+        XCTAssertFalse(SharedMirrorState.canMirror(sessionId: "session", queueItemUuid: "missing", in: defaults))
+    }
+
+    func testMirrorTapIsNotGatedOnTheNavigationAllowedFlag() {
+        prepareMirror()
+        // The button renders on connectedByMe alone, so a drifted
+        // navigationAllowed flag must not silently swallow the tap.
+        SharedWidgetWallControlState.save(navigationAllowed: false, isPartySession: true, to: defaults)
+        XCTAssertTrue(SharedMirrorState.canMirror(sessionId: "session", queueItemUuid: "queue-1", in: defaults))
+    }
+
+    func testUnrelatedSequenceBumpDoesNotCancelTheBoardWrite() {
+        prepareMirror()
+        let receipt = SharedMirrorConfirmation(sessionId: "session", queueItemUuid: "queue-1", mirrored: true, sequence: 6, stateHash: "hash", stateHashOrdered: nil)
+        XCTAssertNotNil(SharedMirrorState.apply(receipt, in: defaults))
+        // A later event carrying the same mirrored slot arrives while the BLE
+        // write is still awaiting readiness. Exact sequence equality used to
+        // make `isCurrent` false here and silently drop the wall write.
+        XCTAssertTrue(SharedMirrorState.persist(items: [makeQueueItem(mirrored: true)], currentIndex: 0, sequence: 11, in: defaults))
+        XCTAssertTrue(SharedMirrorState.isCurrent(receipt, in: defaults))
+        // A real change of orientation or slot still cancels it.
+        XCTAssertTrue(SharedMirrorState.persist(items: [makeQueueItem(mirrored: false)], currentIndex: 0, sequence: 12, in: defaults))
+        XCTAssertFalse(SharedMirrorState.isCurrent(receipt, in: defaults))
+    }
+
+    func testUnconfirmedMirrorRequestIsParkedForReplay() {
+        prepareMirror()
+        let request = SharedMirrorRequest(sessionId: "session", queueItemUuid: "queue-1", mirrored: true)
+        SharedMirrorState.saveRequest(request, in: defaults)
+        XCTAssertEqual(SharedMirrorState.pendingRequest(in: defaults), request)
+
+        // Scoped to the session it was tapped in.
+        defaults.set("other", forKey: SharedConstants.sessionIdKey)
+        XCTAssertNil(SharedMirrorState.pendingRequest(in: defaults))
+        defaults.set("session", forKey: SharedConstants.sessionIdKey)
+        XCTAssertNotNil(SharedMirrorState.pendingRequest(in: defaults))
+
+        SharedMirrorState.clearRequest(in: defaults)
+        XCTAssertNil(SharedMirrorState.pendingRequest(in: defaults))
     }
 
     func testBufferedSocketSnapshotCannotUndoAcceptedMirror() {

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -111,6 +111,11 @@ final class LiveActivityWidgetTests: XCTestCase {
         SharedMirrorState.saveRequest(request, in: defaults)
         XCTAssertEqual(SharedMirrorState.pendingRequest(in: defaults), request)
 
+        // Survives repeated handovers: only an explicit acknowledgement retires it,
+        // so a replay that lands before the board link is back does not lose the tap.
+        XCTAssertNotNil(SharedMirrorState.pendingRequest(in: defaults))
+        XCTAssertNotNil(SharedMirrorState.pendingRequest(in: defaults))
+
         // Scoped to the session it was tapped in.
         defaults.set("other", forKey: SharedConstants.sessionIdKey)
         XCTAssertNil(SharedMirrorState.pendingRequest(in: defaults))
@@ -119,6 +124,31 @@ final class LiveActivityWidgetTests: XCTestCase {
 
         SharedMirrorState.clearRequest(in: defaults)
         XCTAssertNil(SharedMirrorState.pendingRequest(in: defaults))
+    }
+
+    func testParkedMirrorRequestExpiresAndIsDroppedOnRead() {
+        prepareMirror()
+        let stale = Date().addingTimeInterval(-(SharedMirrorRequest.timeToLive + 60))
+        SharedMirrorState.saveRequest(
+            SharedMirrorRequest(sessionId: "session", queueItemUuid: "queue-1", mirrored: true, createdAt: stale),
+            in: defaults
+        )
+        XCTAssertNil(SharedMirrorState.pendingRequest(in: defaults))
+        // Dropped from storage, not just filtered on read.
+        XCTAssertNil(defaults.data(forKey: SharedConstants.pendingMirrorRequestKey))
+    }
+
+    func testMirroredSlotThatIsNoLongerCurrentDoesNotPassTheBoardWriteGate() {
+        prepareMirror()
+        SharedQueueState.save(
+            items: [makeQueueItem(uuid: "queue-1"), makeQueueItem(uuid: "queue-2", climbUuid: "climb-2")],
+            currentIndex: 1,
+            to: defaults
+        )
+        let receipt = SharedMirrorConfirmation(sessionId: "session", queueItemUuid: "queue-1", mirrored: true, sequence: 9, stateHash: "hash", stateHashOrdered: nil)
+        XCTAssertNotNil(SharedMirrorState.apply(receipt, in: defaults))
+        // queue-2 is on the wall, so the mirrored slot must not be written there.
+        XCTAssertFalse(SharedMirrorState.isCurrent(receipt, in: defaults))
     }
 
     func testBufferedSocketSnapshotCannotUndoAcceptedMirror() {

--- a/packages/mobile/modules/live-activity/ios/LiveActivityIntentDiagnostics.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityIntentDiagnostics.swift
@@ -54,6 +54,9 @@ enum LiveActivityIntentCompletionClass: String, Codable, CaseIterable {
     case localNavigationEnabled
     case alreadyAllowed
     case bleFailure
+    /// The server confirmed a mirror but there was no local snapshot to publish
+    /// it against, so neither the widget nor the wall was updated from it.
+    case mirrorNotCommitted
 }
 
 struct LiveActivityIntentDiagnosticRecord: Codable, Equatable {

--- a/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
@@ -345,9 +345,27 @@ public class LiveActivityModule: Module {
     }
 
     private func emitPendingMirror() {
-        guard let defaults = SharedConstants.sharedDefaults,
-              let pending = SharedMirrorState.pending(in: defaults) else { return }
-        emitOrBuffer(name: "queueMirror", body: pending.eventBody)
+        guard let defaults = SharedConstants.sharedDefaults else { return }
+        if let pending = SharedMirrorState.pending(in: defaults) {
+            emitOrBuffer(name: "queueMirror", body: pending.eventBody)
+        }
+        // A tap whose server request never got an answer. JS replays it through
+        // the same mutation the Android notification button uses, then the
+        // confirmed receipt comes back down the normal path.
+        //
+        // Only handed over once a listener is attached, so it is cleared at the
+        // moment it will actually be delivered rather than buffered. Mirroring
+        // is an absolute write, so a request left parked would re-fire on every
+        // foreground and could undo a later in-app flip; `OnStartObserving`
+        // calls back into here, so nothing is lost by waiting.
+        if hasAttachedListener(), let request = SharedMirrorState.pendingRequest(in: defaults) {
+            SharedMirrorState.clearRequest(in: defaults)
+            emitOrBuffer(name: "queueMirror", body: request.eventBody)
+        }
+    }
+
+    private func hasAttachedListener() -> Bool {
+        bufferQueue.sync { hasListener }
     }
 
     private func handleQueueNavigateFromWidget() {
@@ -695,6 +713,7 @@ public class LiveActivityModule: Module {
         if let defaults = SharedConstants.sharedDefaults {
             if defaults.string(forKey: SharedConstants.sessionIdKey) != sessionId {
                 defaults.removeObject(forKey: SharedConstants.pendingMirrorKey)
+                defaults.removeObject(forKey: SharedConstants.pendingMirrorRequestKey)
                 defaults.removeObject(forKey: SharedConstants.queueSequenceKey)
             }
             defaults.set(options.supportsMirroring, forKey: SharedConstants.supportsMirroringKey)
@@ -861,6 +880,7 @@ public class LiveActivityModule: Module {
             defaults.removeObject(forKey: SharedConstants.sessionIdKey)
             defaults.removeObject(forKey: SharedConstants.pendingActionKey)
             defaults.removeObject(forKey: SharedConstants.pendingMirrorKey)
+            defaults.removeObject(forKey: SharedConstants.pendingMirrorRequestKey)
             defaults.removeObject(forKey: SharedConstants.widgetNavigateUrlKey)
             defaults.removeObject(forKey: SharedConstants.widgetTakeControlUrlKey)
             defaults.removeObject(forKey: SharedConstants.authTokenKey)

--- a/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityModule.swift
@@ -108,6 +108,14 @@ public class LiveActivityModule: Module {
             guard let defaults = SharedConstants.sharedDefaults else { return }
             SharedMirrorState.acknowledge(sessionId: sessionId, sequence: sequence, in: defaults)
         }
+        /// JS acted on a parked tap — it either replayed it or decided the slot
+        /// had moved on. Anything it merely could not act on yet (no board link,
+        /// no session) leaves the record alone for the next handover.
+        AsyncFunction("acknowledgeMirrorRequest") { (sessionId: String) in
+            guard let defaults = SharedConstants.sharedDefaults,
+                  SharedMirrorState.pendingRequest(in: defaults)?.sessionId == sessionId else { return }
+            SharedMirrorState.clearRequest(in: defaults)
+        }
 
         AsyncFunction("isAvailable") { () -> [String: Any] in
             if #available(iOS 17.0, *) {
@@ -353,19 +361,15 @@ public class LiveActivityModule: Module {
         // the same mutation the Android notification button uses, then the
         // confirmed receipt comes back down the normal path.
         //
-        // Only handed over once a listener is attached, so it is cleared at the
-        // moment it will actually be delivered rather than buffered. Mirroring
-        // is an absolute write, so a request left parked would re-fire on every
-        // foreground and could undo a later in-app flip; `OnStartObserving`
-        // calls back into here, so nothing is lost by waiting.
-        if hasAttachedListener(), let request = SharedMirrorState.pendingRequest(in: defaults) {
-            SharedMirrorState.clearRequest(in: defaults)
+        // Kept until JS says it acted on it, never cleared on emit: the first
+        // replay after a lock-screen outage can land before the socket or the
+        // board link is back, and dropping it there would lose the tap for
+        // good. Re-emission is safe — mirroring is an absolute write and the
+        // queue provider is single-flight — and the record's own TTL, not this
+        // handover, is what stops a forgotten tap flipping a climb later.
+        if let request = SharedMirrorState.pendingRequest(in: defaults) {
             emitOrBuffer(name: "queueMirror", body: request.eventBody)
         }
-    }
-
-    private func hasAttachedListener() -> Bool {
-        bufferQueue.sync { hasListener }
     }
 
     private func handleQueueNavigateFromWidget() {

--- a/packages/mobile/modules/live-activity/ios/MirrorClimbIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/MirrorClimbIntent.swift
@@ -44,10 +44,11 @@ struct MirrorClimbIntent: LiveActivityIntent {
             return
         }
 
-        // Wake the main app on every exit path, as this intent has always done:
-        // even a refused tap usually means the shared snapshot drifted, and the
-        // handler resyncs. Registered after the diagnostics `defer` so it runs
-        // first and the recorded stage still reflects the post.
+        // Wake the main app on every exit path, where the pre-PR code posted
+        // only after a 200. A refused tap usually means the shared snapshot
+        // drifted, and the handler resyncs; the retryable path needs the wake-up
+        // to hand its parked request over. Registered after the diagnostics
+        // `defer` so it runs first and the recorded stage still reflects it.
         defer {
             postQueueNavigateDarwinNotification()
             #if !WIDGET_EXTENSION
@@ -117,10 +118,18 @@ struct MirrorClimbIntent: LiveActivityIntent {
         }
         #if !WIDGET_EXTENSION
         diagnosticRun.mark(.activityKitUpdated)
-        diagnosticRun.mark(.bleStarted)
-        let succeeded = await LiveActivityBleBridge.writeBoardForIntent(items: updatedItems, currentIndex: index, mirrorReceipt: receipt)
-        diagnosticRun.mark(succeeded ? .bleFinishedSuccess : .bleFinishedFailure)
-        if !succeeded { completionClass = .bleFailure }
+        // Only the current slot is on the wall, so the board is rewritten only
+        // when the mirrored item IS that slot. Matching the slot by uuid means
+        // `index` no longer has to hold the receipt's item, and writing it
+        // regardless would relight whatever climb the queue moved on to. The
+        // freshness gate inside `writeBoardForIntent` validates the live current
+        // slot against this same receipt, so the two now always name one item.
+        if item.uuid == receipt.queueItemUuid {
+            diagnosticRun.mark(.bleStarted)
+            let succeeded = await LiveActivityBleBridge.writeBoardForIntent(items: updatedItems, currentIndex: index, mirrorReceipt: receipt)
+            diagnosticRun.mark(succeeded ? .bleFinishedSuccess : .bleFinishedFailure)
+            if !succeeded { completionClass = .bleFailure }
+        }
         #endif
     }
 

--- a/packages/mobile/modules/live-activity/ios/MirrorClimbIntent.swift
+++ b/packages/mobile/modules/live-activity/ios/MirrorClimbIntent.swift
@@ -1,5 +1,6 @@
 import ActivityKit
 import AppIntents
+import os.log
 
 @available(iOS 17.0, *)
 struct MirrorClimbIntent: LiveActivityIntent {
@@ -7,6 +8,8 @@ struct MirrorClimbIntent: LiveActivityIntent {
     @Parameter(title: "Session") var sessionId: String
     @Parameter(title: "Queue item") var queueItemUuid: String
     @Parameter(title: "Mirrored") var mirrored: Bool
+
+    private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
 
     init() { sessionId = ""; queueItemUuid = ""; mirrored = false }
     init(sessionId: String, queueItemUuid: String, mirrored: Bool) {
@@ -28,14 +31,48 @@ struct MirrorClimbIntent: LiveActivityIntent {
         var completionClass = LiveActivityIntentCompletionClass.serverRejected
         defer { diagnosticRun.complete(completionClass) }
         #endif
-        guard let defaults = SharedConstants.sharedDefaults,
-              SharedMirrorState.canMirror(sessionId: sessionId, queueItemUuid: queueItemUuid, in: defaults)
-        else { return }
+
+        // One notice per firing, the same signal ClimbNavigationIntent carries.
+        // Production TestFlight builds need it to separate "the intent never ran
+        // in the app process" from "it ran and the wall still didn't move".
+        Self.logger.notice("MirrorClimbIntent.perform() running bundle=\(Bundle.main.bundleIdentifier ?? "unknown", privacy: .public) process=\(ProcessInfo.processInfo.processName, privacy: .public) mirrored=\(mirrored, privacy: .public)")
+
+        guard let defaults = SharedConstants.sharedDefaults else {
+            #if !WIDGET_EXTENSION
+            completionClass = .sharedDefaultsUnavailable
+            #endif
+            return
+        }
+
+        // Wake the main app on every exit path, as this intent has always done:
+        // even a refused tap usually means the shared snapshot drifted, and the
+        // handler resyncs. Registered after the diagnostics `defer` so it runs
+        // first and the recorded stage still reflects the post.
+        defer {
+            postQueueNavigateDarwinNotification()
+            #if !WIDGET_EXTENSION
+            diagnosticRun.mark(.darwinPosted)
+            #endif
+        }
+
+        guard SharedMirrorState.canMirror(sessionId: sessionId, queueItemUuid: queueItemUuid, in: defaults) else { return }
+
         #if !WIDGET_EXTENSION
         diagnosticRun.mark(.networkStarted)
         #endif
         let response = await WidgetNetworking.sendMirror(sessionId: sessionId, queueItemUuid: queueItemUuid, mirrored: mirrored)
         guard case .success(let receipt) = response else {
+            if response == .retryableFailure {
+                // No authoritative answer came back, so nothing is decided yet.
+                // Park the tap for the main app to replay over the WebSocket —
+                // the same recovery `pendingActionKey` gives navigation. Without
+                // it a flaky lock-screen network loses the tap with no wall
+                // change, no widget change and nothing to retry.
+                SharedMirrorState.saveRequest(
+                    SharedMirrorRequest(sessionId: sessionId, queueItemUuid: queueItemUuid, mirrored: mirrored),
+                    in: defaults
+                )
+            }
             #if !WIDGET_EXTENSION
             diagnosticRun.mark(response == .retryableFailure ? .networkFinishedRetryable : .networkFinishedTerminal)
             completionClass = response == .retryableFailure ? .retryableNetworkFailure : .serverRejected
@@ -46,36 +83,52 @@ struct MirrorClimbIntent: LiveActivityIntent {
         diagnosticRun.mark(.networkFinishedSuccess)
         completionClass = .success
         #endif
-        if let snapshot = SharedMirrorState.apply(receipt, in: defaults) {
-            let updatedItems = snapshot.items
-            let index = snapshot.index
-            let item = updatedItems[index]
-            let state = ClimbSessionAttributes.ContentState(
-                climbName: item.climbName, climbDifficulty: VGradeFormatter.formatVGrade(item.difficulty),
-                angle: item.angle, currentIndex: index, totalClimbs: updatedItems.count,
-                hasNext: index < updatedItems.count - 1, hasPrevious: index > 0, climbUuid: item.climbUuid,
-                queueItemUuid: item.uuid, mirrored: item.mirrored, supportsMirroring: true,
-                boardConnection: "connectedByMe", holderDisplayName: nil
-            )
-            for activity in Activity<ClimbSessionAttributes>.activities where activity.attributes.sessionId == sessionId && activity.activityState == .active {
-                guard SharedMirrorState.isCurrent(receipt, in: defaults) else { break }
-                await activity.update(ActivityContent(state: state, staleDate: Date().addingTimeInterval(SharedConstants.liveActivityStaleInterval)))
-            }
+        SharedMirrorState.clearRequest(in: defaults)
+
+        // The server has committed the orientation, so the widget and the wall
+        // follow it. Both used to sit inside `if let snapshot = apply(...)`, and
+        // the activity update was additionally gated on an exact queue-sequence
+        // match: either one declining left the climb mirrored on the server
+        // while this phone kept showing and lighting the old orientation, with
+        // nothing to retry.
+        guard let snapshot = SharedMirrorState.apply(receipt, in: defaults),
+              snapshot.items.indices.contains(snapshot.index)
+        else {
             #if !WIDGET_EXTENSION
-            diagnosticRun.mark(.activityKitUpdated)
-            diagnosticRun.mark(.bleStarted)
-            let succeeded = await LiveActivityBleBridge.writeBoardForIntent(items: updatedItems, currentIndex: index, mirrorReceipt: receipt)
-            diagnosticRun.mark(succeeded ? .bleFinishedSuccess : .bleFinishedFailure)
-            if !succeeded { completionClass = .bleFailure }
+            completionClass = .mirrorNotCommitted
             #endif
+            return
         }
+        let updatedItems = snapshot.items
+        let index = snapshot.index
+        let item = updatedItems[index]
+        let state = ClimbSessionAttributes.ContentState(
+            climbName: item.climbName, climbDifficulty: VGradeFormatter.formatVGrade(item.difficulty),
+            angle: item.angle, currentIndex: index, totalClimbs: updatedItems.count,
+            hasNext: index < updatedItems.count - 1, hasPrevious: index > 0, climbUuid: item.climbUuid,
+            queueItemUuid: item.uuid, mirrored: item.mirrored,
+            supportsMirroring: defaults.bool(forKey: SharedConstants.supportsMirroringKey),
+            // The mirror button is only shown while this device drives the wall,
+            // so the optimistic frame keeps the bulb lit and the controls shown.
+            boardConnection: "connectedByMe", holderDisplayName: nil
+        )
+        for activity in Activity<ClimbSessionAttributes>.activities where activity.attributes.sessionId == sessionId && activity.activityState == .active {
+            await activity.update(ActivityContent(state: state, staleDate: Date().addingTimeInterval(SharedConstants.liveActivityStaleInterval)))
+        }
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.activityKitUpdated)
+        diagnosticRun.mark(.bleStarted)
+        let succeeded = await LiveActivityBleBridge.writeBoardForIntent(items: updatedItems, currentIndex: index, mirrorReceipt: receipt)
+        diagnosticRun.mark(succeeded ? .bleFinishedSuccess : .bleFinishedFailure)
+        if !succeeded { completionClass = .bleFailure }
+        #endif
+    }
+
+    private func postQueueNavigateDarwinNotification() {
         CFNotificationCenterPostNotification(
             CFNotificationCenterGetDarwinNotifyCenter(),
             CFNotificationName(SharedConstants.queueNavigateNotification as CFString), nil, nil, true
         )
-        #if !WIDGET_EXTENSION
-        diagnosticRun.mark(.darwinPosted)
-        #endif
     }
 }
 

--- a/packages/mobile/modules/live-activity/ios/SharedConstants.swift
+++ b/packages/mobile/modules/live-activity/ios/SharedConstants.swift
@@ -21,6 +21,12 @@ enum SharedConstants {
     static let supportsMirroringKey = "bs_supports_mirroring"
     static let queueSequenceKey = "bs_queue_sequence"
     static let pendingMirrorKey = "bs_pending_mirror"
+    /// A mirror tap whose server request never got an authoritative answer.
+    /// Written by `MirrorClimbIntent` on a retryable failure and replayed by the
+    /// main app over the WebSocket, the same shape of recovery `pendingActionKey`
+    /// gives navigation. Distinct from `pendingMirrorKey`, which holds a receipt
+    /// the server already confirmed.
+    static let pendingMirrorRequestKey = "bs_pending_mirror_request"
     static let widgetNavigateUrlKey = "bs_widget_navigate_url"
     /// Fully-qualified backend `/api/widget/take-control` URL. The widget
     /// POSTs non-driver lightbulb taps here before enabling local navigation.

--- a/packages/mobile/modules/live-activity/ios/SharedMirrorState.swift
+++ b/packages/mobile/modules/live-activity/ios/SharedMirrorState.swift
@@ -21,9 +21,27 @@ struct SharedMirrorConfirmation: Codable, Equatable, Sendable {
 /// A tap whose server request never got an authoritative answer, kept so the
 /// main app can replay it. Carries no sequence: nothing was committed yet.
 struct SharedMirrorRequest: Codable, Equatable, Sendable {
+    /// How long a parked tap stays replayable. Long enough to survive a cold
+    /// launch and a Bluetooth reconnect, short enough that a tap the climber
+    /// has forgotten about cannot flip a climb under them later in the session.
+    static let timeToLive: TimeInterval = 10 * 60
+
     let sessionId: String
     let queueItemUuid: String
     let mirrored: Bool
+    let createdAt: Date
+
+    init(sessionId: String, queueItemUuid: String, mirrored: Bool, createdAt: Date = Date()) {
+        self.sessionId = sessionId
+        self.queueItemUuid = queueItemUuid
+        self.mirrored = mirrored
+        self.createdAt = createdAt
+    }
+
+    func isFresh(at now: Date = Date()) -> Bool {
+        let age = now.timeIntervalSince(createdAt)
+        return age >= -60 && age <= Self.timeToLive
+    }
 
     var eventBody: [String: Any] {
         ["kind": "request", "sessionId": sessionId, "queueItemUuid": queueItemUuid, "mirrored": mirrored]
@@ -41,10 +59,17 @@ enum SharedMirrorState {
         defaults.set(bytes, forKey: SharedConstants.pendingMirrorRequestKey)
     }
 
-    static func pendingRequest(in defaults: UserDefaults) -> SharedMirrorRequest? {
+    /// The parked tap, if one is still worth replaying. An expired or
+    /// wrong-session record is dropped on read, so nothing accumulates.
+    static func pendingRequest(in defaults: UserDefaults, at now: Date = Date()) -> SharedMirrorRequest? {
         guard let bytes = defaults.data(forKey: SharedConstants.pendingMirrorRequestKey),
               let request = try? JSONDecoder().decode(SharedMirrorRequest.self, from: bytes),
-              request.sessionId == defaults.string(forKey: SharedConstants.sessionIdKey) else { return nil }
+              request.sessionId == defaults.string(forKey: SharedConstants.sessionIdKey)
+        else { return nil }
+        guard request.isFresh(at: now) else {
+            clearRequest(in: defaults)
+            return nil
+        }
         return request
     }
 

--- a/packages/mobile/modules/live-activity/ios/SharedMirrorState.swift
+++ b/packages/mobile/modules/live-activity/ios/SharedMirrorState.swift
@@ -18,9 +18,39 @@ struct SharedMirrorConfirmation: Codable, Equatable, Sendable {
     }
 }
 
+/// A tap whose server request never got an authoritative answer, kept so the
+/// main app can replay it. Carries no sequence: nothing was committed yet.
+struct SharedMirrorRequest: Codable, Equatable, Sendable {
+    let sessionId: String
+    let queueItemUuid: String
+    let mirrored: Bool
+
+    var eventBody: [String: Any] {
+        ["kind": "request", "sessionId": sessionId, "queueItemUuid": queueItemUuid, "mirrored": mirrored]
+    }
+}
+
 /// A durable receipt, retained until JS has applied this sequence (or a newer full sync).
 enum SharedMirrorState {
     private static let lock = NSLock()
+
+    // MARK: - Unconfirmed requests
+
+    static func saveRequest(_ request: SharedMirrorRequest, in defaults: UserDefaults) {
+        guard let bytes = try? JSONEncoder().encode(request) else { return }
+        defaults.set(bytes, forKey: SharedConstants.pendingMirrorRequestKey)
+    }
+
+    static func pendingRequest(in defaults: UserDefaults) -> SharedMirrorRequest? {
+        guard let bytes = defaults.data(forKey: SharedConstants.pendingMirrorRequestKey),
+              let request = try? JSONDecoder().decode(SharedMirrorRequest.self, from: bytes),
+              request.sessionId == defaults.string(forKey: SharedConstants.sessionIdKey) else { return nil }
+        return request
+    }
+
+    static func clearRequest(in defaults: UserDefaults) {
+        defaults.removeObject(forKey: SharedConstants.pendingMirrorRequestKey)
+    }
 
     static func pending(in defaults: UserDefaults) -> SharedMirrorConfirmation? {
         guard let bytes = defaults.data(forKey: SharedConstants.pendingMirrorKey),
@@ -57,23 +87,51 @@ enum SharedMirrorState {
         return true
     }
 
+    /// Whether writing this receipt to the wall is still the right thing to do.
+    ///
+    /// Deliberately NOT keyed on sequence equality. The board write happens after
+    /// an `await` on BLE readiness, so any unrelated queue event arriving in that
+    /// window used to bump `queueSequenceKey` and silently cancel the write — the
+    /// server kept the flip and the wall never moved. What actually matters is
+    /// that the current slot is still this queue item, still carries the
+    /// orientation the server confirmed, and that this device still drives the
+    /// board.
     static func isCurrent(_ receipt: SharedMirrorConfirmation, in defaults: UserDefaults) -> Bool {
         let (items, index) = SharedQueueState.load(from: defaults)
-        return sequence(in: defaults) == receipt.sequence
-            && canMirror(sessionId: receipt.sessionId, queueItemUuid: receipt.queueItemUuid, in: defaults)
-            && items.indices.contains(index) && items[index].mirrored == receipt.mirrored
+        return defaults.string(forKey: SharedConstants.sessionIdKey) == receipt.sessionId
+            && holdsBoard(in: defaults)
+            && items.indices.contains(index)
+            && items[index].uuid == receipt.queueItemUuid
+            && items[index].mirrored == receipt.mirrored
     }
 
-    /// Commit an HTTP result atomically against native WebSocket updates.
+    /// Commit an HTTP result atomically against native WebSocket updates, and
+    /// hand back the snapshot the caller should publish.
+    ///
+    /// The server is authoritative: it already refused a stale slot with
+    /// `MirrorTargetChangedError`, so holding a receipt means the write was
+    /// correct when it committed. The slot is therefore found by uuid rather
+    /// than required to sit at the current index — a widget Next landing while
+    /// the request was in flight used to make this return nil, which dropped
+    /// the widget refresh and the board write on the floor.
+    ///
+    /// Returns nil only when there is nothing to publish: a different session,
+    /// or no queue at all. A receipt older than the committed snapshot leaves
+    /// that snapshot alone and returns it unchanged, so the caller still
+    /// republishes current truth instead of going silent.
     static func apply(_ receipt: SharedMirrorConfirmation, in defaults: UserDefaults) -> (items: [SharedQueueItem], index: Int)? {
         lock.lock()
         defer { lock.unlock() }
-        guard receipt.sessionId == defaults.string(forKey: SharedConstants.sessionIdKey),
-              receipt.sequence >= sequence(in: defaults),
-              let bytes = try? JSONEncoder().encode(receipt) else { return nil }
-        defaults.set(bytes, forKey: SharedConstants.pendingMirrorKey)
-        guard canMirror(sessionId: receipt.sessionId, queueItemUuid: receipt.queueItemUuid, in: defaults) else { return nil }
+        guard receipt.sessionId == defaults.string(forKey: SharedConstants.sessionIdKey) else { return nil }
         let (items, index) = SharedQueueState.load(from: defaults)
+        let publishable: (items: [SharedQueueItem], index: Int)? = items.isEmpty ? nil : (items: items, index: index)
+        // A receipt older than the committed snapshot is not stored: it would
+        // displace a newer one JS has yet to apply.
+        guard receipt.sequence >= sequence(in: defaults) else { return publishable }
+        if let bytes = try? JSONEncoder().encode(receipt) {
+            defaults.set(bytes, forKey: SharedConstants.pendingMirrorKey)
+        }
+        guard items.contains(where: { $0.uuid == receipt.queueItemUuid }) else { return publishable }
         let updatedItems = items.map { item in
             item.uuid == receipt.queueItemUuid ? SharedQueueItem(
                 uuid: item.uuid, climbUuid: item.climbUuid, climbName: item.climbName,
@@ -86,12 +144,24 @@ enum SharedMirrorState {
         return (updatedItems, index)
     }
 
+    /// Whether this device is the one driving the wall.
+    static func holdsBoard(in defaults: UserDefaults) -> Bool {
+        defaults.string(forKey: SharedConstants.boardConnectionKey) == "connectedByMe"
+    }
+
+    /// The pre-request gate.
+    ///
+    /// No `navigationAllowed` check: the button is only rendered for
+    /// `connectedByMe`, and gating the intent on a separately persisted flag is
+    /// exactly what made Prev/Next no-op when the flag drifted from the shown
+    /// state (see the note in `ClimbNavigationIntent.perform`). The queue only
+    /// has to contain the tapped item — whether it is still the current slot is
+    /// the server's call, and it answers with 409.
     static func canMirror(sessionId: String, queueItemUuid: String, in defaults: UserDefaults) -> Bool {
-        let (items, index) = SharedQueueState.load(from: defaults)
+        let (items, _) = SharedQueueState.load(from: defaults)
         return defaults.string(forKey: SharedConstants.sessionIdKey) == sessionId
             && defaults.bool(forKey: SharedConstants.supportsMirroringKey)
-            && defaults.string(forKey: SharedConstants.boardConnectionKey) == "connectedByMe"
-            && SharedWidgetWallControlState.load(from: defaults).navigationAllowed
-            && items.indices.contains(index) && items[index].uuid == queueItemUuid
+            && holdsBoard(in: defaults)
+            && items.contains { $0.uuid == queueItemUuid }
     }
 }

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -409,6 +409,7 @@ type LiveActivityNativeModule = {
   supportsMirrorControl?: boolean;
   getPendingMirror?(): Promise<WidgetMirrorEvent | null>;
   acknowledgeMirror?(sessionId: string, sequence: number): Promise<void>;
+  acknowledgeMirrorRequest?(sessionId: string): Promise<void>;
   isAvailable(): Promise<{ available: boolean }>;
   startSession(options: LiveActivityStartSessionOptions): Promise<void>;
   endSession(): Promise<void>;

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -377,7 +377,8 @@ export type LiveActivityIntentCompletionClass =
   | 'retryableNetworkFailure'
   | 'localNavigationEnabled'
   | 'alreadyAllowed'
-  | 'bleFailure';
+  | 'bleFailure'
+  | 'mirrorNotCommitted';
 
 export type InterruptedLiveActivityIntentDiagnostic = {
   schemaVersion: 1;

--- a/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
@@ -25,7 +25,7 @@ function makeItem(index: number): ClimbQueueItem {
 
 const queue = vi.hoisted(() => ({
   sessionId: 'session-1' as string | null,
-  mirrorCurrentClimb: vi.fn(),
+  mirrorCurrentClimb: vi.fn(async (): Promise<boolean> => true),
   dispatchWidgetMirror: vi.fn(async () => true),
   dispatchWidgetNavigation: vi.fn(),
   state: {
@@ -39,6 +39,7 @@ const widget = vi.hoisted(() => ({
   mirrorListener: null as null | ((event: WidgetMirrorEvent) => void),
   pendingMirror: vi.fn(async (): Promise<WidgetMirrorEvent | null> => null),
   acknowledgeMirror: vi.fn(async () => {}),
+  acknowledgeMirrorRequest: vi.fn(async () => {}),
   listener: null as null | ((event: QueueNavigateEvent) => void),
   boardControlListener: null as null | ((event: BoardControlEvent) => void),
   useLiveActivity: vi.fn(),
@@ -153,6 +154,7 @@ vi.mock('../use-live-activity', () => ({
 vi.mock('../live-activity-plugin', () => ({
   getPendingWidgetMirror: widget.pendingMirror,
   acknowledgeWidgetMirror: widget.acknowledgeMirror,
+  acknowledgeWidgetMirrorRequest: widget.acknowledgeMirrorRequest,
   addWidgetMirrorListener: (listener: (event: WidgetMirrorEvent) => void) => {
     widget.mirrorListener = listener;
     return () => {
@@ -562,6 +564,8 @@ describe('mirror controls', () => {
     queue.dispatchWidgetMirror.mockClear();
     queue.dispatchWidgetMirror.mockResolvedValue(true);
     widget.acknowledgeMirror.mockClear();
+    widget.acknowledgeMirrorRequest.mockClear();
+    queue.mirrorCurrentClimb.mockResolvedValue(true);
     widget.pendingMirror.mockResolvedValue(null);
   });
   const tap = { kind: 'request', sessionId: 'session-1', queueItemUuid: 'queue-item-0', mirrored: true } as const;
@@ -573,6 +577,35 @@ describe('mirror controls', () => {
       widget.mirrorListener?.(tap);
     });
     expect(queue.mirrorCurrentClimb).toHaveBeenCalledWith(true, 'queue-item-0');
+    expect(widget.acknowledgeMirrorRequest).toHaveBeenCalledWith('session-1');
+  });
+  it('keeps a parked tap alive while the board link is still coming back', async () => {
+    // A cold launch replays the tap before Bluetooth reconnects. Acknowledging
+    // it there would lose it, so it stays parked for the next handover.
+    boardState.boardConnection = 'disconnected';
+    render(<LiveActivityBridge boardName="tension" layoutId={1} sizeId={1} setIds="1" />);
+    await act(async () => {
+      widget.mirrorListener?.(tap);
+    });
+    expect(queue.mirrorCurrentClimb).not.toHaveBeenCalled();
+    expect(widget.acknowledgeMirrorRequest).not.toHaveBeenCalled();
+  });
+  it('keeps a parked tap alive when the replayed mutation fails', async () => {
+    queue.mirrorCurrentClimb.mockResolvedValue(false);
+    render(<LiveActivityBridge boardName="tension" layoutId={1} sizeId={1} setIds="1" />);
+    await act(async () => {
+      widget.mirrorListener?.(tap);
+    });
+    expect(queue.mirrorCurrentClimb).toHaveBeenCalledWith(true, 'queue-item-0');
+    expect(widget.acknowledgeMirrorRequest).not.toHaveBeenCalled();
+  });
+  it('retires a parked tap once the queue has moved past its slot', async () => {
+    render(<LiveActivityBridge boardName="tension" layoutId={1} sizeId={1} setIds="1" />);
+    await act(async () => {
+      widget.mirrorListener?.({ ...tap, queueItemUuid: 'old-slot' });
+    });
+    expect(queue.mirrorCurrentClimb).not.toHaveBeenCalled();
+    expect(widget.acknowledgeMirrorRequest).toHaveBeenCalledWith('session-1');
   });
   it.each(['heldByPeer', 'disconnected'] as const)('drops a tap after ownership changes to %s', async (connection) => {
     boardState.boardConnection = connection;

--- a/packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts
+++ b/packages/mobile/src/lib/live-activity/__tests__/widget-target-drift.test.ts
@@ -91,6 +91,7 @@ const TYPESCRIPT_COMPLETION_CLASSES = {
   localNavigationEnabled: true,
   alreadyAllowed: true,
   bleFailure: true,
+  mirrorNotCommitted: true,
 } as const satisfies Record<LiveActivityIntentCompletionClass, true>;
 
 type SwiftConditionalBranch = {

--- a/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
+++ b/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
@@ -13,6 +13,7 @@ import {
   addWidgetMirrorListener,
   getPendingWidgetMirror,
   acknowledgeWidgetMirror,
+  acknowledgeWidgetMirrorRequest,
   type WidgetMirrorEvent,
   addWidgetQueueNavigateListener,
   addBoardControlListener,
@@ -219,12 +220,25 @@ export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: Live
     if (event.kind === 'confirmed') {
       // Native already changed the wall. Replay the sequenced result, never toggle again.
       if (await dispatchWidgetMirror(event)) await acknowledgeWidgetMirror(event.sessionId, event.sequence);
-    } else if (
-      boardConnection === 'connectedByMe' &&
-      boardSupportsMirroring(boardName, layoutId) &&
-      state.currentClimbQueueItem?.uuid === event.queueItemUuid
-    ) {
-      await mirrorCurrentClimb(event.mirrored, event.queueItemUuid);
+      return;
+    }
+    if (!boardSupportsMirroring(boardName, layoutId)) return;
+    if (state.currentClimbQueueItem?.uuid !== event.queueItemUuid) {
+      // The queue moved on, so the server would refuse this anyway. Retire an
+      // iOS tap parked by a failed request rather than replaying it forever.
+      await acknowledgeWidgetMirrorRequest(event.sessionId);
+      return;
+    }
+    // Not holding the board yet is a timing condition, not a verdict: a parked
+    // tap replayed during a cold launch can arrive before Bluetooth reconnects,
+    // so leave it parked for the next handover instead of acknowledging it.
+    if (boardConnection !== 'connectedByMe') return;
+    // Only a server-accepted replay retires the parked tap. The mutation turns
+    // a failure into a toast, which on a locked phone nobody sees, so acking
+    // unconditionally would throw the tap away in exactly the outage it exists
+    // to survive.
+    if (await mirrorCurrentClimb(event.mirrored, event.queueItemUuid)) {
+      await acknowledgeWidgetMirrorRequest(event.sessionId);
     }
   };
   useEffect(() => {

--- a/packages/mobile/src/lib/live-activity/live-activity-plugin.ts
+++ b/packages/mobile/src/lib/live-activity/live-activity-plugin.ts
@@ -121,4 +121,14 @@ export async function acknowledgeWidgetMirror(sessionId: string, sequence: numbe
   await liveActivityNative?.acknowledgeMirror?.(sessionId, sequence);
 }
 
+/**
+ * Retires a parked tap that never reached the server. Call it only once this
+ * side has acted — replayed it, or judged the slot moved on. Leaving it unacked
+ * is what keeps a tap alive across an outage or a cold launch, so never
+ * acknowledge one that was merely not actionable yet.
+ */
+export async function acknowledgeWidgetMirrorRequest(sessionId: string): Promise<void> {
+  await liveActivityNative?.acknowledgeMirrorRequest?.(sessionId);
+}
+
 export type { WidgetMirrorEvent };

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -1765,6 +1765,12 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const mirrorRequestRef = useRef(false);
+  /**
+   * Resolves true only when the server accepted the orientation. A widget tap
+   * replayed from the lock screen is retired on that answer, so a refused or
+   * failed attempt has to be distinguishable from a successful one — a toast
+   * alone would let an offline retry be thrown away.
+   */
   const mirrorCurrentClimb = useCallback(
     async (mirrored: boolean, queueItemUuid: string) => {
       if (
@@ -1772,14 +1778,16 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         stateRef.current.currentClimbQueueItem?.uuid !== queueItemUuid ||
         mirrorRequestRef.current
       )
-        return;
+        return false;
       mirrorRequestRef.current = true;
       try {
         await mutations.mirrorCurrentClimb(mirrored, queueItemUuid);
         // Subscription confirmation normally arrives first; refresh also covers a lost echo.
         await resyncQueueFromServerRef.current();
+        return true;
       } catch (error) {
         showQueueMutationErrorToast(error, t, showToast);
+        return false;
       } finally {
         mirrorRequestRef.current = false;
       }

--- a/packages/mobile/src/providers/queue/queue-contexts.ts
+++ b/packages/mobile/src/providers/queue/queue-contexts.ts
@@ -69,7 +69,8 @@ type QueueContextValue = {
    * can't double-advance when the WebSocket echo lands before the Darwin event.
    * Mirrors web's `dispatchWidgetNavigation`.
    */
-  mirrorCurrentClimb: (mirrored: boolean, queueItemUuid: string) => Promise<void>;
+  /** Resolves true only when the server accepted the orientation. */
+  mirrorCurrentClimb: (mirrored: boolean, queueItemUuid: string) => Promise<boolean>;
   dispatchWidgetMirror: (event: Extract<WidgetMirrorEvent, { kind: 'confirmed' }>) => Promise<boolean>;
   dispatchWidgetNavigation: (item: ClimbQueueItem, correlationId: string) => void;
   /** Replace the playlist suggestion source that drives swipe-through climbs. */

--- a/packages/mobile/targets/BoardseshWidgets/ClimbSessionLiveActivity.swift
+++ b/packages/mobile/targets/BoardseshWidgets/ClimbSessionLiveActivity.swift
@@ -184,6 +184,25 @@ struct ResolvedBoardState {
     let holderDisplayName: String?
 }
 
+/// Orientation and queue slot for the mirror button, pushed state first with
+/// the committed App Group snapshot behind it — the same two-step
+/// `supportsMirroring` already uses.
+///
+/// The fallback matters because a content state that predates these fields, or
+/// a push that never lands, would otherwise leave the button labelled for the
+/// old orientation. Mirroring is an absolute write, so a stale label makes the
+/// next tap send the opposite orientation and undo the flip.
+@available(iOS 17.0, *)
+private func resolveMirrorState(
+    context: ActivityViewContext<ClimbSessionAttributes>
+) -> (queueItemUuid: String?, mirrored: Bool) {
+    let committed = SharedConstants.sharedDefaults.flatMap { SharedQueueState.currentItem(from: $0) }
+    return (
+        queueItemUuid: context.state.queueItemUuid ?? committed?.uuid,
+        mirrored: context.state.mirrored ?? committed?.mirrored ?? false
+    )
+}
+
 @available(iOS 17.0, *)
 private func resolveBoardState(
     context: ActivityViewContext<ClimbSessionAttributes>
@@ -574,12 +593,13 @@ struct ClimbSessionLiveActivity: Widget {
                 .activitySystemActionForegroundColor(VelvetSend.Palette.resolve(.dark).label)
         } dynamicIsland: { context in
             let state = resolveBoardState(context: context)
+            let mirrorState = resolveMirrorState(context: context)
             return DynamicIsland {
                 // Expanded Dynamic Island
                 DynamicIslandExpandedRegion(.leading) {
                     ThumbnailView(
                         climbUuid: context.state.climbUuid,
-                        mirrored: context.state.mirrored ?? false,
+                        mirrored: mirrorState.mirrored,
                         width: 48,
                         height: 60
                     )
@@ -597,8 +617,8 @@ struct ClimbSessionLiveActivity: Widget {
                 DynamicIslandExpandedRegion(.bottom) {
                     SessionFooter(
                         sessionId: context.attributes.sessionId,
-                        queueItemUuid: context.state.queueItemUuid,
-                        mirrored: context.state.mirrored ?? false,
+                        queueItemUuid: mirrorState.queueItemUuid,
+                        mirrored: mirrorState.mirrored,
                         supportsMirroring: context.state.supportsMirroring ?? (SharedConstants.sharedDefaults?.bool(forKey: SharedConstants.supportsMirroringKey) ?? false),
                         state: state,
                         hasPrevious: context.state.hasPrevious,
@@ -737,11 +757,12 @@ private struct LockScreenView: View {
     private var activeView: some View {
         let palette = VelvetSend.Palette.resolve(colorScheme)
         let state = resolveBoardState(context: context)
+        let mirrorState = resolveMirrorState(context: context)
         return HStack(alignment: .top, spacing: VelvetSend.Spacing.md) {
             // Thumbnail
             ThumbnailView(
                 climbUuid: context.state.climbUuid,
-                        mirrored: context.state.mirrored ?? false,
+                mirrored: mirrorState.mirrored,
                 width: 76,
                 height: 96
             )
@@ -777,10 +798,10 @@ private struct LockScreenView: View {
                 // disconnected hide the nav controls entirely so the card
                 // shrinks instead of leaving an empty gap.
                 SessionFooter(
-                        sessionId: context.attributes.sessionId,
-                        queueItemUuid: context.state.queueItemUuid,
-                        mirrored: context.state.mirrored ?? false,
-                        supportsMirroring: context.state.supportsMirroring ?? (SharedConstants.sharedDefaults?.bool(forKey: SharedConstants.supportsMirroringKey) ?? false),
+                    sessionId: context.attributes.sessionId,
+                    queueItemUuid: mirrorState.queueItemUuid,
+                    mirrored: mirrorState.mirrored,
+                    supportsMirroring: context.state.supportsMirroring ?? (SharedConstants.sharedDefaults?.bool(forKey: SharedConstants.supportsMirroringKey) ?? false),
                     state: state,
                     hasPrevious: context.state.hasPrevious,
                     hasNext: context.state.hasNext

--- a/packages/mobile/targets/BoardseshWidgets/MirrorClimbIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/MirrorClimbIntent.swift
@@ -44,10 +44,11 @@ struct MirrorClimbIntent: LiveActivityIntent {
             return
         }
 
-        // Wake the main app on every exit path, as this intent has always done:
-        // even a refused tap usually means the shared snapshot drifted, and the
-        // handler resyncs. Registered after the diagnostics `defer` so it runs
-        // first and the recorded stage still reflects the post.
+        // Wake the main app on every exit path, where the pre-PR code posted
+        // only after a 200. A refused tap usually means the shared snapshot
+        // drifted, and the handler resyncs; the retryable path needs the wake-up
+        // to hand its parked request over. Registered after the diagnostics
+        // `defer` so it runs first and the recorded stage still reflects it.
         defer {
             postQueueNavigateDarwinNotification()
             #if !WIDGET_EXTENSION
@@ -117,10 +118,18 @@ struct MirrorClimbIntent: LiveActivityIntent {
         }
         #if !WIDGET_EXTENSION
         diagnosticRun.mark(.activityKitUpdated)
-        diagnosticRun.mark(.bleStarted)
-        let succeeded = await LiveActivityBleBridge.writeBoardForIntent(items: updatedItems, currentIndex: index, mirrorReceipt: receipt)
-        diagnosticRun.mark(succeeded ? .bleFinishedSuccess : .bleFinishedFailure)
-        if !succeeded { completionClass = .bleFailure }
+        // Only the current slot is on the wall, so the board is rewritten only
+        // when the mirrored item IS that slot. Matching the slot by uuid means
+        // `index` no longer has to hold the receipt's item, and writing it
+        // regardless would relight whatever climb the queue moved on to. The
+        // freshness gate inside `writeBoardForIntent` validates the live current
+        // slot against this same receipt, so the two now always name one item.
+        if item.uuid == receipt.queueItemUuid {
+            diagnosticRun.mark(.bleStarted)
+            let succeeded = await LiveActivityBleBridge.writeBoardForIntent(items: updatedItems, currentIndex: index, mirrorReceipt: receipt)
+            diagnosticRun.mark(succeeded ? .bleFinishedSuccess : .bleFinishedFailure)
+            if !succeeded { completionClass = .bleFailure }
+        }
         #endif
     }
 

--- a/packages/mobile/targets/BoardseshWidgets/MirrorClimbIntent.swift
+++ b/packages/mobile/targets/BoardseshWidgets/MirrorClimbIntent.swift
@@ -1,5 +1,6 @@
 import ActivityKit
 import AppIntents
+import os.log
 
 @available(iOS 17.0, *)
 struct MirrorClimbIntent: LiveActivityIntent {
@@ -7,6 +8,8 @@ struct MirrorClimbIntent: LiveActivityIntent {
     @Parameter(title: "Session") var sessionId: String
     @Parameter(title: "Queue item") var queueItemUuid: String
     @Parameter(title: "Mirrored") var mirrored: Bool
+
+    private static let logger = Logger(subsystem: "com.boardsesh.app", category: "LiveActivityIntent")
 
     init() { sessionId = ""; queueItemUuid = ""; mirrored = false }
     init(sessionId: String, queueItemUuid: String, mirrored: Bool) {
@@ -28,14 +31,48 @@ struct MirrorClimbIntent: LiveActivityIntent {
         var completionClass = LiveActivityIntentCompletionClass.serverRejected
         defer { diagnosticRun.complete(completionClass) }
         #endif
-        guard let defaults = SharedConstants.sharedDefaults,
-              SharedMirrorState.canMirror(sessionId: sessionId, queueItemUuid: queueItemUuid, in: defaults)
-        else { return }
+
+        // One notice per firing, the same signal ClimbNavigationIntent carries.
+        // Production TestFlight builds need it to separate "the intent never ran
+        // in the app process" from "it ran and the wall still didn't move".
+        Self.logger.notice("MirrorClimbIntent.perform() running bundle=\(Bundle.main.bundleIdentifier ?? "unknown", privacy: .public) process=\(ProcessInfo.processInfo.processName, privacy: .public) mirrored=\(mirrored, privacy: .public)")
+
+        guard let defaults = SharedConstants.sharedDefaults else {
+            #if !WIDGET_EXTENSION
+            completionClass = .sharedDefaultsUnavailable
+            #endif
+            return
+        }
+
+        // Wake the main app on every exit path, as this intent has always done:
+        // even a refused tap usually means the shared snapshot drifted, and the
+        // handler resyncs. Registered after the diagnostics `defer` so it runs
+        // first and the recorded stage still reflects the post.
+        defer {
+            postQueueNavigateDarwinNotification()
+            #if !WIDGET_EXTENSION
+            diagnosticRun.mark(.darwinPosted)
+            #endif
+        }
+
+        guard SharedMirrorState.canMirror(sessionId: sessionId, queueItemUuid: queueItemUuid, in: defaults) else { return }
+
         #if !WIDGET_EXTENSION
         diagnosticRun.mark(.networkStarted)
         #endif
         let response = await WidgetNetworking.sendMirror(sessionId: sessionId, queueItemUuid: queueItemUuid, mirrored: mirrored)
         guard case .success(let receipt) = response else {
+            if response == .retryableFailure {
+                // No authoritative answer came back, so nothing is decided yet.
+                // Park the tap for the main app to replay over the WebSocket —
+                // the same recovery `pendingActionKey` gives navigation. Without
+                // it a flaky lock-screen network loses the tap with no wall
+                // change, no widget change and nothing to retry.
+                SharedMirrorState.saveRequest(
+                    SharedMirrorRequest(sessionId: sessionId, queueItemUuid: queueItemUuid, mirrored: mirrored),
+                    in: defaults
+                )
+            }
             #if !WIDGET_EXTENSION
             diagnosticRun.mark(response == .retryableFailure ? .networkFinishedRetryable : .networkFinishedTerminal)
             completionClass = response == .retryableFailure ? .retryableNetworkFailure : .serverRejected
@@ -46,36 +83,52 @@ struct MirrorClimbIntent: LiveActivityIntent {
         diagnosticRun.mark(.networkFinishedSuccess)
         completionClass = .success
         #endif
-        if let snapshot = SharedMirrorState.apply(receipt, in: defaults) {
-            let updatedItems = snapshot.items
-            let index = snapshot.index
-            let item = updatedItems[index]
-            let state = ClimbSessionAttributes.ContentState(
-                climbName: item.climbName, climbDifficulty: VGradeFormatter.formatVGrade(item.difficulty),
-                angle: item.angle, currentIndex: index, totalClimbs: updatedItems.count,
-                hasNext: index < updatedItems.count - 1, hasPrevious: index > 0, climbUuid: item.climbUuid,
-                queueItemUuid: item.uuid, mirrored: item.mirrored, supportsMirroring: true,
-                boardConnection: "connectedByMe", holderDisplayName: nil
-            )
-            for activity in Activity<ClimbSessionAttributes>.activities where activity.attributes.sessionId == sessionId && activity.activityState == .active {
-                guard SharedMirrorState.isCurrent(receipt, in: defaults) else { break }
-                await activity.update(ActivityContent(state: state, staleDate: Date().addingTimeInterval(SharedConstants.liveActivityStaleInterval)))
-            }
+        SharedMirrorState.clearRequest(in: defaults)
+
+        // The server has committed the orientation, so the widget and the wall
+        // follow it. Both used to sit inside `if let snapshot = apply(...)`, and
+        // the activity update was additionally gated on an exact queue-sequence
+        // match: either one declining left the climb mirrored on the server
+        // while this phone kept showing and lighting the old orientation, with
+        // nothing to retry.
+        guard let snapshot = SharedMirrorState.apply(receipt, in: defaults),
+              snapshot.items.indices.contains(snapshot.index)
+        else {
             #if !WIDGET_EXTENSION
-            diagnosticRun.mark(.activityKitUpdated)
-            diagnosticRun.mark(.bleStarted)
-            let succeeded = await LiveActivityBleBridge.writeBoardForIntent(items: updatedItems, currentIndex: index, mirrorReceipt: receipt)
-            diagnosticRun.mark(succeeded ? .bleFinishedSuccess : .bleFinishedFailure)
-            if !succeeded { completionClass = .bleFailure }
+            completionClass = .mirrorNotCommitted
             #endif
+            return
         }
+        let updatedItems = snapshot.items
+        let index = snapshot.index
+        let item = updatedItems[index]
+        let state = ClimbSessionAttributes.ContentState(
+            climbName: item.climbName, climbDifficulty: VGradeFormatter.formatVGrade(item.difficulty),
+            angle: item.angle, currentIndex: index, totalClimbs: updatedItems.count,
+            hasNext: index < updatedItems.count - 1, hasPrevious: index > 0, climbUuid: item.climbUuid,
+            queueItemUuid: item.uuid, mirrored: item.mirrored,
+            supportsMirroring: defaults.bool(forKey: SharedConstants.supportsMirroringKey),
+            // The mirror button is only shown while this device drives the wall,
+            // so the optimistic frame keeps the bulb lit and the controls shown.
+            boardConnection: "connectedByMe", holderDisplayName: nil
+        )
+        for activity in Activity<ClimbSessionAttributes>.activities where activity.attributes.sessionId == sessionId && activity.activityState == .active {
+            await activity.update(ActivityContent(state: state, staleDate: Date().addingTimeInterval(SharedConstants.liveActivityStaleInterval)))
+        }
+        #if !WIDGET_EXTENSION
+        diagnosticRun.mark(.activityKitUpdated)
+        diagnosticRun.mark(.bleStarted)
+        let succeeded = await LiveActivityBleBridge.writeBoardForIntent(items: updatedItems, currentIndex: index, mirrorReceipt: receipt)
+        diagnosticRun.mark(succeeded ? .bleFinishedSuccess : .bleFinishedFailure)
+        if !succeeded { completionClass = .bleFailure }
+        #endif
+    }
+
+    private func postQueueNavigateDarwinNotification() {
         CFNotificationCenterPostNotification(
             CFNotificationCenterGetDarwinNotifyCenter(),
             CFNotificationName(SharedConstants.queueNavigateNotification as CFString), nil, nil, true
         )
-        #if !WIDGET_EXTENSION
-        diagnosticRun.mark(.darwinPosted)
-        #endif
     }
 }
 

--- a/packages/mobile/targets/BoardseshWidgets/SharedConstants.swift
+++ b/packages/mobile/targets/BoardseshWidgets/SharedConstants.swift
@@ -21,6 +21,12 @@ enum SharedConstants {
     static let supportsMirroringKey = "bs_supports_mirroring"
     static let queueSequenceKey = "bs_queue_sequence"
     static let pendingMirrorKey = "bs_pending_mirror"
+    /// A mirror tap whose server request never got an authoritative answer.
+    /// Written by `MirrorClimbIntent` on a retryable failure and replayed by the
+    /// main app over the WebSocket, the same shape of recovery `pendingActionKey`
+    /// gives navigation. Distinct from `pendingMirrorKey`, which holds a receipt
+    /// the server already confirmed.
+    static let pendingMirrorRequestKey = "bs_pending_mirror_request"
     static let widgetNavigateUrlKey = "bs_widget_navigate_url"
     /// Fully-qualified backend `/api/widget/take-control` URL. The widget
     /// POSTs non-driver lightbulb taps here before enabling local navigation.

--- a/packages/mobile/targets/BoardseshWidgets/SharedMirrorState.swift
+++ b/packages/mobile/targets/BoardseshWidgets/SharedMirrorState.swift
@@ -21,9 +21,27 @@ struct SharedMirrorConfirmation: Codable, Equatable, Sendable {
 /// A tap whose server request never got an authoritative answer, kept so the
 /// main app can replay it. Carries no sequence: nothing was committed yet.
 struct SharedMirrorRequest: Codable, Equatable, Sendable {
+    /// How long a parked tap stays replayable. Long enough to survive a cold
+    /// launch and a Bluetooth reconnect, short enough that a tap the climber
+    /// has forgotten about cannot flip a climb under them later in the session.
+    static let timeToLive: TimeInterval = 10 * 60
+
     let sessionId: String
     let queueItemUuid: String
     let mirrored: Bool
+    let createdAt: Date
+
+    init(sessionId: String, queueItemUuid: String, mirrored: Bool, createdAt: Date = Date()) {
+        self.sessionId = sessionId
+        self.queueItemUuid = queueItemUuid
+        self.mirrored = mirrored
+        self.createdAt = createdAt
+    }
+
+    func isFresh(at now: Date = Date()) -> Bool {
+        let age = now.timeIntervalSince(createdAt)
+        return age >= -60 && age <= Self.timeToLive
+    }
 
     var eventBody: [String: Any] {
         ["kind": "request", "sessionId": sessionId, "queueItemUuid": queueItemUuid, "mirrored": mirrored]
@@ -41,10 +59,17 @@ enum SharedMirrorState {
         defaults.set(bytes, forKey: SharedConstants.pendingMirrorRequestKey)
     }
 
-    static func pendingRequest(in defaults: UserDefaults) -> SharedMirrorRequest? {
+    /// The parked tap, if one is still worth replaying. An expired or
+    /// wrong-session record is dropped on read, so nothing accumulates.
+    static func pendingRequest(in defaults: UserDefaults, at now: Date = Date()) -> SharedMirrorRequest? {
         guard let bytes = defaults.data(forKey: SharedConstants.pendingMirrorRequestKey),
               let request = try? JSONDecoder().decode(SharedMirrorRequest.self, from: bytes),
-              request.sessionId == defaults.string(forKey: SharedConstants.sessionIdKey) else { return nil }
+              request.sessionId == defaults.string(forKey: SharedConstants.sessionIdKey)
+        else { return nil }
+        guard request.isFresh(at: now) else {
+            clearRequest(in: defaults)
+            return nil
+        }
         return request
     }
 

--- a/packages/mobile/targets/BoardseshWidgets/SharedMirrorState.swift
+++ b/packages/mobile/targets/BoardseshWidgets/SharedMirrorState.swift
@@ -18,9 +18,39 @@ struct SharedMirrorConfirmation: Codable, Equatable, Sendable {
     }
 }
 
+/// A tap whose server request never got an authoritative answer, kept so the
+/// main app can replay it. Carries no sequence: nothing was committed yet.
+struct SharedMirrorRequest: Codable, Equatable, Sendable {
+    let sessionId: String
+    let queueItemUuid: String
+    let mirrored: Bool
+
+    var eventBody: [String: Any] {
+        ["kind": "request", "sessionId": sessionId, "queueItemUuid": queueItemUuid, "mirrored": mirrored]
+    }
+}
+
 /// A durable receipt, retained until JS has applied this sequence (or a newer full sync).
 enum SharedMirrorState {
     private static let lock = NSLock()
+
+    // MARK: - Unconfirmed requests
+
+    static func saveRequest(_ request: SharedMirrorRequest, in defaults: UserDefaults) {
+        guard let bytes = try? JSONEncoder().encode(request) else { return }
+        defaults.set(bytes, forKey: SharedConstants.pendingMirrorRequestKey)
+    }
+
+    static func pendingRequest(in defaults: UserDefaults) -> SharedMirrorRequest? {
+        guard let bytes = defaults.data(forKey: SharedConstants.pendingMirrorRequestKey),
+              let request = try? JSONDecoder().decode(SharedMirrorRequest.self, from: bytes),
+              request.sessionId == defaults.string(forKey: SharedConstants.sessionIdKey) else { return nil }
+        return request
+    }
+
+    static func clearRequest(in defaults: UserDefaults) {
+        defaults.removeObject(forKey: SharedConstants.pendingMirrorRequestKey)
+    }
 
     static func pending(in defaults: UserDefaults) -> SharedMirrorConfirmation? {
         guard let bytes = defaults.data(forKey: SharedConstants.pendingMirrorKey),
@@ -57,23 +87,51 @@ enum SharedMirrorState {
         return true
     }
 
+    /// Whether writing this receipt to the wall is still the right thing to do.
+    ///
+    /// Deliberately NOT keyed on sequence equality. The board write happens after
+    /// an `await` on BLE readiness, so any unrelated queue event arriving in that
+    /// window used to bump `queueSequenceKey` and silently cancel the write — the
+    /// server kept the flip and the wall never moved. What actually matters is
+    /// that the current slot is still this queue item, still carries the
+    /// orientation the server confirmed, and that this device still drives the
+    /// board.
     static func isCurrent(_ receipt: SharedMirrorConfirmation, in defaults: UserDefaults) -> Bool {
         let (items, index) = SharedQueueState.load(from: defaults)
-        return sequence(in: defaults) == receipt.sequence
-            && canMirror(sessionId: receipt.sessionId, queueItemUuid: receipt.queueItemUuid, in: defaults)
-            && items.indices.contains(index) && items[index].mirrored == receipt.mirrored
+        return defaults.string(forKey: SharedConstants.sessionIdKey) == receipt.sessionId
+            && holdsBoard(in: defaults)
+            && items.indices.contains(index)
+            && items[index].uuid == receipt.queueItemUuid
+            && items[index].mirrored == receipt.mirrored
     }
 
-    /// Commit an HTTP result atomically against native WebSocket updates.
+    /// Commit an HTTP result atomically against native WebSocket updates, and
+    /// hand back the snapshot the caller should publish.
+    ///
+    /// The server is authoritative: it already refused a stale slot with
+    /// `MirrorTargetChangedError`, so holding a receipt means the write was
+    /// correct when it committed. The slot is therefore found by uuid rather
+    /// than required to sit at the current index — a widget Next landing while
+    /// the request was in flight used to make this return nil, which dropped
+    /// the widget refresh and the board write on the floor.
+    ///
+    /// Returns nil only when there is nothing to publish: a different session,
+    /// or no queue at all. A receipt older than the committed snapshot leaves
+    /// that snapshot alone and returns it unchanged, so the caller still
+    /// republishes current truth instead of going silent.
     static func apply(_ receipt: SharedMirrorConfirmation, in defaults: UserDefaults) -> (items: [SharedQueueItem], index: Int)? {
         lock.lock()
         defer { lock.unlock() }
-        guard receipt.sessionId == defaults.string(forKey: SharedConstants.sessionIdKey),
-              receipt.sequence >= sequence(in: defaults),
-              let bytes = try? JSONEncoder().encode(receipt) else { return nil }
-        defaults.set(bytes, forKey: SharedConstants.pendingMirrorKey)
-        guard canMirror(sessionId: receipt.sessionId, queueItemUuid: receipt.queueItemUuid, in: defaults) else { return nil }
+        guard receipt.sessionId == defaults.string(forKey: SharedConstants.sessionIdKey) else { return nil }
         let (items, index) = SharedQueueState.load(from: defaults)
+        let publishable: (items: [SharedQueueItem], index: Int)? = items.isEmpty ? nil : (items: items, index: index)
+        // A receipt older than the committed snapshot is not stored: it would
+        // displace a newer one JS has yet to apply.
+        guard receipt.sequence >= sequence(in: defaults) else { return publishable }
+        if let bytes = try? JSONEncoder().encode(receipt) {
+            defaults.set(bytes, forKey: SharedConstants.pendingMirrorKey)
+        }
+        guard items.contains(where: { $0.uuid == receipt.queueItemUuid }) else { return publishable }
         let updatedItems = items.map { item in
             item.uuid == receipt.queueItemUuid ? SharedQueueItem(
                 uuid: item.uuid, climbUuid: item.climbUuid, climbName: item.climbName,
@@ -86,12 +144,24 @@ enum SharedMirrorState {
         return (updatedItems, index)
     }
 
+    /// Whether this device is the one driving the wall.
+    static func holdsBoard(in defaults: UserDefaults) -> Bool {
+        defaults.string(forKey: SharedConstants.boardConnectionKey) == "connectedByMe"
+    }
+
+    /// The pre-request gate.
+    ///
+    /// No `navigationAllowed` check: the button is only rendered for
+    /// `connectedByMe`, and gating the intent on a separately persisted flag is
+    /// exactly what made Prev/Next no-op when the flag drifted from the shown
+    /// state (see the note in `ClimbNavigationIntent.perform`). The queue only
+    /// has to contain the tapped item — whether it is still the current slot is
+    /// the server's call, and it answers with 409.
     static func canMirror(sessionId: String, queueItemUuid: String, in defaults: UserDefaults) -> Bool {
-        let (items, index) = SharedQueueState.load(from: defaults)
+        let (items, _) = SharedQueueState.load(from: defaults)
         return defaults.string(forKey: SharedConstants.sessionIdKey) == sessionId
             && defaults.bool(forKey: SharedConstants.supportsMirroringKey)
-            && defaults.string(forKey: SharedConstants.boardConnectionKey) == "connectedByMe"
-            && SharedWidgetWallControlState.load(from: defaults).navigationAllowed
-            && items.indices.contains(index) && items[index].uuid == queueItemUuid
+            && holdsBoard(in: defaults)
+            && items.contains { $0.uuid == queueItemUuid }
     }
 }


### PR DESCRIPTION
## Summary

Tapping Mirror on the iOS Live Activity flipped the climb on the server but did nothing on the phone: the wall kept the old orientation and the button kept saying "Mirror climb" until the backend's own push caught up seconds later. Because mirroring is an absolute write and the button label is what decides which orientation the next tap sends, that stale label then turned a second tap into an un-mirror, which is why reopening the app showed the climb unmirrored.

Verified against production before touching anything: backend release is current `main`, and the logs for the reporter's session carry two `ClimbMirrored` publishes, so `POST /api/widget/mirror` was authorised, accepted and committed. Previous and Next from the same Live Activity lit the wall throughout, so background Bluetooth and the intent-to-app routing were both healthy. That puts the failure entirely in what `MirrorClimbIntent` does *after* the server answers 200.

Everything there sat inside one `if let snapshot = SharedMirrorState.apply(...)`, and the widget refresh was additionally gated on `isCurrent`, which demanded an exact `queueSequence` match. Either gate declining meant no widget update, no board write, and nothing parked to retry — while the server kept the flip. Navigation has neither gate, which is exactly why Prev/Next kept working. The specific gate that tripped on the reporter's device is not pinned down (this build sends nothing to Sentry, and a normally-completed intent run is never surfaced), so rather than guess, this closes every path that produces those symptoms and leaves a signal for next time.

- The server's 200 is now authoritative. The ActivityKit update and the board write run off the committed snapshot instead of being conditional on local bookkeeping agreeing.
- `apply` finds the slot by queue-item uuid instead of requiring it to still sit at the current index, so a widget Next landing mid-request no longer discards a confirmed result. A receipt older than the committed snapshot still leaves that snapshot alone, and is no longer stored where it could displace a newer one.
- `isCurrent` no longer requires sequence equality. The board write happens after an await on Bluetooth readiness, so any unrelated queue event arriving in that window used to cancel it silently. It now checks what actually matters: same slot, same orientation, still holding the board.
- A retryable network failure parks the tap in the App Group and the main app replays it through the same mutation the Android notification button uses, the way `pendingActionKey` already rescues navigation. Before, a flaky lock-screen network lost the tap with no feedback.
- The pre-request gate drops its `navigationAllowed` requirement. The button renders on `connectedByMe` alone, so gating the intent on a separately persisted flag reproduces the drift bug Prev/Next removed this check to fix.
- The widget falls back to the committed App Group snapshot for orientation and queue slot when the pushed fields are absent, the way `supportsMirroring` already does, so a lost push cannot leave a label that inverts the next tap.
- The intent gets the `os_log` notice navigation carries, plus a `mirrorNotCommitted` completion class so "server confirmed and the wall followed" and "server confirmed and nothing followed" stop landing in the same bucket.

No backend change: production already serves the endpoint and publishes the event.

Author-side verification: `vp run typecheck:mobile`, `vp run test:mobile`, `vp run check:mobile-bundle` and `vp check` all pass. The Swift changes are covered by new cases in `LiveActivityWidgetTests` (moved index still commits, an unrelated sequence bump no longer cancels the write, a stale receipt is not stored, the parked request round-trips, the tap survives a drifted `navigationAllowed`). Swift itself cannot be compiled on the Linux dev box, so the iOS test target runs in CI. Not yet exercised against a physical board.

## Release Notes

- Mirror a climb from the lock screen and the wall flips with it, straight away.

## Test plan

1. Needs a Tension board, Bluetooth on, and a session.
2. Lock the phone. Tap Mirror on the Live Activity.
3. Wall relights mirrored. Button now reads Unmirror climb.
4. Tap it again. Wall returns. Button reads Mirror climb.
5. Open the app. Climb shows that same orientation.

## Risk

Risk: 5/5 — changes the Live Activity Bluetooth write path and a native App Intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Tjnbem2yjSRuaYhaRjoPb
