### PR TITLE
fix(mobile): keep swipes on the list the climber is browsing

### DIFF
--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -31,6 +31,7 @@ import { randomUUID } from 'expo-crypto';
 import {
   computeNavigationStateWithSuggestions,
   findUpcomingQueueItemsWithSuggestions,
+  resolveNavigationSuggestionSource,
   boardSupportsMirroring,
 } from '@boardsesh/play-view';
 import { climbToQueueItem, resolveCommittableQueueItem } from '../../lib/climb-to-queue-item';
@@ -324,7 +325,6 @@ export function PlayDrawer({
     null,
   );
   // Only crew-captured tracks expire with the latch; explicit previews stay private.
-  const crewCapturedSuggestionSourceRef = useRef(false);
   // True when the preview is the live wall climb (accessory bar) — the displayed
   // climb IS the one physically lit, which is what the "On the wall" pill states.
   const [drawerPreviewIsWallClimb, setDrawerPreviewIsWallClimb] = useState(false);
@@ -619,7 +619,23 @@ export function PlayDrawer({
     wallHeldLocally,
   } = useLightbulbControl({ onRelayToHolder: handleRelayToHolder, canRelay: canRelayToHolder });
   const lightbulbLabelKind = getBleLightbulbLabelKind(lightbulbPressAction, lightbulbHolderIsAuthoritative);
-  const navigationSuggestionSource = drawerPreviewSuggestionSource ?? playlistSuggestionSource;
+  // A suggestion source belongs to one lineage (issue #5403). The provider's
+  // source describes the COMMITTED climb's track; a pinned preview navigates the
+  // track it was opened with, or no track at all. It used to fall back to the
+  // provider's here, so a list tap that opened as a source-less preview inherited
+  // whatever list was activated before it and swiped through climbs the climber
+  // had filtered out. The committed half also drops a track that no longer holds
+  // the current climb.
+  const navigationSuggestionSource = useMemo(
+    () =>
+      resolveNavigationSuggestionSource({
+        previewItem: drawerPreviewItem,
+        previewSource: drawerPreviewSuggestionSource,
+        committedItem: currentClimbQueueItem,
+        committedSource: playlistSuggestionSource,
+      }),
+    [drawerPreviewItem, drawerPreviewSuggestionSource, currentClimbQueueItem, playlistSuggestionSource],
+  );
   // Forward navigation skips queued climbs the wall can't draw (issue #5099), so
   // canNext, the header peek and "N left" agree with where a swipe actually lands.
   //
@@ -810,10 +826,6 @@ export function PlayDrawer({
     if (isSharedSession) return;
     const timer = setTimeout(() => {
       setSharedBrowseLatched(false);
-      if (crewCapturedSuggestionSourceRef.current) {
-        setDrawerPreviewSuggestionSource(null);
-        crewCapturedSuggestionSourceRef.current = false;
-      }
     }, SHARED_BROWSE_LATCH_RELEASE_MS);
     return () => clearTimeout(timer);
   }, [isSharedSession]);
@@ -1030,7 +1042,6 @@ export function PlayDrawer({
     setSharedBrowseLatched(false);
     setDrawerPreviewItem(null);
     setDrawerPreviewSuggestionSource(null);
-    crewCapturedSuggestionSourceRef.current = false;
     setDrawerPreviewIsWallClimb(false);
     // Mirroring is drawer-local per displayed climb: every other navigation
     // resets it, and carrying a preview's mirror onto the committed head would
@@ -1085,7 +1096,6 @@ export function PlayDrawer({
     if (browseByDefaultRef.current) return;
     setDrawerPreviewItem(null);
     setDrawerPreviewSuggestionSource(null);
-    crewCapturedSuggestionSourceRef.current = false;
   }, [activeAngle]);
 
   // Re-anchor the pinned preview at the live angle. Only fetches while the
@@ -1181,7 +1191,6 @@ export function PlayDrawer({
       const pinnedItem = previewItem ?? (opensAsBrowse ? climbToQueueItem(selectedClimb) : null);
       setDrawerPreviewItem(pinnedItem);
       setDrawerPreviewSuggestionSource(pinnedItem ? playlistSuggestionSource : null);
-      crewCapturedSuggestionSourceRef.current = false;
       setDrawerPreviewIsWallClimb(pinnedItem ? (options?.previewIsWallClimb ?? false) : false);
       // Opening a COMMITTED climb is the third latch exit: the queue-sheet tap,
       // a playlist activation and the accessory-of-current open all deliberately
@@ -1227,11 +1236,6 @@ export function PlayDrawer({
     if (previewTarget.viewOnly) {
       if (!previewTarget.targetItem) return;
       setDrawerPreviewItem(previewTarget.targetItem);
-      // Keep this browse track if a peer moves the shared queue off the list.
-      if (browseByDefault && !drawerPreviewSuggestionSource && navigationSuggestionSource) {
-        setDrawerPreviewSuggestionSource(navigationSuggestionSource);
-        crewCapturedSuggestionSourceRef.current = true;
-      }
       // Swiping off the lit climb makes "this is the wall climb" false — the
       // flag means displayed-equals-wall, and the wall didn't move.
       setDrawerPreviewIsWallClimb(false);
@@ -1249,7 +1253,6 @@ export function PlayDrawer({
     drawerPreviewSuggestionSource,
     drawerPreviewItem,
     navigationState.prevItem,
-    navigationSuggestionSource,
     previousClimb,
     lightOnSwipe,
     browseByDefault,
@@ -1266,11 +1269,6 @@ export function PlayDrawer({
     if (previewTarget.viewOnly) {
       if (!previewTarget.targetItem) return;
       setDrawerPreviewItem(previewTarget.targetItem);
-      // Keep this browse track if a peer moves the shared queue off the list.
-      if (browseByDefault && !drawerPreviewSuggestionSource && navigationSuggestionSource) {
-        setDrawerPreviewSuggestionSource(navigationSuggestionSource);
-        crewCapturedSuggestionSourceRef.current = true;
-      }
       // See handlePrev: displayed-equals-wall stops being true the moment the
       // swipe lands somewhere else.
       setDrawerPreviewIsWallClimb(false);
@@ -1288,7 +1286,6 @@ export function PlayDrawer({
     drawerPreviewSuggestionSource,
     drawerPreviewItem,
     navigationState.nextItem,
-    navigationSuggestionSource,
     nextClimb,
     lightOnSwipe,
     browseByDefault,
@@ -1342,13 +1339,16 @@ export function PlayDrawer({
     // walk from A to Z the source still says the pass began at A — and committing
     // that verbatim would aim next/previous and the remaining count at A's
     // neighbours, several swipes behind where the climber is standing.
+    //
+    // No guard here for a climb the source does not contain. `drawerPreviewItem`
+    // is by construction on this preview's own track, and the lineage rule lives
+    // in `resolveNavigationSuggestionSource` — don't re-add a call-site check.
     setCurrentClimb(item, {
       playlistSuggestionSource: reanchorPlaylistSuggestionSource(drawerPreviewSuggestionSource, item.climb?.uuid),
     });
     setSharedBrowseLatched(false);
     setDrawerPreviewItem(null);
     setDrawerPreviewSuggestionSource(null);
-    crewCapturedSuggestionSourceRef.current = false;
     setDrawerPreviewIsWallClimb(false);
     // Mirroring is drawer-local per displayed climb and every other navigation
     // resets it (see `handleBackToLive`). The commit has to as well: the
@@ -1588,7 +1588,6 @@ export function PlayDrawer({
       if (getSimilarClimbTapMode(viewer, { inSharedSession: browseByDefault }) === 'preview') {
         setDrawerPreviewItem(queueItem);
         setDrawerPreviewSuggestionSource(null);
-        crewCapturedSuggestionSourceRef.current = false;
         // A different climb is on screen now, so it is not the lit one.
         setDrawerPreviewIsWallClimb(false);
         clearMirror();
@@ -1604,7 +1603,6 @@ export function PlayDrawer({
       // clear any preview that was showing.
       setDrawerPreviewItem(null);
       setDrawerPreviewSuggestionSource(null);
-      crewCapturedSuggestionSourceRef.current = false;
       clearMirror();
       // The favorite override is cleared by the climb-change effect.
       setIsTickBarActive(false);

--- a/packages/mobile/src/components/play-drawer/QueueList.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueList.tsx
@@ -4,7 +4,12 @@ import { BottomSheetFlatList } from '@expo/ui/community/bottom-sheet';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import type { Climb, ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
-import { getPlaylistSuggestedClimbs, createPlaylistSuggestionSource, getQueueBoardKey } from '@boardsesh/queue';
+import {
+  getPlaylistSuggestedClimbs,
+  createPlaylistSuggestionSource,
+  getQueueBoardKey,
+  reanchorPlaylistSuggestionSource,
+} from '@boardsesh/queue';
 import { buildQueueListModel, type QueueFlatRow } from '@boardsesh/play-view';
 import { withSheetBottomInset } from '../sheet-content-inset';
 import { QueueItemRow, type QueueItemRowBoard, POSITION_SLOT_WIDTH, SEPARATOR_INSET } from '../QueueItemRow';
@@ -135,25 +140,35 @@ function QueueListComponent({
     [playlistSuggestionSource, queue],
   );
 
-  // Same hook — and therefore the same cached page — the queue provider re-anchors
-  // `next` onto after a board switch, so the sheet and the swipe never disagree
-  // about what comes next on this board.
+  // Page 0 of the board's popular-by-ascents list, unfiltered on purpose: these
+  // rows are how a climber finds something outside the filters they are browsing
+  // with, and filtering them would leave a narrow filter with an empty area. The
+  // queue provider no longer reads this feed at all — a swipe stops at the end of
+  // the climber's own list rather than walking into it (issue #5403).
   const { climbs: boardContinuationClimbs } = useBoardContinuationFeed(board, active);
 
-  const suggestions = useMemo<Climb[]>(() => {
+  // The ROWS may mix provenances; a swipe TRACK may not (issue #5403). The rows
+  // are a labelled discovery surface — topping a short playlist up with the
+  // board's own feed is the point of them — but a tap used to mint one track
+  // spanning both, so swiping off a filtered playlist walked silently into
+  // climbs the climber had filtered out. Keep the two segments separable, and
+  // let `handleSuggestionPress` pick the one the tapped climb came from.
+  const { suggestions, feedSuggestions } = useMemo(() => {
     const queued = new Set(queue.map((item) => item.climb?.uuid).filter((uuid): uuid is string => !!uuid));
     const seen = new Set<string>();
-    const out: Climb[] = [];
-    const add = (climbs: readonly Climb[]) => {
+    const merged: Climb[] = [];
+    const fromFeed: Climb[] = [];
+    const add = (climbs: readonly Climb[], isFeed: boolean) => {
       for (const climb of climbs) {
         if (!climb?.uuid || queued.has(climb.uuid) || seen.has(climb.uuid)) continue;
         seen.add(climb.uuid);
-        out.push(climb);
+        merged.push(climb);
+        if (isFeed) fromFeed.push(climb);
       }
     };
-    add(playlistSuggestions);
-    add(boardContinuationClimbs);
-    return out;
+    add(playlistSuggestions, false);
+    add(boardContinuationClimbs, true);
+    return { suggestions: merged, feedSuggestions: fromFeed };
   }, [playlistSuggestions, boardContinuationClimbs, queue]);
 
   const rows = useMemo<QueueListRow[]>(
@@ -225,24 +240,34 @@ function QueueListComponent({
   const handleSuggestionPress = useCallback(
     (climb: Climb) => {
       hapticSelection();
-      // Build a suggestion source anchored at the tapped climb from the CURRENT
-      // suggestions list, so the play drawer can keep swiping forward through the
-      // rest of the suggestions (mirrors how the climbs-list browse activation
-      // seeds a source from its loaded climbs).
-      const source = createPlaylistSuggestionSource({
-        playlistUuid: QUEUE_SUGGESTION_SOURCE_ID,
-        activatedClimb: climb,
-        climbs: suggestions,
-        boardKey: getQueueBoardKey({
-          board_name: board.boardName,
-          layout_id: board.layoutId,
-          size_id: board.sizeId,
-          set_ids: board.setIds,
+      // One provenance per track (issue #5403). A tap on a row from the climber's
+      // own playlist re-enters THAT track, re-anchored on the tapped climb, and
+      // nothing from the board feed joins it. A tap on a feed row gets a track of
+      // feed climbs only. The rows may interleave the two; the track never does.
+      const fromFeed = feedSuggestions.some(({ uuid }) => uuid === climb.uuid);
+      if (!fromFeed) {
+        // A playlist row only exists while a playlist source does, so this cannot
+        // come back null in practice; the guard keeps the tap from being dropped.
+        const reanchored = reanchorPlaylistSuggestionSource(playlistSuggestionSource, climb.uuid);
+        if (reanchored) onSuggestionPress(climb, reanchored);
+        return;
+      }
+      onSuggestionPress(
+        climb,
+        createPlaylistSuggestionSource({
+          playlistUuid: QUEUE_SUGGESTION_SOURCE_ID,
+          activatedClimb: climb,
+          climbs: feedSuggestions,
+          boardKey: getQueueBoardKey({
+            board_name: board.boardName,
+            layout_id: board.layoutId,
+            size_id: board.sizeId,
+            set_ids: board.setIds,
+          }),
         }),
-      });
-      onSuggestionPress(climb, source);
+      );
     },
-    [onSuggestionPress, suggestions, board],
+    [onSuggestionPress, feedSuggestions, playlistSuggestionSource, board],
   );
 
   const renderRow = useCallback(

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-anonymous.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-anonymous.test.tsx
@@ -85,6 +85,10 @@ const session = vi.hoisted(() => ({
   // The committed queue head. Null in the preview-only cases (the drawer renders
   // the pinned preview); set where a case needs a live climb to fall back to.
   currentItem: null as { uuid: string; climb: unknown } | null,
+  // The real queue, read by `computeNavigationStateWithSuggestions` when
+  // `useRealNavigation` is on. Empty by default: most cases here drive
+  // navigation through the canned `nextItem` above instead.
+  queue: [] as { uuid: string; climb: unknown }[],
 }));
 // What board presence says is physically lit. Mutated between renders so a case
 // can move the wall UNDER a browsing climber — which is the whole premise of the
@@ -155,6 +159,9 @@ vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ t
 vi.mock('@boardsesh/play-view', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@boardsesh/play-view')>();
   return {
+    // Real: the #5403 lineage rule (preview vs. committed track) is exactly
+    // what the source-less-preview cases in this file exercise.
+    resolveNavigationSuggestionSource: actual.resolveNavigationSuggestionSource,
     // The prefetch walk: these suites assert on the displayed board, not on
     // what is warmed ahead, so nothing is ahead.
     findUpcomingQueueItemsWithSuggestions: () => [],
@@ -249,7 +256,7 @@ vi.mock('../../Icon', () => ({ Icon: () => null }));
 
 // --- Hooks / providers -------------------------------------------------------
 vi.mock('../../../providers/queue-provider', () => ({
-  useQueueData: () => ({ queue: [], currentClimbQueueItem: session.currentItem }),
+  useQueueData: () => ({ queue: session.queue, currentClimbQueueItem: session.currentItem }),
   useQueueActions: () => queueActions,
   useQueueSessionId: () => ({ sessionId: session.sessionId }),
   useIsSharedSession: () => session.isShared,
@@ -394,6 +401,7 @@ beforeEach(() => {
   session.sessionId = null;
   session.nextItem = null;
   session.currentItem = null;
+  session.queue = [];
   wall.uuid = null;
   lightbulb.lit = false;
   wall.name = null;
@@ -442,8 +450,18 @@ describe('PlayDrawer — the shared-session browse latch', () => {
     expect(lastDisplayedClimbUuid()).toBe(SIMILAR_CLIMB.uuid);
   });
 
+  // Before #5403's fix, a browse that walked onto a suggestion-track peek
+  // CAPTURED that track into `drawerPreviewSuggestionSource` on the first swipe
+  // (`crewCapturedSuggestionSourceRef`), so it kept going even after the
+  // provider's own committed track was cleared out from under it — a private
+  // copy of a list the climber's browse had no independent claim to. That
+  // capture is gone: a preview belongs to ONE lineage (the track it was opened
+  // with, or none), so once the committed track disappears there is nothing
+  // left to walk. A mid-browse peek is never in the real queue either (it is
+  // only inserted on commit), so the queue has no fallback successor for it —
+  // the swipe is a dead end, not a landing on `thirdClimb`.
   it.each(['next', 'previous'] as const)(
-    'keeps the playlist after browsing %s and a peer leaves its track',
+    'stops at a dead end instead of continuing on a captured copy after a peer leaves the track',
     (direction) => {
       CREW();
       session.useRealNavigation = true;
@@ -471,7 +489,7 @@ describe('PlayDrawer — the shared-session browse latch', () => {
       view.rerender(drawerElement('member', target));
       act(swipe);
 
-      expect(lastDisplayedClimbUuid()).toBe(thirdClimb.uuid);
+      expect(lastDisplayedClimbUuid()).toBe(SIMILAR_CLIMB.uuid);
       expect(queueActions.nextClimb).not.toHaveBeenCalled();
       expect(queueActions.previousClimb).not.toHaveBeenCalled();
       expect(queueActions.setCurrentClimb).not.toHaveBeenCalled();
@@ -866,6 +884,90 @@ describe('PlayDrawer — the shared-session browse latch', () => {
       (lastActionBarProps().onCommit as () => void)();
     });
     expect(queueActions.setCurrentClimb).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Issue #5403: a preview that carries no suggestion source of its own must
+// navigate the QUEUE, never a track left behind by an earlier, unrelated
+// activation. `resolveNavigationSuggestionSource` (@boardsesh/play-view) is
+// pinned pure elsewhere; what only a render can see is that PlayDrawer actually
+// calls it instead of falling back to the provider's committed source, and that
+// nothing captures that committed source into the preview later either.
+describe('PlayDrawer — source-less preview walks the queue (#5403)', () => {
+  // A climb list carrying no board metadata classifies as 'unknown' rather than
+  // 'incompatible', so the mismatched `activeBoard` default in this file (tension)
+  // never interferes with the queue walk under test.
+  const climb = (uuid: string, name: string): Climb => ({ ...CLIMB, uuid, name }) as unknown as Climb;
+
+  it('walks the queue instead of a leftover track when a source-less preview swipes', () => {
+    // Forces the swipe to stay view-only even solo, so the drawer's own
+    // navigation resolves the target rather than a mocked `nextClimb()`.
+    setSetting('lightOnSwipe', false);
+    session.useRealNavigation = true;
+    const a = climb('climb-a', 'A');
+    const p = climb('climb-p', 'P');
+    const z = climb('climb-z', 'Z');
+    const q = climb('climb-q', 'Q');
+    // The provider is still tracking an EARLIER activation's list — [A, P, Z] —
+    // which a source-less preview must never inherit.
+    session.suggestionSource = {
+      playlistUuid: 'climblist',
+      activatedClimbUuid: a.uuid,
+      boardKey: 'kilter:1:10:1,20',
+      climbs: [a, p, z],
+    } as unknown as PlaylistSuggestionSource;
+    const itemA = { uuid: 'queue-a', climb: a };
+    const itemP = { uuid: 'queue-p', climb: p };
+    const itemQ = { uuid: 'queue-q', climb: q };
+    session.currentItem = itemA;
+    session.queue = [itemA, itemP, itemQ];
+
+    // A list tap that pins P as a preview with no suggestion source of its own.
+    render(drawerElement('member', { climb: p, options: { previewQueueItem: itemP }, nonce: 1 }));
+
+    act(() => {
+      (lastActionBarProps().onNextClick as () => void)();
+    });
+
+    expect(lastDisplayedClimbUuid()).toBe(q.uuid);
+  });
+
+  it('does not capture a leftover track on the second swipe of a source-less browse', () => {
+    session.isShared = true;
+    session.sessionId = 'session-1';
+    session.useRealNavigation = true;
+    const a = climb('climb-a', 'A');
+    const p = climb('climb-p', 'P');
+    const z = climb('climb-z', 'Z');
+    const q = climb('climb-q', 'Q');
+    const r = climb('climb-r', 'R');
+    session.suggestionSource = {
+      playlistUuid: 'climblist',
+      activatedClimbUuid: a.uuid,
+      boardKey: 'kilter:1:10:1,20',
+      climbs: [a, p, z],
+    } as unknown as PlaylistSuggestionSource;
+    const itemA = { uuid: 'queue-a', climb: a };
+    const itemP = { uuid: 'queue-p', climb: p };
+    const itemQ = { uuid: 'queue-q', climb: q };
+    const itemR = { uuid: 'queue-r', climb: r };
+    session.currentItem = itemA;
+    session.queue = [itemA, itemP, itemQ, itemR];
+
+    render(drawerElement('member', { climb: p, options: { previewQueueItem: itemP }, nonce: 1 }));
+
+    act(() => {
+      (lastActionBarProps().onNextClick as () => void)();
+    });
+    expect(lastDisplayedClimbUuid()).toBe(q.uuid);
+
+    // If the old bug's capture still fired, this second swipe would have picked
+    // up [A, P, Z] on the first swipe and landed on Z here instead of the queue's
+    // real successor.
+    act(() => {
+      (lastActionBarProps().onNextClick as () => void)();
+    });
+    expect(lastDisplayedClimbUuid()).toBe(r.uuid);
   });
 });
 

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
@@ -116,7 +116,12 @@ vi.mock('../../../lib/graphql/use-active-board', () => ({
 // Navigation is driven per-case so a peek can be aimed at another board.
 // `@boardsesh/board-config` and `lib/board-details` stay REAL: the resolver
 // reads real layouts, sizes and hold placements, which is the whole question.
-vi.mock('@boardsesh/play-view', () => ({
+vi.mock('@boardsesh/play-view', async (importOriginal) => ({
+  // Real: PlayDrawer calls this to resolve the navigation source (#5403); every
+  // case here drives navigation through the canned `navigation.state` above, so
+  // it only ever sees a null preview item and returns the (irrelevant) source.
+  resolveNavigationSuggestionSource: (await importOriginal<typeof import('@boardsesh/play-view')>())
+    .resolveNavigationSuggestionSource,
   findUpcomingQueueItemsWithSuggestions: () => prefetchWalk.items,
   computeNavigationStateWithSuggestions: () => navigation.state,
   boardSupportsMirroring: () => true,

--- a/packages/mobile/src/components/play-drawer/__tests__/queue-list-suggestions.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/queue-list-suggestions.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Climb, ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
+
+// Issue #5403: the queue sheet's suggestion rows mix two provenances — a short
+// playlist topped up with the board's own popular-by-ascents feed — and that mix
+// is fine for DISPLAY. It stopped being fine for NAVIGATION: a tap used to mint
+// one track spanning both segments, so swiping off a filtered playlist walked
+// silently into feed climbs the climber had filtered out. `handleSuggestionPress`
+// now picks the track from whichever segment the tapped climb actually came
+// from. This file renders the real QueueList and taps real rows, so a future
+// change that quietly re-merges the two segments at the call site (rather than
+// only in the row list) fails here even though the pure track-building helpers
+// stay green.
+
+type ViewProps = { children?: ReactNode; testID?: string; style?: unknown };
+
+// Mutable per-test: the board-scoped feed `useBoardContinuationFeed` hands back.
+const feedFixture = vi.hoisted(() => ({ climbs: [] as Climb[] }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: ViewProps) => createElement('div', null, children),
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: ViewProps & { onPress?: () => void; accessibilityLabel?: string }) =>
+    createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
+  Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('@expo/ui/community/bottom-sheet', () => ({
+  BottomSheetFlatList: ({
+    data,
+    renderItem,
+    keyExtractor,
+  }: {
+    data: unknown[];
+    renderItem: (info: { item: unknown; index: number }) => ReactNode;
+    keyExtractor: (item: unknown, index: number) => string;
+  }) =>
+    createElement(
+      'div',
+      null,
+      data.map((item, index) => createElement('div', { key: keyExtractor(item, index) }, renderItem({ item, index }))),
+    ),
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { separator: '#ccc', secondaryBackground: '#fff' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+
+vi.mock('../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 10: 40, 16: 64 },
+}));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#888' } }));
+vi.mock('../../sheet-content-inset', () => ({ withSheetBottomInset: (style: unknown) => style }));
+vi.mock('../use-queue-drag', () => ({
+  useQueueDrag: () => ({
+    isDragging: false,
+    controls: { shared: {}, onRowHeight: vi.fn(), makeHandleGesture: vi.fn() },
+  }),
+}));
+vi.mock('../../Text', () => ({ Text: ({ children }: ViewProps) => createElement('span', null, children) }));
+vi.mock('../../ClimbListItemContent', () => ({ ClimbListItemContent: () => createElement('span', null) }));
+vi.mock('../../QueueItemRow', () => ({
+  POSITION_SLOT_WIDTH: 28,
+  SEPARATOR_INSET: 200,
+  QueueItemRow: () => createElement('div'),
+}));
+
+// The board-scoped popular feed. Mocked directly (rather than the underlying
+// `useSearchClimbs`) so each case controls exactly which climbs come back as
+// FEED-provenance without touching GraphQL plumbing.
+vi.mock('../../../providers/queue/use-board-continuation-feed', () => ({
+  useBoardContinuationFeed: () => ({ climbs: feedFixture.climbs, isSettled: true }),
+}));
+
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueueSessionId: () => ({ sessionId: null }),
+}));
+vi.mock('../../../providers/party-profile-provider', () => ({
+  usePartyProfile: () => ({ profile: null, isLoading: false }),
+}));
+
+import { QueueList } from '../QueueList';
+
+const board = { boardName: 'kilter' as const, layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 };
+
+function climb(uuid: string): Climb {
+  return { uuid, name: `Climb ${uuid}` } as Climb;
+}
+
+function renderList(
+  playlistSuggestionSource: PlaylistSuggestionSource | null,
+  onSuggestionPress: (climb: Climb, source: PlaylistSuggestionSource) => void,
+) {
+  return render(
+    createElement(QueueList, {
+      queue: [] as ClimbQueueItem[],
+      currentItemUuid: null,
+      board,
+      isEditMode: false,
+      showHistory: true,
+      showFullHistory: true,
+      selectedItems: new Set<string>(),
+      playlistSuggestionSource,
+      active: true,
+      onToggleSelect: vi.fn(),
+      onClimbPress: vi.fn(),
+      onRemove: vi.fn(),
+      onShowFullHistory: vi.fn(),
+      onTickHistory: vi.fn(),
+      onSuggestionPress,
+      reorderQueue: vi.fn(),
+    }),
+  );
+}
+
+describe('QueueList suggestion row provenance (#5403)', () => {
+  beforeEach(() => {
+    feedFixture.climbs = [];
+  });
+
+  it('re-anchors the playlist track on a playlist-derived row, with no feed climb along for the ride', () => {
+    const activatedClimb = climb('activated');
+    const playlistFollow = climb('playlist-follow');
+    const source: PlaylistSuggestionSource = {
+      playlistUuid: 'climblist',
+      activatedClimbUuid: activatedClimb.uuid,
+      boardKey: 'kilter:1:10:1,2',
+      climbs: [activatedClimb, playlistFollow],
+    };
+    const feedClimb = climb('feed-only');
+    feedFixture.climbs = [feedClimb];
+    const onSuggestionPress = vi.fn<(climb: Climb, source: PlaylistSuggestionSource) => void>();
+
+    const { getByLabelText } = renderList(source, onSuggestionPress);
+    fireEvent.click(getByLabelText(playlistFollow.name));
+
+    expect(onSuggestionPress).toHaveBeenCalledTimes(1);
+    const [pressedClimb, resultSource] = onSuggestionPress.mock.calls[0] as [Climb, PlaylistSuggestionSource];
+    expect(pressedClimb.uuid).toBe(playlistFollow.uuid);
+    const resultUuids = resultSource.climbs.map((c) => c.uuid);
+    expect(resultUuids).toContain(playlistFollow.uuid);
+    expect(resultUuids).not.toContain(feedClimb.uuid);
+    // Re-anchored, not a fresh source: the playlist's own identity survives.
+    expect(resultSource.playlistUuid).toBe('climblist');
+    expect(resultSource.activatedClimbUuid).toBe(playlistFollow.uuid);
+  });
+
+  it('mints a feed-only track on a feed-derived row, with no playlist climb along for the ride', () => {
+    const activatedClimb = climb('activated');
+    const playlistFollow = climb('playlist-follow');
+    const source: PlaylistSuggestionSource = {
+      playlistUuid: 'climblist',
+      activatedClimbUuid: activatedClimb.uuid,
+      boardKey: 'kilter:1:10:1,2',
+      climbs: [activatedClimb, playlistFollow],
+    };
+    const feedClimbA = climb('feed-a');
+    const feedClimbB = climb('feed-b');
+    feedFixture.climbs = [feedClimbA, feedClimbB];
+    const onSuggestionPress = vi.fn<(climb: Climb, source: PlaylistSuggestionSource) => void>();
+
+    const { getByLabelText } = renderList(source, onSuggestionPress);
+    fireEvent.click(getByLabelText(feedClimbA.name));
+
+    expect(onSuggestionPress).toHaveBeenCalledTimes(1);
+    const [pressedClimb, resultSource] = onSuggestionPress.mock.calls[0] as [Climb, PlaylistSuggestionSource];
+    expect(pressedClimb.uuid).toBe(feedClimbA.uuid);
+    const resultUuids = resultSource.climbs.map((c) => c.uuid);
+    expect(resultUuids).toEqual(expect.arrayContaining([feedClimbA.uuid, feedClimbB.uuid]));
+    expect(resultUuids).not.toContain(playlistFollow.uuid);
+    expect(resultUuids).not.toContain(activatedClimb.uuid);
+    expect(resultSource.playlistUuid).not.toBe('climblist');
+  });
+});

--- a/packages/mobile/src/lib/__tests__/queue-snapshot-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/queue-snapshot-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
+import { BOARD_FEED_SUGGESTION_SOURCE_ID } from '../playlists/board-feed-suggestion-source';
 
 vi.mock('@react-native-async-storage/async-storage', () => {
   let storage: Record<string, string> = {};
@@ -117,5 +118,33 @@ describe('queue-snapshot-store', () => {
     await setStoredQueueSnapshot({ queue: [], currentClimbQueueItem: null, playlistSuggestionSource: source });
     const stored = await getStoredQueueSnapshot();
     expect(stored?.playlistSuggestionSource?.climbs).toHaveLength(10);
+  });
+
+  // Issue #5403: up to 2.5.0 a board switch replaced the climber's own list with
+  // the board's unfiltered popular-by-ascents feed, and THAT replacement is what
+  // got persisted. Restoring one after the upgrade would reinstall the swipe bug
+  // for exactly the people who hit it, so the read path drops it — the queue
+  // itself is untouched, only the stale track.
+  it('drops a persisted board-feed source on read, keeping the queue and current item', async () => {
+    const { getStoredQueueSnapshot, setStoredQueueSnapshot } = await import('../queue-snapshot-store');
+    const queue = [makeQueueItem('a'), makeQueueItem('b')];
+    const source = { ...makeSuggestionSource(3, 1), playlistUuid: BOARD_FEED_SUGGESTION_SOURCE_ID };
+    await setStoredQueueSnapshot({ queue, currentClimbQueueItem: queue[0], playlistSuggestionSource: source });
+
+    const stored = await getStoredQueueSnapshot();
+    expect(stored?.playlistSuggestionSource).toBeNull();
+    expect(stored?.queue).toEqual(queue);
+    expect(stored?.currentClimbQueueItem).toEqual(queue[0]);
+  });
+
+  it('leaves a persisted climblist source untouched on read', async () => {
+    const { getStoredQueueSnapshot, setStoredQueueSnapshot } = await import('../queue-snapshot-store');
+    const queue = [makeQueueItem('a')];
+    const source = { ...makeSuggestionSource(3, 1), playlistUuid: 'climblist' };
+    await setStoredQueueSnapshot({ queue, currentClimbQueueItem: queue[0], playlistSuggestionSource: source });
+
+    const stored = await getStoredQueueSnapshot();
+    expect(stored?.playlistSuggestionSource).toEqual(source);
+    expect(stored?.queue).toEqual(queue);
   });
 });

--- a/packages/mobile/src/lib/queue-snapshot-store.ts
+++ b/packages/mobile/src/lib/queue-snapshot-store.ts
@@ -14,6 +14,7 @@
 // when the shape changes so stale values are ignored rather than misread.
 
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
+import { BOARD_FEED_SUGGESTION_SOURCE_ID } from './playlists/board-feed-suggestion-source';
 import { getPreference, setPreference, removePreference } from './preference-store';
 import type { UserStorageOwner } from './user-storage-owner';
 
@@ -43,8 +44,28 @@ function capSuggestionSource(source: PlaylistSuggestionSource | null): PlaylistS
   return { ...source, climbs: source.climbs.slice(windowStart, windowStart + MAX_PERSISTED_SUGGESTION_CLIMBS) };
 }
 
-export function getStoredQueueSnapshot(_owner?: UserStorageOwner | null): Promise<LocalQueueSnapshot | null> {
-  return getPreference<LocalQueueSnapshot>(QUEUE_SNAPSHOT_KEY);
+/**
+ * Drop a persisted board-feed track on the way in.
+ *
+ * Up to 2.5.0 a board switch replaced the climber's own list with the board's
+ * unfiltered popular-by-ascents feed, and that replacement was persisted. It is
+ * exactly the track that served climbs the climber had filtered out (issue
+ * #5403), so restoring one after the upgrade would reinstall the bug for the
+ * people who hit it. The queue itself is untouched — this is one bad field, not
+ * a reason to bump `QUEUE_SNAPSHOT_KEY` and throw away everyone's solo queue.
+ *
+ * Board-feed sources the fixed build writes are harmless (they carry the
+ * climber's own masked list), so dropping them costs a restored climber their
+ * swipe track once, not their queue.
+ */
+function dropBoardFeedSource(snapshot: LocalQueueSnapshot | null): LocalQueueSnapshot | null {
+  if (!snapshot?.playlistSuggestionSource) return snapshot;
+  if (snapshot.playlistSuggestionSource.playlistUuid !== BOARD_FEED_SUGGESTION_SOURCE_ID) return snapshot;
+  return { ...snapshot, playlistSuggestionSource: null };
+}
+
+export async function getStoredQueueSnapshot(_owner?: UserStorageOwner | null): Promise<LocalQueueSnapshot | null> {
+  return dropBoardFeedSource(await getPreference<LocalQueueSnapshot>(QUEUE_SNAPSHOT_KEY));
 }
 
 export function setStoredQueueSnapshot(

--- a/packages/mobile/src/providers/__tests__/queue-provider-board-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-board-switch.test.tsx
@@ -322,11 +322,8 @@ describe('QueueProvider board switch (#5099)', () => {
     await waitFor(() => expect(latest().playlistSuggestionSource).toBeNull());
   });
 
-  it('restores the browsed list when the climber switches back before the feed lands', async () => {
+  it('restores the browsed list when the climber switches back', async () => {
     await activateKilterBrowse();
-    // Feed deliberately empty: this is the window BEFORE the re-anchor replaces
-    // the source, which is the only window in which masking restores anything.
-    continuationFeed.climbs = [];
 
     act(() => activeBoardStore.set(boards.tension));
     await waitFor(() => expect(latest().playlistSuggestionSource).toBeNull());
@@ -336,19 +333,24 @@ describe('QueueProvider board switch (#5099)', () => {
     expect(latest().playlistSuggestionSource?.boardKey).toBe(KILTER_BOARD_KEY);
   });
 
-  it('comes back to the board feed, not the browsed list, once the re-anchor has run', async () => {
-    // The honest limitation of one source slot: the re-anchor REPLACES the
-    // climblist source, so a round trip that waits for the feed lands on the
-    // board's popular list. Asserted so the trade-off can't drift unnoticed.
+  it('keeps coming back to the browsed list on every round trip — masking never replaces it', async () => {
+    // Issue #5403: masking used to be a one-shot window. Once the re-anchor
+    // engine (`useBoardContinuationFeed` + the pending-source effect) landed a
+    // board-scoped popular feed, it REPLACED the climblist source for good, so a
+    // round trip that waited for the feed came back to the board's popular list
+    // instead of what the climber was browsing. That engine is gone: masking is
+    // now the whole of it, so the original source survives no matter how long the
+    // climber lingers on the other board before switching back.
     await activateKilterBrowse();
-    continuationFeed.climbs = [makeClimb('feed-1', 'tension', 8), makeClimb('feed-2', 'tension', 8)];
 
     act(() => activeBoardStore.set(boards.tension));
-    await waitFor(() => expect(latest().playlistSuggestionSource?.boardKey).toBe(TENSION_BOARD_KEY));
+    await waitFor(() => expect(latest().playlistSuggestionSource).toBeNull());
+    // Give any stray effect a chance to run before switching back.
+    await act(async () => {});
 
     act(() => activeBoardStore.set(boards.kilter));
-    await waitFor(() => expect(latest().playlistSuggestionSource?.boardKey).toBe(KILTER_BOARD_KEY));
-    expect(latest().playlistSuggestionSource?.playlistUuid).toBe('board-feed');
+    await waitFor(() => expect(latest().playlistSuggestionSource?.playlistUuid).toBe('climblist'));
+    expect(latest().playlistSuggestionSource?.boardKey).toBe(KILTER_BOARD_KEY);
   });
 
   it('holds the solo snapshot save until the active board query settles', async () => {
@@ -416,13 +418,20 @@ describe('QueueProvider board switch (#5099)', () => {
     await waitFor(() => expect(latest().playlistSuggestionSource).toBeNull());
   });
 
-  it('arms the continuation feed only while a held source is off-board', async () => {
+  it('never touches the board continuation feed — masking has nothing left to re-anchor onto', async () => {
+    // Issue #5403: the provider used to arm `useBoardContinuationFeed` the
+    // moment a held source went off-board, fetch the board's popular list, and
+    // replace the masked source with it. That whole engine is deleted, so the
+    // hook mocked below should never see a single call, board switch or not.
     await activateKilterBrowse();
-    expect(continuationFeed.enabledCalls.every((enabled) => enabled === false)).toBe(true);
+    expect(continuationFeed.enabledCalls).toHaveLength(0);
 
     act(() => activeBoardStore.set(boards.tension));
+    await waitFor(() => expect(latest().playlistSuggestionSource).toBeNull());
+    // Give any stray effect a chance to fire before asserting the negative.
+    await act(async () => {});
 
-    await waitFor(() => expect(continuationFeed.enabledCalls.at(-1)).toBe(true));
+    expect(continuationFeed.enabledCalls).toHaveLength(0);
   });
 
   it('does not append a foreign-board climb to the queue on the swipe after a switch', async () => {
@@ -438,24 +447,24 @@ describe('QueueProvider board switch (#5099)', () => {
     expect(latest().state.currentClimbQueueItem?.climb.uuid).toBe('kilter-current');
   });
 
-  it('re-anchors onto the new board feed so the next swipe lands on this board', async () => {
+  it('ignores an available board feed after masking — a swipe just stops at the end of the list', async () => {
+    // Issue #5403: even a feed with climbs sitting right there must not be
+    // consulted. The provider used to re-anchor onto it (`tension-1`,
+    // `tension-2` below), which fed climbers climbs they had filtered out and
+    // never asked for. Masking is now the whole of it: the source stays null and
+    // the swipe finds nothing past the one queued (kilter) climb.
     await activateKilterBrowse();
     continuationFeed.climbs = [makeClimb('tension-1', 'tension', 8), makeClimb('tension-2', 'tension', 8)];
 
     act(() => activeBoardStore.set(boards.tension));
-    await waitFor(() => expect(latest().playlistSuggestionSource?.boardKey).toBe(TENSION_BOARD_KEY));
-    // The current (kilter) climb anchors the feed, or navigation would find
-    // nothing after it and dead-end exactly as before.
-    expect(latest().playlistSuggestionSource?.climbs.map((climb) => climb.uuid)).toEqual([
-      'kilter-current',
-      'tension-1',
-      'tension-2',
-    ]);
+    await waitFor(() => expect(latest().playlistSuggestionSource).toBeNull());
+    await act(async () => {});
+    expect(latest().playlistSuggestionSource).toBeNull();
 
     act(() => latest().nextClimb());
 
-    await waitFor(() => expect(latest().state.currentClimbQueueItem?.climb.uuid).toBe('tension-1'));
-    expect(latest().state.queue.map((item) => item.climb.uuid)).toEqual(['kilter-current', 'tension-1']);
+    expect(latest().state.currentClimbQueueItem?.climb.uuid).toBe('kilter-current');
+    expect(latest().state.queue).toHaveLength(1);
   });
 
   it('yields to a real activation that landed while the feed was in flight', async () => {
@@ -527,7 +536,16 @@ describe('QueueProvider board switch (#5099)', () => {
     expect(latest().state.queue.some(({ climb }) => climb.uuid === foreign.uuid)).toBe(false);
   });
 
-  it('replaces an all-foreign restored source even when its board key matches', async () => {
+  it('masks out an all-foreign restored source even when its board key matches, with no feed to fall back to', async () => {
+    // Issue #5403: this restored source has NOTHING compatible with tension once
+    // normalized (both `current` and `foreign` are kilter climbs), so the old
+    // anchor-preserving branch handed `createBoardFeedSuggestionSource` an empty
+    // feed and then filled it from `useBoardContinuationFeed` — replacing the
+    // restored source with the board's popular list. That re-anchor engine is
+    // gone: an anchor with nothing to follow is just null
+    // (`createBoardFeedSuggestionSource` returns null for an empty feed), and
+    // `compatible` below — sitting right there in the mocked continuation feed —
+    // must stay untouched.
     activeBoardStore.set(boards.tension);
     const current = makeClimb('kilter-current', 'kilter', 1);
     const currentItem = makeItem('item-current', current);
@@ -543,9 +561,13 @@ describe('QueueProvider board switch (#5099)', () => {
       savedAt: '2026-06-10T00:00:00.000Z',
     });
     renderProvider();
-    await waitFor(() => expect(latest().playlistSuggestionSource?.playlistUuid).toBe('board-feed'));
+    await waitFor(() => expect(latest().state.currentClimbQueueItem?.uuid).toBe(currentItem.uuid));
+    expect(latest().playlistSuggestionSource).toBeNull();
     act(() => latest().nextClimb());
-    expect(latest().state.currentClimbQueueItem?.climb.uuid).toBe(compatible.uuid);
+    // No source, and nothing queued past the current item: the swipe is a
+    // dead end that changes nothing, rather than a landing on `compatible`.
+    expect(latest().state.currentClimbQueueItem?.climb.uuid).toBe(current.uuid);
+    expect(latest().state.queue).toHaveLength(1);
     expect(toast.showToast).not.toHaveBeenCalled();
   });
 
@@ -718,7 +740,16 @@ describe('QueueProvider cross-board swipe skip (#5099)', () => {
     expect(toast.showToast).toHaveBeenCalledTimes(1);
   });
 
-  it('stays quiet about a dead end while the re-anchor feed is still loading', async () => {
+  it('announces a dead end immediately on a live board switch — there is no loading window to wait through', async () => {
+    // Issue #5403: the dead-end notice used to gate on the re-anchor feed's
+    // `isSettled` flag, staying quiet until a fetch resolved (or re-anchoring
+    // before it ever had to speak). That fetch is gone — `forwardSelection` is a
+    // synchronous `useMemo` now — so the notice fires on the very commit the
+    // switch lands on, with nothing left to wait through and no feed to rescue it.
+    //
+    // This block defaults to tension; start on kilter so the queue is fully
+    // on-board at first and the switch below is the thing under test.
+    activeBoardStore.set(boards.kilter);
     const kilterClimb = makeClimb('kilter-current', 'kilter', 1);
     const storedQueue = [
       makeItem('item-kilter-current', kilterClimb),
@@ -727,32 +758,27 @@ describe('QueueProvider cross-board swipe skip (#5099)', () => {
     queueSnapshotStore.getStoredQueueSnapshot.mockResolvedValue({
       queue: storedQueue,
       currentClimbQueueItem: storedQueue[0],
-      playlistSuggestionSource: {
-        playlistUuid: 'climblist',
-        activatedClimbUuid: kilterClimb.uuid,
-        boardKey: KILTER_BOARD_KEY,
-        climbs: [kilterClimb],
-      },
+      playlistSuggestionSource: null,
       savedAt: '2026-06-10T00:00:00.000Z',
     });
-    continuationFeed.isSettled = false;
 
     render(createElement(QueueProvider, null, createElement(Probe, { onSnapshot: (s) => snapshots.push(s) })));
     await waitFor(() => expect(latest().state.queue).toHaveLength(2));
-    // Flush every queued effect without burning wall-clock time. The dead-end
-    // notice fires from an effect on commit, so this is all it needs to appear.
+    // Nothing to say yet: `item-kilter-a` is still compatible with the kilter
+    // board the climber is standing at.
+    expect(toast.showToast).not.toHaveBeenCalled();
+
+    act(() => activeBoardStore.set(boards.tension));
+
+    await waitFor(() => expect(toast.showToast).toHaveBeenCalledWith('boardConfigMismatch.queueOffBoardToast', 'info'));
+    expect(analytics.track).toHaveBeenCalledWith(
+      'Queue Climb Skipped on Board Switch',
+      expect.objectContaining({ trigger: 'queue_dead_end', skippedCount: 1, advancedToClimbUuid: null }),
+    );
+    // No continuation feed ever arrives to rescue it — the queue and the notice
+    // both stay exactly as they are.
     await act(async () => {});
-
-    // Announcing a dead end mid-fetch would be contradicted the moment the feed
-    // lands and re-anchors.
-    expect(toast.showToast).not.toHaveBeenCalled();
-
-    continuationFeed.climbs = [makeClimb('tension-feed', 'tension', 8)];
-    continuationFeed.isSettled = true;
-    act(() => activeBoardStore.set({ ...boards.tension }));
-    await waitFor(() => expect(latest().playlistSuggestionSource?.boardKey).toBe(TENSION_BOARD_KEY));
-    expect(toast.showToast).not.toHaveBeenCalled();
-    act(() => latest().nextClimb());
-    expect(latest().state.currentClimbQueueItem?.climb.uuid).toBe('tension-feed');
+    expect(toast.showToast).toHaveBeenCalledTimes(1);
+    expect(latest().playlistSuggestionSource).toBeNull();
   });
 });

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -56,6 +56,7 @@ import {
 import { getStoredActiveBoard } from '../lib/active-board-store';
 import { useActiveBoard, useSetActiveBoard } from '../lib/graphql/use-active-board';
 import {
+  anchoredSuggestionSource,
   findPreviousQueueItemWithSuggestions,
   selectNextQueueItemWithSuggestions,
   shouldDefaultToBrowse,
@@ -106,7 +107,6 @@ import {
   createBoardFeedSuggestionSource,
   normalizeBoardSuggestionSource,
 } from '../lib/playlists/board-feed-suggestion-source';
-import { useBoardContinuationFeed } from './queue/use-board-continuation-feed';
 import { useCrossBoardAddGate } from './queue/use-cross-board-add-gate';
 import { useQueueRegrade } from './queue/use-queue-regrade';
 import { useQueueResolveClimbs } from './queue/use-queue-resolve-climbs';
@@ -333,16 +333,31 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // call site rather than the one activation helper, and an unknown active board
   // fails open.
   //
-  // Masked rather than cleared, so switching straight back before the re-anchor
-  // lands returns the climber to the list they were browsing. Only until then:
-  // the re-anchor below REPLACES the stale source, so a round trip that waits
-  // for the feed comes back to the board's popular list, not the original
-  // browse. One slot, one source — holding a source per board would need state
-  // that outlives the snapshot we persist.
-  const currentClimbForSource = state.currentClimbQueueItem?.climb;
+  // Masked rather than cleared, so switching straight back returns the climber
+  // to the list they were browsing. One slot, one source — holding a source per
+  // board would need state that outlives the snapshot we persist.
+  //
+  // Masking is the whole of it. A board switch used to REPLACE the masked source
+  // with the board's popular-by-ascents feed so a swipe had somewhere to go; that
+  // fed climbers climbs they had filtered out and never asked for (issue #5403).
+  // A swipe now stops at the end of the climber's own list instead.
+  //
+  // The mask is also where the source stops steering swipes once the climber
+  // moves off its list. Plenty of paths move the current climb without going
+  // through `setCurrentClimb` — a crew member's CurrentClimbChanged, a widget
+  // Next/Previous tap, joining a session already parked on a climb — and a
+  // source that no longer holds the current climb would keep aiming next/prev at
+  // a list nobody is on. `anchoredSuggestionSource` is the same predicate the
+  // play drawer resolves with, applied here during render so it holds for every
+  // writer at once. It used to be an effect, which left one render in which a
+  // swipe walked the stale list (issue #5403). The state is left alone: return
+  // to a climb on the list and the track is live again.
+  const currentClimbItemForSource = state.currentClimbQueueItem;
+  const currentClimbForSource = currentClimbItemForSource?.climb;
   const playlistSuggestionSource = useMemo(() => {
-    if (!rawPlaylistSuggestionSource || !activeBoard || activeBoardKey == null) return rawPlaylistSuggestionSource;
-    if (rawPlaylistSuggestionSource.boardKey !== activeBoardKey) return null;
+    const anchored = anchoredSuggestionSource(rawPlaylistSuggestionSource, currentClimbItemForSource);
+    if (!anchored || !activeBoard || activeBoardKey == null) return anchored;
+    if (anchored.boardKey !== activeBoardKey) return null;
     const target = getPlaylistRenderBoardTarget({
       boardName: activeBoard.boardType,
       layoutId: activeBoard.layoutId,
@@ -350,18 +365,18 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       setIds: activeBoard.setIds,
       angle: activeBoard.angle,
     });
-    const normalized = normalizeBoardSuggestionSource(
-      rawPlaylistSuggestionSource,
-      (climb) => canAddClimbToBoard(climb, target).ok,
-    );
+    const normalized = normalizeBoardSuggestionSource(anchored, (climb) => canAddClimbToBoard(climb, target).ok);
     // Old mixed snapshots can also have a foreign current climb. Preserve its
     // position as an anchor, never as a successor, so the surviving list is reachable.
     if (
       currentClimbForSource &&
-      normalized !== rawPlaylistSuggestionSource &&
-      rawPlaylistSuggestionSource.climbs.some(({ uuid }) => uuid === currentClimbForSource.uuid) &&
+      normalized !== anchored &&
+      anchored.climbs.some(({ uuid }) => uuid === currentClimbForSource.uuid) &&
       !normalized.climbs.some(({ uuid }) => uuid === currentClimbForSource.uuid)
     ) {
+      // Despite the helper's name, the climbs here are `normalized.climbs` —
+      // the climber's OWN source masked down to this board, never a popular
+      // feed. Nothing outside their list can enter through this call.
       return createBoardFeedSuggestionSource({
         anchorClimb: currentClimbForSource,
         feedClimbs: normalized.climbs,
@@ -369,7 +384,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       });
     }
     return normalized;
-  }, [rawPlaylistSuggestionSource, activeBoard, activeBoardKey, currentClimbForSource]);
+  }, [rawPlaylistSuggestionSource, activeBoard, activeBoardKey, currentClimbItemForSource, currentClimbForSource]);
   const playlistSuggestionSourceRef = useRef<PlaylistSuggestionSource | null>(null);
   playlistSuggestionSourceRef.current = playlistSuggestionSource;
   const { showToast } = useToast();
@@ -377,57 +392,6 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   const { t } = useTranslation('session');
   // The cross-board strings live beside the BLE spill-skip notice they mirror.
   const { t: tSettings } = useTranslation('settings');
-
-  // Re-anchor, don't dead-end. Once the held source is masked out there is
-  // nothing for a forward swipe to follow, so pull the board's own popular list
-  // and rebuild the source against it. Armed ONLY while a source is held that
-  // belongs to another board — a one-shot per board switch — because the
-  // provider is mounted for the whole session and an ungated feed would keep
-  // fetching. It is the same hook, input and cache entry the queue sheet's
-  // suggestion list uses, so the swipe and the sheet can't disagree.
-  const suggestionSourceIsOffBoard = rawPlaylistSuggestionSource !== null && playlistSuggestionSource === null;
-  // Carries `angle`, while `activeBoardKey` above deliberately does not. The two
-  // answer different questions and the difference is load-bearing both ways:
-  // masking asks "is this feed for this WALL", which a tilt does not change (so
-  // tilting mid-session must not retire the feed), while the search input asks
-  // "which climbs, at which grades", which a tilt does change — grades are
-  // stored per angle. It also has to match what `QueueItemRowBoard` carries,
-  // since the queue sheet passes that same shape to this hook and the shared
-  // `['searchClimbs', input]` entry is the reason the second reader is free.
-  const activeBoardSearchConfig = useMemo(
-    () =>
-      activeBoard
-        ? {
-            boardName: activeBoard.boardType,
-            layoutId: activeBoard.layoutId,
-            sizeId: activeBoard.sizeId,
-            setIds: activeBoard.setIds,
-            angle: activeBoard.angle,
-          }
-        : null,
-    [activeBoard],
-  );
-  const { climbs: boardContinuationClimbs, isSettled: boardContinuationIsSettled } = useBoardContinuationFeed(
-    activeBoardSearchConfig,
-    suggestionSourceIsOffBoard,
-  );
-  const anchorClimbForReanchor = state.currentClimbQueueItem?.climb ?? null;
-  const pendingReanchoredSource = useMemo(() => {
-    if (!suggestionSourceIsOffBoard || activeBoardKey == null || !anchorClimbForReanchor) return null;
-    return createBoardFeedSuggestionSource({
-      anchorClimb: anchorClimbForReanchor,
-      feedClimbs: boardContinuationClimbs,
-      boardKey: activeBoardKey,
-    });
-  }, [suggestionSourceIsOffBoard, activeBoardKey, anchorClimbForReanchor, boardContinuationClimbs]);
-  useEffect(() => {
-    if (!pendingReanchoredSource) return;
-    // Replace only the exact rejected source. A matching key may still contain
-    // no usable climbs, while a newer activation or explicit clear must win.
-    setPlaylistSuggestionSourceState((current) =>
-      current === rawPlaylistSuggestionSource ? pendingReanchoredSource : current,
-    );
-  }, [pendingReanchoredSource, rawPlaylistSuggestionSource]);
 
   // The signed-in user's display name + avatar (undefined while signed out or
   // still loading). Sent with JOIN_SESSION so the backend roster shows real
@@ -1666,9 +1630,12 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // exactly the dead end that most needs explaining. So report the STATE here
   // rather than the action that cannot happen.
   //
-  // Once per board (re-armed the moment forward navigation works again), and
-  // never before the continuation feed has settled, or this announces a dead end
-  // during the re-anchor fetch and contradicts itself a beat later.
+  // Once per board, re-armed the moment forward navigation works again.
+  //
+  // Only when climbs were actually SKIPPED. Simply reaching the end of the
+  // climber's own list is not a dead end worth a message: nothing vanished, and
+  // a notice there would fire on every list end to explain a rule the climber
+  // wrote themselves (issue #5403). "0 left" beside a disabled Next says it.
   const deadEndReportedBoardKeyRef = useRef<string | null>(null);
   const forwardSelection = useMemo(
     () =>
@@ -1686,9 +1653,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       deadEndReportedBoardKeyRef.current = null;
       return;
     }
-    // A settled feed can already have a usable source waiting for its state commit.
-    if (!boardContinuationIsSettled || pendingReanchoredSource || deadEndReportedBoardKeyRef.current === activeBoardKey)
-      return;
+    if (deadEndReportedBoardKeyRef.current === activeBoardKey) return;
     deadEndReportedBoardKeyRef.current = activeBoardKey;
     // A swipe from here can add nothing to this; don't let it repeat the news.
     skipRunReportedForCurrentRef.current = true;
@@ -1700,15 +1665,7 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       }),
       'info',
     );
-  }, [
-    forwardSelection,
-    boardContinuationIsSettled,
-    pendingReanchoredSource,
-    activeBoardKey,
-    showToast,
-    tSettings,
-    trackClimbsSkippedOnBoard,
-  ]);
+  }, [forwardSelection, activeBoardKey, showToast, tSettings, trackClimbsSkippedOnBoard]);
 
   const nextClimb = useCallback(() => {
     const { queue, currentClimbQueueItem } = stateRef.current;
@@ -1826,35 +1783,16 @@ export function QueueProvider({ children }: { children: ReactNode }) {
 
   // Moving off the list hands swipes back to the queue. Swipes are list-first
   // (issue #4829): while the current climb is in `playlistSuggestionSource.climbs`
-  // next/previous walk that ordered list. But plenty of things move the current
-  // climb without going through `setCurrentClimb` — a crew member's
-  // CurrentClimbChanged, a widget Next/Previous tap (dispatchWidgetNavigation),
-  // or joining a session that's already parked on a climb. If any of them lands
-  // on a climb outside the list, a stale source would keep steering swipes into
-  // a list the climber isn't on, so drop it and fall back to plain queue
-  // navigation.
+  // next/previous walk that ordered list. Plenty of things move the current climb
+  // without going through `setCurrentClimb` — a crew member's CurrentClimbChanged,
+  // a widget Next/Previous tap, or joining a session already parked on a climb.
   //
-  // Local paths that legitimately keep the source all land on a climb that IS in
-  // the list — activation, a committed peek, a snapshot restore, setQueue with a
-  // matching source — so they're untouched. A null current (or a still-thin peer
-  // climb with no uuid) is a no-op: the source outlives an empty queue.
-  //
-  // This works on the provider's useState copy, which is the only one mobile
-  // reads; the reducer's SET_PLAYLIST_SUGGESTION_SOURCE field is written for
-  // persistence but never read back for navigation.
-  //
-  // Effect, not synchronous: between a peer's CurrentClimbChanged landing in the
-  // reducer and this effect running after the next render,
-  // `playlistSuggestionSourceRef` still holds the old list. A swipe inside that
-  // single render window walks the stale list one more step. It needs a swipe
-  // and a peer event in the same frame, so it is accepted rather than plumbed
-  // through the reducer.
-  const currentListClimbUuid = state.currentClimbQueueItem?.climb?.uuid;
-  useEffect(() => {
-    if (!playlistSuggestionSource || !currentListClimbUuid) return;
-    if (playlistSuggestionSource.climbs.some(({ uuid }) => uuid === currentListClimbUuid)) return;
-    setPlaylistSuggestionSourceState(null);
-  }, [currentListClimbUuid, playlistSuggestionSource]);
+  // That guard used to live here as an effect, which left one render in which a
+  // swipe walked the stale list. It now lives in
+  // `resolveNavigationSuggestionSource` (@boardsesh/play-view), evaluated during
+  // render at the point of use, so it holds for every writer at once and needs no
+  // render window (issue #5403). The source is left in place; navigation simply
+  // stops consulting it while it does not anchor the current climb.
 
   const publishPlaybackState = useCallback(
     (input: PublishPlaybackStateInput) => mutations.publishPlaybackState(input),

--- a/packages/shared/play-view/src/__tests__/queue-navigation.test.ts
+++ b/packages/shared/play-view/src/__tests__/queue-navigation.test.ts
@@ -10,6 +10,8 @@ import {
   computeNavigationStateWithSuggestions,
   findUpcomingQueueItemsWithSuggestions,
   selectNextQueueItemWithSuggestions,
+  resolveNavigationSuggestionSource,
+  anchoredSuggestionSource,
 } from '../queue-navigation';
 
 function makeClimb(uuid: string): Climb {
@@ -431,10 +433,12 @@ describe('computeNavigationStateWithSuggestions', () => {
     expect(state.nextItem?.climb.uuid).toBe('y');
     expect(state.nextItem?.suggested).toBe(true);
     // `x` is first in the list and first in the queue, so there is nothing to
-    // swipe back to on either side; remainingCount stays queue-based.
+    // swipe back to on either side.
     expect(state.canPrevious).toBe(false);
     expect(state.prevItem).toBeNull();
-    expect(state.remainingCount).toBe(0);
+    // One forward swipe is available — onto `y` — so "1 left" is the honest
+    // count even though the queue tail is empty (issue #5403).
+    expect(state.remainingCount).toBe(1);
   });
 
   it('lights up canPrevious from the list predecessor for a queued climb mid-list (#4829)', () => {
@@ -451,8 +455,8 @@ describe('computeNavigationStateWithSuggestions', () => {
     expect(state.prevItem?.suggested).toBe(true);
     expect(state.canNext).toBe(true);
     expect(state.nextItem?.climb.uuid).toBe('w2');
-    // Queue-based: nothing after `w1` in the queue.
-    expect(state.remainingCount).toBe(0);
+    // Nothing after `w1` in the queue, but `w2` is one swipe away down the list.
+    expect(state.remainingCount).toBe(1);
   });
 
   it('lights up both directions for a view-only preview (orphan current in the playlist)', () => {
@@ -732,4 +736,88 @@ it('prefetches the same reachable climbs as board-aware forward navigation', () 
     queueItemOnBoard('tension-2', 'tension', 8),
   ];
   expect(findUpcomingQueueItemsWithSuggestions(queue, queue[0], null, 2, TENSION_BOARD)).toEqual([queue[3], queue[4]]);
+});
+
+describe('a suggestion track belongs to one lineage (#5403)', () => {
+  const previewedClimb = makeClimb('previewed');
+  const leftoverNeighbour = makeClimb('leftover-neighbour');
+
+  it('never lends the committed track to a source-less preview', () => {
+    // The trap: the leftover track DOES contain the previewed climb, so a
+    // membership check alone would hand it over. A pinned preview is a different
+    // lineage regardless — it navigates its own track or none.
+    const leftover = makeSource(previewedClimb, [previewedClimb, leftoverNeighbour]);
+    expect(
+      resolveNavigationSuggestionSource({
+        previewItem: itemFor(previewedClimb),
+        previewSource: null,
+        committedItem: itemFor(previewedClimb),
+        committedSource: leftover,
+      }),
+    ).toBeNull();
+  });
+
+  it('uses the track the preview was opened with', () => {
+    const own = makeSource(previewedClimb, [previewedClimb, makeClimb('own-neighbour')]);
+    const leftover = makeSource(previewedClimb, [previewedClimb, leftoverNeighbour]);
+    expect(
+      resolveNavigationSuggestionSource({
+        previewItem: itemFor(previewedClimb),
+        previewSource: own,
+        committedItem: itemFor(previewedClimb),
+        committedSource: leftover,
+      }),
+    ).toBe(own);
+  });
+
+  it('keeps the committed track while it anchors the committed climb', () => {
+    const committed = makeClimb('committed');
+    const track = makeSource(committed, [committed, makeClimb('after')]);
+    expect(
+      resolveNavigationSuggestionSource({
+        previewItem: null,
+        previewSource: null,
+        committedItem: itemFor(committed),
+        committedSource: track,
+      }),
+    ).toBe(track);
+  });
+
+  it('drops a committed track the current climb has moved off', () => {
+    const elsewhere = makeClimb('elsewhere');
+    const track = makeSource(makeClimb('anchor'), [makeClimb('anchor'), makeClimb('after')]);
+    expect(
+      resolveNavigationSuggestionSource({
+        previewItem: null,
+        previewSource: null,
+        committedItem: itemFor(elsewhere),
+        committedSource: track,
+      }),
+    ).toBeNull();
+  });
+
+  it('keeps a track with nothing to anchor against, so an empty queue can seed from it', () => {
+    const first = makeClimb('first');
+    const track = makeSource(first, [first, makeClimb('second')]);
+    expect(anchoredSuggestionSource(track, null)).toBe(track);
+  });
+});
+
+describe("the end of the climber's own list (#5403)", () => {
+  it('dead-ends instead of continuing, and says 0 left', () => {
+    const last = makeClimb('last');
+    const track = makeSource(makeClimb('first'), [makeClimb('first'), last]);
+    const queue = [itemFor(last)];
+    const state = computeNavigationStateWithSuggestions(queue, queue[0], track);
+    expect(state.canNext).toBe(false);
+    expect(state.nextItem).toBeNull();
+    expect(state.remainingCount).toBe(0);
+  });
+
+  it('stops the prefetch walk there too', () => {
+    const last = makeClimb('last');
+    const track = makeSource(makeClimb('first'), [makeClimb('first'), last]);
+    const queue = [itemFor(last)];
+    expect(findUpcomingQueueItemsWithSuggestions(queue, queue[0], track, 5)).toEqual([]);
+  });
 });

--- a/packages/shared/play-view/src/queue-navigation.ts
+++ b/packages/shared/play-view/src/queue-navigation.ts
@@ -1,10 +1,6 @@
 import type { Climb, ClimbQueueItem, ClimbQueue, PlaylistSuggestionSource } from '@boardsesh/queue';
 import { getPlaylistSuggestedClimbs, getPlaylistPeekQueueItemUuid } from '@boardsesh/queue';
-import {
-  classifyClimbBoardCompatibility,
-  findNextCompatibleQueueItem,
-  type ActiveBoardForCompatibility,
-} from '@boardsesh/board-config';
+import { findNextCompatibleQueueItem, type ActiveBoardForCompatibility } from '@boardsesh/board-config';
 import type { NavigationState } from './types';
 
 /**
@@ -281,33 +277,82 @@ export function findPreviousQueueItemWithSuggestions(
 }
 
 /**
- * How many climbs after `currentIndex` a forward swipe can actually visit.
- *
- * The queue keeps cross-board climbs (they stay tappable in the queue sheet),
- * but a swipe walks past them, so counting them would over-report "N left" —
- * the climber would be promised swipes that never happen. With no `activeConfig`
- * nothing classifies as incompatible and this is the plain remaining count.
+ * Ceiling on the forward walk behind `remainingCount`. The action bar shows a
+ * small number and a climber never reads past a couple of dozen, so counting
+ * every reachable climb in a long queue would cost a full walk to tell two
+ * indistinguishable answers apart.
  */
-function countDrawableAfter(
-  queue: ClimbQueue,
-  currentIndex: number,
-  activeConfig: ActiveBoardForCompatibility | undefined,
-): number {
-  let count = 0;
-  for (let index = currentIndex >= 0 ? currentIndex + 1 : 0; index < queue.length; index++) {
-    if (classifyClimbBoardCompatibility(activeConfig, queue[index].climb) !== 'incompatible') count++;
-  }
-  return count;
+const REMAINING_COUNT_CAP = 99;
+
+/**
+ * Which suggestion source, if any, steers next/prev for what is on screen.
+ *
+ * A source belongs to exactly one lineage. The provider's source describes the
+ * COMMITTED climb's track. A pinned PREVIEW is a different lineage: it navigates
+ * the track it was opened with, or no track at all. A preview never borrows,
+ * inherits, or captures the committed track — issue #5403, where a list tap that
+ * opened as a source-less preview inherited the track from an earlier activation
+ * on a different list, and swiping walked climbs the climber had filtered out.
+ *
+ * The committed track is usable only while it still anchors the committed climb.
+ * That predicate lives here, evaluated during render at the point of use, rather
+ * than in an effect beside whoever wrote the current climb: roughly eight call
+ * sites write it without going through the activation helper, and an effect
+ * leaves one render in which navigation is computed against the old track.
+ */
+export function resolveNavigationSuggestionSource({
+  previewItem,
+  previewSource,
+  committedItem,
+  committedSource,
+}: {
+  previewItem: ClimbQueueItem | null;
+  previewSource: PlaylistSuggestionSource | null;
+  committedItem: ClimbQueueItem | null;
+  committedSource: PlaylistSuggestionSource | null;
+}): PlaylistSuggestionSource | null {
+  if (previewItem) return previewSource;
+  return anchoredSuggestionSource(committedSource, committedItem);
+}
+
+/**
+ * The committed half of {@link resolveNavigationSuggestionSource}: a source is
+ * only usable while its ordered list still contains the climb being navigated
+ * from. Off the list, next/prev fall back to the queue.
+ *
+ * Exported so the queue provider can derive its own navigation source through
+ * the same predicate instead of keeping a second copy of the rule — its
+ * `nextClimb` / `previousClimb` read the source directly and never see the
+ * drawer's resolver call.
+ *
+ * With nothing to navigate from — no item, or a still-thin peer climb with no
+ * uuid — the source is kept: it outlives an empty queue, and forward navigation
+ * seeds the first pass from it.
+ */
+export function anchoredSuggestionSource(
+  source: PlaylistSuggestionSource | null,
+  item: ClimbQueueItem | null,
+): PlaylistSuggestionSource | null {
+  const climbUuid = item?.climb?.uuid;
+  if (!source || !climbUuid) return source;
+  return source.climbs.some(({ uuid }) => uuid === climbUuid) ? source : null;
 }
 
 /**
  * computeNavigationState over the list-first swipe rules: canNext/nextItem and
  * canPrevious/prevItem come from the active suggestion source's ordered list
  * whenever the current climb is on it (in either direction), and from the queue
- * otherwise. remainingCount stays queue-based to match web's action-bar
- * remaining count.
+ * otherwise.
  *
- * `activeConfig` is forwarded to the forward scan and to `remainingCount`, so
+ * `remainingCount` counts the forward WALK, not the queue tail: it is the number
+ * of climbs a climber could actually reach by swiping, capped at
+ * {@link REMAINING_COUNT_CAP}. Counting the tail instead let the bar read "N
+ * left" beside a dead Next button at the end of a list (issue #5403), which is
+ * the opposite of what the number is for. It is also what makes the dead end
+ * self-explanatory without a message: "0 left" beside a disabled Next says the
+ * list ended, and the list ended where the climber's own filter says it does.
+ *
+ * `activeConfig` is forwarded to the forward scan and through the walk, so
  * `canNext`, the header peek and "N left" all agree with the climb a swipe
  * actually lands on. Backward navigation is deliberately
  * left alone: swiping back should return you where you came from, and a
@@ -322,8 +367,13 @@ export function computeNavigationStateWithSuggestions(
   const nextItem = selectNextQueueItemWithSuggestions(queue, currentClimbQueueItem, source, activeConfig).item;
   const prevItem = findPreviousQueueItemWithSuggestions(queue, currentClimbQueueItem, source);
 
-  const currentIndex = currentClimbQueueItem ? queue.findIndex(({ uuid }) => uuid === currentClimbQueueItem.uuid) : -1;
-  const remainingCount = countDrawableAfter(queue, currentIndex, activeConfig);
+  const remainingCount = findUpcomingQueueItemsWithSuggestions(
+    queue,
+    currentClimbQueueItem,
+    source,
+    REMAINING_COUNT_CAP,
+    activeConfig,
+  ).length;
 
   return {
     canNext: nextItem !== null,


### PR DESCRIPTION
## Summary

A climber filtered the climbs list to one setter, tapped a climb, put it on the wall, and the player walked forward onto a climb by a different setter that was not in their list. Closes #5403.

Confirmed from telemetry and the public Woods snapshot rather than inferred. Fifteen of the sixteen climbs in that session are by setter `MyClimbs`; the one they complained about, "Uhhhh" by `Stubbs`, is the exception, and it reached the player as a `playlist-peek:` item rather than a tap. `MyClimbs` sets 33 of the 424 listed climbs on that board size, so the filter was real. Their swipes commit, because `lightOnSwipe` defaults on, so a climb that should only have been previewed went to the wall.

Two defects produce that, both fixed here.

**The continuation feed ignored the climber's filters.** A board switch replaced their track with the board's unfiltered popular-by-ascents feed so a swipe had somewhere to go, and the queue sheet minted one track spanning both its playlist rows and that feed. A swipe now stops at the end of the climber's own list. The sheet's rows stay unfiltered, because they are how you find something outside the filters you are browsing with, but a tap mints a track from the one segment it came from.

**A pinned preview borrowed a leftover track.** A list tap that opened as a preview carried no track of its own, so next/prev fell back to whatever list was activated before it. A suggestion source now belongs to one lineage: a preview navigates the track it was opened with or none, and a committed track is usable only while it still anchors the current climb. That predicate lives in `resolveNavigationSuggestionSource` and is evaluated during render, so it holds for every writer of the current climb instead of one render late — it replaces an effect that left exactly that window open.

Two supporting changes. `remainingCount` counts the forward walk instead of the queue tail, so the bar can no longer read "N left" beside a dead Next button; "0 left" is what makes the dead end self-explanatory without a message. And persisted board-feed tracks are dropped on read, so upgrading does not restore the bug for the people who hit it.

No toast at the dead end. The existing skip notices exist because climbs vanished invisibly. Here nothing vanishes, the list ends where the climber's own filter says it does, and a notice would fire on every list end to explain a rule they wrote. The rest timer is the exception and already handles it: it asks the same selector and says the queue ended.

Author-side verification: play-view 321 pass, queue 138 pass, mobile and shared typecheck green. The lineage guard was mutation-tested — rewriting it as `previewSource ?? committedSource` is caught by exactly one test, and the test is built so a weaker membership assertion would not catch it.

Reviewers, the one behaviour change most likely to read as a regression: a crew member browsing a source-less preview now swipes the queue rather than capturing the host's leftover track. That is the intended correction.

## Release Notes

- Swiping stays on the list you are browsing, so you stop landing on climbs you filtered out
- The climb counter now matches the climbs you can actually swipe to

## Test plan

1. Sign in, open Climbs, filter to one setter.
2. Tap a climb, then tap Put on the wall.
3. Swipe forward through the climbs.
4. Every climb shown is by that setter.
5. At the list end, swipe does nothing and the counter reads 0.

## Risk

Risk: 3/5 — shared queue-navigation package plus the mobile play drawer and queue provider; no BLE, backend, or migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155f9ctHxHgArb4iv66BaSp
