### PR TITLE
fix(ci): stop a JS-only push from deleting a live OTA preview

### DIFF
--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -155,6 +155,10 @@ jobs:
       branch: ${{ steps.decide.outputs.branch }}
       fork_skip: ${{ steps.decide.outputs.fork_skip }}
       cleanup_reason: ${{ steps.decide.outputs.cleanup_reason }}
+      # Whether this revision can shrink the set of platforms the preview branch
+      # serves — the only thing the pre-publish reset exists to reconcile. See the
+      # native-fingerprint predicate below.
+      needs_reset: ${{ steps.decide.outputs.needs_reset }}
       # The head SHA captured HERE, in the secret-free gate, is the exact commit the
       # publish job checks out — pinning it closes the TOCTOU where a fork could push
       # after the maintainer gate but before the publish checkout of the moving
@@ -171,6 +175,9 @@ jobs:
             let prNumber = '';
             let forkSkip = false;
             let cleanupReason = '';
+            // Default to the old unconditional reset. Only a resolved file list that
+            // provably cannot move the native fingerprint clears it.
+            let needsReset = true;
             // The exact commit the publish job will check out (pinned at gate time, no
             // secrets in scope). For pull_request we take the triggering commit
             // directly; for comment / dispatch we resolve it via the API below.
@@ -190,6 +197,30 @@ jobs:
               path === 'scripts/lib/eoas.ts' ||
               path === '.github/workflows/mobile-ota-preview.yml';
 
+            // Paths that can move the native fingerprint, and therefore turn a
+            // platform native-only mid-PR. Mirrors the native-input globs the
+            // screenshot app cache is keyed on in mobile-screenshots-ios.yml.
+            const affectsNativeFingerprint = (path) =>
+              path === 'packages/mobile/app.config.ts' ||
+              path === 'packages/mobile/package.json' ||
+              path.startsWith('packages/mobile/plugins/') ||
+              path.startsWith('packages/mobile/modules/') ||
+              path.startsWith('packages/mobile/locales/') ||
+              path.startsWith('packages/mobile/ios/') ||
+              path.startsWith('packages/mobile/android/') ||
+              path.startsWith('patches/') ||
+              path === 'package.json' ||
+              path === 'pnpm-lock.yaml' ||
+              path === 'pnpm-workspace.yaml';
+
+            // Also decides whether the preview branch has to be reset before this
+            // revision publishes. The reset exists for ONE case: a revision that turns
+            // native-only stops publishing a platform, leaving that platform's previous
+            // update surfable and stale. A revision that cannot move the fingerprint
+            // always republishes every platform the last one did, so its new update
+            // simply supersedes the old — deleting the branch first would only take a
+            // live preview away from whoever is testing it for the length of a publish
+            // (~13 minutes). Anything unresolved keeps the old unconditional reset.
             const hasMobileChanges = async (number) => {
               const files = await github.paginate(github.rest.pulls.listFiles, {
                 owner: context.repo.owner,
@@ -197,6 +228,7 @@ jobs:
                 pull_number: Number(number),
                 per_page: 100,
               });
+              needsReset = files.some((file) => affectsNativeFingerprint(file.filename));
               return files.some((file) => affectsMobilePreview(file.filename));
             };
 
@@ -291,21 +323,89 @@ jobs:
             }
 
             const branch = prNumber ? `pr-${prNumber}` : '';
-            core.info(`event=${context.eventName} action=${action} branch=${branch || '(none)'} head_sha=${headSha || '(none)'} fork_skip=${forkSkip}`);
+            core.info(`event=${context.eventName} action=${action} branch=${branch || '(none)'} head_sha=${headSha || '(none)'} fork_skip=${forkSkip} needs_reset=${needsReset}`);
             core.setOutput('action', action);
             core.setOutput('pr_number', String(prNumber));
             core.setOutput('branch', branch);
             core.setOutput('fork_skip', String(forkSkip));
             core.setOutput('cleanup_reason', cleanupReason);
