### PR TITLE
fix(mobile): stop a collected JS wrapper killing the live SQLite handle

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -1039,6 +1039,79 @@ close: expo-sqlite enters `closeAsync()` synchronously from the parent's cleanup
 React runs before this child's. What it buys is the window after the unmount commit —
 queries already in flight are carried by the process-lifetime reference (#5300).
 
+### When the native handle dies under us (#5410)
+
+Everything above is about a connection that is LOCKED, or one the provider CLOSED.
+There is a third failure, and on Android it was the largest of the three:
+BOARDSESH-G1, 239 users and 2593 events over 30 days, every SQLite consumer dead at
+once until the climber force-quits.
+
+**The mechanism.** Opening `boardsesh.db` a second time with equal options does not
+open a second connection. Android's constructor finds the cached `NativeDatabase` and
+hands the same instance back:
+
+```kotlin
+findCachedDatabase { it.databasePath == databasePath && it.openOptions == options
+                     && !options.useNewConnection }?.let { it.addRef(); return@Constructor it }
+```
+
+expo-modules-core's `SharedObjectRegistry.add()` then registers that one native object
+again under a fresh id, minting an independent C++ `NativeState` for the new JS
+wrapper. `~NativeState` runs the releaser, so garbage-collecting **any** wrapper calls
+`sharedObjectDidRelease()` → `ref.close()` → `mHybridData.resetNative()` on the
+connection every other wrapper is still using. `NativeDatabase.kt` neither consults its
+refcount nor sets `isClosed` there, so `maybeThrowForClosedDatabase` still waves the
+next call through and `sqlite3_prepare_v2` dereferences a freed pointer.
+
+Refcounting does not protect against this. #5300's retention pin keeps `sqlite3_close`
+from running; it has nothing to say about reachability. iOS is unaffected —
+`SharedObjectRegistry.swift` reuses the id and native state for a second registration,
+and the iOS `NativeDatabase` does not override `sharedObjectDidRelease` — so this is an
+Android-only parity gap, filed upstream. It is not patchable here: `patches/` is hashed
+into the native fingerprint, so a patched fix could not reach the affected users by OTA.
+
+**Prevention.** `db/connection-pin.ts` holds every wrapper for this file strongly for
+the life of the process, so none can ever be collected. Four funnels feed it: the
+provider's `onInit`, `DatabaseHandleLifecycle`'s effect, `initializeDatabase` (where
+reassigning `latestDatabase` is what makes the previous wrapper collectable), and the
+dev lock holder. Transaction connections are refused — `useNewConnection` bypasses the
+cache, so their release is already correct and pinning them would leak one object per
+offline write. The set is strong and never evicted on purpose; a weak container is the
+bug, and the entry you evict may be the one whose collection kills the live connection.
+
+This is ORTHOGONAL to the retraction machinery above. That is about liveness (never
+hand a reader a closed connection); this is about reachability (never let a wrapper be
+collected). Both are needed.
+
+**Recovery.** `classifySqliteHandleError` (`@boardsesh/offline-sync`) tells the dead
+shape apart from a lock — conjunctively, needing the expo-sqlite rejection frame AND
+the `NullPointerException`, because a bare NPE is the most common native error there
+is. Detection hangs off `reportError` via `db/dead-handle.ts`, a registration seam that
+exists because error-reporting → connection → error-reporting would be a cycle.
+
+Recovery retracts the handle synchronously first, which alone stops the storm, then
+opens a replacement and retargets the existing init ladder onto it — so migrations, the
+lock backoff and the single publish site are all reused. A chain epoch stops a ladder
+parked in a retry gap from waking up and migrating the replacement a second time.
+
+The replacement MUST be opened with `useNewConnection: true`. A plain re-open is served
+the same dead instance: nothing closed it, so its refcount never reached zero and
+`removeCachedDatabase` never evicted it. Draining the refcount by repeated `closeAsync`
+was rejected — JS cannot read the count, so the stopping rule would be "call it until it
+throws", and the throw is the bug being recovered from.
+
+Because the provider never re-renders during a recovery, its context value still points
+at the dead instance. Consumers that take their database from `useSQLiteContext()` must
+therefore go through `useOfflineDatabase()` instead, which prefers the published handle
+and falls back to the provider's. Writers still gate on `useOfflineSchemaReady()`; that
+hook decides WHICH connection, not WHETHER.
+
+Bounded at two recoveries per process, 30s apart. Telemetry: Sentry
+`kind: 'sqlite-dead-handle'` with `phase: detected | reopened | failed`, and
+`Offline SQLite Handle Recovered` in PostHog. Deliberately kept out of the
+`sqlite-init` aggregate, whose `elapsedMs` distribution sizes the retry window and
+would be corrupted by a mid-session failure that is not contention at all.
+
 ## What stays the same
 
 | Component             | Status                                                                                                        |

--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -69,6 +69,11 @@ vi.mock('@boardsesh/offline-sync', () => ({
 // only needs the wipe callback, so stub the module rather than the world.
 vi.mock('../../db/connection', () => ({
   clearUserData: (...args: unknown[]) => clearUserDataMock(...args),
+  // `useOfflineDatabase` subscribes to handle swaps so a dead-handle recovery's
+  // replacement reaches the scheduler (#5410). Nothing here swaps one, so the
+  // subscription is inert and the hook falls back to the provider's connection.
+  getDatabaseHandle: () => null,
+  subscribeDatabaseHandle: () => () => {},
 }));
 
 // use-current-user-id reads the JWT out of SecureStore via lib/auth-store, whose

--- a/packages/mobile/src/components/offline-sync-bridge.tsx
+++ b/packages/mobile/src/components/offline-sync-bridge.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react';
-import { useSQLiteContext } from 'expo-sqlite';
+import { useOfflineDatabase } from '../db/use-offline-database';
 import { useQueryClient } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import { notifyBootstrapMetadataChanged, notifyScopeDownloadComplete, setSyncProgress } from '../sync';
@@ -53,7 +53,10 @@ export function OfflineEngineFlagSync() {
  * host app — offline sync is best-effort and must not take the UI down with it.
  */
 export function OfflineSyncBridge() {
-  const db = useSQLiteContext();
+  // Not `useSQLiteContext()` directly: a dead-handle recovery opens a REPLACEMENT
+  // connection without the provider ever re-rendering, so the context value would
+  // still be the wrapper around the dead native instance (#5410).
+  const db = useOfflineDatabase();
   const queryClient = useQueryClient();
   const { isAuthenticated } = useAuth();
   const snapshotSource = useSnapshotSource();

--- a/packages/mobile/src/components/settings/DevOfflineWritesScreen.tsx
+++ b/packages/mobile/src/components/settings/DevOfflineWritesScreen.tsx
@@ -43,6 +43,8 @@ const FAULT_MODES: { mode: WriteFaultMode; label: string }[] = [
   { mode: 'android-lock-no-code', label: 'Android lock (no code)' },
   { mode: 'disk-full', label: 'Disk full (not retryable)' },
   { mode: 'commit-then-throw', label: 'Commit, then throw' },
+  { mode: 'android-dead-handle', label: 'Dead native handle (#5410)' },
+  { mode: 'closed-resource', label: 'Access to closed resource' },
 ];
 
 const FAIL_ATTEMPT_CHOICES = [1, 99];

--- a/packages/mobile/src/components/settings/StorageSettingsScreen.tsx
+++ b/packages/mobile/src/components/settings/StorageSettingsScreen.tsx
@@ -15,7 +15,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useFocusEffect } from 'expo-router';
-import { useSQLiteContext } from 'expo-sqlite';
+import { useOfflineDatabase } from '../../db/use-offline-database';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   getDownloadedScopeKeys,
@@ -77,7 +77,10 @@ export function StorageSettingsScreen() {
   const { systemColors } = useTheme();
   const confirm = useConfirm();
   const { showToast } = useToast();
-  const db = useSQLiteContext();
+  // Not `useSQLiteContext()` directly: a dead-handle recovery opens a REPLACEMENT
+  // connection without the provider ever re-rendering, so the context value would
+  // still be the wrapper around the dead native instance (#5410).
+  const db = useOfflineDatabase();
   // Live as soon as the launch gate opens — after the first init attempt, whatever
   // it did — so on a contended launch this connection has no tables yet. Folded into
   // the query KEY below rather than gating the query: a failed measurement renders

--- a/packages/mobile/src/db/__tests__/connection-pin.test.ts
+++ b/packages/mobile/src/db/__tests__/connection-pin.test.ts
@@ -1,0 +1,93 @@
+// The rules that bound the pin set. `connection-pin.ts` imports expo-sqlite for
+// TYPES only, so this suite needs no mocking and runs in the node environment.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../lib/error-reporting', () => ({ reportError: vi.fn() }));
+
+import { pinDatabase, isDatabasePinned, pinnedDatabaseCount, resetDatabasePinsForTests } from '../connection-pin';
+
+/** The shape `pinDatabase` reads: path, options, and the native object it also pins. */
+function connection(overrides: Record<string, unknown> = {}): never {
+  return {
+    databasePath: '/data/user/0/com.boardsesh.app/databases/boardsesh.db',
+    options: {},
+    nativeDatabase: {},
+    ...overrides,
+  } as never;
+}
+
+beforeEach(() => {
+  resetDatabasePinsForTests();
+});
+
+describe('pinDatabase', () => {
+  it('pins a connection to the app database', () => {
+    const db = connection();
+    pinDatabase(db);
+    expect(isDatabasePinned(db)).toBe(true);
+    expect(pinnedDatabaseCount()).toBe(1);
+  });
+
+  it('is idempotent, because onInit, the effect and the init chain all see the same connection', () => {
+    const db = connection();
+    pinDatabase(db);
+    pinDatabase(db);
+    pinDatabase(db);
+    expect(pinnedDatabaseCount()).toBe(1);
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])('tolerates %s', (_label, value) => {
+    expect(() => {
+      pinDatabase(value);
+    }).not.toThrow();
+    expect(pinnedDatabaseCount()).toBe(0);
+  });
+
+  it('refuses a transaction connection', () => {
+    // `withExclusiveTransactionAsync` opens with this flag, so it gets a genuinely
+    // separate native object whose release is correct. Pinning them would leak one
+    // connection object per offline write.
+    const txn = connection({ options: { useNewConnection: true } });
+    pinDatabase(txn);
+    expect(isDatabasePinned(txn)).toBe(false);
+    expect(pinnedDatabaseCount()).toBe(0);
+  });
+
+  it('refuses a connection to some other database file', () => {
+    const other = connection({ databasePath: '/data/user/0/com.boardsesh.app/databases/other.db' });
+    pinDatabase(other);
+    expect(isDatabasePinned(other)).toBe(false);
+  });
+
+  it('pins the native object as well as the wrapper', () => {
+    // The NativeState lives on the native object, so pinning it directly means an
+    // upstream refactor of the wrapper cannot silently un-pin us.
+    const native = {};
+    const db = connection({ nativeDatabase: native });
+    pinDatabase(db);
+    expect(isDatabasePinned(native as never)).toBe(true);
+  });
+
+  it('counts mounts rather than set entries', () => {
+    pinDatabase(connection());
+    pinDatabase(connection());
+    expect(pinnedDatabaseCount()).toBe(2);
+  });
+
+  it('pins a connection that reports no path, rather than guessing', () => {
+    const db = connection({ databasePath: undefined });
+    pinDatabase(db);
+    expect(isDatabasePinned(db)).toBe(true);
+  });
+});
+
+describe('isDatabasePinned', () => {
+  it('is false for an unpinned connection and for nothing at all', () => {
+    expect(isDatabasePinned(connection())).toBe(false);
+    expect(isDatabasePinned(null)).toBe(false);
+    expect(isDatabasePinned(undefined)).toBe(false);
+  });
+});

--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -42,6 +42,7 @@ import {
   releaseDatabaseHandle,
   registerReplacementOpener,
   resetDeadHandleRecoveryForTests,
+  MIN_RECOVERY_INTERVAL_MS,
 } from '../connection';
 import { noteDatabaseHandleFailure } from '../dead-handle';
 import { isSchemaReady } from '../schema-ready';
@@ -1201,8 +1202,15 @@ describe('initializeDatabase lock contention (#4104)', () => {
     /** A live replacement over the real test database, plus the opener that yields it. */
     function createReplacement() {
       const calls: ({ useNewConnection?: boolean } | undefined)[] = [];
+      // How many init chains reached this connection. The epoch guards exist to keep
+      // it at one: two chains running migrations against one file is the contention
+      // the ladder exists to survive, self-inflicted.
+      let queueTableDdl = 0;
       const replacement = {
-        execAsync: (source: string) => realDb.execAsync(source),
+        execAsync: (source: string) => {
+          if (/CREATE TABLE IF NOT EXISTS pending_mutations/i.test(source)) queueTableDdl += 1;
+          return realDb.execAsync(source);
+        },
         getFirstAsync: <T>(source: string, ...params: unknown[]) =>
           realDb.getFirstAsync<T>(source, ...(params as never[])),
         runAsync: (source: string, ...params: unknown[]) => realDb.runAsync(source, ...(params as never[])),
@@ -1215,7 +1223,7 @@ describe('initializeDatabase lock contention (#4104)', () => {
         calls.push({ useNewConnection: true });
         return replacement;
       });
-      return { replacement, opener, calls };
+      return { replacement, opener, calls, queueTableDdl: () => queueTableDdl };
     }
 
     beforeEach(() => {
@@ -1327,6 +1335,98 @@ describe('initializeDatabase lock contention (#4104)', () => {
         expect.objectContaining({ shape: 'dead-native-handle', origin: 'report', recovered: true }),
       );
     });
+
+    it('opens one connection even once the interval gate would allow another', async () => {
+      // The cap and the 30s gate alone would hide a missing single-flight for a
+      // same-tick burst. Hold the opener open, step past the gate, and fire again:
+      // only `activeRecovery` can stop the second one.
+      let releaseOpen: (db: SQLiteDatabase) => void = () => {};
+      const pending = new Promise<SQLiteDatabase>((resolve) => {
+        releaseOpen = resolve;
+      });
+      const { replacement } = createReplacement();
+      const opener = vi.fn(() => pending);
+      registerReplacementOpener(opener);
+
+      noteDatabaseHandleFailure(new Error(DEAD_HANDLE_MESSAGE), 'report');
+      expect(opener).toHaveBeenCalledTimes(1);
+
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + MIN_RECOVERY_INTERVAL_MS + 1_000);
+      noteDatabaseHandleFailure(new Error(DEAD_HANDLE_MESSAGE), 'report');
+      expect(opener).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+
+      releaseOpen(replacement);
+      await vi.waitFor(() => {
+        expect(getDatabaseHandle()).not.toBeNull();
+      });
+    });
+
+    it('stops the in-flight init chain instead of migrating the replacement twice', async () => {
+      // A chain parked in a retry gap must not wake up and run a second migration
+      // against the connection the recovery just published.
+      vi.useFakeTimers();
+      const contended = createContendedDatabase();
+      void initializeDatabase(contended.db);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(getDatabaseHandle()).toBeNull();
+
+      vi.useRealTimers();
+      const { opener, replacement } = createReplacement();
+      registerReplacementOpener(opener);
+      noteDatabaseHandleFailure(new Error(DEAD_HANDLE_MESSAGE), 'report');
+      await vi.waitFor(() => {
+        expect(getDatabaseHandle()).toBe(replacement);
+      });
+
+      // The old chain's target becomes healthy and its backoff elapses. It must stay
+      // stopped: the epoch moved on when the recovery retargeted the lifecycle.
+      contended.unlock();
+      vi.useFakeTimers();
+      await vi.advanceTimersByTimeAsync(INIT_RETRY_DELAYS_MS[0] + INIT_RETRY_DELAYS_MS[1] + 1_000);
+      vi.useRealTimers();
+
+      expect(getDatabaseHandle()).toBe(replacement);
+    });
+
+    it('stops a chain whose recovery landed mid-attempt, not only mid-backoff', async () => {
+      // The production case: the attempt is slow BECAUSE the file is contended, so
+      // the recovery lands while it is in flight rather than during a retry gap. The
+      // guard after the sleep cannot catch that one — the chain is already past it.
+      const { opener, replacement, queueTableDdl } = createReplacement();
+      let recoveryFired = false;
+      const contended = createContendedDatabase({
+        onFailure: () => {
+          if (recoveryFired) return;
+          recoveryFired = true;
+          registerReplacementOpener(opener);
+          noteDatabaseHandleFailure(new Error(DEAD_HANDLE_MESSAGE), 'report');
+        },
+      });
+
+      await initializeDatabase(contended.db);
+      await vi.waitFor(() => {
+        expect(getDatabaseHandle()).toBe(replacement);
+      });
+
+      // The superseded chain must not come back and publish its own target.
+      contended.unlock();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(getDatabaseHandle()).toBe(replacement);
+      // Both chains publish the same object, so the handle alone cannot tell them
+      // apart. The migration count can: the superseded chain must never have
+      // retargeted onto the replacement and run the DDL a second time.
+      expect(queueTableDdl()).toBe(1);
+    });
+
+    // NOT COVERED: the epoch guard that runs straight after an attempt, as opposed to
+    // the one after the sleep (covered above). It only matters when a SUPERSEDED
+    // attempt SUCCEEDS — the supersede branch would then refund and retarget onto the
+    // replacement, running the DDL a second time against a file the recovery may still
+    // be writing. Three attempts to drive that through this harness deadlocked on the
+    // launch gate rather than reproducing it, so the guard ships on its reasoning
+    // alone. Worth revisiting with a harness that can hold an attempt open.
 
     it('does not recover from a lock, which the existing ladder already handles', async () => {
       const { opener } = createReplacement();

--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -40,7 +40,10 @@ import {
   INIT_LOCK_RETRY_DELAYS_MS,
   setDatabaseHandle,
   releaseDatabaseHandle,
+  registerReplacementOpener,
+  resetDeadHandleRecoveryForTests,
 } from '../connection';
+import { noteDatabaseHandleFailure } from '../dead-handle';
 import { isSchemaReady } from '../schema-ready';
 import { resetDatabaseInitializationForTests } from '../testing';
 import {
@@ -1172,5 +1175,169 @@ describe('initializeDatabase lock contention (#4104)', () => {
 
     expect(getDatabaseHandle()).toBeNull();
     expect(isSchemaReady()).toBe(false);
+  });
+
+  // #5410: a collected JS wrapper frees the native binding the live connection is
+  // still using. Prevention lives in `connection-pin.ts`; this is the safety net,
+  // and the thing it must get right is that a plain re-open is served the SAME dead
+  // instance, so the replacement has to be opened with `useNewConnection: true`.
+  describe('dead native handle recovery', () => {
+    const DEAD_HANDLE_MESSAGE =
+      "Call to function 'NativeDatabase.prepareAsync' has been rejected.\n→ Caused by: java.lang.NullPointerException: java.lang.NullPointerException";
+
+    /** A connection whose every call hits the freed pointer. */
+    function createDeadDatabase(): SQLiteDatabase {
+      const fail = async (): Promise<never> => {
+        throw new Error(DEAD_HANDLE_MESSAGE);
+      };
+      return {
+        execAsync: fail,
+        getFirstAsync: fail,
+        runAsync: fail,
+        withExclusiveTransactionAsync: fail,
+      } as unknown as SQLiteDatabase;
+    }
+
+    /** A live replacement over the real test database, plus the opener that yields it. */
+    function createReplacement() {
+      const calls: ({ useNewConnection?: boolean } | undefined)[] = [];
+      const replacement = {
+        execAsync: (source: string) => realDb.execAsync(source),
+        getFirstAsync: <T>(source: string, ...params: unknown[]) =>
+          realDb.getFirstAsync<T>(source, ...(params as never[])),
+        runAsync: (source: string, ...params: unknown[]) => realDb.runAsync(source, ...(params as never[])),
+        withExclusiveTransactionAsync: (task: (txn: unknown) => Promise<void>) =>
+          realDb.withExclusiveTransactionAsync(task as never),
+        options: { useNewConnection: true },
+        databasePath: 'boardsesh.db',
+      } as unknown as SQLiteDatabase;
+      const opener = vi.fn(async () => {
+        calls.push({ useNewConnection: true });
+        return replacement;
+      });
+      return { replacement, opener, calls };
+    }
+
+    beforeEach(() => {
+      resetDeadHandleRecoveryForTests();
+    });
+
+    afterEach(() => {
+      resetDeadHandleRecoveryForTests();
+    });
+
+    it('retracts the handle synchronously, before the re-open has resolved', () => {
+      const { opener } = createReplacement();
+      registerReplacementOpener(opener);
+      setDatabaseHandle(createDeadDatabase());
+
+      noteDatabaseHandleFailure(new Error(DEAD_HANDLE_MESSAGE), 'report');
+
+      // This alone stops the storm: every reader re-reads per call, so they fall back
+      // to the network instead of throwing again — worth it even if the re-open fails.
+      expect(getDatabaseHandle()).toBeNull();
+      expect(isSchemaReady()).toBe(false);
+    });
+
+    it('opens the replacement with useNewConnection, which is the whole escape', async () => {
+      const { opener } = createReplacement();
+      registerReplacementOpener(opener);
+
+      noteDatabaseHandleFailure(new Error(DEAD_HANDLE_MESSAGE), 'report');
+      await vi.waitFor(() => {
+        expect(getDatabaseHandle()).not.toBeNull();
+      });
+
+      // Without this flag the constructor is served the dead instance from
+      // `cachedDatabases` — its refcount never reached zero, so nothing evicted it.
+      expect(opener).toHaveBeenCalledTimes(1);
+    });
+
+    it('runs the migrations on the replacement rather than publishing a bare connection', async () => {
+      const { opener } = createReplacement();
+      registerReplacementOpener(opener);
+
+      noteDatabaseHandleFailure(new Error(DEAD_HANDLE_MESSAGE), 'report');
+      await vi.waitFor(() => {
+        expect(isSchemaReady()).toBe(true);
+      });
+
+      await expect(realDb.getFirstAsync('SELECT COUNT(*) AS n FROM pending_mutations')).resolves.toEqual({ n: 0 });
+    });
+
+    it('opens one connection however many consumers hit the dead handle at once', async () => {
+      const { opener } = createReplacement();
+      registerReplacementOpener(opener);
+
+      for (let consumer = 0; consumer < 10; consumer += 1) {
+        noteDatabaseHandleFailure(new Error(DEAD_HANDLE_MESSAGE), 'report');
+      }
+      await vi.waitFor(() => {
+        expect(getDatabaseHandle()).not.toBeNull();
+      });
+
+      expect(opener).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops at the cap instead of re-opening forever when the replacement is dead too', async () => {
+      const opener = vi.fn(async () => createDeadDatabase());
+      registerReplacementOpener(opener);
+
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        noteDatabaseHandleFailure(new Error(DEAD_HANDLE_MESSAGE), 'report');
+        await vi.waitFor(() => {
+          expect(opener).toHaveBeenCalled();
+        });
+      }
+
+      // One per process here: the 30s interval gate holds the second attempt back.
+      expect(opener.mock.calls.length).toBeLessThanOrEqual(2);
+      expect(getDatabaseHandle()).toBeNull();
+    });
+
+    it('keeps the replacement when a later provider connection arrives', async () => {
+      const { opener, replacement } = createReplacement();
+      registerReplacementOpener(opener);
+
+      noteDatabaseHandleFailure(new Error(DEAD_HANDLE_MESSAGE), 'report');
+      await vi.waitFor(() => {
+        expect(getDatabaseHandle()).toBe(replacement);
+      });
+
+      // A remount's `openDatabaseAsync` is still served the dead native instance from
+      // the cache, so retargeting onto it would publish a dead handle as ready.
+      await initializeDatabase(createDeadDatabase());
+      expect(getDatabaseHandle()).toBe(replacement);
+      expect(isSchemaReady()).toBe(true);
+    });
+
+    it('reports the detection and the recovery under their own kind', async () => {
+      const { opener } = createReplacement();
+      registerReplacementOpener(opener);
+
+      noteDatabaseHandleFailure(new Error(DEAD_HANDLE_MESSAGE), 'report');
+      await vi.waitFor(() => {
+        expect(getDatabaseHandle()).not.toBeNull();
+      });
+
+      const kinds = reportErrorMock.mock.calls.map(([, context]) => context?.tags?.kind);
+      expect(kinds.filter((kind) => kind === 'sqlite-dead-handle')).toHaveLength(2);
+      expect(trackMock).toHaveBeenCalledWith(
+        SHARED_EVENTS.OfflineSqliteHandleRecovered,
+        expect.objectContaining({ shape: 'dead-native-handle', origin: 'report', recovered: true }),
+      );
+    });
+
+    it('does not recover from a lock, which the existing ladder already handles', async () => {
+      const { opener } = createReplacement();
+      registerReplacementOpener(opener);
+      const live = createDeadDatabase();
+      setDatabaseHandle(live);
+
+      expect(noteDatabaseHandleFailure(new Error(LOCK_ERROR_MESSAGE), 'report')).toBe(false);
+
+      expect(opener).not.toHaveBeenCalled();
+      expect(getDatabaseHandle()).toBe(live);
+    });
   });
 });

--- a/packages/mobile/src/db/__tests__/reopen.test.ts
+++ b/packages/mobile/src/db/__tests__/reopen.test.ts
@@ -1,0 +1,30 @@
+// `useNewConnection: true` is the entire escape from the poisoned cache (#5410), and
+// it is one word in one call. Without it the re-open is served the SAME dead
+// instance — nothing closed it, so its refcount never reached zero and
+// `removeCachedDatabase` never evicted it — and the whole recovery path silently
+// republishes a dead handle as ready.
+//
+// The recovery tests in connection.test.ts inject a mock opener, so they never
+// exercise this call. This suite is the only thing standing between that flag and a
+// tidy-up.
+import { describe, it, expect, vi } from 'vitest';
+
+const openDatabaseAsyncMock = vi.hoisted(() =>
+  vi.fn(async (_name: string, _options?: { useNewConnection?: boolean }) => ({ marker: 'replacement' })),
+);
+vi.mock('expo-sqlite', () => ({ openDatabaseAsync: openDatabaseAsyncMock }));
+
+import { openReplacementDatabase } from '../reopen';
+import { DATABASE_NAME } from '../database-name';
+
+describe('openReplacementDatabase', () => {
+  it('bypasses the connection cache', async () => {
+    await openReplacementDatabase();
+    expect(openDatabaseAsyncMock).toHaveBeenCalledWith(DATABASE_NAME, { useNewConnection: true });
+  });
+
+  it('opens the app database, not some other file', async () => {
+    await openReplacementDatabase();
+    expect(openDatabaseAsyncMock).toHaveBeenCalledWith(DATABASE_NAME, expect.anything());
+  });
+});

--- a/packages/mobile/src/db/connection-pin.ts
+++ b/packages/mobile/src/db/connection-pin.ts
@@ -1,0 +1,126 @@
+// Every JS wrapper we have ever seen for `boardsesh.db`, held strongly, forever.
+//
+// WHY (#5410). On Android, opening the app database a second time with equal
+// options does NOT open a second connection — `SQLiteModule.kt`'s constructor
+// finds the cached one and hands it straight back:
+//
+//   findCachedDatabase { it.databasePath == databasePath && it.openOptions == options
+//                        && !options.useNewConnection }?.let { it.addRef(); return@Constructor it }
+//
+// expo-modules-core then registers that ONE native instance a second time
+// (`SharedObjectRegistry.add()`), minting a fresh id and an independent C++
+// `NativeState` for the new JS wrapper. `~NativeState` runs the releaser, so when
+// the garbage collector reclaims ANY of those wrappers, `SharedObjectRegistry.delete`
+// calls `NativeDatabase.sharedObjectDidRelease()` → `ref.close()` →
+// `mHybridData.resetNative()` — on the connection every OTHER wrapper is still using.
+//
+// `NativeDatabase.kt` neither consults its refcount nor sets `isClosed` there, so
+// `maybeThrowForClosedDatabase` still waves the next call through and
+// `sqlite3_prepare_v2` dereferences a freed pointer. That is BOARDSESH-G1: a
+// message-less `java.lang.NullPointerException` from a database nothing closed,
+// after which every read, every sync cycle and every tick write fails until the
+// climber force-quits (239 users / 2593 events over 30 days).
+//
+// So the fix is reachability, not refcounting: a wrapper that can never become
+// garbage can never run its releaser. We create wrappers from four places — the
+// retention handle (#5300), every `SQLiteProvider` mount, `latestDatabase` in
+// `connection.ts` (which is OVERWRITTEN on each remount, and that overwrite is what
+// makes the previous wrapper collectable), and the dev lock holder — and all four
+// funnel through `pinDatabase`.
+//
+// THE SET IS STRONG, AND THAT IS THE POINT. `WeakSet`, `WeakRef` and
+// `FinalizationRegistry` all let the collector reclaim the wrapper, which is
+// precisely the bug. Do not "optimise" this into a weak container, and do not add
+// eviction at any bound: the entry you evict may be the one whose collection kills
+// the live connection.
+//
+// This is ORTHOGONAL to `setDatabaseHandle(null)` / `releaseDatabaseHandle` /
+// `retractSupersededHandle` in `connection.ts`. Those are about LIVENESS — never
+// hand a reader a connection the provider has closed (#5292, #5366). This is about
+// REACHABILITY — never let a wrapper be collected. Both are still needed; neither
+// replaces the other.
+//
+// iOS is unaffected: `SharedObjectRegistry.swift` reuses the id and native state for
+// a second registration, and the iOS `NativeDatabase` does not override
+// `sharedObjectDidRelease` at all. This is an Android-only parity gap in
+// expo-modules-core, filed upstream; we cannot patch it here because `patches/` is
+// hashed into the native fingerprint, so a patched fix could not reach the affected
+// users by OTA.
+
+import type { SQLiteDatabase } from 'expo-sqlite';
+import { reportError } from '../lib/error-reporting';
+import { DATABASE_NAME } from './database-name';
+
+/**
+ * Deliberately strong, deliberately never cleared. Holds both the `SQLiteDatabase`
+ * wrapper and its `nativeDatabase`: the wrapper transitively retains the native
+ * object today, but the `NativeState` lives on the NATIVE one, so pinning it
+ * directly means an upstream refactor of the wrapper cannot silently un-pin us.
+ */
+const pinned = new Set<object>();
+
+/** Mounts pinned, not set size — each mount contributes two entries. */
+let pinnedMounts = 0;
+
+/**
+ * Above this many mounts something is remounting the provider in a loop, which is
+ * worth knowing about: the production remount rate is currently unmeasured, and it
+ * is what decides whether this set's growth ever matters. Reported once, never
+ * acted on — see the eviction warning in the header.
+ */
+const PIN_COUNT_REPORT_THRESHOLD = 20;
+let hasReportedPinGrowth = false;
+
+/**
+ * Pin a connection so garbage collection can never destroy the native handle behind it.
+ *
+ * Idempotent and tolerant of null/undefined, because it is called from `onInit`, from
+ * an effect, and from the init chain — all of which can see the same connection.
+ */
+export function pinDatabase(db: SQLiteDatabase | null | undefined): void {
+  if (db === null || db === undefined) return;
+
+  // Transaction connections must NOT be pinned. `withExclusiveTransactionAsync` opens
+  // with `useNewConnection: true`, and the constructor predicate above short-circuits
+  // on that flag — so a transaction gets a genuinely separate `NativeDatabase` whose
+  // release is correct and whose `closeAsync` really does set `isClosed`. Pinning them
+  // would leak one connection object per offline write, which is the one way this
+  // module could become a problem of its own. This line is what bounds the set.
+  if (db.options?.useNewConnection === true) return;
+
+  // Cheap honesty check: if a second database ever appears, it gets its own module
+  // rather than quietly sharing this one's lifetime.
+  if (typeof db.databasePath === 'string' && !db.databasePath.endsWith(DATABASE_NAME)) return;
+
+  if (pinned.has(db)) return;
+  pinned.add(db);
+  const native: unknown = (db as { nativeDatabase?: unknown }).nativeDatabase;
+  if (typeof native === 'object' && native !== null) pinned.add(native);
+  pinnedMounts += 1;
+
+  // Fast Refresh pins on every reload, so this would fire constantly in development.
+  if (!__DEV__ && !hasReportedPinGrowth && pinnedMounts > PIN_COUNT_REPORT_THRESHOLD) {
+    hasReportedPinGrowth = true;
+    reportError(new Error(`SQLite connections pinned: ${pinnedMounts}`), {
+      tags: { source: 'offline-sync', kind: 'sqlite-pin-growth' },
+      extra: { pinnedMounts },
+    });
+  }
+}
+
+/** Whether `db` is pinned. The GC simulation in the tests asserts against this. */
+export function isDatabasePinned(db: SQLiteDatabase | null | undefined): boolean {
+  return db !== null && db !== undefined && pinned.has(db);
+}
+
+/** How many connections have been pinned, counting one per mount rather than per entry. */
+export function pinnedDatabaseCount(): number {
+  return pinnedMounts;
+}
+
+/** Test-only. Drops every pin so a suite can drive the first-mount path more than once. */
+export function resetDatabasePinsForTests(): void {
+  pinned.clear();
+  pinnedMounts = 0;
+  hasReportedPinGrowth = false;
+}

--- a/packages/mobile/src/db/connection-retention.ts
+++ b/packages/mobile/src/db/connection-retention.ts
@@ -29,9 +29,17 @@
 // and `closeAsync` reaches `exsqlite3_close` only when `removeCachedDatabase` sees the
 // refcount fall to zero. Holding one extra handle and never closing it pins the count
 // at >= 1, so every `SQLiteProvider` teardown still runs and still decrements but can
-// no longer free anything under an in-flight query. The connection stays valid
+// no longer free anything under an in-flight query. The connection stays OPEN
 // (`isClosed` is only set inside the branch that actually closes), so the provider's
 // next mount gets the same live connection back instead of reopening the file.
+//
+// WHAT THIS DOES NOT BUY, AND ONCE READ AS IF IT DID (#5410). Open is not the same as
+// usable. The extra handle is a SECOND JS wrapper over one native object, and on
+// Android expo-modules-core registers that object a second time with its own C++
+// `NativeState` — so collecting EITHER wrapper destroys the native binding while
+// `isClosed` stays false and the refcount stays >= 1. Pinning the refcount says
+// nothing about reachability. `connection-pin.ts` is what covers that, and this
+// handle is pinned there like every other.
 //
 // WHAT IT COSTS. Nothing that would otherwise have been reclaimed: the app has exactly
 // one database and needs it for the whole process, and the SQLite module's own

--- a/packages/mobile/src/db/connection-retention.ts
+++ b/packages/mobile/src/db/connection-retention.ts
@@ -47,7 +47,8 @@
 
 import { openDatabaseAsync, type SQLiteDatabase } from 'expo-sqlite';
 import { reportError } from '../lib/error-reporting';
-import { DATABASE_NAME } from './connection';
+import { DATABASE_NAME } from './database-name';
+import { pinDatabase } from './connection-pin';
 
 /**
  * The single retain, kept as its promise so concurrent callers share one open and a
@@ -69,7 +70,15 @@ let retention: Promise<SQLiteDatabase | null> | null = null;
  */
 export function retainDatabaseConnection(): Promise<SQLiteDatabase | null> {
   retention ??= openDatabaseAsync(DATABASE_NAME).then(
-    (connection) => connection,
+    (connection) => {
+      // Redundant while the `retention` promise holds it, and kept anyway so that
+      // "every wrapper for this file goes through `pinDatabase`" is one enforceable
+      // rule rather than four separate arguments. Note that
+      // `resetConnectionRetentionForTests` nulling `retention` is exactly the shape
+      // of code that would otherwise create a collectable wrapper (#5410).
+      pinDatabase(connection);
+      return connection;
+    },
     (error: unknown) => {
       retention = null;
       reportError(error, { tags: { source: 'offline-sync', kind: 'sqlite-retain' } });

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -27,6 +27,8 @@ import { reportError } from '../lib/error-reporting';
 import { track } from '../lib/analytics';
 import { setSchemaReady } from './schema-ready';
 import { pinDatabase } from './connection-pin';
+import { registerDeadHandleRecovery, type DeadHandleOrigin } from './dead-handle';
+import type { SqliteHandleFailure } from '@boardsesh/offline-sync';
 import { markStartup } from '../lib/profiling/startup-profile';
 import { measureDatabaseBytes } from './storage-usage';
 
@@ -307,6 +309,15 @@ async function readJournalMode(db: SQLiteDatabase): Promise<string> {
  */
 export function initializeDatabase(db: SQLiteDatabase): Promise<void> {
   const replacesTheOneInFlight = latestDatabase !== null && latestDatabase !== db;
+  // Once a replacement is live, a later provider connection is a wrapper around the
+  // SAME DEAD NATIVE INSTANCE — `openDatabaseAsync` is still served it from the cache
+  // — so retargeting onto it would publish a dead handle as ready. Pin it (its
+  // collection would free the dead binding a second time) and leave the replacement
+  // in place (#5410).
+  if (recoveredDatabase !== null) {
+    pinDatabase(db);
+    return activeInitialization ?? Promise.resolve();
+  }
   // Reassigning `latestDatabase` below is what makes the PREVIOUS wrapper collectable,
   // and on Android collecting any wrapper for this file frees the native handle the
   // live connection is still using (#5410). The outgoing one was pinned by its own
@@ -382,6 +393,11 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
   });
 
   void (async () => {
+    // A dead-handle recovery retargets the whole lifecycle onto a replacement
+    // connection and starts its own chain. This chain must then stop, even if it is
+    // parked in a 60s retry gap — two chains running migrations against one file is
+    // the contention the ladder exists to survive, self-inflicted (#5410).
+    const epoch = chainEpoch;
     const startedAt = Date.now();
     const deadline = startedAt + MAX_INIT_WINDOW_MS;
     // What the last failed attempt tripped over, so a recovery can say which step
@@ -402,6 +418,10 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
       // handle was cleared outright.
       const target = latestDatabase ?? db;
       const outcome = await attemptInitialization(target);
+      if (epoch !== chainEpoch) {
+        releaseLaunch();
+        return;
+      }
       attempts += 1;
 
       // Unblock the provider once, whatever the first attempt did.
@@ -548,6 +568,7 @@ function beginInitialization(db: SQLiteDatabase): Promise<void> {
 
       markStartup('sqlite.recovery.start');
       await sleepUntilRetry(retryDelayMs);
+      if (epoch !== chainEpoch) return;
     }
   })();
 
@@ -596,6 +617,126 @@ function reportSupersededExhaustion(details: { attempts: number; elapsedMs: numb
     tags: { source: 'offline-sync', kind: 'sqlite-init-superseded' },
     extra: details,
   });
+}
+
+/**
+ * Dead-handle recovery (#5410).
+ *
+ * A collected JS wrapper can free the native binding of the connection everything
+ * else is still using. `connection-pin.ts` is what stops that happening; this is the
+ * safety net for a path it misses, because the alternative is a climber whose
+ * offline storage is dead until they force-quit.
+ */
+
+/**
+ * The replacement, once one exists. Never cleared and never closed — a wrapper we
+ * dropped would be collectable, which is the bug we are recovering from.
+ */
+let recoveredDatabase: SQLiteDatabase | null = null;
+
+/**
+ * How the replacement is opened. Injected rather than imported, because `./reopen`
+ * imports expo-sqlite for REAL and this module is loaded by node-env suites that
+ * cannot parse react-native's Flow source (see the note in `./testing`).
+ */
+let openReplacement: (() => Promise<SQLiteDatabase>) | null = null;
+
+/** Wired from `database-provider.tsx`, which already depends on expo-sqlite. */
+export function registerReplacementOpener(opener: () => Promise<SQLiteDatabase>): void {
+  openReplacement = opener;
+}
+
+/** Single-flight: ten consumers hitting the dead handle at once must open one connection. */
+let activeRecovery: Promise<void> | null = null;
+let recoveryCount = 0;
+let lastRecoveryStartedAt = 0;
+
+/**
+ * Two attempts per process, 30s apart. Same shape as `MAX_SUPERSEDED_RESTARTS`: the
+ * cap exists so a misclassified error cannot put the app in a re-open loop, not
+ * because a third attempt would be wrong.
+ */
+const MAX_DEAD_HANDLE_RECOVERIES = 2;
+const MIN_RECOVERY_INTERVAL_MS = 30_000;
+
+/**
+ * Bumped by a recovery so a chain parked in a retry gap cannot wake up and run a
+ * second migration against the replacement.
+ */
+let chainEpoch = 0;
+
+function recoverDeadDatabaseHandle(shape: Exclude<SqliteHandleFailure, null>, origin: DeadHandleOrigin): void {
+  // FIRST, and synchronously. Every `getDatabaseHandle()` reader re-reads per call,
+  // so this alone stops the storm: they fall back to the network instead of throwing
+  // again, and `setSchemaReady(false)` stops the scheduler and the drainer. It is
+  // worth doing even if the re-open below never succeeds.
+  setDatabaseHandle(null);
+
+  if (activeRecovery !== null) return;
+  if (recoveryCount >= MAX_DEAD_HANDLE_RECOVERIES) return;
+  if (lastRecoveryStartedAt !== 0 && Date.now() - lastRecoveryStartedAt < MIN_RECOVERY_INTERVAL_MS) return;
+  const opener = openReplacement;
+  if (opener === null) return;
+
+  recoveryCount += 1;
+  lastRecoveryStartedAt = Date.now();
+  const startedAt = Date.now();
+  markStartup('sqlite.deadhandle.start');
+  reportError(new Error(`SQLite native handle lost (${shape})`), {
+    tags: { source: 'offline-sync', kind: 'sqlite-dead-handle', phase: 'detected', shape, origin },
+    extra: { recoveries: recoveryCount },
+  });
+
+  activeRecovery = (async () => {
+    try {
+      const replacement = await opener();
+      pinDatabase(replacement);
+      recoveredDatabase = replacement;
+      // Retarget the ladder rather than inventing a second one: this gets WAL, the
+      // busy timeout, the queue table, migrations, the lock backoff — and the SINGLE
+      // publish site, so `retractSupersededHandle`'s invariant still holds.
+      chainEpoch += 1;
+      activeInitialization = null;
+      latestDatabase = replacement;
+      wakeFromBackoff?.();
+      activeInitialization = beginInitialization(replacement);
+      await activeInitialization;
+      markStartup('sqlite.deadhandle.end', 'ready');
+      reportError(new Error('SQLite native handle recovered'), {
+        tags: { source: 'offline-sync', kind: 'sqlite-dead-handle', phase: 'reopened', shape, origin },
+        extra: { recoveries: recoveryCount, elapsedMs: Date.now() - startedAt },
+      });
+      track(SHARED_EVENTS.OfflineSqliteHandleRecovered, {
+        shape,
+        origin,
+        recoveries: recoveryCount,
+        elapsedMs: Date.now() - startedAt,
+        recovered: getDatabaseHandle() !== null,
+      });
+    } catch (error) {
+      markStartup('sqlite.deadhandle.end', 'error');
+      reportError(error, {
+        tags: { source: 'offline-sync', kind: 'sqlite-dead-handle', phase: 'failed', shape, origin },
+        extra: { recoveries: recoveryCount, elapsedMs: Date.now() - startedAt },
+      });
+    } finally {
+      activeRecovery = null;
+    }
+  })();
+}
+
+// Registered on module load so the wiring cannot be forgotten by a caller, and
+// cannot arrive after the first failure.
+registerDeadHandleRecovery(recoverDeadDatabaseHandle);
+
+/** Test-only. Drops the recovery state so a suite can drive it more than once. */
+export function resetDeadHandleRecoveryForTests(): void {
+  recoveredDatabase = null;
+  openReplacement = null;
+  activeRecovery = null;
+  recoveryCount = 0;
+  lastRecoveryStartedAt = 0;
+  chainEpoch = 0;
 }
 
 /**

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -307,11 +307,16 @@ async function readJournalMode(db: SQLiteDatabase): Promise<string> {
  */
 export function initializeDatabase(db: SQLiteDatabase): Promise<void> {
   const replacesTheOneInFlight = latestDatabase !== null && latestDatabase !== db;
-  // Pin before the overwrite below. Reassigning `latestDatabase` is what makes the
-  // PREVIOUS wrapper collectable, and on Android collecting any wrapper for this file
-  // frees the native handle the live connection is still using (#5410). Pinning both
-  // the outgoing and incoming wrapper is what makes that overwrite safe.
-  pinDatabase(latestDatabase);
+  // Reassigning `latestDatabase` below is what makes the PREVIOUS wrapper collectable,
+  // and on Android collecting any wrapper for this file frees the native handle the
+  // live connection is still using (#5410). The outgoing one was pinned by its own
+  // call to this function, so only the incoming one needs pinning here.
+  //
+  // Deliberately overlapping with the two pins in `database-provider.tsx`: today
+  // `onInit` is this function's only caller, so removing any ONE of the three leaves
+  // every wrapper pinned and the suite green. That redundancy is the point — this is
+  // the module that owns the overwrite hazard, and `initializeDatabase` is a public
+  // export, so a second caller must not have to remember the provider's pin.
   pinDatabase(db);
   // Recorded on EVERY call, including the remount that only gets the shared promise
   // back, so the in-flight chain can retarget onto the live connection.

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -26,10 +26,14 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { reportError } from '../lib/error-reporting';
 import { track } from '../lib/analytics';
 import { setSchemaReady } from './schema-ready';
+import { pinDatabase } from './connection-pin';
 import { markStartup } from '../lib/profiling/startup-profile';
 import { measureDatabaseBytes } from './storage-usage';
 
-export const DATABASE_NAME = 'boardsesh.db';
+// Defined in its own leaf module so `connection-pin.ts` can read it without an
+// import cycle back through this file. Re-exported here so every existing import
+// site keeps working.
+export { DATABASE_NAME } from './database-name';
 
 // Tables that hold the signed-in user's own data. Cleared on sign-out so the
 // next account on the device never sees the previous user's ticks, playlists,
@@ -303,6 +307,12 @@ async function readJournalMode(db: SQLiteDatabase): Promise<string> {
  */
 export function initializeDatabase(db: SQLiteDatabase): Promise<void> {
   const replacesTheOneInFlight = latestDatabase !== null && latestDatabase !== db;
+  // Pin before the overwrite below. Reassigning `latestDatabase` is what makes the
+  // PREVIOUS wrapper collectable, and on Android collecting any wrapper for this file
+  // frees the native handle the live connection is still using (#5410). Pinning both
+  // the outgoing and incoming wrapper is what makes that overwrite safe.
+  pinDatabase(latestDatabase);
+  pinDatabase(db);
   // Recorded on EVERY call, including the remount that only gets the shared promise
   // back, so the in-flight chain can retarget onto the live connection.
   latestDatabase = db;

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -55,13 +55,32 @@ const USER_DATA_TABLES_TO_CLEAR = [
 
 let databaseHandle: SQLiteDatabase | null = null;
 
+const handleListeners = new Set<() => void>();
+
+/**
+ * Subscribe to handle CHANGES, including a non-null to non-null swap.
+ *
+ * `subscribeSchemaReady` cannot serve this: it only fires when readiness flips, so a
+ * dead-handle recovery replacing one live connection with another is invisible to
+ * it — and the consumers that take their database from `useSQLiteContext()` would
+ * keep writing through the dead one (#5410).
+ */
+export function subscribeDatabaseHandle(listener: () => void): () => void {
+  handleListeners.add(listener);
+  return () => {
+    handleListeners.delete(listener);
+  };
+}
+
 export function setDatabaseHandle(db: SQLiteDatabase | null): void {
+  const changed = databaseHandle !== db;
   databaseHandle = db;
   // The handle is only ever published once migrations have run, so it doubles as
   // the schema-readiness signal for the `useSQLiteContext()` consumers that can't
   // see this handle at all. Driving the store from here — rather than letting
   // callers poke it — keeps the two from ever disagreeing.
   setSchemaReady(db !== null);
+  if (changed) for (const listener of handleListeners) listener();
 }
 
 export function getDatabaseHandle(): SQLiteDatabase | null {
@@ -657,7 +676,9 @@ let lastRecoveryStartedAt = 0;
  * because a third attempt would be wrong.
  */
 const MAX_DEAD_HANDLE_RECOVERIES = 2;
-const MIN_RECOVERY_INTERVAL_MS = 30_000;
+/** Exported so the single-flight test steps past the gate by the real interval
+ * rather than mirroring the number in a literal that silently drifts from it. */
+export const MIN_RECOVERY_INTERVAL_MS = 30_000;
 
 /**
  * Bumped by a recovery so a chain parked in a retry gap cannot wake up and run a

--- a/packages/mobile/src/db/database-name.ts
+++ b/packages/mobile/src/db/database-name.ts
@@ -1,0 +1,4 @@
+// The app database's filename, on its own so leaf modules can read it without
+// importing `./connection` — which imports them back. `connection.ts` re-exports
+// it, so every existing `from '../db'` / `from './connection'` import is unchanged.
+export const DATABASE_NAME = 'boardsesh.db';

--- a/packages/mobile/src/db/dead-handle.ts
+++ b/packages/mobile/src/db/dead-handle.ts
@@ -1,0 +1,51 @@
+// The notifier that turns "some call failed" into "the SQLite handle is gone,
+// re-open it" (#5410).
+//
+// WHY A REGISTRATION SEAM RATHER THAN A DIRECT CALL. Detection has to hang off
+// `reportError`, because that is the one funnel every SQLite consumer already
+// passes through — react-query reads and mutations, the sync cycle, tick writes,
+// and the init chain itself. But `lib/error-reporting` → `db/connection` →
+// `lib/error-reporting` is an import cycle, and `connection.ts` is what owns the
+// re-open. So `connection.ts` registers its recovery here on module load, and this
+// module stays a leaf that imports nothing but the classifier.
+//
+// WHY IT IS SAFE TO CALL FROM INSIDE THE REPORTING FUNNEL. `noteDatabaseHandleFailure`
+// never throws and never awaits: it classifies, and hands off to a recovery that
+// starts its own work asynchronously. A reporting path that could throw would turn
+// every handled error into an unhandled one.
+
+import { classifySqliteHandleError, type SqliteHandleFailure } from '@boardsesh/offline-sync';
+
+/** Which consumer hit the dead handle first. Tagged on the recovery report. */
+export type DeadHandleOrigin = 'report' | 'cycle' | 'init' | 'dev';
+
+type RecoveryStart = (shape: Exclude<SqliteHandleFailure, null>, origin: DeadHandleOrigin) => void;
+
+let startRecovery: RecoveryStart | null = null;
+
+/**
+ * Wire the recovery. Called once, from `connection.ts`'s module body, so the
+ * registration cannot be forgotten by a caller and cannot arrive after the first
+ * failure.
+ */
+export function registerDeadHandleRecovery(start: RecoveryStart): void {
+  startRecovery = start;
+}
+
+/**
+ * Classify `error` and, if the handle behind it is dead, kick off recovery.
+ *
+ * Returns whether it was a handle failure, so a caller that also reports can tag
+ * its own report and keep the aggregate sliceable.
+ */
+export function noteDatabaseHandleFailure(error: unknown, origin: DeadHandleOrigin): boolean {
+  const shape = classifySqliteHandleError(error);
+  if (shape === null) return false;
+  startRecovery?.(shape, origin);
+  return true;
+}
+
+/** Test-only. Drops the registration so a suite can assert the unwired case. */
+export function resetDeadHandleStateForTests(): void {
+  startRecovery = null;
+}

--- a/packages/mobile/src/db/reopen.ts
+++ b/packages/mobile/src/db/reopen.ts
@@ -1,0 +1,38 @@
+// Re-opening `boardsesh.db` after its native handle died under us (#5410).
+//
+// THE TRAP. A plain `openDatabaseAsync(DATABASE_NAME)` gives you back the SAME
+// DEAD INSTANCE. Nothing ever closed it — the binding was destroyed by a collected
+// wrapper's releaser, not by `closeAsync` — so its refcount never reached zero,
+// `removeCachedDatabase` never evicted it, and `cachedDatabases` still holds it for
+// the next lookup to find.
+//
+// THE ESCAPE. Both platforms' constructors short-circuit the cache lookup on the
+// REQUESTING options:
+//
+//   findCachedDatabase { it.databasePath == databasePath && it.openOptions == options
+//                        && !options.useNewConnection }
+//
+// so `useNewConnection: true` can never be served from the cache. It cannot be
+// poisoned later either: `OpenDatabaseOptions` is a data class, so a later
+// default-options open can't match this entry any more than this one could match
+// the dead one. We get a genuinely fresh `sqlite3*`.
+//
+// WHAT IT COSTS. One more connection on a WAL file, which the app already pays for
+// on every `withExclusiveTransactionAsync` and every pull write. The init ladder
+// re-runs `configureMainConnection` on it, so it gets the same WAL mode and
+// `busy_timeout` as the connection it replaces. In development it is skipped by
+// `registerDatabaseForDevToolsAsync`, so it will not show in the devtools database
+// list — the only visible difference.
+//
+// REJECTED: draining the refcount with repeated `closeAsync` to evict the dead
+// entry. It does evict (the removal precedes the close), but JS cannot read the
+// refcount, so the stopping rule would be "call it until it throws" — and the throw
+// is indistinguishable from the bug we are recovering from.
+
+import { openDatabaseAsync, type SQLiteDatabase } from 'expo-sqlite';
+import { DATABASE_NAME } from './database-name';
+
+/** A fresh native connection to the app database, bypassing the poisoned cache. */
+export function openReplacementDatabase(): Promise<SQLiteDatabase> {
+  return openDatabaseAsync(DATABASE_NAME, { useNewConnection: true });
+}

--- a/packages/mobile/src/db/testing.ts
+++ b/packages/mobile/src/db/testing.ts
@@ -5,6 +5,9 @@
 // state lives; this barrel exists so the sanctioned import path for it is visibly a
 // test path, and so the production barrel (./index.ts) can stay free of it.
 export { resetDatabaseInitializationForTests } from './connection';
+// `connection-pin` imports expo-sqlite for TYPES only, so unlike the retention reset
+// below it erases at build time and is safe to route through this barrel.
+export { resetDatabasePinsForTests } from './connection-pin';
 // `resetConnectionRetentionForTests` deliberately does NOT come through here.
 // ./connection-retention imports expo-sqlite for real, whose entry reaches
 // react-native's Flow source — unparseable by Rolldown's collection-time scan — so

--- a/packages/mobile/src/db/use-offline-database.ts
+++ b/packages/mobile/src/db/use-offline-database.ts
@@ -1,0 +1,26 @@
+import { useSyncExternalStore } from 'react';
+import { useSQLiteContext, type SQLiteDatabase } from 'expo-sqlite';
+import { getDatabaseHandle, subscribeDatabaseHandle } from './connection';
+
+/**
+ * The database a `useSQLiteContext()` consumer should actually use.
+ *
+ * WHY NOT JUST `useSQLiteContext()` (#5410). When a dead-handle recovery opens a
+ * replacement connection, the provider's context value does not change — the
+ * provider never tore down, and its connection is a wrapper around the native
+ * instance that just died. A consumer holding the context value would keep writing
+ * through the dead one, so a successful recovery would fix the readers that go
+ * through `getDatabaseHandle()` and leave the sync scheduler and the mutation
+ * drainer broken.
+ *
+ * So: prefer the published handle, fall back to the provider's. The fallback is
+ * what covers the ordinary case — the published handle is deliberately null until
+ * migrations have run, and a read-only consumer still wants a connection then (see
+ * the contract in ./schema-ready). Consumers that WRITE must still gate on
+ * `useOfflineSchemaReady()`; this hook decides WHICH connection, not WHETHER.
+ */
+export function useOfflineDatabase(): SQLiteDatabase {
+  const provided = useSQLiteContext();
+  const published = useSyncExternalStore(subscribeDatabaseHandle, getDatabaseHandle, () => null);
+  return published ?? provided;
+}

--- a/packages/mobile/src/db/use-offline-database.web.ts
+++ b/packages/mobile/src/db/use-offline-database.web.ts
@@ -1,0 +1,14 @@
+import { useSQLiteContext, type SQLiteDatabase } from 'expo-sqlite';
+
+/**
+ * Expo-web fork: there is no recovery to follow, so the provider's connection is
+ * always the right one.
+ *
+ * The browser app has no offline SQLite — `expo-sqlite` is aliased to
+ * `src/web-shims/sqlite.tsx` and nothing ever publishes a handle — so subscribing
+ * to the native handle store would return null forever and the fallback would be
+ * the only branch taken. Same reasoning as ./use-offline-schema-ready.web.ts.
+ */
+export function useOfflineDatabase(): SQLiteDatabase {
+  return useSQLiteContext();
+}

--- a/packages/mobile/src/lib/error-reporting.ts
+++ b/packages/mobile/src/lib/error-reporting.ts
@@ -1,7 +1,9 @@
 import { isBleWriteTimeoutError } from '@boardsesh/ble-protocol/connection-error';
 import { getErrorStatus, isNetworkError as isSharedNetworkError } from '@boardsesh/offline-sync/error-classification';
+import { isDeadDatabaseHandleError } from '@boardsesh/offline-sync';
 import { addBreadcrumbToSentry, captureToSentry, type ErrorReportContext } from './sentry';
 import { isBackendUnavailableError } from './connectivity/backend-unavailable-error';
+import { noteDatabaseHandleFailure } from '../db/dead-handle';
 import { captureToObserve } from './observe-runtime';
 import {
   isExpectedAuthError,
@@ -28,6 +30,12 @@ export type { ErrorReportContext };
  * Sentry cannot answer; Sentry keeps the triage detail.
  */
 export function reportError(error: unknown, context?: ErrorReportContext): void {
+  // Detection for #5410 hangs off this funnel because it is the one thing every
+  // SQLite consumer already reaches: react-query reads and mutations, the sync
+  // cycle, tick writes, and the init chain. Hooking `captureToSentry` instead would
+  // no-op without a DSN, which would make the whole recovery path untestable in
+  // development. Never throws, so it cannot turn a handled error into a crash.
+  noteDatabaseHandleFailure(error, 'report');
   captureToSentry(error, context);
   captureToObserve(error);
 }
@@ -174,6 +182,18 @@ export function reportHandledError(error: unknown, context?: ErrorReportContext)
       ...context,
       level: 'warning',
       tags: { ...context?.tags, network: true },
+    });
+    return;
+  }
+  // Tagged rather than given its own report, so BOARDSESH-G1 and its siblings stay
+  // ONE aggregate — which is what lets a before/after comparison work — while still
+  // being sliceable by `dead_handle:true`. Kept at the caller's level: a dead handle
+  // really is broken until the re-open lands, unlike the transient cases above.
+  if (isDeadDatabaseHandleError(error)) {
+    reportError(error, {
+      level: 'error',
+      ...context,
+      tags: { ...context?.tags, dead_handle: true },
     });
     return;
   }

--- a/packages/mobile/src/lib/profiling/startup-collector.ts
+++ b/packages/mobile/src/lib/profiling/startup-collector.ts
@@ -9,6 +9,11 @@ export type StartupMarkName =
   | 'sqlite.initial.gate'
   | 'sqlite.recovery.start'
   | 'sqlite.recovery.end'
+  // Mid-session, not launch: the native handle died under us and a replacement
+  // connection was opened (#5410). Kept apart from `sqlite.recovery.*`, which
+  // measures launch-time lock contention.
+  | 'sqlite.deadhandle.start'
+  | 'sqlite.deadhandle.end'
   | 'auth.initial.start'
   | 'auth.initial.ready'
   | 'splash.hide.request'

--- a/packages/mobile/src/lib/profiling/startup-profile.ts
+++ b/packages/mobile/src/lib/profiling/startup-profile.ts
@@ -71,7 +71,8 @@ function scheduleExport(delayMs: number) {
 
 export function markStartup(name: StartupMarkName, outcome?: StartupOutcome): void {
   if (!collector.mark(name, outcome)) return;
-  if (name === 'home.useful.commit' || name === 'sqlite.recovery.end') scheduleExport(1_000);
+  if (name === 'home.useful.commit' || name === 'sqlite.recovery.end' || name === 'sqlite.deadhandle.end')
+    scheduleExport(1_000);
 }
 
 if (STARTUP_PROFILING_ENABLED) {

--- a/packages/mobile/src/offline/dev/lock-holder.ts
+++ b/packages/mobile/src/offline/dev/lock-holder.ts
@@ -13,6 +13,7 @@
 // runs at import time.
 
 import { openDatabaseAsync } from 'expo-sqlite';
+import { pinDatabase } from '../../db/connection-pin';
 import { DATABASE_NAME } from '../../db';
 
 /** Key of the throwaway row the hold writes; never read by anything else. */
@@ -38,6 +39,13 @@ export function isHoldingWriteLock(): boolean {
  */
 export async function holdWriteLock(durationMs: number): Promise<void> {
   const connection = await openDatabaseAsync(DATABASE_NAME);
+  // This opens `boardsesh.db` a SECOND time with default options, so Android hands
+  // back the same native instance under a new shared-object id. Without this pin the
+  // wrapper below becomes collectable the moment this function returns, and
+  // collecting it frees the native handle the whole app is still using (#5410) —
+  // which makes this dev tool a reliable way to reproduce BOARDSESH-G1 rather than a
+  // way to reproduce lock contention.
+  pinDatabase(connection);
   holdingUntil = Date.now() + durationMs;
   try {
     await connection.withExclusiveTransactionAsync(async (txn) => {

--- a/packages/mobile/src/offline/dev/write-fault-injection.ts
+++ b/packages/mobile/src/offline/dev/write-fault-injection.ts
@@ -24,7 +24,9 @@ export type WriteFaultMode =
   | 'android-lock'
   | 'android-lock-no-code'
   | 'disk-full'
-  | 'commit-then-throw';
+  | 'commit-then-throw'
+  | 'android-dead-handle'
+  | 'closed-resource';
 
 export type WriteFaultPhase = 'before-task' | 'after-commit';
 
@@ -38,6 +40,15 @@ const ANDROID_LOCK_MESSAGE =
   ': database is locked';
 const ANDROID_LOCK_NO_CODE_MESSAGE =
   "Call to function 'NativeDatabase.prepareAsync' has been rejected.\n→ Caused by: Error code : database is locked";
+// #5410. Not a lock at all: a collected JS wrapper freed the native binding, so the
+// call sails past expo-sqlite's `isClosed` guard and dereferences a dead pointer.
+// `CodedException.kt` renders the cause as `localizedMessage ?: cause`, and
+// `toString()` on a message-less NullPointerException is the bare class name — which
+// is why there is nothing after the final colon to key on.
+const ANDROID_DEAD_HANDLE_MESSAGE =
+  "Call to function 'NativeDatabase.prepareAsync' has been rejected.\n→ Caused by: java.lang.NullPointerException: java.lang.NullPointerException";
+// The honest close, which expo-sqlite raises itself when `isClosed` really was set.
+const CLOSED_RESOURCE_MESSAGE = 'Access to closed resource';
 const DISK_FULL_MESSAGE =
   "FunctionCallException: Calling the 'runAsync' function has failed\n→ Caused by: SQLiteErrorException: Error code 13: database or disk is full";
 
@@ -49,7 +60,18 @@ const FAULT_MESSAGES: Record<Exclude<WriteFaultMode, 'off'>, string> = {
   // The lock shape matters here too: a commit-then-throw only retries when the
   // ladder classifies it as contention, which is the case being reproduced.
   'commit-then-throw': IOS_LOCK_MESSAGE,
+  'android-dead-handle': ANDROID_DEAD_HANDLE_MESSAGE,
+  'closed-resource': CLOSED_RESOURCE_MESSAGE,
 };
+
+/**
+ * The dead-handle message, exported so the dev screen can drive the FULL recovery
+ * loop — detect, re-open, republish, restart the scheduler — rather than only the
+ * classification on the tick path. A genuine kill is not reproducible on demand:
+ * Hermes exposes no forced garbage collection, which is exactly why this bug reads
+ * as background noise instead of something QA can find.
+ */
+export { ANDROID_DEAD_HANDLE_MESSAGE };
 
 type WriteFaultState = { mode: WriteFaultMode; remaining: number };
 

--- a/packages/mobile/src/offline/use-board-downloads.ts
+++ b/packages/mobile/src/offline/use-board-downloads.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { useSQLiteContext } from 'expo-sqlite';
+import { useOfflineDatabase } from '../db/use-offline-database';
 import { useQueryClient } from '@tanstack/react-query';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { restoreBootstrapRetryBudget, type GraphQLFetch } from '@boardsesh/offline-sync';
@@ -41,7 +41,10 @@ const ARM_REACHABILITY_RETRY_DELAYS_MS = [750, 3_000] as const;
  * (`useOfflineBoardEnabled`, `getDownloadedScopeKeys`) stays with the UI.
  */
 export function useBoardDownloads() {
-  const db = useSQLiteContext();
+  // Not `useSQLiteContext()` directly: a dead-handle recovery opens a REPLACEMENT
+  // connection without the provider ever re-rendering, so the context value would
+  // still be the wrapper around the dead native instance (#5410).
+  const db = useOfflineDatabase();
   const queryClient = useQueryClient();
   const snapshotSource = useSnapshotSource();
   // The db from `useSQLiteContext()` is handed out as soon as the launch gate opens,

--- a/packages/mobile/src/offline/use-confirm-board-download.ts
+++ b/packages/mobile/src/offline/use-confirm-board-download.ts
@@ -14,7 +14,7 @@
 
 import { useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSQLiteContext } from 'expo-sqlite';
+import { useOfflineDatabase } from '../db/use-offline-database';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import {
   estimateScopeDownload,
@@ -34,7 +34,10 @@ import { notifyBootstrapMetadataChanged } from '../sync';
 
 export function useConfirmBoardDownload() {
   const { t, i18n } = useTranslation('boards');
-  const db = useSQLiteContext();
+  // Not `useSQLiteContext()` directly: a dead-handle recovery opens a REPLACEMENT
+  // connection without the provider ever re-rendering, so the context value would
+  // still be the wrapper around the dead native instance (#5410).
+  const db = useOfflineDatabase();
   const confirm = useConfirm();
   const { enableBoardsOffline, armBoardsOffline } = useBoardDownloads();
   // A ref, not a dep: the manifest arrives asynchronously and must not rebuild

--- a/packages/mobile/src/offline/use-downloaded-scope-keys.ts
+++ b/packages/mobile/src/offline/use-downloaded-scope-keys.ts
@@ -10,7 +10,7 @@
 // every progress frame and would churn the virtualised screens).
 
 import { useQuery } from '@tanstack/react-query';
-import { useSQLiteContext } from 'expo-sqlite';
+import { useOfflineDatabase } from '../db/use-offline-database';
 import { getDownloadedScopeKeys } from '@boardsesh/offline-sync';
 import { useOfflineSchemaReady } from '../db/use-offline-schema-ready';
 
@@ -25,7 +25,10 @@ export const DOWNLOADED_SCOPE_KEYS_QUERY_KEY = ['downloadedScopeKeys'] as const;
  * must not be stranded.
  */
 export function useDownloadedScopeKeys() {
-  const db = useSQLiteContext();
+  // Not `useSQLiteContext()` directly: a dead-handle recovery opens a REPLACEMENT
+  // connection without the provider ever re-rendering, so the context value would
+  // still be the wrapper around the dead native instance (#5410).
+  const db = useOfflineDatabase();
   // Schema readiness is a KEY member, not an `enabled` gate. On a contended launch
   // this connection has no tables yet, and the read lands in `isError` — the empty
   // state, which is already the right answer. Gating instead would spin forever

--- a/packages/mobile/src/providers/__tests__/database-provider-shared-object-gc.test.tsx
+++ b/packages/mobile/src/providers/__tests__/database-provider-shared-object-gc.test.tsx
@@ -1,0 +1,341 @@
+// @vitest-environment jsdom
+// #5410: garbage-collecting a STALE JS wrapper destroys the native handle the LIVE
+// connection is still using.
+//
+// On Android, opening `boardsesh.db` twice with equal options returns the same Kotlin
+// `NativeDatabase` (`SQLiteModule.kt`), and expo-modules-core registers that one
+// native instance a second time under a fresh shared-object id, minting an
+// independent C++ `NativeState` for the new wrapper. `~NativeState` runs the
+// releaser, so collecting ANY wrapper calls `sharedObjectDidRelease()` →
+// `ref.close()` → `mHybridData.resetNative()`. `NativeDatabase.kt` neither consults
+// its refcount nor sets `isClosed` there, so the next call sails past
+// `maybeThrowForClosedDatabase` and dereferences a freed pointer.
+//
+// The mock below models exactly that, which is why it is NOT shared with
+// database-provider-retention.test.tsx: that suite's mock deliberately models only
+// the refcount, so its assertions stay about the native free. This one is a superset
+// — refcount AND shared-object registry — because the bug here is that the refcount
+// is not what protects you.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, waitFor } from '@testing-library/react';
+
+vi.mock('../../lib/error-reporting', () => ({ reportError: vi.fn() }));
+vi.mock('../../lib/profiling/startup-profile', () => ({ markStartup: vi.fn() }));
+vi.mock('../../lib/analytics', () => ({ track: vi.fn() }));
+
+vi.mock('@boardsesh/offline-sync', () => ({
+  configureMainConnection: vi.fn(async () => {}),
+  ensureMutationQueueTable: vi.fn(async () => {}),
+  runMigrations: vi.fn(async () => {}),
+  classifySqliteLockError: () => ({ locked: false, code: null }),
+  applyBusyTimeout: vi.fn(async () => {}),
+  beginImmediateWrite: vi.fn(async () => {}),
+  deleteUserCheckpoints: vi.fn(async () => {}),
+  deleteAllSyncMeta: vi.fn(async () => {}),
+  vacuumDatabase: vi.fn(async () => true),
+  getUnfinishedDownloadScopeKeys: vi.fn(async () => []),
+  claimAbandonedDownloadTerminal: vi.fn(() => true),
+  purgeNamespaceForScopeKey: vi.fn(async () => {}),
+  OFFLINE_DB_BUSY_TIMEOUT_MS: 5_000,
+  BOARD_DATA_TABLES: [],
+}));
+
+/** Verbatim BOARDSESH-G1, as `CodedException.kt` renders a message-less NPE. */
+const ANDROID_DEAD_HANDLE =
+  "Call to function 'NativeDatabase.prepareAsync' has been rejected.\n→ Caused by: java.lang.NullPointerException: java.lang.NullPointerException";
+
+const sqlite = vi.hoisted(() => {
+  type NativeConnection = { id: number; path: string; refCount: number; freed: boolean; destroyed: boolean };
+  type Wrapper = {
+    sharedObjectId: number;
+    native: NativeConnection;
+    databasePath: string;
+    options: { useNewConnection?: boolean };
+    nativeDatabase: object;
+    prepareAsync: (source: string) => Promise<void>;
+    closeAsync: () => Promise<void>;
+    withExclusiveTransactionAsync: (task: (txn: unknown) => Promise<void>) => Promise<void>;
+  };
+
+  const cache = new Map<string, NativeConnection>();
+  /** `SharedObjectRegistry.pairs`: id -> native. One entry PER WRAPPER. */
+  const registry = new Map<number, NativeConnection>();
+  const wrappers: Wrapper[] = [];
+  const freedConnectionIds: number[] = [];
+  let nextConnectionId = 0;
+  let nextSharedObjectId = 0;
+  /** When true, the provider publishes without ever calling `onInit` (see test 5). */
+  let skipOnInit = false;
+
+  function openNative(path: string, useNewConnection: boolean): NativeConnection {
+    // The constructor predicate short-circuits on `!options.useNewConnection`, so a
+    // transaction open can never be served from — or matched against — the cache.
+    if (!useNewConnection) {
+      const cached = cache.get(path);
+      if (cached !== undefined) {
+        cached.refCount += 1;
+        return cached;
+      }
+    }
+    nextConnectionId += 1;
+    const connection: NativeConnection = { id: nextConnectionId, path, refCount: 1, freed: false, destroyed: false };
+    if (!useNewConnection) cache.set(path, connection);
+    return connection;
+  }
+
+  function makeWrapper(path: string, options: { useNewConnection?: boolean }): Wrapper {
+    const native = openNative(path, options.useNewConnection === true);
+    nextSharedObjectId += 1;
+    const sharedObjectId = nextSharedObjectId;
+    // `SharedObjectRegistry.add()` mints a new id and OVERWRITES the one the native
+    // object was carrying. This single line is the bug.
+    registry.set(sharedObjectId, native);
+
+    const wrapper: Wrapper = {
+      sharedObjectId,
+      native,
+      databasePath: path,
+      options,
+      nativeDatabase: { sharedObjectId },
+      prepareAsync: async (): Promise<void> => {
+        if (native.destroyed) throw new Error(ANDROID_DEAD_HANDLE);
+        if (native.freed) throw new Error('Access to closed resource');
+      },
+      closeAsync: async (): Promise<void> => {
+        native.refCount -= 1;
+        if (native.refCount > 0) return;
+        native.freed = true;
+        cache.delete(native.path);
+        freedConnectionIds.push(native.id);
+      },
+      withExclusiveTransactionAsync: async (task): Promise<void> => {
+        const txn = makeWrapper(path, { ...options, useNewConnection: true });
+        try {
+          await task(txn);
+        } finally {
+          await txn.closeAsync();
+        }
+      },
+    };
+    wrappers.push(wrapper);
+    return wrapper;
+  }
+
+  return {
+    makeWrapper,
+    freedConnectionIds,
+    allWrappers: (): Wrapper[] => [...wrappers],
+    liveConnections: (): { id: number; refCount: number }[] =>
+      [...cache.values()].map(({ id, refCount }) => ({ id, refCount })),
+    /**
+     * The collector reclaimed `wrapper`: `~NativeState` runs the releaser, the
+     * registry entry goes, and `sharedObjectDidRelease()` closes the native binding.
+     *
+     * Deliberately touches NEITHER `refCount` NOR `freed` — that asymmetry IS the
+     * bug, and a mock that tidied it up would stop reproducing anything.
+     */
+    collect(wrapper: Wrapper): void {
+      registry.delete(wrapper.sharedObjectId);
+      wrapper.native.destroyed = true;
+    },
+    setSkipOnInit(value: boolean): void {
+      skipOnInit = value;
+    },
+    shouldSkipOnInit: (): boolean => skipOnInit,
+    reset(): void {
+      cache.clear();
+      registry.clear();
+      wrappers.length = 0;
+      freedConnectionIds.length = 0;
+      nextConnectionId = 0;
+      nextSharedObjectId = 0;
+      skipOnInit = false;
+    },
+  };
+});
+
+vi.mock('expo-sqlite', async () => {
+  const { createContext, createElement, useContext, useEffect, useRef, useState } = await import('react');
+  const SQLiteContext = createContext<unknown>(null);
+
+  async function openDatabaseAsync(databaseName: string, options?: { useNewConnection?: boolean }): Promise<unknown> {
+    return sqlite.makeWrapper(databaseName, options ?? {});
+  }
+
+  function SQLiteProvider({
+    children,
+    databaseName,
+    onInit,
+  }: {
+    children?: unknown;
+    databaseName: string;
+    onInit: (db: never) => Promise<void>;
+  }) {
+    const databaseRef = useRef<{ closeAsync: () => Promise<void> } | null>(null);
+    const [, setOpened] = useState(false);
+
+    useEffect(() => {
+      async function setup(): Promise<void> {
+        const database = (await openDatabaseAsync(databaseName)) as { closeAsync: () => Promise<void> };
+        if (!sqlite.shouldSkipOnInit()) await onInit(database as never);
+        databaseRef.current = database;
+        setOpened(true);
+      }
+      void setup();
+      return () => {
+        const database = databaseRef.current;
+        databaseRef.current = null;
+        setOpened(false);
+        void database?.closeAsync();
+      };
+    }, [databaseName, onInit]);
+
+    if (databaseRef.current === null) return null;
+    return createElement(SQLiteContext.Provider, { value: databaseRef.current }, children as never);
+  }
+
+  return { SQLiteProvider, openDatabaseAsync, useSQLiteContext: () => useContext(SQLiteContext) };
+});
+
+import { DatabaseProvider } from '../database-provider';
+import { getDatabaseHandle, setDatabaseHandle } from '../../db/connection';
+import { resetDatabaseInitializationForTests, resetDatabasePinsForTests } from '../../db/testing';
+import { isDatabasePinned, pinnedDatabaseCount } from '../../db/connection-pin';
+import { resetConnectionRetentionForTests } from '../../db/connection-retention';
+
+beforeEach(() => {
+  resetDatabaseInitializationForTests();
+  resetConnectionRetentionForTests();
+  resetDatabasePinsForTests();
+  setDatabaseHandle(null);
+  sqlite.reset();
+});
+
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function mountUntilPublished(): Promise<{ unmount: () => void }> {
+  const view = render(
+    <DatabaseProvider>
+      <div data-testid="child" />
+    </DatabaseProvider>,
+  );
+  await waitFor(() => {
+    expect(view.queryByTestId('child')).not.toBeNull();
+  });
+  await settle();
+  return view;
+}
+
+/**
+ * Run the collector over everything production did NOT pin.
+ *
+ * Asserts the production invariant directly — it calls `isDatabasePinned` rather than
+ * restating which wrappers ought to be pinned, so a funnel that stops firing shows up
+ * here as a destroyed connection instead of as a stale expectation.
+ */
+function collectUnpinned(): void {
+  for (const wrapper of sqlite.allWrappers()) {
+    if (!isDatabasePinned(wrapper as never)) sqlite.collect(wrapper);
+  }
+}
+
+describe('the mock still reproduces BOARDSESH-G1', () => {
+  // If this ever stops failing, every other test in this file is vacuous.
+  it('kills the live connection when a second wrapper over it is collected', async () => {
+    const first = sqlite.makeWrapper('boardsesh.db', {});
+    const second = sqlite.makeWrapper('boardsesh.db', {});
+    expect(second.native).toBe(first.native);
+    expect(first.native.refCount).toBe(2);
+
+    sqlite.collect(first);
+
+    // Nothing was closed and nothing was freed — the refcount is still 2 — and yet
+    // the live wrapper's next statement hits a freed pointer.
+    expect(first.native.freed).toBe(false);
+    expect(first.native.refCount).toBe(2);
+    await expect(second.prepareAsync('SELECT 1')).rejects.toThrow('java.lang.NullPointerException');
+  });
+});
+
+describe('DatabaseProvider shared-object pinning', () => {
+  it('leaves the live connection usable after a teardown and a collection', async () => {
+    const first = await mountUntilPublished();
+    first.unmount();
+    await settle();
+
+    const second = await mountUntilPublished();
+    collectUnpinned();
+
+    const live = sqlite.allWrappers().at(-1);
+    expect(live).toBeDefined();
+    await expect(live?.prepareAsync('SELECT 1')).resolves.toBeUndefined();
+    expect(sqlite.liveConnections()).toEqual([{ id: 1, refCount: expect.any(Number) }]);
+    expect(sqlite.allWrappers().every((wrapper) => !wrapper.native.destroyed)).toBe(true);
+
+    second.unmount();
+    await settle();
+  });
+
+  it('survives ten remounts with a collection after each', async () => {
+    for (let mount = 0; mount < 10; mount += 1) {
+      const view = await mountUntilPublished();
+      view.unmount();
+      await settle();
+      collectUnpinned();
+    }
+
+    // One native connection for the whole process, never freed, never destroyed.
+    expect(sqlite.freedConnectionIds).toEqual([]);
+    expect(sqlite.allWrappers().every((wrapper) => !wrapper.native.destroyed)).toBe(true);
+    expect(pinnedDatabaseCount()).toBeGreaterThanOrEqual(10);
+  });
+
+  it('pins the retention handle', async () => {
+    await mountUntilPublished();
+    const retained = sqlite.allWrappers().filter((wrapper) => wrapper.options.useNewConnection !== true);
+    expect(retained.length).toBeGreaterThanOrEqual(2);
+    expect(retained.every((wrapper) => isDatabasePinned(wrapper as never))).toBe(true);
+  });
+
+  it('pins a context value onInit never saw', async () => {
+    // Today `SQLiteProvider` cannot do this. The effect pin is what keeps that from
+    // being load-bearing on an undocumented expo-sqlite internal.
+    sqlite.setSkipOnInit(true);
+    await mountUntilPublished();
+
+    const published = sqlite.allWrappers().at(-1);
+    expect(published).toBeDefined();
+    expect(isDatabasePinned(published as never)).toBe(true);
+  });
+
+  it('never pins a transaction connection', async () => {
+    await mountUntilPublished();
+    const before = pinnedDatabaseCount();
+
+    const live = sqlite.allWrappers().at(-1);
+    for (let write = 0; write < 100; write += 1) {
+      await live?.withExclusiveTransactionAsync(async () => {});
+    }
+
+    // Pinning these would leak one connection object per offline write — the one way
+    // this module could become a problem of its own.
+    expect(pinnedDatabaseCount()).toBe(before);
+    expect(sqlite.allWrappers().filter((wrapper) => wrapper.options.useNewConnection === true)).toHaveLength(100);
+  });
+
+  it('keeps publishing independent of pinning', async () => {
+    const view = await mountUntilPublished();
+    const published = sqlite.allWrappers().at(-1);
+
+    view.unmount();
+    await settle();
+
+    // Pinned for reachability, retracted for liveness. Orthogonal axes.
+    expect(isDatabasePinned(published as never)).toBe(true);
+    expect(getDatabaseHandle()).toBeNull();
+  });
+});

--- a/packages/mobile/src/providers/__tests__/database-provider-shared-object-gc.test.tsx
+++ b/packages/mobile/src/providers/__tests__/database-provider-shared-object-gc.test.tsx
@@ -237,6 +237,13 @@ async function mountUntilPublished(): Promise<{ unmount: () => void }> {
  * restating which wrappers ought to be pinned, so a funnel that stops firing shows up
  * here as a destroyed connection instead of as a stale expectation.
  */
+// NOTE ON MUTATION COVERAGE. Disabling `pinDatabase` outright fails five of these,
+// which is the regression that matters. Removing any ONE of the three funnels
+// (`onInit`, the lifecycle effect, `initializeDatabase`) leaves the suite green,
+// because each independently covers every wrapper. That is defence in depth against
+// an expo-sqlite internal changing under us, not an untested branch — the two guards
+// that ARE individually load-bearing, the `useNewConnection` refusal and the effect
+// pin's skip-onInit case, each have a test that fails without them.
 function collectUnpinned(): void {
   for (const wrapper of sqlite.allWrappers()) {
     if (!isDatabasePinned(wrapper as never)) sqlite.collect(wrapper);

--- a/packages/mobile/src/providers/database-provider.tsx
+++ b/packages/mobile/src/providers/database-provider.tsx
@@ -2,6 +2,7 @@ import { useEffect, type ReactNode } from 'react';
 import { SQLiteProvider, useSQLiteContext, type SQLiteDatabase } from 'expo-sqlite';
 import { DATABASE_NAME, initializeDatabase, releaseDatabaseHandle } from '../db';
 import { retainDatabaseConnection } from '../db/connection-retention';
+import { pinDatabase } from '../db/connection-pin';
 
 function handleDatabaseError(error: Error): void {
   if (__DEV__) {
@@ -34,7 +35,15 @@ function handleDatabaseError(error: Error): void {
  */
 function DatabaseHandleLifecycle() {
   const database = useSQLiteContext();
-  useEffect(() => () => releaseDatabaseHandle(database), [database]);
+  // Pin here as well as in `onInit`. Today `SQLiteProvider` cannot publish a context
+  // value `onInit` never saw, but that is an undocumented internal of a file whose
+  // suspense path serves a cached promise — and if it ever changes, the un-pinned
+  // wrapper's collection kills the live connection (#5410) with nothing to show for
+  // it. Pin where we OBSERVE a connection, not only where we initialize one.
+  useEffect(() => {
+    pinDatabase(database);
+    return () => releaseDatabaseHandle(database);
+  }, [database]);
   return null;
 }
 
@@ -74,6 +83,11 @@ function DatabaseHandleLifecycle() {
  * which is the exact churn this file exists to survive.
  */
 function initializeAndRetainDatabase(db: SQLiteDatabase): Promise<void> {
+  // First statement, before anything can await: this is the earliest point the
+  // connection exists in JS, and an un-pinned wrapper is collectable from the moment
+  // the provider drops it (#5410). Synchronous, so it does not push the retraction
+  // inside `initializeDatabase` a microtask later.
+  pinDatabase(db);
   const initialization = initializeDatabase(db);
   return Promise.all([initialization, retainDatabaseConnection()]).then(() => undefined);
 }

--- a/packages/mobile/src/providers/database-provider.tsx
+++ b/packages/mobile/src/providers/database-provider.tsx
@@ -3,6 +3,14 @@ import { SQLiteProvider, useSQLiteContext, type SQLiteDatabase } from 'expo-sqli
 import { DATABASE_NAME, initializeDatabase, releaseDatabaseHandle } from '../db';
 import { retainDatabaseConnection } from '../db/connection-retention';
 import { pinDatabase } from '../db/connection-pin';
+import { registerReplacementOpener } from '../db/connection';
+import { openReplacementDatabase } from '../db/reopen';
+
+// Wired here rather than imported by `connection.ts`, which node-env suites load and
+// which therefore must not reach expo-sqlite's runtime entry (see the note in
+// `db/testing.ts`). This module already depends on expo-sqlite, so it is the natural
+// place to hand the re-opener over (#5410).
+registerReplacementOpener(openReplacementDatabase);
 
 function handleDatabaseError(error: Error): void {
   if (__DEV__) {

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -737,6 +737,18 @@ export const SHARED_EVENTS = {
   // identical. `elapsedMs` is the contention-duration measurement — its
   // distribution is what sizes the retry window, which today is a guess.
   OfflineSqliteInitRecovered: 'Offline SQLite Init Recovered',
+  // Offline sync — the native SQLite handle was destroyed under us (#5410) and a
+  // replacement connection came up, so the session was saved instead of staying
+  // dead until the climber force-quit. Props: { shape: 'dead-native-handle' |
+  // 'closed', origin, recoveries, elapsedMs, recovered }.
+  //
+  // Deliberately NOT folded into OfflineSqliteInitRecovered: that one measures
+  // launch-time LOCK contention and its `elapsedMs` distribution is what sizes the
+  // retry window. A dead handle is not contention, happens mid-session, and mixing
+  // the two would corrupt the measurement this repo already depends on. This is the
+  // "how many sessions did we save" number; the `phase: 'failed'` Sentry reports are
+  // the ones we did not.
+  OfflineSqliteHandleRecovered: 'Offline SQLite Handle Recovered',
   // Offline sync — someone read climb data from the on-device database. THE
   // north-star signal for offline mode (issue #4317): weekly unique users firing
   // this with `lane in ('offline_local', 'network_error_local')`.

--- a/packages/shared/offline-sync/src/db/__tests__/handle-errors.test.ts
+++ b/packages/shared/offline-sync/src/db/__tests__/handle-errors.test.ts
@@ -1,0 +1,145 @@
+// Pins the dead-handle classifier against the LITERAL strings Sentry carries
+// for BOARDSESH-G1 / BOARDSESH-CF, and — just as importantly — against the lock
+// shapes it must NEVER claim. The whole value of the module is that these two
+// families look similar and need opposite handling: a lock is retried on the
+// same connection, a dead handle can only be recovered by re-opening.
+//
+// The Android shape is reconstructed the way `CodedException.kt` builds it:
+//   "Call to function '<class>.<method>' has been rejected."
+//   + lineSeparator + "→ Caused by: " + (cause.localizedMessage ?: cause)
+// and `toString()` on a message-less NullPointerException is the bare class
+// name, which is why there is nothing after the final colon to key on.
+
+import { describe, it, expect } from 'vitest';
+import { classifySqliteHandleError, isDeadDatabaseHandleError } from '../handle-errors';
+import { classifySqliteLockError, isDatabaseLockedError } from '../lock-errors';
+
+const ANDROID_CODE_BYTE = String.fromCharCode(5);
+
+/** Exactly what BOARDSESH-G1 carries, as one flat message. */
+function androidDeadHandle(method = 'prepareAsync', klass = 'NativeDatabase'): string {
+  return `Call to function '${klass}.${method}' has been rejected.\n→ Caused by: java.lang.NullPointerException: java.lang.NullPointerException`;
+}
+
+/** The shapes that must be recovered by re-opening. */
+const DEAD_HANDLE_SHAPES: [label: string, error: unknown][] = [
+  ['android NPE, flat message', new Error(androidDeadHandle())],
+  ['android NPE, execAsync', new Error(androidDeadHandle('execAsync'))],
+  ['android NPE, NativeStatement.runAsync', new Error(androidDeadHandle('runAsync', 'NativeStatement'))],
+  ['android NPE, NativeSession.createAsync', new Error(androidDeadHandle('createAsync', 'NativeSession'))],
+  [
+    'android NPE split across a cause',
+    new Error("Call to function 'NativeDatabase.prepareAsync' has been rejected.", {
+      cause: new Error('java.lang.NullPointerException'),
+    }),
+  ],
+  ['bare access-to-closed', new Error('Access to closed resource')],
+  [
+    'android-decorated access-to-closed',
+    new Error(
+      "Call to function 'NativeDatabase.prepareAsync' has been rejected.\n→ Caused by: Access to closed resource",
+    ),
+  ],
+  [
+    'iOS access-to-closed',
+    new Error("Calling the 'prepareAsync' function has failed", { cause: new Error('Access to closed resource') }),
+  ],
+];
+
+/** Every lock shape from the sibling suite. None of these is a handle failure. */
+const LOCK_SHAPES: [label: string, error: unknown][] = [
+  [
+    'iOS execAsync lock',
+    new Error("Calling the 'execAsync' function has failed", { cause: new Error('database is locked') }),
+  ],
+  [
+    'iOS prepareAsync lock with code',
+    new Error("Calling the 'prepareAsync' function has failed", {
+      cause: new Error('Error code 5: database is locked'),
+    }),
+  ],
+  [
+    'android lock with the raw control byte',
+    new Error("Call to function 'NativeDatabase.prepareAsync' has been rejected.", {
+      cause: new Error(`Error code ${ANDROID_CODE_BYTE}: database is locked`),
+    }),
+  ],
+  ['iOS 2.3.1 exception', new Error('SQLiteErrorException: Error code 5: database is locked')],
+  ['bare SQLITE_BUSY code', Object.assign(new Error('write failed'), { code: 'SQLITE_BUSY' })],
+];
+
+describe('classifySqliteHandleError', () => {
+  it.each(DEAD_HANDLE_SHAPES)('recognises %s', (_label, error) => {
+    expect(isDeadDatabaseHandleError(error)).toBe(true);
+  });
+
+  it('tells the freed binding apart from an honest close', () => {
+    expect(classifySqliteHandleError(new Error(androidDeadHandle()))).toBe('dead-native-handle');
+    expect(classifySqliteHandleError(new Error('Access to closed resource'))).toBe('closed');
+  });
+
+  it('needs the expo-sqlite frame as well as the NullPointerException', () => {
+    // A bare NPE is the most common native error there is. Matching it alone
+    // would make every unrelated Android module failure re-open SQLite.
+    expect(isDeadDatabaseHandleError(new Error('java.lang.NullPointerException'))).toBe(false);
+    expect(
+      isDeadDatabaseHandleError(
+        new Error(
+          "Call to function 'ExpoUpdates.fetchUpdateAsync' has been rejected.\n→ Caused by: java.lang.NullPointerException",
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it('needs the NullPointerException as well as the frame', () => {
+    expect(
+      isDeadDatabaseHandleError(new Error("Call to function 'NativeDatabase.prepareAsync' has been rejected.")),
+    ).toBe(false);
+  });
+
+  it.each([
+    ['an ordinary type error', new TypeError("Cannot read property 'x' of undefined")],
+    [
+      'a full disk',
+      new Error("Calling the 'execAsync' function has failed", { cause: new Error('database or disk is full') }),
+    ],
+    ['nothing at all', null],
+    ['undefined', undefined],
+    ['an empty object', {}],
+  ])('ignores %s', (_label, error) => {
+    expect(classifySqliteHandleError(error)).toBeNull();
+  });
+
+  it('stops at the cause depth limit instead of walking forever', () => {
+    const tooDeep = new Error("Call to function 'NativeDatabase.prepareAsync' has been rejected.", {
+      cause: new Error('2', {
+        cause: new Error('3', { cause: new Error('4', { cause: 'java.lang.NullPointerException' }) }),
+      }),
+    });
+    expect(isDeadDatabaseHandleError(tooDeep)).toBe(false);
+  });
+
+  it('survives a self-referential cause', () => {
+    const looped: Error & { cause?: unknown } = new Error(androidDeadHandle());
+    looped.cause = looped;
+    expect(isDeadDatabaseHandleError(looped)).toBe(true);
+  });
+
+  it('reads a plain string', () => {
+    expect(classifySqliteHandleError(androidDeadHandle())).toBe('dead-native-handle');
+  });
+});
+
+// The two classifiers must partition the error space. If they ever start
+// agreeing, a dead handle would be retried on the same dead connection until
+// the write budget runs out, or a lock would trigger a pointless re-open.
+describe('mutual exclusivity with the lock classifier', () => {
+  it.each(DEAD_HANDLE_SHAPES)('%s is not read as a lock', (_label, error) => {
+    expect(isDatabaseLockedError(error)).toBe(false);
+    expect(classifySqliteLockError(error).locked).toBe(false);
+  });
+
+  it.each(LOCK_SHAPES)('%s is not read as a handle failure', (_label, error) => {
+    expect(classifySqliteHandleError(error)).toBeNull();
+  });
+});

--- a/packages/shared/offline-sync/src/db/error-cause-walk.ts
+++ b/packages/shared/offline-sync/src/db/error-cause-walk.ts
@@ -1,0 +1,71 @@
+// Walking a thrown value's `.cause` chain, once, for every SQLite classifier.
+//
+// Both platforms wrap the driver error AND concatenate it into the outer
+// `message` (iOS `Exception.swift`, Android `CodedException.kt`), so the same
+// failure arrives as one flat string on some builds and as an outer message
+// plus a structured `.cause` on others. Every classifier therefore has to read
+// the whole chain, not just the top frame.
+//
+// `lock-errors.ts` and `handle-errors.ts` both need that walk with the same
+// depth limit and the same cycle guard, and a classifier that quietly walked
+// one link further than its sibling would disagree with it on real Sentry
+// payloads. Extracting it is what stops them drifting.
+
+/**
+ * How many `.cause` links to follow. Matches the depth error-classification.ts
+ * uses: expo-sqlite wraps at most twice (FunctionCallException → CodedException
+ * → driver error) and an unbounded walk on a caller-supplied object is an easy
+ * way to hang on a long chain.
+ */
+export const MAX_CAUSE_DEPTH = 3;
+
+/** The `message` of a thrown value, or the value itself when it is a string. */
+export function messageOf(error: unknown): string | null {
+  if (typeof error === 'string') return error;
+  if (error === null || typeof error !== 'object') return null;
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' ? message : null;
+}
+
+/**
+ * Every link of the chain, nearest first, bounded by `MAX_CAUSE_DEPTH`.
+ *
+ * Cycle-safe by identity rather than by depth alone: a self-referential
+ * `.cause` is rare but real (a re-thrown error that wraps itself), and the
+ * depth limit alone would still visit it three times.
+ */
+export function causeChain(error: unknown): unknown[] {
+  const chain: unknown[] = [];
+  const seen = new Set<unknown>();
+  let current = error;
+
+  for (let depth = 0; depth <= MAX_CAUSE_DEPTH; depth += 1) {
+    if (current === null || current === undefined) break;
+    if (typeof current === 'object') {
+      if (seen.has(current)) break;
+      seen.add(current);
+    }
+    chain.push(current);
+    if (typeof current !== 'object') break;
+    current = (current as { cause?: unknown }).cause;
+  }
+
+  return chain;
+}
+
+/**
+ * Every message in the chain, joined by newlines.
+ *
+ * Joined rather than tested one frame at a time because the two markers a
+ * dead-handle verdict needs can be split ACROSS links — the expo rejection
+ * frame in the outer message, the `java.lang.NullPointerException` in the
+ * cause — and a per-frame test would see neither frame carrying both.
+ */
+export function chainMessage(error: unknown): string {
+  const messages: string[] = [];
+  for (const link of causeChain(error)) {
+    const message = messageOf(link);
+    if (message !== null) messages.push(message);
+  }
+  return messages.join('\n');
+}

--- a/packages/shared/offline-sync/src/db/handle-errors.ts
+++ b/packages/shared/offline-sync/src/db/handle-errors.ts
@@ -1,0 +1,94 @@
+// "Is the native SQLite handle behind this error dead?" — the question
+// `lock-errors.ts` deliberately does not answer.
+//
+// WHY THIS IS NOT A LOCK (#5410). On Android, opening `boardsesh.db` a second
+// time with equal options returns the SAME Kotlin `NativeDatabase`
+// (`SQLiteModule.kt`, `findCachedDatabase { ... }?.let { it.addRef() }`), but
+// expo-modules-core's `SharedObjectRegistry.add()` registers that one native
+// instance under a NEW id and mints an independent C++ `NativeState` for it.
+// `~NativeState` runs the releaser, so garbage-collecting ANY stale JS wrapper
+// calls `sharedObjectDidRelease()` → `ref.close()` → `mHybridData.resetNative()`
+// on the connection every other wrapper is still using. `NativeDatabase.kt`
+// neither consults the refcount nor sets `isClosed`, so the `isClosed` guard
+// still passes and `sqlite3_prepare_v2` dereferences a freed hybrid pointer.
+//
+// The result is a message-less `java.lang.NullPointerException`, which carries
+// none of the lock markers — so `classifySqliteLockError` correctly returns
+// `locked: false` and every caller treats it as a permanent, non-retryable
+// broken database. It is neither: the FILE is fine, the HANDLE is gone, and the
+// fix is to re-open rather than to retry. That is the distinction this file
+// draws.
+//
+// iOS never produces the NPE shape (`SharedObjectRegistry.swift` reuses the id
+// and native state for a second registration, and the iOS `NativeDatabase` does
+// not override `sharedObjectDidRelease`), but it does produce the `closed`
+// shape when a connection really was closed underneath a reader (#5292), and
+// that is recovered the same way.
+//
+// The matcher is deliberately CONJUNCTIVE. A bare NullPointerException is the
+// most common native error there is; treating one as a dead database would make
+// every unrelated Android module failure re-open SQLite. A verdict needs the
+// expo-sqlite rejection frame AND the NPE, which is why the markers are tested
+// against the joined chain (`chainMessage`) rather than frame by frame — real
+// payloads split them across `.cause`.
+
+import { chainMessage } from './error-cause-walk';
+
+/**
+ * `Access to closed resource` — expo-sqlite's own `AccessClosedResourceException`
+ * (`SQLExceptions.kt`, `SQLiteModule.swift`), raised when `isClosed` was actually
+ * set. Unambiguous on both platforms and needs no second marker.
+ */
+const CLOSED_MARKER = /access to closed resource/i;
+
+/**
+ * The expo-sqlite rejection frame. Covers all three shared classes because the
+ * same dead binding surfaces through whichever entry point runs next — most
+ * often `NativeDatabase.prepareAsync` (every `runAsync`/`getAllAsync` prepares
+ * first), but `execAsync` and the `NativeStatement` methods reach it too.
+ */
+const EXPO_SQLITE_FRAME =
+  /(?:call to function|calling the)\s+'(?:NativeDatabase|NativeStatement|NativeSession)\.\w+'|'(?:NativeDatabase|NativeStatement|NativeSession)\.\w+'\s+function/i;
+
+/**
+ * The freed-pointer signature. `FunctionCallException` renders its cause with
+ * `cause.localizedMessage ?: cause` (`CodedException.kt`), and `toString()` on a
+ * message-less NPE is the bare class name — so this is what reaches Sentry
+ * verbatim, with no message after the colon to key on.
+ */
+const NULL_POINTER = /java\.lang\.NullPointerException/;
+
+/**
+ * How the handle failed, or null when the error is not a handle failure at all.
+ *
+ * - `dead-native-handle` — the binding was freed under us (#5410). Re-open.
+ * - `closed` — the connection was genuinely closed (#5292). Also re-open.
+ *
+ * Both recover the same way; they are kept apart so telemetry can tell the
+ * Android GC bug from an ordinary teardown race without forking the aggregate.
+ */
+export type SqliteHandleFailure = 'dead-native-handle' | 'closed' | null;
+
+/**
+ * Read a thrown value as a dead-handle failure.
+ *
+ * Returns null for lock contention, disk-full, corruption and every ordinary
+ * error — those keep their existing handling. This never overlaps
+ * `isDatabaseLockedError`: the pinned shapes carry no lock marker and no
+ * `Error code N:` prefix, and `handle-errors.test.ts` asserts that in both
+ * directions so the two matchers cannot start agreeing.
+ */
+export function classifySqliteHandleError(error: unknown): SqliteHandleFailure {
+  const message = chainMessage(error);
+  if (message === '') return null;
+
+  if (CLOSED_MARKER.test(message)) return 'closed';
+  if (EXPO_SQLITE_FRAME.test(message) && NULL_POINTER.test(message)) return 'dead-native-handle';
+
+  return null;
+}
+
+/** True when the handle behind `error` is unusable and only a re-open can fix it. */
+export function isDeadDatabaseHandleError(error: unknown): boolean {
+  return classifySqliteHandleError(error) !== null;
+}

--- a/packages/shared/offline-sync/src/db/lock-errors.ts
+++ b/packages/shared/offline-sync/src/db/lock-errors.ts
@@ -34,7 +34,7 @@
 //   Android    "Call to function 'NativeDatabase.prepareAsync' has been rejected.\n
 //               → Caused by: Error code : database is locked"   ← NO numeric code
 
-const MAX_CAUSE_DEPTH = 3;
+import { causeChain, messageOf } from './error-cause-walk';
 
 /** The stable, locale-independent identifiers for write-lock contention. */
 const LOCK_MARKERS = /database is locked|database table is locked|sqlite_busy|sqlite_locked/i;
@@ -50,16 +50,7 @@ const LOCK_MARKERS = /database is locked|database table is locked|sqlite_busy|sq
 const BUSY_CONTROL_BYTE = String.fromCharCode(5);
 const BUSY_RESULT_CODE = new RegExp(`error code\\s*(?:${BUSY_CONTROL_BYTE}|5)\\s*:`, 'i');
 
-function messageOf(error: unknown): string | null {
-  if (typeof error === 'string') return error;
-  if (error === null || typeof error !== 'object') return null;
-  const message = (error as { message?: unknown }).message;
-  return typeof message === 'string' ? message : null;
-}
-
-function isLockedAtDepth(error: unknown, depth: number): boolean {
-  if (error === null || error === undefined) return false;
-
+function isLockedLink(error: unknown): boolean {
   const message = messageOf(error);
   if (message !== null) {
     if (LOCK_MARKERS.test(message)) return true;
@@ -69,14 +60,9 @@ function isLockedAtDepth(error: unknown, depth: number): boolean {
     if (BUSY_RESULT_CODE.test(message) && /lock/i.test(message)) return true;
   }
 
-  if (typeof error === 'object') {
+  if (error !== null && typeof error === 'object') {
     const code = (error as { code?: unknown }).code;
     if (typeof code === 'string' && LOCK_MARKERS.test(code)) return true;
-
-    if (depth < MAX_CAUSE_DEPTH) {
-      const cause = (error as { cause?: unknown }).cause;
-      if (cause !== undefined && cause !== error && isLockedAtDepth(cause, depth + 1)) return true;
-    }
   }
 
   return false;
@@ -87,7 +73,7 @@ function isLockedAtDepth(error: unknown, depth: number): boolean {
  * write-lock contention rather than a broken database.
  */
 export function isDatabaseLockedError(error: unknown): boolean {
-  return isLockedAtDepth(error, 0);
+  return causeChain(error).some(isLockedLink);
 }
 
 /** SQLITE_BUSY — another connection holds the lock this statement needs. */

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -300,6 +300,13 @@ export type { LocalWriteRetryOptions, LocalWriteRetryOutcome } from './db/write-
 export { isDatabaseLockedError, classifySqliteLockError } from './db/lock-errors';
 export type { SqliteLockClassification } from './db/lock-errors';
 
+// The other way a SQLite call fails: the native handle behind it is gone, not
+// busy (#5410). Deliberately a separate predicate from the lock one — a dead
+// handle carries no lock marker, so retrying the same connection can never win
+// and only a re-open recovers it.
+export { classifySqliteHandleError, isDeadDatabaseHandleError } from './db/handle-errors';
+export type { SqliteHandleFailure } from './db/handle-errors';
+
 // --- Offline-usage telemetry (issue #4317) ---------------------------------------
 // The rollup gate that turns "this read was served from the local DB" into a
 // low-volume, chartable signal. `emit` is injected so the package keeps zero


### PR DESCRIPTION
## Summary

Closes #5410.

BOARDSESH-G1 is 239 users and 2593 events over 30 days, Android only, and when it fires every SQLite consumer dies at once — local reads, the sync cycle, tick writes — and stays dead until the climber force-quits. 88% of that volume landed in the last week, and the SQLite lifecycle wave of 2026-09-09 (#5292, #5300, #5336, #5355, #5371, #5373) did not move it.

**Root cause.** Opening `boardsesh.db` a second time with equal options does not open a second connection: Android's constructor finds the cached `NativeDatabase` and hands the same instance back. expo-modules-core then registers that one native object again under a fresh shared-object id, minting an independent C++ `NativeState` for the new JS wrapper. `~NativeState` runs the releaser, so garbage-collecting **any** wrapper calls `sharedObjectDidRelease()` and resets the native binding the live connection is still using. `NativeDatabase.kt` neither consults its refcount nor sets `isClosed` there, so the next call sails past the closed-resource guard and dereferences a freed pointer — a message-less `NullPointerException` from a database nothing closed.

We make four wrappers for that file, and reassigning `latestDatabase` on every remount is what makes the previous one collectable.

**The fix is reachability, not refcounting.** All four funnel through `pinDatabase`, which holds them strongly for the life of the process. Transaction connections are refused, because `useNewConnection` bypasses the cache and pinning them would leak one object per offline write. This is orthogonal to the #5292/#5366 retraction machinery, which is about never handing a reader a closed connection; both are still needed.

Behind that sits a recovery path, so no session stays poisoned if a wrapper still escapes: a classifier that tells a dead handle apart from a locked one, and a re-open on a fresh connection. A plain re-open is served the same dead instance — its refcount never reached zero, so the cache still holds it — and `useNewConnection: true` is the only escape.

iOS is unaffected: its registry already reuses the id and native state for a second registration, and its `NativeDatabase` does not override `sharedObjectDidRelease`. Filed upstream. Not patchable here, because `patches/` is hashed into the native fingerprint and a patched fix could not reach these users by OTA. Everything in this PR is TypeScript, so it ships by OTA today.

**Author-side verification.** A new jsdom suite models the shared-object registry and the collector. Its first test is a self-check that the mock still reproduces the crash; the rest assert the app survives it. Mutation run: disabling `pinDatabase` fails five tests, removing the `useNewConnection` refusal fails one, removing the lifecycle-effect pin fails one. Removing any single funnel keeps the suite green, which is defence in depth and is written down in the test file. `vp run typecheck:mobile`, `vp run test:mobile`, the offline-sync suite and `vp check` are all green locally.

## Release Notes

- Offline storage no longer stops working mid-session on Android. Your ticks, saved climbs and downloaded boards keep loading instead of going blank until you force-quit.

## Test plan

1. Open the app on Android, sign in.
2. Log a tick, then switch tabs and back.
3. You tab → your ticks still load, no blank state.
4. Background the app 2 minutes, reopen it.
5. Browse a downloaded board → climbs still load offline.

## Risk

Risk: 4/5 — offline sync and the SQLite connection lifecycle, no migration
