### PR TITLE
perf: broaden the challenge to /list and /setter/ — the farm moved, it did not leave

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -400,7 +400,7 @@ back because GraphQL, WebSockets, and `/og` share that hostname.
   of `boardsesh-backend` on 2026-09-10 had Applebot issuing 173 of the 436
   `/graphql` requests on the service.
 
-  3. `managed_challenge` on the climb-view surface, **last**. This is the only
+  3. `managed_challenge` on the board-content surface (`/view/`, `/list`, `/setter/`), **last**. This is the only
      rule that can catch an ordinary browser string, so every agent we have a
      verdict on has to be judged before it.
 
@@ -432,6 +432,22 @@ back because GraphQL, WebSockets, and `/og` share that hostname.
 
   Caching cannot substitute for this. The scraper walks unique URLs, so every
   request is a cache miss by construction — an edge cache only helps repeats.
+
+  **Broadened three hours after it shipped, because the farm moved rather than
+  left.** The first rule covered `/view/` only. A sample at 08:34-08:53 UTC the
+  same day (n=501) found the same nine rotating strings sending **zero**
+  climb-view requests and instead 102 `/setter/` and 67 `/list` — 81% of its
+  remaining traffic, with `/list` the expensive half at 395 ms average against
+  `/setter/`'s 167 ms. Expect this again: the surface list is the part of this
+  rule that needs re-checking after each change, not the mechanism.
+
+  The **homepage is deliberately still open**. The farm hit it 8 times in that
+  window, and it is the page a real first-time visitor is most likely to reach
+  before any `cf_clearance` cookie exists.
+
+  The rule's description string still reads `boardsesh:climb-view-challenge`
+  even though it now covers three surfaces. That is the never-rename contract:
+  renaming the marker orphans the live rule and creates a second one beside it.
 
   **Order is load-bearing and enforced by the tool.** `upsertCacheRule` rewrites
   our rules as one contiguous group in declared order, because a rule-by-rule

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -128,8 +128,13 @@ export const CRAWLER_ALLOW_RULE_DESCRIPTION =
   'boardsesh:allow-search-crawlers (managed by scripts/cloudflare-apply.ts)';
 export const CRAWLER_BLOCK_RULE_DESCRIPTION = 'boardsesh:block-seo-scrapers (managed by scripts/cloudflare-apply.ts)';
 
-/** Marker for the climb-view managed-challenge rule. Same never-rename contract as above. */
-export const CLIMB_VIEW_CHALLENGE_RULE_DESCRIPTION =
+/**
+ * Marker for the board-content managed-challenge rule. Same never-rename
+ * contract as above — the STRING still says `climb-view` because renaming it
+ * would orphan the live rule and create a second one beside it, even though the
+ * rule now also covers `/list` and `/setter/`.
+ */
+export const BOARD_CONTENT_CHALLENGE_RULE_DESCRIPTION =
   'boardsesh:climb-view-challenge (managed by scripts/cloudflare-apply.ts)';
 
 /** Marker for the climb-view rate-limit rule. Same never-rename contract as above. */
@@ -390,6 +395,14 @@ export const LIST_PAGE_PATH_SUFFIX = '/list';
 
 /** Path segment every climb-view URL shape shares, in both trees and all four locales. */
 export const CLIMB_VIEW_PATH_SEGMENT = '/view/';
+
+/**
+ * Setter front doors. A `contains` rather than a `starts_with` so the `/de`,
+ * `/es` and `/fr` twins are covered by the same clause — Cloudflare cannot
+ * strip a locale prefix, and enumerating the cross product here would drift
+ * from the locale list.
+ */
+export const SETTER_PATH_SEGMENT = '/setter/';
 
 /**
  * The substring shared by every name the NextAuth session cookie can carry.
@@ -656,8 +669,27 @@ export const CLIMB_VIEW_RATE_LIMIT_EXPRESSION = CLIMB_VIEW_SURFACE_EXPRESSION;
  * WAF can only test that a cookie NAME is present, so `Cookie:
  * <session-name>=anything` would be a one-line bypass for the scraper. The
  * clearance cookie already keeps a logged-in climber from being re-challenged.
+ *
+ * **Broadened from `/view/` alone to `/view/` + `/list` + `/setter/` three
+ * hours after it shipped, because the farm did not leave — it moved.** Same
+ * nine rotating strings, measured 2026-09-11 08:34-08:53 UTC (n=501): zero
+ * climb-view requests, and instead 102 `/setter/` and 67 `/list`, 81% of what
+ * it still sends. `/list` is the expensive half at 395 ms average against
+ * `/setter/`'s 167 ms.
+ *
+ * The homepage is deliberately still NOT challenged. The farm hit it 8 times
+ * in that window, and it is the one page a real first-time visitor is most
+ * likely to land on before any clearance cookie exists.
+ *
+ * `/setter/` is a `contains`, not a `starts_with`, so the `/de`, `/es` and
+ * `/fr` twins come along; Cloudflare cannot strip a locale prefix. `/list`
+ * keeps `ends_with` to match the cache rule's definition of the same surface.
  */