+            core.setOutput('needs_reset', String(needsReset));
             core.setOutput('head_sha', headSha);
+
+  # ── Say so BEFORE the branch disappears. A reset takes the preview offline for the
+  # length of a publish (~13 min); with no notice that reads as "the preview is gone",
+  # and the usual reaction — re-dispatching the workflow by hand — only opens a second
+  # hole. Trusted job: no OTA secrets, no checkout, no PR-author code. It writes the
+  # same sticky marker `announce` owns, so the final result overwrites this notice.
+  notify:
+    needs: gate
+    if: needs.gate.outputs.action == 'publish' && needs.gate.outputs.needs_reset == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Note that the preview branch is rebuilding
+        uses: actions/github-script@v7
+        env:
+          BRANCH: ${{ needs.gate.outputs.branch }}
+          PR_NUMBER: ${{ needs.gate.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
+        with:
+          script: |
+            const branch = process.env.BRANCH;
+            const prNumber = Number(process.env.PR_NUMBER);
+            const sha = (process.env.HEAD_SHA || '').slice(0, 7);
+            const marker = '<!-- mobile-ota-preview -->';
+
+            // Only speak up where a preview already exists to lose. A first publish has
+            // no comment yet, and inventing one would promise a preview before the
+            // compatibility check has had its say.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber, per_page: 100,
+            });
+            const isActionsComment = (comment) =>
+              comment.user?.login === 'github-actions[bot]' && comment.user?.type === 'Bot';
+            const existing = comments.find(
+              (comment) => isActionsComment(comment) && comment.body?.includes(marker),
+            );
+            if (!existing) {
+              core.info('No preview comment to update — nothing is being taken offline.');
+              return;
+            }
+
+            const body = [
+              marker,
+              `### 📱 OTA preview — \`${branch}\``,
+              '',
+              `🔄 Rebuilding **\`${branch}\`** from commit \`${sha}\`. This commit changes native ` +
+                `configuration, so the branch is reset before republishing and is **unavailable for ` +
+                `roughly 12 minutes**.`,
+              '',
+              `It comes back on its own — don't re-run this workflow, which would start the wait over. ` +
+                `This comment is replaced with the result.`,
+            ].join('\n');
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body,
+            });
 
   # ── Reconcile the mutable pr-N branch before publishing this revision. The
   # management delete runs without a checkout, install, or PR-authored code and
   # completes before the token-bearing publisher starts. This removes stale
   # platform updates when a newer revision becomes native-only.
+  #
+  # It runs ONLY when the gate saw a path that can move the native fingerprint. A
+  # JS-only revision republishes every platform the previous one did, so the new
+  # update supersedes the old one in place and the branch never goes away — the
+  # delete would otherwise strand whoever is testing the preview for the length of
+  # a publish. The gate defaults needs_reset to true, so anything it could not
+  # resolve still resets.
   reset:
     needs: gate
-    if: needs.gate.outputs.action == 'publish'
+    if: needs.gate.outputs.action == 'publish' && needs.gate.outputs.needs_reset == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
@@ -390,7 +490,13 @@ jobs:
   # admin credentials are never in scope while PR-author code runs.
   publish:
     needs: [gate, reset]
-    if: needs.gate.outputs.action == 'publish'
+    # `reset` is skipped for a JS-only revision, and a skipped `needs` job would
+    # otherwise skip this one too. Keep the edge (publish must still queue behind an
+    # in-flight reset via the shared mutation lane) but accept 'skipped' alongside
+    # 'success'. A reset that FAILED still blocks: the branch state is then unknown.
+    if: >-
+      !cancelled() && needs.gate.outputs.action == 'publish' &&
+      needs.reset.result != 'failure'
     runs-on: ubuntu-latest
     # Each platform may perform six attempts with 34 minutes of backoff. The job
     # publishes iOS then Android, so leave room for both bounded retry sets — a
