### PR TITLE
fix: show every setter for a board, not just those graded at your angle

### DIFF
--- a/packages/backend/src/__tests__/serial-plan-guard.test.ts
+++ b/packages/backend/src/__tests__/serial-plan-guard.test.ts
@@ -139,9 +139,11 @@ describe('withSerialPlan', () => {
 
 describe('getSetterStats guard (#4105)', () => {
   it('issues the guard before the board_climbs aggregate', async () => {
-    // This query hash-joins board_climbs x board_climb_stats over a whole layout
-    // and groups by setter. It fires from the same search drawer as searchClimbs,
-    // so it kept exhausting /dev/shm after #3856 guarded the search paths.
+    // This query scans board_climbs over a whole layout and groups by setter.
+    // It fires from the same search drawer as searchClimbs, so it kept exhausting
+    // /dev/shm after #3856 guarded the search paths. It no longer joins
+    // board_climb_stats (#5404), but a seq scan feeding a HashAggregate is still a
+    // shape the planner parallelizes, so the guard stays.
     const { fakeDb, callOrder, executedStatements, queries } = createFakeDb();
 
     await getSetterStats(fakeDb as unknown as DbInstance, {

--- a/packages/backend/src/__tests__/setter-stats-moonboard.test.ts
+++ b/packages/backend/src/__tests__/setter-stats-moonboard.test.ts
@@ -18,6 +18,13 @@ import { climbQueries } from '../graphql/resolvers/climbs/queries';
 // fixes: the resolver no longer short-circuits, and the predicate is gated by
 // isSizeScopedBoard rather than deleted outright (so size filtering still
 // works for Aurora boards like Kilter).
+//
+// It also covers #5404: the query used to INNER JOIN board_climb_stats at the
+// requested angle, so a setter vanished from the picker unless one of their
+// climbs carried a stats row at exactly the board's tilt. The suite now asserts
+// the aggregate is angle-blind on every board, and that the is_listed / is_draft
+// / required_set_ids guards that the dropped join was implicitly providing are
+// enforced on their own.
 
 function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext {
   return {
@@ -32,10 +39,32 @@ function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext 
   } as ConnectionContext;
 }
 
-async function seedClimb(boardType: string, uuid: string, name: string, setter: string, sizeIdsSql: string) {
+type SeedClimbOptions = {
+  boardType: string;
+  uuid: string;
+  name: string;
+  setter: string;
+  /** Raw SQL for compatible_size_ids — 'NULL' for MoonBoard, which never populates it. */
+  sizeIdsSql: string;
+  /** Raw SQL for required_set_ids. Defaults to set 1, the sets every test board is fitted with. */
+  requiredSetIdsSql?: string;
+  isListed?: boolean;
+  isDraft?: boolean;
+};
+
+async function seedClimb({
+  boardType,
+  uuid,
+  name,
+  setter,
+  sizeIdsSql,
+  requiredSetIdsSql = 'ARRAY[1]::integer[]',
+  isListed = true,
+  isDraft = false,
+}: SeedClimbOptions) {
   await db.execute(sql`
-    INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed, compatible_size_ids)
-    VALUES (${uuid}, ${boardType}, 1, ${setter}, ${name}, '', 'p1r1', true, ${sql.raw(sizeIdsSql)})
+    INSERT INTO board_climbs (uuid, board_type, layout_id, setter_username, name, description, frames, is_listed, is_draft, compatible_size_ids, required_set_ids)
+    VALUES (${uuid}, ${boardType}, 1, ${setter}, ${name}, '', 'p1r1', ${isListed}, ${isDraft}, ${sql.raw(sizeIdsSql)}, ${sql.raw(requiredSetIdsSql)})
   `);
 }
 
@@ -46,46 +75,117 @@ async function seedStats(boardType: string, uuid: string, angle: number, display
   `);
 }
 
+const SEEDED_UUIDS = [
+  'moon-setter-climb-1',
+  'moon-setter-climb-2',
+  'moon-unlisted-climb',
+  'moon-draft-climb',
+  'kilter-sized-setter-climb',
+  'kilter-other-size-setter-climb',
+  'kilter-other-set-climb',
+  'woods-angle-20-climb',
+  'woods-angle-70-climb',
+];
+
 describe('setterStats — size filter skips MoonBoard, still applies to Aurora boards (real DB)', () => {
   beforeAll(async () => {
     // MoonBoard climbs: compatible_size_ids stays NULL, as in production —
     // populate-denormalized-columns skips the size-edges step for moonboard.
-    await seedClimb('moonboard', 'moon-setter-climb-1', 'Moon one', 'moon-setter', 'NULL');
+    await seedClimb({
+      boardType: 'moonboard',
+      uuid: 'moon-setter-climb-1',
+      name: 'Moon one',
+      setter: 'moon-setter',
+      sizeIdsSql: 'NULL',
+    });
     await seedStats('moonboard', 'moon-setter-climb-1', 40, 20, 50);
-    await seedClimb('moonboard', 'moon-setter-climb-2', 'Moon two', 'moon-setter', 'NULL');
+    await seedClimb({
+      boardType: 'moonboard',
+      uuid: 'moon-setter-climb-2',
+      name: 'Moon two',
+      setter: 'moon-setter',
+      sizeIdsSql: 'NULL',
+    });
     await seedStats('moonboard', 'moon-setter-climb-2', 40, 22, 30);
+
+    // MoonBoard skips the size predicate entirely, so is_listed / is_draft are the
+    // only things keeping these two out of the picker (#5404). Both carry stats
+    // rows, so they'd have leaked under the old angle join too.
+    await seedClimb({
+      boardType: 'moonboard',
+      uuid: 'moon-unlisted-climb',
+      name: 'Moon unlisted',
+      setter: 'moon-unlisted-setter',
+      sizeIdsSql: 'NULL',
+      isListed: false,
+    });
+    await seedStats('moonboard', 'moon-unlisted-climb', 40, 20, 5);
+    await seedClimb({
+      boardType: 'moonboard',
+      uuid: 'moon-draft-climb',
+      name: 'Moon draft',
+      setter: 'moon-draft-setter',
+      sizeIdsSql: 'NULL',
+      isDraft: true,
+    });
 
     // Kilter climbs: one compatible with size 10, one only with size 99 — the
     // size filter must still apply to size-scoped boards.
-    await seedClimb(
-      'kilter',
-      'kilter-sized-setter-climb',
-      'Fits size 10',
-      'kilter-sized-setter',
-      'ARRAY[10]::integer[]',
-    );
+    await seedClimb({
+      boardType: 'kilter',
+      uuid: 'kilter-sized-setter-climb',
+      name: 'Fits size 10',
+      setter: 'kilter-sized-setter',
+      sizeIdsSql: 'ARRAY[10]::integer[]',
+    });
     await seedStats('kilter', 'kilter-sized-setter-climb', 40, 18, 100);
-    await seedClimb(
-      'kilter',
-      'kilter-other-size-setter-climb',
-      'Fits size 99 only',
-      'kilter-other-size-setter',
-      'ARRAY[99]::integer[]',
-    );
+    await seedClimb({
+      boardType: 'kilter',
+      uuid: 'kilter-other-size-setter-climb',
+      name: 'Fits size 99 only',
+      setter: 'kilter-other-size-setter',
+      sizeIdsSql: 'ARRAY[99]::integer[]',
+    });
     await seedStats('kilter', 'kilter-other-size-setter-climb', 40, 19, 80);
+    // Needs a set the board isn't fitted with — the climb list drops it, so the
+    // picker must not offer its setter either.
+    await seedClimb({
+      boardType: 'kilter',
+      uuid: 'kilter-other-set-climb',
+      name: 'Needs set 99',
+      setter: 'kilter-other-set-setter',
+      sizeIdsSql: 'ARRAY[10]::integer[]',
+      requiredSetIdsSql: 'ARRAY[99]::integer[]',
+    });
+    await seedStats('kilter', 'kilter-other-set-climb', 40, 19, 70);
+
+    // Woods, the board that surfaced #5404: each climb carries exactly one stats
+    // row, at the angle it was set at. Neither of these is at 25°.
+    await seedClimb({
+      boardType: 'woods',
+      uuid: 'woods-angle-20-climb',
+      name: 'Woods at twenty',
+      setter: 'woods-setter',
+      sizeIdsSql: 'ARRAY[1]::integer[]',
+    });
+    await seedStats('woods', 'woods-angle-20-climb', 20, 16, 3);
+    await seedClimb({
+      boardType: 'woods',
+      uuid: 'woods-angle-70-climb',
+      name: 'Woods at seventy',
+      setter: 'woods-setter',
+      sizeIdsSql: 'ARRAY[1]::integer[]',
+    });
+    await seedStats('woods', 'woods-angle-70-climb', 70, 24, 1);
   });
 
   afterAll(async () => {
-    await db.execute(sql`
-      DELETE FROM board_climb_stats WHERE climb_uuid IN (
-        'moon-setter-climb-1', 'moon-setter-climb-2', 'kilter-sized-setter-climb', 'kilter-other-size-setter-climb'
-      )
-    `);
-    await db.execute(sql`
-      DELETE FROM board_climbs WHERE uuid IN (
-        'moon-setter-climb-1', 'moon-setter-climb-2', 'kilter-sized-setter-climb', 'kilter-other-size-setter-climb'
-      )
-    `);
+    const seededUuidList = sql.join(
+      SEEDED_UUIDS.map((uuid) => sql`${uuid}`),
+      sql`, `,
+    );
+    await db.execute(sql`DELETE FROM board_climb_stats WHERE climb_uuid IN (${seededUuidList})`);
+    await db.execute(sql`DELETE FROM board_climbs WHERE uuid IN (${seededUuidList})`);
   });
 
   it('returns MoonBoard setters with correct counts for the fixed board size, sizeId 1', async () => {
@@ -108,17 +208,56 @@ describe('setterStats — size filter skips MoonBoard, still applies to Aurora b
     expect(result).toEqual([{ setterUsername: 'kilter-sized-setter', climbCount: 1 }]);
   });
 
-  it('accepts a negative angle (Aurora boards support negative tilt) and returns an empty result for the unmatched stats join', async () => {
-    // Mobile's setter filter sends the live board angle. There's no
-    // board_climb_stats row at -5° for any seeded climb here, so the inner
-    // join simply yields no rows — the request must not be rejected outright.
+  it('excludes a setter whose only climb needs a set the board is not fitted with', async () => {
     const result = await climbQueries.setterStats(
+      null,
+      { input: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1', angle: 40 } },
+      makeCtx(),
+    );
+
+    expect(result.map((setter) => setter.setterUsername)).not.toContain('kilter-other-set-setter');
+  });
+
+  it('offers unlisted climbs and drafts to nobody, now that the stats join no longer hides them', async () => {
+    const result = await climbQueries.setterStats(
+      null,
+      { input: { boardName: 'moonboard', layoutId: 1, sizeId: 1, setIds: '1', angle: 40 } },
+      makeCtx(),
+    );
+
+    const setterNames = result.map((setter) => setter.setterUsername);
+    expect(setterNames).not.toContain('moon-unlisted-setter');
+    expect(setterNames).not.toContain('moon-draft-setter');
+  });
+
+  it('returns a Woods setter at an angle none of their climbs was set at (#5404)', async () => {
+    // The reporter's case: both climbs sit at 20° and 70°, the board is at 25°.
+    // The old angle-scoped inner join returned nothing here.
+    const result = await climbQueries.setterStats(
+      null,
+      { input: { boardName: 'woods', layoutId: 1, sizeId: 1, setIds: '1', angle: 25 } },
+      makeCtx(),
+    );
+
+    expect(result).toEqual([{ setterUsername: 'woods-setter', climbCount: 2 }]);
+  });
+
+  it('returns the same setters at every angle, including a negative tilt (#5404)', async () => {
+    // Mobile's setter filter sends the live board angle. Aurora boards support
+    // negative tilt, and the angle must change nothing about who is offered.
+    const atFortyDegrees = await climbQueries.setterStats(
+      null,
+      { input: { boardName: 'moonboard', layoutId: 1, sizeId: 1, setIds: '1', angle: 40 } },
+      makeCtx(),
+    );
+    const atNegativeFive = await climbQueries.setterStats(
       null,
       { input: { boardName: 'moonboard', layoutId: 1, sizeId: 1, setIds: '1', angle: -5 } },
       makeCtx(),
     );
 
-    expect(result).toEqual([]);
+    expect(atNegativeFive).toEqual(atFortyDegrees);
+    expect(atNegativeFive).toEqual([{ setterUsername: 'moon-setter', climbCount: 2 }]);
   });
 
   it('rejects angle -91 (outside the -90..90 board-tilt range)', async () => {

--- a/packages/db/src/queries/climbs/__tests__/setter-stats.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/setter-stats.test.ts
@@ -35,13 +35,18 @@ const MOONBOARD_PARAMS: BoardRouteParams = {
  */
 function createFakeSetterStatsDb() {
   const whereClauses: string[] = [];
+  const orderByClauses: string[] = [];
 
   const builder: Record<string, unknown> = {};
-  for (const method of ['from', 'groupBy', 'orderBy', 'limit']) {
+  for (const method of ['from', 'groupBy', 'limit']) {
     builder[method] = () => builder;
   }
   builder.where = (condition: SQL | undefined) => {
     whereClauses.push(condition ? dialect.sqlToQuery(condition).sql : '');
+    return builder;
+  };
+  builder.orderBy = (...expressions: SQL[]) => {
+    orderByClauses.push(expressions.map((expression) => dialect.sqlToQuery(expression).sql).join(', '));
     return builder;
   };
   builder.then = (
@@ -58,7 +63,7 @@ function createFakeSetterStatsDb() {
     transaction: (callback: (transactionDb: typeof tx) => unknown) => callback(tx),
   };
 
-  return { fakeDb, whereClauses };
+  return { fakeDb, whereClauses, orderByClauses };
 }
 
 void describe('getSetterStats — community-hidden climbs (#5049)', () => {
@@ -113,6 +118,19 @@ void describe('getSetterStats — angle-blind setter universe (#5404)', () => {
     assert.match(whereClauses[0], /"board_climbs"\."required_set_ids" <@ ARRAY\[/);
     // Kilter is size-scoped, so the size containment predicate stays.
     assert.match(whereClauses[0], /"board_climbs"\."compatible_size_ids" @> ARRAY\[/);
+  });
+
+  void it('breaks count ties on the username so the 50-row cut is stable', async () => {
+    const { fakeDb, orderByClauses } = createFakeSetterStatsDb();
+
+    await getSetterStats(fakeDb as unknown as DbInstance, SETTER_PARAMS);
+
+    // The tail of this list is one-climb setters, so ties at the LIMIT 50 boundary
+    // are common. Without the second key Postgres may return a different 50 each
+    // time and the picker flickers between refetches.
+    assert.equal(orderByClauses.length, 1);
+    assert.match(orderByClauses[0], /count\(\*\) DESC/);
+    assert.match(orderByClauses[0], /"board_climbs"\."setter_username" ASC/);
   });
 
   void it('lets MoonBoard climbs through while required_set_ids is still backfilling', async () => {

--- a/packages/db/src/queries/climbs/__tests__/setter-stats.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/setter-stats.test.ts
@@ -16,16 +16,28 @@ const SETTER_PARAMS: BoardRouteParams = {
   angle: 40,
 };
 
+const MOONBOARD_PARAMS: BoardRouteParams = {
+  board_name: 'moonboard',
+  layout_id: 1,
+  size_id: 1,
+  set_ids: [1],
+  angle: 40,
+};
+
 /**
  * A drizzle stand-in that renders whatever WHERE the query builds and returns no
  * rows. The claim under test is which predicates reach Postgres, so rendering
  * the SQL is the assertion — running it would only re-check Postgres.
+ *
+ * `innerJoin` is deliberately absent from the stubbed methods: the query must not
+ * join `board_climb_stats` (#5404), and a re-added join should blow up here rather
+ * than slip through green.
  */
 function createFakeSetterStatsDb() {
   const whereClauses: string[] = [];
 
   const builder: Record<string, unknown> = {};
-  for (const method of ['from', 'innerJoin', 'groupBy', 'orderBy', 'limit']) {
+  for (const method of ['from', 'groupBy', 'orderBy', 'limit']) {
     builder[method] = () => builder;
   }
   builder.where = (condition: SQL | undefined) => {
@@ -66,5 +78,56 @@ void describe('getSetterStats — community-hidden climbs (#5049)', () => {
 
     assert.match(whereClauses[0], /"board_climbs"\."is_hidden" = \$\d+/);
     assert.match(whereClauses[0], /ilike/i);
+  });
+});
+
+void describe('getSetterStats — angle-blind setter universe (#5404)', () => {
+  void it('never scopes the aggregate by board_climb_stats', async () => {
+    const { fakeDb, whereClauses } = createFakeSetterStatsDb();
+
+    await getSetterStats(fakeDb as unknown as DbInstance, SETTER_PARAMS);
+
+    // The angle-scoped INNER JOIN is the bug: it hid every setter with no climb
+    // graded at the board's current tilt. Nothing may reference the stats table.
+    assert.ok(
+      !whereClauses[0].includes('board_climb_stats'),
+      `expected no board_climb_stats reference, got: ${whereClauses[0]}`,
+    );
+    assert.ok(!whereClauses[0].includes('angle'), `expected no angle predicate, got: ${whereClauses[0]}`);
+  });
+
+  void it('excludes unlisted climbs and drafts, which the dropped join used to exclude for free', async () => {
+    const { fakeDb, whereClauses } = createFakeSetterStatsDb();
+
+    await getSetterStats(fakeDb as unknown as DbInstance, SETTER_PARAMS);
+
+    assert.match(whereClauses[0], /"board_climbs"\."is_listed" = \$\d+/);
+    assert.match(whereClauses[0], /"board_climbs"\."is_draft" = \$\d+/);
+  });
+
+  void it('scopes to the sets the board is fitted with', async () => {
+    const { fakeDb, whereClauses } = createFakeSetterStatsDb();
+
+    await getSetterStats(fakeDb as unknown as DbInstance, SETTER_PARAMS);
+
+    assert.match(whereClauses[0], /"board_climbs"\."required_set_ids" <@ ARRAY\[/);
+    // Kilter is size-scoped, so the size containment predicate stays.
+    assert.match(whereClauses[0], /"board_climbs"\."compatible_size_ids" @> ARRAY\[/);
+  });
+
+  void it('lets MoonBoard climbs through while required_set_ids is still backfilling', async () => {
+    const { fakeDb, whereClauses } = createFakeSetterStatsDb();
+
+    await getSetterStats(fakeDb as unknown as DbInstance, MOONBOARD_PARAMS);
+
+    assert.match(whereClauses[0], /"board_climbs"\."required_set_ids" is null/i);
+    // MoonBoard never populates compatible_size_ids — the size predicate is skipped
+    // entirely for it (#4008), so the draft/listed guards are all that stand between
+    // the picker and other people's drafts.
+    assert.ok(
+      !whereClauses[0].includes('compatible_size_ids'),
+      `expected no size predicate for MoonBoard, got: ${whereClauses[0]}`,
+    );
+    assert.match(whereClauses[0], /"board_climbs"\."is_draft" = \$\d+/);
   });
 });

--- a/packages/db/src/queries/climbs/setter-stats.ts
+++ b/packages/db/src/queries/climbs/setter-stats.ts
@@ -1,13 +1,13 @@
 import { isSizeScopedBoard } from '@boardsesh/board-config';
 import { and, eq, ilike, sql } from 'drizzle-orm';
 import type { DbInstance } from '../../client/postgres';
-import { boardClimbs, boardClimbStats } from '../../schema/index';
+import { boardClimbs } from '../../schema/index';
 import { withSerialPlan } from '../util/serial-plan';
 import type { BoardRouteParams } from './types';
 
 /**
  * One row in the setter-stats result: a setter's username and how many
- * climbs they've authored on the given board/layout/angle. Returned by
+ * climbs they've authored on the given board/layout/size. Returned by
  * `getSetterStats` and consumed by the search drawer's setter filter
  * autocomplete on both web and mobile.
  */
@@ -19,15 +19,38 @@ export type SetterStat = {
 /**
  * Aggregate setter usernames with their climb counts for a board configuration.
  *
- * Joins `board_climbs` with `board_climb_stats` so we only count climbs that
- * actually exist at the requested angle (the inner join drops setters whose
- * climbs have no stats row at the angle). An optional `searchQuery` filters
- * setter usernames with a case-insensitive substring match for autocomplete.
+ * Deliberately angle-blind, and `params.angle` is ignored. Climb-list membership
+ * is angle-independent — `countClimbs` and `runStandardSearch` both LEFT JOIN
+ * `board_climb_stats`, so the angle decides a climb's grade and its sort position,
+ * never whether it exists. This query used to INNER JOIN stats at the angle, which
+ * meant a setter only appeared if one of their climbs happened to carry a stats row
+ * at exactly the board's current tilt (#5404).
  *
- * Capped at 50 rows ordered by descending climb count for UI performance.
+ * Woods is the board that proved it. Every Woods climb has exactly one stats row,
+ * at the angle it was set at (Aurora boards replicate stats across angles; Woods
+ * does not), so the join reduced woods/layout 1/size 1 from 15 setters to 3 and
+ * hid the board's most prolific setter — 246 climbs, none of them at 25°.
  *
- * Community-hidden climbs are excluded, matching `searchClimbs`: the count next
- * to a setter's name has to mean the climbs the filter will actually surface.
+ * The counts mean the climbs this filter can surface at this board configuration,
+ * before the drawer's other filters. Notably NOT mirrored from `createClimbFilters`
+ * is the boulders/routes `frames_count` condition: both clients default to
+ * boulders-only, so a setter's count can include multi-frame routes the default list
+ * omits. Mirroring it would mean plumbing a search param into SetterStatsInput.
+ *
+ * Every other predicate tracks `baseConditions` in create-climb-filters.ts, so the
+ * picker and the list agree on the universe:
+ *
+ * - `is_listed` / `is_draft` — previously enforced only as a side effect of the
+ *   stats join (drafts have no stats rows). They have to be explicit now. This is
+ *   load-bearing on MoonBoard rather than cosmetic: the size predicate below is
+ *   skipped for MoonBoard, so nothing else would keep other people's drafts out of
+ *   the picker. `is_listed` is nullable and `= true` drops NULLs, matching the list.
+ * - `required_set_ids` — the sets this board is fitted with. MoonBoard (and freshly
+ *   saved drafts) can leave the column NULL while it backfills, so MoonBoard allows
+ *   NULL through, the same escape `setIdsConditions` makes.
+ * - Community-hidden climbs are excluded (#5049). Unlike the list's
+ *   `hiddenClimbCondition`, there is no name-search exception here — this query's
+ *   `searchQuery` filters `setter_username`, not the climb name.
  *
  * Size-scoped boards (everything but MoonBoard) are filtered to climbs whose
  * `compatible_size_ids` contains the requested size, using array containment
@@ -35,29 +58,46 @@ export type SetterStat = {
  * index. MoonBoard has a single fixed product size and never populates
  * `compatible_size_ids`, so the size predicate is skipped entirely for it —
  * `size_id = ANY(NULL)` evaluates to NULL and would otherwise drop every
- * MoonBoard row. This is deliberately board-type-gated rather than
- * NULL-tolerant: Kilter draft climbs can also have a NULL
- * `compatible_size_ids` (see the "Draft climbs may have NULL
- * compatible_size_ids" comments in search-climbs.ts) and must stay excluded.
+ * MoonBoard row (#4008).
  *
- * Runs under `withSerialPlan`: this hash-joins the two biggest catalog tables
- * over a whole layout and aggregates them, which the planner is happy to run as
- * a parallel hash join. It fires from the same search drawer as `searchClimbs`
- * on the same table pair, so it kept exhausting `/dev/shm` after #3856 guarded
- * the search paths themselves (#4105). The LIMIT 50 applies after the GROUP BY,
- * so it does not bound the scan.
+ * Capped at 50 rows ordered by descending climb count, with a username tiebreaker
+ * so the cut is deterministic — the long tail is dominated by one-climb setters,
+ * and an unordered tie at row 50 would make the picker flicker between refetches.
+ *
+ * Runs under `withSerialPlan`: a scan of the whole layout in `board_climbs` feeding
+ * a HashAggregate is a plan the planner is happy to parallelize, and the per-worker
+ * DSM allocations are what kept exhausting `/dev/shm` (#4105). The LIMIT 50 applies
+ * after the GROUP BY, so it does not bound the scan.
  */
 export const getSetterStats = async (
   db: DbInstance,
   params: BoardRouteParams,
   searchQuery?: string,
 ): Promise<SetterStat[]> => {
+  // MoonBoard leaves required_set_ids NULL until the backfill runs; better to offer
+  // a setter than to hide one. Mirrors `allowNullRequiredSets` in create-climb-filters.
+  const allowNullRequiredSets = params.board_name === 'moonboard';
+
   const whereConditions = [
     eq(boardClimbs.boardType, params.board_name),
     eq(boardClimbs.layoutId, params.layout_id),
-    eq(boardClimbStats.angle, params.angle),
+    eq(boardClimbs.isListed, true),
+    eq(boardClimbs.isDraft, false),
     ...(isSizeScopedBoard(params.board_name)
       ? [sql`${boardClimbs.compatibleSizeIds} @> ARRAY[${params.size_id}]::int[]`]
+      : []),
+    ...(params.set_ids.length > 0
+      ? [
+          allowNullRequiredSets
+            ? sql`(${boardClimbs.requiredSetIds} IS NULL OR ${boardClimbs.requiredSetIds} <@ ARRAY[${sql.join(
+                params.set_ids.map((id) => sql`${id}`),
+                sql`, `,
+              )}]::int[])`
+            : sql`${boardClimbs.requiredSetIds} <@ ARRAY[${sql.join(
+                params.set_ids.map((id) => sql`${id}`),
+                sql`, `,
+              )}]::int[]`,
+        ]
       : []),
     sql`${boardClimbs.setterUsername} IS NOT NULL`,
     sql`${boardClimbs.setterUsername} != ''`,
@@ -78,13 +118,9 @@ export const getSetterStats = async (
         climb_count: sql<number>`count(*)::int`,
       })
       .from(boardClimbs)
-      .innerJoin(
-        boardClimbStats,
-        and(eq(boardClimbStats.climbUuid, boardClimbs.uuid), eq(boardClimbStats.boardType, params.board_name)),
-      )
       .where(and(...whereConditions))
       .groupBy(boardClimbs.setterUsername)
-      .orderBy(sql`count(*) DESC`)
+      .orderBy(sql`count(*) DESC`, sql`${boardClimbs.setterUsername} ASC`)
       .limit(50),
   );
 

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -254,7 +254,7 @@ input SetterStatsInput {
   sizeId: Int!
   "Comma-separated set IDs"
   setIds: String!
-  "Board angle in degrees"
+  "Board angle in degrees. Accepted and ignored: the setter list is the same at every angle (#5404)."
   angle: Int!
   "Case-insensitive substring filter on setter username (for autocomplete)"
   search: String
@@ -262,7 +262,7 @@ input SetterStatsInput {
 
 """
 A setter username paired with the number of climbs they've authored
-for a given board configuration and angle.
+for a given board configuration. Angle-independent.
 """
 type SetterStat {
   "Setter's username"

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -7616,7 +7616,7 @@ export type SetterSearchResult = {
 
 /**
  * A setter username paired with the number of climbs they've authored
- * for a given board configuration and angle.
+ * for a given board configuration. Angle-independent.
  */
 export type SetterStat = {
   __typename?: 'SetterStat';
@@ -7631,7 +7631,7 @@ export type SetterStat = {
  * Used to power the setter filter autocomplete in the search drawer.
  */
 export type SetterStatsInput = {
-  /** Board angle in degrees */
+  /** Board angle in degrees. Accepted and ignored: the setter list is the same at every angle (#5404). */
   angle: Scalars['Int']['input'];
   /** Board type (e.g., 'kilter', 'tension') */
   boardName: Scalars['String']['input'];

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -250,7 +250,7 @@ export const climbTypeDefs = /* GraphQL */ `
     sizeId: Int!
     "Comma-separated set IDs"
     setIds: String!
-    "Board angle in degrees"
+    "Board angle in degrees. Accepted and ignored: the setter list is the same at every angle (#5404)."
     angle: Int!
     "Case-insensitive substring filter on setter username (for autocomplete)"
     search: String
@@ -258,7 +258,7 @@ export const climbTypeDefs = /* GraphQL */ `
 
   """
   A setter username paired with the number of climbs they've authored
-  for a given board configuration and angle.
+  for a given board configuration. Angle-independent.
   """
   type SetterStat {
     "Setter's username"

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -7613,7 +7613,7 @@ export type SetterSearchResult = {
 
 /**
  * A setter username paired with the number of climbs they've authored
- * for a given board configuration and angle.
+ * for a given board configuration. Angle-independent.
  */
 export type SetterStat = {
   __typename?: 'SetterStat';
@@ -7628,7 +7628,7 @@ export type SetterStat = {
  * Used to power the setter filter autocomplete in the search drawer.
  */
 export type SetterStatsInput = {
-  /** Board angle in degrees */
+  /** Board angle in degrees. Accepted and ignored: the setter list is the same at every angle (#5404). */
   angle: Scalars['Int']['input'];
   /** Board type (e.g., 'kilter', 'tension') */
   boardName: Scalars['String']['input'];

--- a/packages/web/app/lib/api-docs/openapi-routes.ts
+++ b/packages/web/app/lib/api-docs/openapi-routes.ts
@@ -191,7 +191,7 @@ registry.registerPath({
   path: '/api/v1/{board_name}/{layout_id}/{size_id}/{set_ids}/{angle}/setters',
   summary: 'Get setters for a board configuration',
   description:
-    'Returns a list of climb setters for the specified board configuration, ordered by number of climbs set.',
+    'Returns a list of climb setters for the specified board configuration, ordered by number of climbs set. The result is the same at every angle.',
   tags: ['Climbs'],
   request: {
     params: z.object({
@@ -199,7 +199,7 @@ registry.registerPath({
       layout_id: z.string().describe('Layout ID'),
       size_id: z.string().describe('Size ID'),
       set_ids: z.string().describe('Comma-separated set IDs'),
-      angle: z.string().describe('Board angle in degrees'),
+      angle: z.string().describe('Board angle in degrees. Accepted and ignored: setters are not angle-scoped.'),
     }),
   },
   responses: {


### PR DESCRIPTION
## Summary

The setter filter's autocomplete INNER JOINed `board_climb_stats` at the board's current angle, so a setter only appeared if one of their climbs happened to carry a stats row at exactly that tilt. Climb-list membership has never worked that way — `countClimbs` and `runStandardSearch` both LEFT JOIN stats, so the angle decides a climb's grade and its sort position, never whether it exists. The picker and the list disagreed about what exists.

Woods made it fatal. Every Woods climb has exactly one stats row, at the angle it was set at (Aurora boards replicate stats across angles; Woods does not). On woods / layout 1 / size 1 that offered 3 of the board's 15 setters at 25°, and hid the most prolific setter of the lot — 246 climbs, none of them at 25°. Kilter carried the same defect more quietly: 28,753 of 69,285 setters survived the join at 40°.

The fix drops the join and aggregates `board_climbs` alone, on every board. Three predicates the join was providing as a side effect become explicit, mirroring `baseConditions` and `setIdsConditions` in `create-climb-filters`:

- `is_listed` / `is_draft` — load-bearing on MoonBoard rather than cosmetic. The size predicate is skipped there, so nothing else was keeping other people's drafts out of the picker. Production holds 117 MoonBoard drafts across 50 setter names.
- `required_set_ids` — `set_ids` was already a required input field, parsed into `params` and then never read.

Also adds a username tiebreaker to the count ordering. The tail is now dominated by one-climb setters, and an unordered tie at the 50-row cut made the list flicker between refetches.

**Author-side verification.** Measured on production with `EXPLAIN (ANALYZE, BUFFERS)` on the worst case (kilter / layout 1 / size 10 / 40°): 986 ms → 568 ms, 81,355 → 50,320 buffers. The new guards are free — `board_climbs_search_filter_idx` leads on `(board_type, layout_id, is_listed, is_draft)`. Running the shipped query against production returns Andy_Raether first with 246 climbs and all 15 Woods setters, with Kilter's order identical across two runs. No setter who appears today changes count: `board_climb_stats` is PK'd on `(board_type, climb_uuid, angle)`, so the join contributed at most one row per climb.

Every guard was mutation-tested. Dropping `is_listed`, `is_draft`, `required_set_ids`, or the tiebreaker each turns a named test red, as does re-adding the angle join.

Closes #5404

## Release Notes

- Every setter for your board now shows up in the setter filter, whatever angle you're on

## Test plan

1. Open Climbs on a Woods board at 25°.
2. Open filters, tap Setters. Andy_Raether is listed.
3. Tap him, then apply. His climbs fill the list.
4. Change the board angle. The setter list is unchanged.
5. Repeat on Kilter: setters still listed, counts sensible.

## Risk

Risk: 2/5 — one read-only query, no schema change, backend-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpAKLboqet8jSD1aQNwjsb