-export const CLIMB_VIEW_CHALLENGE_EXPRESSION = CLIMB_VIEW_SURFACE_EXPRESSION;
+export const BOARD_CONTENT_CHALLENGE_EXPRESSION =
+  `(http.host eq "${WWW_HOSTNAME}"` +
+  ` and (http.request.uri.path contains "${CLIMB_VIEW_PATH_SEGMENT}"` +
+  ` or ends_with(http.request.uri.path, "${LIST_PAGE_PATH_SUFFIX}")` +
+  ` or http.request.uri.path contains "${SETTER_PATH_SEGMENT}"))`;
 
 /**
  * The apex, and only the apex. `http.host` is the request's Host header, so this
@@ -851,8 +883,8 @@ export const desiredCloudflareState: CloudflareDesiredState = {
     // browser string, so every agent we have an opinion about — allowed or
     // blocked — has to be judged before it.
     {
-      description: CLIMB_VIEW_CHALLENGE_RULE_DESCRIPTION,
-      expression: CLIMB_VIEW_CHALLENGE_EXPRESSION,
+      description: BOARD_CONTENT_CHALLENGE_RULE_DESCRIPTION,
+      expression: BOARD_CONTENT_CHALLENGE_EXPRESSION,
       action: 'managed_challenge',
       enabled: true,
     },

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -13,11 +13,11 @@ import {
   ASSETS_HOSTNAME,
   desiredR2Buckets,
   BACKEND_BOARD_RENDER_CACHE_RULE_DESCRIPTION,
+  BOARD_CONTENT_CHALLENGE_RULE_DESCRIPTION,
   BOARD_RENDER_CACHE_RULE_DESCRIPTION,
   CACHE_RULE_DESCRIPTION,
   CRAWLER_ALLOW_RULE_DESCRIPTION,
   CRAWLER_ALLOW_TOKENS,
-  CLIMB_VIEW_CHALLENGE_RULE_DESCRIPTION,
   CRAWLER_BLOCK_RULE_DESCRIPTION,
   CRAWLER_BLOCK_TOKENS,
   CLIMB_VIEW_PATH_SEGMENT,
@@ -816,12 +816,66 @@ describe('www cost-control rules (#4650)', () => {
     }
   });
 
+  it('challenges every surface the farm moved to, and not the homepage', () => {
+    // Parses the SHIPPED expression rather than restating its logic. A helper
+    // that re-implemented the three clauses would pass no matter what the rule
+    // actually said, which is the failure mode worth guarding against here.
+    const expression = desired.wafRules.find(
+      (rule) => rule.description === BOARD_CONTENT_CHALLENGE_RULE_DESCRIPTION,
+    )!.expression;
+
+    const containsTokens = [...expression.matchAll(/http\.request\.uri\.path contains "([^"]+)"/g)].map(
+      ([, token]) => token,
+    );
+    const endsWithTokens = [...expression.matchAll(/ends_with\(http\.request\.uri\.path, "([^"]+)"\)/g)].map(
+      ([, token]) => token,
+    );
+    // If the expression ever stops using these two forms this test would start
+    // passing vacuously, so assert it still parses into something.
+    expect(containsTokens.length + endsWithTokens.length).toBeGreaterThan(0);
+
+    const challenged = (path: string): boolean =>
+      containsTokens.some((token) => path.includes(token)) || endsWithTokens.some((token) => path.endsWith(token));
+
+    // What the farm actually fetched in the 2026-09-11 08:34-08:53 window,
+    // after the /view/-only rule pushed it off climb pages: 102 /setter/,
+    // 67 /list.
+    for (const path of [
+      '/kilter/original/12x12-square/screw_bolt/40/view/some-climb',
+      '/de/tension/two-mirror/12-high-x-12-wide/wood_plastic/50/list',
+      '/kilter/original/12x12-square/screw_bolt/40/list',
+      '/setter/someclimber',
+      '/fr/setter/someclimber',
+    ]) {
+      expect(challenged(path), `${path} must be challenged`).toBe(true);
+    }
+
+    // The homepage stays open on purpose — it is where a real first-time
+    // visitor lands before any clearance cookie exists, and the farm hit it
+    // 8 times against 169 for the surfaces above.
+    for (const path of ['/', '/about', '/legal', '/gyms']) {
+      expect(challenged(path), `${path} must stay open`).toBe(false);
+    }
+  });
+
+  it('balances its parentheses', () => {
+    // A stray paren installs nothing and the deploy still goes green.
+    const expression = desired.wafRules.find(
+      (rule) => rule.description === BOARD_CONTENT_CHALLENGE_RULE_DESCRIPTION,
+    )!.expression;
+    const opens = expression.split('(').length - 1;
+    const closes = expression.split(')').length - 1;
+    expect(opens).toBe(closes);
+  });
+
   it('challenges the climb-view surface, and does it last', () => {
     // The scraper this exists for rotates ordinary Chrome/Edge/Safari strings,
     // so no token list reaches it. What separates it from a person is that it
     // executes no JavaScript — 350 climb pages and zero `/_next/static` chunks
     // in a 2026-09-11 sample — and a managed challenge is exactly that test.
-    const challengeRule = desired.wafRules.find((rule) => rule.description === CLIMB_VIEW_CHALLENGE_RULE_DESCRIPTION);
+    const challengeRule = desired.wafRules.find(
+      (rule) => rule.description === BOARD_CONTENT_CHALLENGE_RULE_DESCRIPTION,
+    );
     expect(challengeRule?.action).toBe('managed_challenge');
     expect(challengeRule?.expression).toContain('/view/');
     expect(challengeRule?.expression).toContain(`http.host eq "${WWW_HOSTNAME}"`);
@@ -838,7 +892,7 @@ describe('www cost-control rules (#4650)', () => {
     // Qwant had to be added: they were passing by default, which stops working
     // the moment an unlisted agent gets challenged.
     const challengeIndex = desired.wafRules.findIndex(
-      (rule) => rule.description === CLIMB_VIEW_CHALLENGE_RULE_DESCRIPTION,
+      (rule) => rule.description === BOARD_CONTENT_CHALLENGE_RULE_DESCRIPTION,
     );
     expect(desired.wafRules.indexOf(allowRule!)).toBeLessThan(challengeIndex);
     expect(allowRule?.action).toBe('skip');
@@ -882,7 +936,7 @@ describe('managed rule ordering and foreign-rule safety', () => {
       CRAWLER_BLOCK_RULE_DESCRIPTION,
       // Last on purpose: it is the only rule that can catch an ordinary browser
       // string, so both UA verdicts must be reached first.
-      CLIMB_VIEW_CHALLENGE_RULE_DESCRIPTION,
+      BOARD_CONTENT_CHALLENGE_RULE_DESCRIPTION,
     ]);
     // The pre-existing rule keeps its Cloudflare-assigned id rather than being
     // recreated, so its analytics and history survive.


### PR DESCRIPTION
## Summary

The `/view/`-only challenge from #5390 worked. Three hours of production says so:

| Measure | Before | After | Change |
|---|---|---|---|
| Requests/hour | 9,297 | 1,691 | −82% |
| web spend, same 3h window | $0.273 | $0.052 | −81% |
| 5xx | 4,200/day | 0 since deploy | gone |

**But the farm did not leave — it moved.** A sample at 08:34–08:53 UTC (n=501) found the same nine rotating Chrome, Edge and Safari strings sending **zero** climb-view requests, and instead:

| Target | Requests | Avg duration |
|---|---|---|
| `/setter/` | 102 | 167 ms (mostly 404s) |
| `/list` | 67 | **395 ms** |
| homepage | 8 | 120 ms |
| scattered `/b/`, `/gym/` | 31 | — |

That is 81% of its remaining traffic on two surfaces the first rule did not cover, and `/list` is server-rendered — now its most expensive target.

So the expression grows from `/view/` to `/view/` + `/list` + `/setter/`.

### Decisions worth reviewing

- **The homepage stays open.** 8 requests against 169, and it is the page a real first-time visitor is most likely to reach before any `cf_clearance` cookie exists. Challenging it would be the first change that meaningfully taxes real arrivals.
- **`/setter/` is a `contains`, not a `starts_with`**, so the `/de`, `/es` and `/fr` twins are covered by one clause. Cloudflare cannot strip a locale prefix, and enumerating the cross product would drift from the locale list.
- **`/list` keeps `ends_with`**, matching how the existing cache rule defines the same surface.
- **The rule's description string is unchanged** — still `boardsesh:climb-view-challenge` despite covering three surfaces. Renaming the marker orphans the live rule and creates a second one beside it, so only the TypeScript constant is renamed.

Search engines are unaffected: the allow rule runs first and its `skip` covers the whole ruleset. Verified live on the current rule — Googlebot gets `200` on a climb page while a plain Chrome string gets `403 cf-mitigated: challenge`.

### On the guard

My first version of the test re-implemented the three clauses using the path constants, which would have passed no matter what the shipped expression said. It now **parses `BOARD_CONTENT_CHALLENGE_EXPRESSION` itself** and evaluates the parsed clauses against real paths, plus asserts the parse found something so it cannot go vacuous.

### Author-side verification

- `scripts` + `deploy-app-subdomain` green (115 files, 2203 tests); `web` green (394 files, 4575 tests).
- `vp check` clean.
- **Mutation-tested four ways**, all caught: dropping the `/setter/` clause, dropping the `/list` clause, widening to the homepage, and unbalancing a paren.

Cloudflare rules are applied by `cf:apply` on production deploy, not by this PR.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. Open a climb page on boardsesh.com. Brief check may appear, then it loads.
2. Open a board's list page. It loads.
3. Open a setter page from a climb. It loads.

## Risk

Risk: 3/5 — widens an interstitial to two more signed-out content surfaces; wrong scope costs real visits, and the homepage carve-out is the line worth checking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KpFE1RPEpZxYXfDcFKQmg
