### PR TITLE
fix(mobile): off-centre loading spinner on Android buttons

### DIFF
--- a/packages/mobile/src/components/Button.android.tsx
+++ b/packages/mobile/src/components/Button.android.tsx
@@ -175,7 +175,13 @@ export function Button({
             <CircularProgressIndicator
               color={spinnerColor}
               strokeWidth={2}
-              modifiers={[size(config.iconSize, config.iconSize), padding(0, 0, 8, 0)]}
+              // Padding must come before size: `.size().padding()` shrinks the
+              // indicator into the padded remainder of its own fixed box
+              // (drawing it small and off-centre), while `.padding().size()`
+              // draws it full-size with the padding as true outer margin —
+              // matching how the sibling `Icon` (size PROP + external padding)
+              // renders.
+              modifiers={[padding(0, 0, 8, 0), size(config.iconSize, config.iconSize)]}
             />
           ) : iconSource ? (
             <Icon source={iconSource} size={config.iconSize} modifiers={[padding(0, 0, 8, 0)]} />

--- a/packages/mobile/src/components/SwitcherForm.android.tsx
+++ b/packages/mobile/src/components/SwitcherForm.android.tsx
@@ -195,7 +195,9 @@ function renderRow(row: SwitcherRow, errorColor: string): ReactNode {
       return (
         <Row key={row.key} modifiers={[fillMaxWidth(), ROW_PADDING]} verticalAlignment="center">
           {row.busy ? (
-            <CircularProgressIndicator modifiers={[size(20, 20), padding(0, 0, spacing[3], 0)]} strokeWidth={2} />
+            // Padding before size, not after — see Button.android.tsx for why
+            // the reverse order draws the indicator shrunk and off-centre.
+            <CircularProgressIndicator modifiers={[padding(0, 0, spacing[3], 0), size(20, 20)]} strokeWidth={2} />
           ) : null}
           <Text style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
             {row.label}


### PR DESCRIPTION
## Summary
- The Android `CircularProgressIndicator` shown while a button is loading (e.g. "Check for updates" on the What's New screen) chained its Compose modifiers as `size(20, 20)` *then* `padding(end: 8)` — padding applied after a fixed size shrinks into that same box instead of adding outer margin, so the spinner rendered smaller and shifted left instead of centred in its icon slot.
- Reordered to `padding(...)` before `size(...)` in both `Button.android.tsx` and the identical pattern in `SwitcherForm.android.tsx`, matching how the sibling `Icon` (fixed size prop + external padding) already renders correctly.

## Release Notes

Fixed a shrunken, off-centre spinner on Android loading buttons (like "Check for updates" on What's New).

## Test plan
1. Android → More → What's New → tap "Check for updates" → spinner sits centred, full-size, where the refresh icon was.

## Risk
Risk: 2/5 — Android-only Compose modifier order fix on two existing loading spinners, no behavior change outside their layout.