@@ -663,6 +769,9 @@ jobs:
           BASE_FINGERPRINT_IOS: ${{ needs.publish.outputs.base_fingerprint_ios }}
           BASE_FINGERPRINT_ANDROID: ${{ needs.publish.outputs.base_fingerprint_android }}
           BEHIND_MAIN: ${{ needs.publish.outputs.behind_main }}
+          # 'false' means the branch was NOT reset before this publish, so a revision
+          # that ships nothing leaves the previous revision's bundle in place.
+          NEEDS_RESET: ${{ needs.gate.outputs.needs_reset }}
         with:
           script: |
             const branch = process.env.BRANCH;
@@ -731,6 +840,13 @@ jobs:
             // nativeOnly: nothing shipped, nothing errored — the skip is a legitimate
             // native change, not a failure, so don't flag it red.
             const nativeOnly = !anyPublished && !anyFailed && nativeSkip;
+            // A JS-only revision skips the pre-publish reset, so when it ships nothing
+            // the branch keeps serving the last revision that did publish. Testers must
+            // not read an unchanged switcher entry as "this commit is live".
+            const staleNote =
+              !anyPublished && process.env.NEEDS_RESET === 'false'
+                ? ` **\`${branch}\` still serves the last revision that published**, not this commit.`
+                : '';
             let headline;
             let deployState;
             let deployDesc;
@@ -745,13 +861,14 @@ jobs:
                 `No \`${branch}\` preview was published: this PR is **behind a native change on \`main\`**, so ` +
                 `its bundle targets a fingerprint no current build runs. Rebase onto \`main\` and push. If this ` +
                 `PR adds no native code of its own, that republishes the preview against the fingerprint ` +
-                `testers are on; if it does, this check will then say so and it needs a TestFlight/Play build.`;
+                `testers are on; if it does, this check will then say so and it needs a TestFlight/Play build.` +
+                staleNote;
               deployState = 'inactive';
               deployDesc = `${branch}: behind a native change on main — rebase, then re-check`;
             } else if (nativeOnly) {
               headline =
                 `This PR is a **native change**, so it can't ride OTA — ship a TestFlight/Play build to test it. ` +
-                `No \`${branch}\` preview was published.`;
+                `No \`${branch}\` preview was published.` + staleNote;
               deployState = 'inactive';
               deployDesc = `${branch}: native change — no OTA preview`;
             } else {

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -203,6 +203,12 @@ jobs:
             const affectsNativeFingerprint = (path) =>
               path === 'packages/mobile/app.config.ts' ||
               path === 'packages/mobile/package.json' ||
+              // Declares the extra fingerprint sources and the autolinking hook, and
+              // hashes itself, so editing it moves runtimeVersion on its own.
+              path === 'packages/mobile/fingerprint.config.js' ||
+              // @bacons/apple-targets Xcode extensions (the widget) — native by
+              // definition, and prebuilt into the iOS project.
+              path.startsWith('packages/mobile/targets/') ||
               path.startsWith('packages/mobile/plugins/') ||
               path.startsWith('packages/mobile/modules/') ||
               path.startsWith('packages/mobile/locales/') ||

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -1148,12 +1148,26 @@ above — no per-tester build. Workflow: `.github/workflows/mobile-ota-preview.y
 
 - **Reconcile, then publish.** Every same-repository PR synchronization runs, even after the last
   mobile file leaves the diff. A no-longer-mobile revision removes its preview. A mobile revision
-  first deletes the mutable `pr-<number>` branch, then runs `eoas publish --branch pr-<number>` for
-  each compatible platform. That reset prevents an older compatible update from remaining surfable
-  when a newer commit is native-only on one or both platforms. The production channel stays baked in
-  app config and no same-named channel or map job is created. Xprem exposes the branch through
-  `/branch_lists` when it matches the production channel's `pr-*` surfing pattern and the running
-  binary's exact runtimeVersion/platform.
+  runs `eoas publish --branch pr-<number>` for each compatible platform. The production channel stays
+  baked in app config and no same-named channel or map job is created. Xprem exposes the branch
+  through `/branch_lists` when it matches the production channel's `pr-*` surfing pattern and the
+  running binary's exact runtimeVersion/platform.
+- **The branch is reset only for a native change.** The reset exists to stop an older compatible
+  update staying surfable when a newer commit turns native-only on one or both platforms. Only a
+  revision that can move the native fingerprint can do that, so the gate scans the PR diff for
+  fingerprint paths (`packages/mobile/app.config.ts`, `plugins/`, `modules/`, `locales/`, `ios/`,
+  `android/`, `packages/mobile/package.json`, `patches/`, the root manifest and lockfile) and emits
+  `needs_reset`. A JS-only revision — a test-only commit, a copy fix — skips the reset entirely and
+  its new update supersedes the old one in place, so the preview never leaves the picker. A native
+  revision still resets, and the `notify` job says so on the PR before the branch goes away: the
+  publish takes roughly 12 minutes, and re-running the workflow by hand only starts that wait over.
+  `needs_reset` defaults to true, so anything the gate cannot resolve keeps the old behaviour.
+  Because a skipped job would otherwise skip its dependents, `publish` guards with `!cancelled()`
+  and blocks only on `needs.reset.result == 'failure'`.
+- **A revision that publishes nothing leaves the last good bundle up.** With no reset, a JS-only PR
+  that falls behind a native change on `main` publishes neither platform and `pr-<number>` keeps
+  serving the last revision that did publish — better for a tester than an empty branch, but the
+  sticky comment says which, so an unchanged picker entry is not read as "this commit is live".
 - **Source maps stay local to the runner.** The shared publisher generates external maps for these
   exports, but the preview workflow intentionally has no `SENTRY_AUTH_TOKEN` and never uploads them.
   It runs PR-authored code, so granting a Sentry upload credential would cross the preview security
@@ -1223,7 +1237,8 @@ above — no per-tester build. Workflow: `.github/workflows/mobile-ota-preview.y
   GitHub **Deployment** to the `pr-preview` environment so the PR shows a green "ready" marker; the
   cleanup marks it inactive on close.
 - **Cleanup + storage.** The per-PR concurrency lane serializes reset/publish/close so a late upload
-  cannot recreate a branch after cleanup. On PR close, or whenever the current diff no longer affects
+  cannot recreate a branch after cleanup. `publish` keeps the `needs: [gate, reset]` edge even when
+  the reset is skipped, so it still queues behind an in-flight reset. On PR close, or whenever the current diff no longer affects
   mobile, `pr-<number>` is deleted via `scripts/ota-preview-cleanup.ts delete --branch pr-<number>`.
   The trusted fork follow-up performs the same reconciliation for fork pushes and closes. A daily
   sweep reaps preview branches whose PR is no longer open and fails red on an unavailable or

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -1155,8 +1155,9 @@ above — no per-tester build. Workflow: `.github/workflows/mobile-ota-preview.y
 - **The branch is reset only for a native change.** The reset exists to stop an older compatible
   update staying surfable when a newer commit turns native-only on one or both platforms. Only a
   revision that can move the native fingerprint can do that, so the gate scans the PR diff for
-  fingerprint paths (`packages/mobile/app.config.ts`, `plugins/`, `modules/`, `locales/`, `ios/`,
-  `android/`, `packages/mobile/package.json`, `patches/`, the root manifest and lockfile) and emits
+  fingerprint paths (`packages/mobile/app.config.ts`, `fingerprint.config.js`, `plugins/`, `modules/`,
+  `locales/`, `targets/`, `ios/`, `android/`, `packages/mobile/package.json`, `patches/`, the root
+  manifest and lockfile — every extra source `packages/mobile/fingerprint.config.js` declares) and emits
   `needs_reset`. A JS-only revision — a test-only commit, a copy fix — skips the reset entirely and
   its new update supersedes the old one in place, so the preview never leaves the picker. A native
   revision still resets, and the `notify` job says so on the PR before the branch goes away: the

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -573,6 +573,23 @@ describe('mobile OTA preview branch isolation + S3 lifecycle coupling', () => {
     // that only when a platform can go native-only mid-PR, which needs a fingerprint
     // path. A JS-only revision republishes in place.
     expect(preview).toContain('const affectsNativeFingerprint = (path) =>');
+    // Every declared fingerprint input in packages/mobile/fingerprint.config.js must
+    // be covered, or a native revision skips the reset and strands a stale platform.
+    for (const nativePath of [
+      "path === 'packages/mobile/app.config.ts'",
+      "path === 'packages/mobile/package.json'",
+      "path === 'packages/mobile/fingerprint.config.js'",
+      "path.startsWith('packages/mobile/targets/')",
+      "path.startsWith('packages/mobile/plugins/')",
+      "path.startsWith('packages/mobile/modules/')",
+      "path.startsWith('packages/mobile/locales/')",
+      "path.startsWith('packages/mobile/ios/')",
+      "path.startsWith('packages/mobile/android/')",
+      "path.startsWith('patches/')",
+      "path === 'pnpm-lock.yaml'",
+    ]) {
+      expect(preview).toContain(nativePath);
+    }
     expect(preview).toContain('needsReset = files.some((file) => affectsNativeFingerprint(file.filename));');
     expect(preview).toMatch(
       /^  reset:\n\s+needs: gate\n\s+if: needs\.gate\.outputs\.action == 'publish' && needs\.gate\.outputs\.needs_reset == 'true'$/m,

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -566,6 +566,55 @@ describe('mobile OTA preview branch isolation + S3 lifecycle coupling', () => {
     expect(preview).toContain("['branch', `/api/apps/${appId}/branches/${encoded}`]");
   });
 
+  it('resets only when a revision can shrink the published platform set', () => {
+    const preview = readWorkflow(OTA_PREVIEW);
+
+    // The reset takes a live preview offline for the length of a publish. It is worth
+    // that only when a platform can go native-only mid-PR, which needs a fingerprint
+    // path. A JS-only revision republishes in place.
+    expect(preview).toContain('const affectsNativeFingerprint = (path) =>');
+    expect(preview).toContain('needsReset = files.some((file) => affectsNativeFingerprint(file.filename));');
+    expect(preview).toMatch(
+      /^  reset:\n\s+needs: gate\n\s+if: needs\.gate\.outputs\.action == 'publish' && needs\.gate\.outputs\.needs_reset == 'true'$/m,
+    );
+    expect(preview).toContain('needs_reset: ${{ steps.decide.outputs.needs_reset }}');
+    expect(preview).toContain("core.setOutput('needs_reset', String(needsReset));");
+
+    // An unresolved file list must keep the old unconditional reset: the declaration
+    // starts true and only a completed scan can clear it.
+    expect(preview).toContain('let needsReset = true;');
+
+    // A skipped reset skips its dependents unless the condition uses a status
+    // function, so publish must tolerate 'skipped' while still blocking on 'failure'.
+    const publishCondition = preview.match(/^  publish:\n[\s\S]*?\n    runs-on:/m)?.[0] ?? '';
+    expect(publishCondition).toContain('!cancelled()');
+    expect(publishCondition).toContain("needs.reset.result != 'failure'");
+    expect(preview).toMatch(/^  announce:\n\s+needs: \[gate, reset, publish\]\n\s+if: \$\{\{ !cancelled\(\)/m);
+  });
+
+  it('warns on the PR before a reset takes the preview offline', () => {
+    const preview = readWorkflow(OTA_PREVIEW);
+
+    // Without notice, a reset reads as "the preview is gone" and invites a manual
+    // re-dispatch, which resets the branch a second time.
+    const notifyOffset = preview.indexOf('\n  notify:');
+    expect(notifyOffset).toBeGreaterThan(0);
+    expect(notifyOffset).toBeLessThan(preview.indexOf('\n  reset:'));
+    expect(preview).toMatch(
+      /^  notify:\n\s+needs: gate\n\s+if: needs\.gate\.outputs\.action == 'publish' && needs\.gate\.outputs\.needs_reset == 'true'$/m,
+    );
+    // Trusted job: it must never hold an OTA credential.
+    const notifyJob = preview.slice(notifyOffset, preview.indexOf('\n  reset:'));
+    expect(notifyJob).not.toContain('EOO_TOKEN');
+    expect(notifyJob).not.toContain('OTA_ADMIN_PASSWORD');
+    expect(notifyJob).not.toContain('environment:');
+    expect(notifyJob).not.toContain('actions/checkout');
+    // It edits the same sticky comment announce owns, and never creates a new one.
+    expect(notifyJob).toContain("const marker = '<!-- mobile-ota-preview -->';");
+    expect(notifyJob).toContain('github.rest.issues.updateComment');
+    expect(notifyJob).not.toContain('github.rest.issues.createComment');
+  });
+
   it('authorizes comments before dispatching them into the trusted PR lifecycle lane', () => {
     const preview = readWorkflow(OTA_PREVIEW);
     expect(preview).toContain('github.rest.repos.getCollaboratorPermissionLevel');


### PR DESCRIPTION
## Summary

A test-only push to a PR with a live OTA preview took the preview out of the in-app picker for 13 minutes. On #5409 it happened three times in under an hour.

| Event | Time (2026-09-11) |
| --- | --- |
| `reset` deleted `pr-5409` (commit b710d6f) | 23:16:39 |
| `publish` restored it | 23:28:59 |
| `reset` deleted it again (test-only commit 557357c) | 23:31:40 |
| `publish` restored it | 23:44:41 |
| `reset` deleted it again (manual dispatch) | 23:54:55 |
| `publish` restored it | 2026-09-12 00:06:10 |

`cleanup` was not the cause and behaved correctly. The gate scans the whole PR diff, the new tests live under `packages/mobile/`, so the action was `publish`. The cause is the `reset` job, which deleted the mutable branch before every publish.

`reset` exists for one case, stated in its own comment: a revision that turns native-only stops publishing a platform, leaving that platform's previous update surfable and stale. Only a change that can move the native fingerprint can do that. A JS-only revision always republishes every platform the last one did, so its new update supersedes the old one in place and the branch never has to go away.

The gate now scans the same paginated file list for fingerprint paths and emits `needs_reset`. `reset` runs only when that is true. `needsReset` is declared `true`, so an unresolved file list keeps the old unconditional behaviour. The predicate covers every extra source `packages/mobile/fingerprint.config.js` declares, and a test pins that list.

Because a skipped job would otherwise skip its dependents, `publish` guards with `!cancelled()` and blocks only on a `reset` that actually failed. It keeps the `needs: [gate, reset]` edge and the shared mutation lane, so it still queues behind an in-flight reset.

Two follow-ons:

- A new trusted `notify` job updates the sticky comment before a native reset, saying the branch is rebuilding and asking people not to re-run the workflow. That is what caused the third hole on #5409. It holds no OTA credential, checks out nothing, and only edits a comment that already exists.
- With no reset, a JS-only PR that falls behind a native change on `main` publishes neither platform and the branch keeps serving the last revision that did. Better for a tester than an empty branch, so the announce comment now says which revision is up.

Author-side verification: `vp check`, `vp run typecheck`, and the `mobile-ci-env-parity`, `mobile-ota-publish-workflow`, `ota-preview-cleanup` and `pr-test-plan-workflow` suites all green. Every embedded `github-script` block passes `node --check`. The three new guards were mutation-tested against seven edits (unconditional reset, `needsReset` defaulting false, no fingerprint scan, `notify` removed, `notify` creating instead of updating, `notify` holding the admin password, `publish` dropping `!cancelled()`); each was caught.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 3/5 — changes the publish pipeline's branch reconciliation, but the fallback is the current behaviour and no credential boundary moves.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjrcrheXD8LcYmmSwGzpP5
